### PR TITLE
Trust implemented as Daemon using gossip.

### DIFF
--- a/modules/core/src/main/scala/org/tesselation/config/Config.scala
+++ b/modules/core/src/main/scala/org/tesselation/config/Config.scala
@@ -61,6 +61,14 @@ object Config {
     )
   )
 
+  val trustConfig = ConfigValue.default(
+    TrustConfig(
+      TrustDaemonConfig(
+        10.minutes
+      )
+    )
+  )
+
   def load[F[_]: Async]: F[AppConfig] =
     env("CL_APP_ENV")
       .default("testnet")
@@ -72,8 +80,8 @@ object Config {
       .load[F]
 
   def default[F[_]](environment: AppEnvironment): ConfigValue[F, AppConfig] =
-    (keyConfig, httpConfig, dbConfig, gossipConfig).parMapN { (key, http, db, gossip) =>
-      AppConfig(environment, key, http, db, gossip)
+    (keyConfig, httpConfig, dbConfig, gossipConfig, trustConfig).parMapN { (key, http, db, gossip, trust) =>
+      AppConfig(environment, key, http, db, gossip, trust)
     }
 
 }

--- a/modules/core/src/main/scala/org/tesselation/config/types.scala
+++ b/modules/core/src/main/scala/org/tesselation/config/types.scala
@@ -13,7 +13,8 @@ object types {
     keyConfig: KeyConfig,
     httpConfig: HttpConfig,
     dbConfig: DBConfig,
-    gossipConfig: GossipConfig
+    gossipConfig: GossipConfig,
+    trustConfig: TrustConfig
   )
 
   case class DBConfig(
@@ -49,6 +50,14 @@ object types {
   case class GossipConfig(
     storage: RumorStorageConfig,
     daemon: GossipDaemonConfig
+  )
+
+  case class TrustDaemonConfig(
+    interval: FiniteDuration
+  )
+
+  case class TrustConfig(
+    daemon: TrustDaemonConfig
   )
 
   case class HttpServerConfig(

--- a/modules/core/src/main/scala/org/tesselation/domain/trust/storage/TrustStorage.scala
+++ b/modules/core/src/main/scala/org/tesselation/domain/trust/storage/TrustStorage.scala
@@ -5,6 +5,8 @@ import org.tesselation.schema.trust.{InternalTrustUpdateBatch, PublicTrust, Trus
 
 trait TrustStorage[F[_]] {
   def updateTrust(trustUpdates: InternalTrustUpdateBatch): F[Unit]
+  def updatePredictedTrust(trustUpdates: Map[PeerId, Double]): F[Unit]
   def getTrust: F[Map[PeerId, TrustInfo]]
   def getPublicTrust: F[PublicTrust]
+  def updatePeerPublicTrustInfo(peerId: PeerId, publicTrust: PublicTrust): F[Unit]
 }

--- a/modules/core/src/main/scala/org/tesselation/http/p2p/P2PClient.scala
+++ b/modules/core/src/main/scala/org/tesselation/http/p2p/P2PClient.scala
@@ -2,7 +2,7 @@ package org.tesselation.http.p2p
 
 import cats.effect.Concurrent
 
-import org.tesselation.http.p2p.clients.{ClusterClient, GossipClient, SignClient}
+import org.tesselation.http.p2p.clients._
 import org.tesselation.kryo.KryoSerializer
 
 import org.http4s.client._
@@ -11,6 +11,7 @@ trait P2PClient[F[_]] {
   val sign: SignClient[F]
   val cluster: ClusterClient[F]
   val gossip: GossipClient[F]
+  val trust: TrustClient[F]
 }
 
 object P2PClient {
@@ -22,5 +23,6 @@ object P2PClient {
       val sign: SignClient[F] = SignClient.make[F](client)
       val cluster: ClusterClient[F] = ClusterClient.make[F](client)
       val gossip: GossipClient[F] = GossipClient.make[F](client)
+      val trust: TrustClient[F] = TrustClient.make[F](client)
     }
 }

--- a/modules/core/src/main/scala/org/tesselation/http/p2p/clients/TrustClient.scala
+++ b/modules/core/src/main/scala/org/tesselation/http/p2p/clients/TrustClient.scala
@@ -1,0 +1,27 @@
+package org.tesselation.http.p2p.clients
+
+import cats.effect.Concurrent
+
+import org.tesselation.ext.codecs.BinaryCodec._
+import org.tesselation.http.p2p.PeerResponse
+import org.tesselation.http.p2p.PeerResponse.PeerResponse
+import org.tesselation.kryo.KryoSerializer
+import org.tesselation.schema.trust.PublicTrust
+
+import org.http4s.client.Client
+import org.http4s.client.dsl.Http4sClientDsl
+
+trait TrustClient[F[_]] {
+  // Replace with publicTrust
+  def getPublicTrust: PeerResponse[F, PublicTrust]
+}
+
+object TrustClient {
+
+  def make[F[_]: Concurrent: KryoSerializer](client: Client[F]): TrustClient[F] =
+    new TrustClient[F] with Http4sClientDsl[F] {
+
+      def getPublicTrust: PeerResponse[F, PublicTrust] =
+        PeerResponse[F, PublicTrust]("trust")(client)
+    }
+}

--- a/modules/core/src/main/scala/org/tesselation/infrastructure/trust/TrustDaemon.scala
+++ b/modules/core/src/main/scala/org/tesselation/infrastructure/trust/TrustDaemon.scala
@@ -1,0 +1,66 @@
+package org.tesselation.infrastructure.trust
+
+import cats.Parallel
+import cats.effect.std.Random
+import cats.effect.{Async, Spawn, Temporal}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import org.tesselation.config.types.TrustDaemonConfig
+import org.tesselation.domain.Daemon
+import org.tesselation.domain.trust.storage.TrustStorage
+import org.tesselation.kryo.KryoSerializer
+import org.tesselation.schema.peer.PeerId
+import org.tesselation.schema.trust.TrustInfo
+import org.tesselation.security.SecurityProvider
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait TrustDaemon[F[_]] extends Daemon[F]
+
+object TrustDaemon {
+
+  def make[F[_]: Async: SecurityProvider: KryoSerializer: Random: Parallel](
+    cfg: TrustDaemonConfig,
+    trustStorage: TrustStorage[F],
+    selfPeerId: PeerId
+  ): TrustDaemon[F] = new TrustDaemon[F] {
+
+    private val logger = Slf4jLogger.getLogger[F]
+
+    def start: F[Unit] =
+      for {
+        _ <- Spawn[F].start(modelUpdate.foreverM).void
+      } yield ()
+
+    private def calculatePredictedTrust(trust: Map[PeerId, TrustInfo]): Map[PeerId, Double] = {
+      val selfTrustLabels = trust.flatMap { case (peerId, trustInfo) => trustInfo.publicTrust.map(peerId -> _) }
+      val allNodesTrustLabels = trust.view.mapValues(_.peerLabels).toMap + (selfPeerId -> selfTrustLabels)
+
+      val peerIdToIdx = allNodesTrustLabels.keys.zipWithIndex.toMap
+      val idxToPeerId = peerIdToIdx.map(_.swap)
+
+      val trustNodes = allNodesTrustLabels.map {
+        case (peerId, labels) =>
+          TrustNode(peerIdToIdx(peerId), 0, 0, labels.map {
+            case (pid, label) =>
+              TrustEdge(peerIdToIdx(peerId), peerIdToIdx(pid), label, peerId == selfPeerId)
+          }.toList)
+      }.toList
+
+      SelfAvoidingWalk
+        .runWalkFeedbackUpdateSingleNode(peerIdToIdx(selfPeerId), trustNodes)
+        .edges
+        .map(e => idxToPeerId(e.dst) -> e.trust)
+        .toMap
+    }
+
+    private def modelUpdate: F[Unit] =
+      for {
+        _ <- Temporal[F].sleep(cfg.interval)
+        predictedTrust <- trustStorage.getTrust.map(calculatePredictedTrust)
+        _ <- trustStorage.updatePredictedTrust(predictedTrust)
+      } yield ()
+
+  }
+}

--- a/modules/core/src/main/scala/org/tesselation/infrastructure/trust/storage/TrustStorage.scala
+++ b/modules/core/src/main/scala/org/tesselation/infrastructure/trust/storage/TrustStorage.scala
@@ -33,6 +33,21 @@ object TrustStorage {
       def getPublicTrust: F[PublicTrust] = getTrust.map { trust =>
         PublicTrust(trust.mapFilter { _.publicTrust })
       }
+
+      def updatePeerPublicTrustInfo(peerId: PeerId, publicTrust: PublicTrust): F[Unit] = trust.update { t =>
+        t.updatedWith(peerId) { trustInfo =>
+          trustInfo
+            .orElse(Some(TrustInfo()))
+            .map(_.copy(peerLabels = publicTrust.labels))
+        }
+      }
+
+      override def updatePredictedTrust(trustUpdates: Map[PeerId, Double]): F[Unit] = trust.update { t =>
+        t ++ trustUpdates.map {
+          case (k, v) =>
+            k -> t.getOrElse(k, TrustInfo()).copy(predictedTrust = Some(v))
+        }
+      }
     }
 
 }

--- a/modules/core/src/main/scala/org/tesselation/modules/Daemons.scala
+++ b/modules/core/src/main/scala/org/tesselation/modules/Daemons.scala
@@ -11,6 +11,7 @@ import org.tesselation.domain.Daemon
 import org.tesselation.http.p2p.P2PClient
 import org.tesselation.infrastructure.cluster.daemon.NodeStateDaemon
 import org.tesselation.infrastructure.gossip.{GossipDaemon, RumorHandler}
+import org.tesselation.infrastructure.trust.TrustDaemon
 import org.tesselation.kryo.KryoSerializer
 import org.tesselation.schema.peer.PeerId
 import org.tesselation.security.SecurityProvider
@@ -37,7 +38,8 @@ object Daemons {
           nodeId,
           cfg.gossipConfig.daemon
         ),
-      NodeStateDaemon.make(storages.node, services.gossip)
+      NodeStateDaemon.make(storages.node, services.gossip),
+      TrustDaemon.make(cfg.trustConfig.daemon, storages.trust, nodeId)
     ).traverse(_.start).void
 
 }


### PR DESCRIPTION
Model code not yet enabled, so mostly a stub for now.
Add a configuration for trust with an interval for daemon. Daemon is structured
same as Gossip daemon in terms of classes used. Relies on trustStorage data assumed to be updated by gossip and updates internal storage with predictions.

This is for feature parity with existing codebase. Long term requirements will need model updates.