### PR TITLE
Add TrustPush program connecting trust update with gossip

### DIFF
--- a/modules/core/src/main/scala/org/tesselation/Main.scala
+++ b/modules/core/src/main/scala/org/tesselation/Main.scala
@@ -54,7 +54,7 @@ object Main extends IOApp {
                         services <- Services.make[IO](cfg, nodeId, keyPair, storages, queues).asResource
                         programs <- Programs.make[IO](storages, services, p2pClient, nodeId).asResource
 
-                        rumorHandler = RumorHandlers.make[IO](storages.cluster).handlers
+                        rumorHandler = RumorHandlers.make[IO](storages.cluster, storages.trust).handlers
                         _ <- Daemons.start(storages, services, queues, p2pClient, rumorHandler, nodeId, cfg).asResource
 
                         api = HttpApi.make[IO](storages, queues, services, programs, cfg.environment)

--- a/modules/core/src/main/scala/org/tesselation/domain/cluster/programs/TrustPush.scala
+++ b/modules/core/src/main/scala/org/tesselation/domain/cluster/programs/TrustPush.scala
@@ -1,0 +1,30 @@
+package org.tesselation.domain.cluster.programs
+
+import cats.effect.Async
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import org.tesselation.domain.gossip.Gossip
+import org.tesselation.domain.trust.storage.TrustStorage
+
+object TrustPush {
+
+  def make[F[_]: Async](
+    trustStorage: TrustStorage[F],
+    gossip: Gossip[F]
+  ): TrustPush[F] = new TrustPush[F](trustStorage, gossip) {}
+
+}
+
+sealed abstract class TrustPush[F[_]: Async] private (
+  trustStorage: TrustStorage[F],
+  gossip: Gossip[F]
+) {
+
+  def publishUpdated(): F[Unit] =
+    for {
+      trust <- trustStorage.getPublicTrust
+      _ <- gossip.spread(trust)
+    } yield {}
+
+}

--- a/modules/core/src/main/scala/org/tesselation/infrastructure/gossip/RumorHandlers.scala
+++ b/modules/core/src/main/scala/org/tesselation/infrastructure/gossip/RumorHandlers.scala
@@ -6,7 +6,9 @@ import cats.syntax.semigroupk._
 import cats.syntax.show._
 
 import org.tesselation.domain.cluster.storage.ClusterStorage
+import org.tesselation.domain.trust.storage.TrustStorage
 import org.tesselation.infrastructure.cluster.rumour.handler.nodeStateHandler
+import org.tesselation.infrastructure.trust.handler.trustHandler
 import org.tesselation.kryo.KryoSerializer
 
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -14,15 +16,19 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 object RumorHandlers {
 
   def make[F[_]: Async: KryoSerializer](
-    clusterStorage: ClusterStorage[F]
+    clusterStorage: ClusterStorage[F],
+    trustStorage: TrustStorage[F]
   ): RumorHandlers[F] =
-    new RumorHandlers[F](clusterStorage) {}
+    new RumorHandlers[F](clusterStorage, trustStorage) {}
 }
 
 sealed abstract class RumorHandlers[F[_]: Async: KryoSerializer] private (
-  clusterStorage: ClusterStorage[F]
+  clusterStorage: ClusterStorage[F],
+  trustStorage: TrustStorage[F]
 ) {
   private val nodeState = nodeStateHandler(clusterStorage)
+
+  private val trust = trustHandler(trustStorage)
 
   private val debug: RumorHandler[F] = {
     val logger = Slf4jLogger.getLogger[F]
@@ -42,5 +48,5 @@ sealed abstract class RumorHandlers[F[_]: Async: KryoSerializer] private (
     strHandler <+> optIntHandler
   }
 
-  val handlers: RumorHandler[F] = nodeState <+> debug
+  val handlers: RumorHandler[F] = nodeState <+> debug <+> trust
 }

--- a/modules/core/src/main/scala/org/tesselation/infrastructure/trust/handler.scala
+++ b/modules/core/src/main/scala/org/tesselation/infrastructure/trust/handler.scala
@@ -1,0 +1,31 @@
+package org.tesselation.infrastructure.trust
+
+import cats.Applicative
+import cats.effect.Async
+import cats.syntax.flatMap._
+import cats.syntax.show._
+
+import org.tesselation.domain.trust.storage.TrustStorage
+import org.tesselation.infrastructure.gossip.RumorHandler
+import org.tesselation.kryo.KryoSerializer
+import org.tesselation.schema.gossip.ReceivedRumor
+import org.tesselation.schema.trust.PublicTrust
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object handler {
+
+  def trustHandler[F[_]: Async: KryoSerializer](
+    trustStorage: TrustStorage[F]
+  ): RumorHandler[F] = {
+    val logger = Slf4jLogger.getLogger[F]
+
+    RumorHandler.fromReceivedRumorFn[F, PublicTrust](latestOnly = true) {
+      case ReceivedRumor(origin, trust) =>
+        logger.info(s"Received trust=${trust} from id=${origin.show}") >> {
+          // Placeholder for updating trust scores
+          Applicative[F].unit
+        }
+    }
+  }
+}

--- a/modules/core/src/main/scala/org/tesselation/modules/HttpApi.scala
+++ b/modules/core/src/main/scala/org/tesselation/modules/HttpApi.scala
@@ -34,7 +34,7 @@ sealed abstract class HttpApi[F[_]: Async: KryoSerializer] private (
 ) {
   private val healthRoutes = HealthRoutes[F](services.healthcheck).routes
   private val clusterRoutes =
-    ClusterRoutes[F](programs.joining, programs.peerDiscovery, storages.cluster, storages.trust)
+    ClusterRoutes[F](programs.joining, programs.peerDiscovery, programs.trustPush, storages.cluster, storages.trust)
   private val registrationRoutes = RegistrationRoutes[F](services.cluster)
   private val gossipRoutes = routes.GossipRoutes[F](storages.rumor, queues.rumor, services.gossip)
   private val trustRoutes = routes.TrustRoutes[F](storages.trust)

--- a/modules/core/src/main/scala/org/tesselation/modules/Programs.scala
+++ b/modules/core/src/main/scala/org/tesselation/modules/Programs.scala
@@ -4,7 +4,7 @@ import cats.effect.Async
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
-import org.tesselation.domain.cluster.programs.{Joining, PeerDiscovery}
+import org.tesselation.domain.cluster.programs.{Joining, PeerDiscovery, TrustPush}
 import org.tesselation.http.p2p.P2PClient
 import org.tesselation.kryo.KryoSerializer
 import org.tesselation.schema.peer.PeerId
@@ -31,10 +31,12 @@ object Programs {
         nodeId,
         pd
       )
-    } yield new Programs[F](pd, joining) {}
+      trustPush = TrustPush.make(storages.trust, services.gossip)
+    } yield new Programs[F](pd, joining, trustPush) {}
 }
 
 sealed abstract class Programs[F[_]: Async: SecurityProvider: KryoSerializer] private (
   val peerDiscovery: PeerDiscovery[F],
-  val joining: Joining[F]
-) {}
+  val joining: Joining[F],
+  val trustPush: TrustPush[F]
+)

