### PR TITLE
Fix logging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,9 @@ object Dependencies {
     def circe(artifact: String): ModuleID = "io.circe" %% s"circe-$artifact" % V.circe
     def ciris(artifact: String): ModuleID = "is.cir" %% artifact % V.ciris
     def derevo(artifact: String): ModuleID = "tf.tofu" %% s"derevo-$artifact" % V.derevo
-    def doobie(artifact: String): ModuleID = "org.tpolecat" %% s"doobie-$artifact" % V.doobie
+
+    def doobie(artifact: String): ModuleID =
+      ("org.tpolecat" %% s"doobie-$artifact" % V.doobie).exclude("org.slf4j", "slf4j-api")
     def droste(artifact: String): ModuleID = "io.higherkindness" %% s"droste-$artifact" % V.droste
     def fs2Data(artifact: String): ModuleID = "org.gnieh" %% s"fs2-data-$artifact" % V.fs2Data
     def http4s(artifact: String): ModuleID = "org.http4s" %% s"http4s-$artifact" % V.http4s


### PR DESCRIPTION
`slf4j-api` needs to be excluded since `hikari` a transitive dependency of `doobie` depends on `slf4j-api` in version `2.0` which is incomaptible with `1.7` that we currently use everywhere.