### PR TITLE
Add p2p routes for trust polling from storage & test. 

### DIFF
--- a/modules/core/src/main/scala/org/tesselation/domain/trust/storage/TrustStorage.scala
+++ b/modules/core/src/main/scala/org/tesselation/domain/trust/storage/TrustStorage.scala
@@ -1,10 +1,10 @@
 package org.tesselation.domain.trust.storage
 
-import org.tesselation.schema.cluster
-import org.tesselation.schema.cluster.TrustInfo
 import org.tesselation.schema.peer.PeerId
+import org.tesselation.schema.trust.{InternalTrustUpdateBatch, PublicTrust, TrustInfo}
 
 trait TrustStorage[F[_]] {
-  def updateTrust(trustUpdates: cluster.InternalTrustUpdateBatch): F[Unit]
-  def getTrust(): F[Map[PeerId, TrustInfo]]
+  def updateTrust(trustUpdates: InternalTrustUpdateBatch): F[Unit]
+  def getTrust: F[Map[PeerId, TrustInfo]]
+  def getPublicTrust: F[PublicTrust]
 }

--- a/modules/core/src/main/scala/org/tesselation/http/routes/ClusterRoutes.scala
+++ b/modules/core/src/main/scala/org/tesselation/http/routes/ClusterRoutes.scala
@@ -12,6 +12,7 @@ import org.tesselation.ext.http4s.refined._
 import org.tesselation.schema.cluster._
 import org.tesselation.schema.peer.JoinRequest
 import org.tesselation.schema.peer.Peer.toP2PContext
+import org.tesselation.schema.trust.InternalTrustUpdateBatch
 
 import com.comcast.ip4s.Host
 import org.http4s.HttpRoutes

--- a/modules/core/src/main/scala/org/tesselation/http/routes/TrustRoutes.scala
+++ b/modules/core/src/main/scala/org/tesselation/http/routes/TrustRoutes.scala
@@ -1,0 +1,30 @@
+package org.tesselation.http.routes
+
+import cats.effect.Async
+import cats.syntax.flatMap._
+
+import org.tesselation.domain.trust.storage.TrustStorage
+import org.tesselation.ext.codecs.BinaryCodec._
+import org.tesselation.kryo.KryoSerializer
+
+import org.http4s._
+import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server.Router
+
+final case class TrustRoutes[F[_]: Async: KryoSerializer](
+  trustStorage: TrustStorage[F]
+) extends Http4sDsl[F] {
+  private[routes] val prefixPath = "/trust"
+
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
+    case GET -> Root =>
+      trustStorage.getPublicTrust.flatMap { publicTrust =>
+        Ok(publicTrust)
+      }
+  }
+
+  val p2pRoutes: HttpRoutes[F] = Router(
+    prefixPath -> httpRoutes
+  )
+}