--- a/modules/shared/src/main/scala/org/tesselation/schema/kryo/package.scala
+++ b/modules/shared/src/main/scala/org/tesselation/schema/kryo/package.scala
@@ -9,6 +9,7 @@ import org.tesselation.schema.address.AddressCache
 import org.tesselation.schema.gossip._
 import org.tesselation.schema.node.NodeState
 import org.tesselation.schema.peer.SignRequest
+import org.tesselation.schema.trust.PublicTrust
 import org.tesselation.security.signature.Signed
 import org.tesselation.security.signature.signature.SignatureProof
 
@@ -35,6 +36,7 @@ package object kryo {
     NodeState.SessionStarted.getClass -> 212,
     NodeState.Offline.getClass -> 213,
     NodeState.StartingSession.getClass -> 214,
-    NodeState.Unknown.getClass -> 215
+    NodeState.Unknown.getClass -> 215,
+    classOf[PublicTrust] -> 216
   )
 }

--- a/modules/shared/src/main/scala/org/tesselation/schema/trust.scala
+++ b/modules/shared/src/main/scala/org/tesselation/schema/trust.scala
@@ -5,7 +5,6 @@ import org.tesselation.schema.peer.PeerId
 import derevo.cats.show
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import io.estatico.newtype.macros.newtype
 
 object trust {
 
@@ -30,7 +29,8 @@ object trust {
   }
 
   @derive(decoder, encoder, show)
-  @newtype
-  case class PublicTrust(labels: Map[PeerId, Double])
+  case class PublicTrust(
+    labels: Map[PeerId, Double]
+  )
 
 }


### PR DESCRIPTION
Simple program takes internal updates and publishes latest PublicTrust
snapshot. Avoided incremental updates to keep it simpler as data is
extremely small (labels and observations only.)

Triggered from CLI trust update after storage is updated. Spreads
gossip and add an empty handler which will be used in subsequent PR.

Adds randomization factor to handle issues with reversions in scores
to avoid problem with seenHashes. Removed @newtype due to addition
of UUID for randomness.