--- a/modules/core/src/main/scala/org/tesselation/modules/HttpApi.scala
+++ b/modules/core/src/main/scala/org/tesselation/modules/HttpApi.scala
@@ -37,6 +37,7 @@ sealed abstract class HttpApi[F[_]: Async: KryoSerializer] private (
     ClusterRoutes[F](programs.joining, programs.peerDiscovery, storages.cluster, storages.trust)
   private val registrationRoutes = RegistrationRoutes[F](services.cluster)
   private val gossipRoutes = routes.GossipRoutes[F](storages.rumor, queues.rumor, services.gossip)
+  private val trustRoutes = routes.TrustRoutes[F](storages.trust)
 
   private val debugRoutes = DebugRoutes[F](storages, services).routes
 
@@ -50,7 +51,8 @@ sealed abstract class HttpApi[F[_]: Async: KryoSerializer] private (
     healthRoutes <+>
       clusterRoutes.p2pRoutes <+>
       registrationRoutes.p2pRoutes <+>
-      gossipRoutes.p2pRoutes
+      gossipRoutes.p2pRoutes <+>
+      trustRoutes.p2pRoutes
 
   private val cliRoutes: HttpRoutes[F] =
     healthRoutes <+>

--- a/modules/core/src/test/scala/org/tesselation/http/routes/TrustRoutesSuite.scala
+++ b/modules/core/src/test/scala/org/tesselation/http/routes/TrustRoutesSuite.scala
@@ -1,0 +1,39 @@
+package org.tesselation.http.routes
+
+import cats.effect._
+import cats.effect.unsafe.implicits.global
+
+import org.tesselation.infrastructure.trust.storage.TrustStorage
+import org.tesselation.kryo.{KryoSerializer, coreKryoRegistrar}
+import org.tesselation.schema.generators._
+import org.tesselation.schema.peer.PeerId
+import org.tesselation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
+
+import org.http4s.Method._
+import org.http4s._
+import org.http4s.client.dsl.io._
+import org.http4s.syntax.literals._
+import suite.HttpSuite
+
+object TrustRoutesSuite extends HttpSuite {
+  test("GET trust succeeds") {
+    val req = GET(uri"/trust")
+    val peer = (for {
+      peers <- peersGen()
+    } yield peers.head).sample.get
+
+    KryoSerializer
+      .forAsync[IO](coreKryoRegistrar)
+      .use { implicit kryoPool =>
+        for {
+          trust <- Ref[IO].of(Map.empty[PeerId, TrustInfo])
+          ts = TrustStorage.make[IO](trust)
+          _ <- ts.updateTrust(
+            InternalTrustUpdateBatch(List(InternalTrustUpdate(peer.id, 0.5)))
+          )
+          routes = TrustRoutes[IO](ts).p2pRoutes
+        } yield expectHttpStatus(routes, req)(Status.Ok)
+      }
+      .unsafeRunSync()
+  }
+}

--- a/modules/core/src/test/scala/org/tesselation/infrastructure/trust/storage/TrustStorageSuite.scala
+++ b/modules/core/src/test/scala/org/tesselation/infrastructure/trust/storage/TrustStorageSuite.scala
@@ -2,9 +2,9 @@ package org.tesselation.infrastructure.trust.storage
 
 import cats.effect.{IO, Ref}
 
-import org.tesselation.schema.cluster.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
 import org.tesselation.schema.generators._
 import org.tesselation.schema.peer.PeerId
+import org.tesselation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
 
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers
@@ -19,7 +19,7 @@ object TrustStorageSuite extends SimpleIOSuite with Checkers {
         _ <- cs.updateTrust(
           InternalTrustUpdateBatch(List(InternalTrustUpdate(peer.id, 0.5)))
         )
-        updatedTrust <- cs.getTrust()
+        updatedTrust <- cs.getTrust
       } yield expect(updatedTrust(peer.id).trustLabel.get == 0.5)
     }
   }

--- a/modules/shared/src/main/scala/org/tesselation/schema/cluster.scala
+++ b/modules/shared/src/main/scala/org/tesselation/schema/cluster.scala
@@ -19,20 +19,6 @@ object cluster {
   @derive(decoder, encoder, show)
   case class PeerToJoin(id: PeerId, ip: Host, p2pPort: Port)
 
-  @derive(decoder, encoder, show)
-  case class InternalTrustUpdate(id: PeerId, trust: Double)
-
-  @derive(decoder, encoder, show)
-  case class InternalTrustUpdateBatch(updates: List[InternalTrustUpdate])
-
-  @derive(decoder, encoder, show)
-  case class TrustInfo(
-    trustLabel: Option[Double] = None,
-    predictedTrust: Option[Double] = None,
-    observationAdjustmentTrust: Option[Double] = None,
-    peerLabels: Map[PeerId, Double] = Map.empty
-  )
-
   object PeerToJoin {
 
     implicit def apply(p2PContext: P2PContext): PeerToJoin =

--- a/modules/shared/src/main/scala/org/tesselation/schema/trust.scala
+++ b/modules/shared/src/main/scala/org/tesselation/schema/trust.scala
@@ -1,0 +1,36 @@
+package org.tesselation.schema
+
+import org.tesselation.schema.peer.PeerId
+
+import derevo.cats.show
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import io.estatico.newtype.macros.newtype
+
+object trust {
+
+  @derive(decoder, encoder, show)
+  case class InternalTrustUpdate(id: PeerId, trust: Double)
+
+  @derive(decoder, encoder, show)
+  case class InternalTrustUpdateBatch(updates: List[InternalTrustUpdate])
+
+  @derive(decoder, encoder, show)
+  case class TrustInfo(
+    trustLabel: Option[Double] = None,
+    predictedTrust: Option[Double] = None,
+    observationAdjustmentTrust: Option[Double] = None,
+    peerLabels: Map[PeerId, Double] = Map.empty
+  ) {
+
+    val publicTrust: Option[Double] =
+      trustLabel
+        .map(t => Math.max(-1, t + observationAdjustmentTrust.getOrElse(0d)))
+        .orElse(observationAdjustmentTrust.map(t => Math.max(-1, t)))
+  }
+
+  @derive(decoder, encoder, show)
+  @newtype
+  case class PublicTrust(labels: Map[PeerId, Double])
+
+}


### PR DESCRIPTION
Moved trust related schema to own object. Add calculation for offset of trust and defined case class / Kryo registrar update. Corresponding test of http routes.

