### PR TITLE
Enable model with simple transitive test.

### DIFF
--- a/modules/core/src/main/scala/org/tesselation/infrastructure/trust/SelfAvoidingWalk.scala
+++ b/modules/core/src/main/scala/org/tesselation/infrastructure/trust/SelfAvoidingWalk.scala
@@ -337,16 +337,15 @@ object SelfAvoidingWalk extends StrictLogging {
   ): TrustNode = {
 
     var nodesCycle = nodes
-    // TODO: Fix stack overflow issue
-    //    if (nodesCycle.size > 2) { //note, need min of 3 nodes
-    //      println(s"runWalkFeedbackUpdateSingleNode nodes ${nodes.toList} for node $selfId")
-    //      (0 until feedbackCycles).foreach { cycle =>
-    //        println(s"feedback cycle $cycle for node $selfId")
-    //        nodesCycle = runWalkBatchesFeedback(selfId, nodes, batchIterationSize, epsilon, maxIterations)
-    //      }
-    //    }
+    if (nodesCycle.size > 2) { //note, need min of 3 nodes
+      //          println(s"runWalkFeedbackUpdateSingleNode nodes ${nodes.toList} for node $selfId")
+      (0 until feedbackCycles).foreach { cycle =>
+        //            println(s"feedback cycle $cycle for node $selfId")
+        nodesCycle = runWalkBatchesFeedback(selfId, nodes, batchIterationSize, epsilon, maxIterations)
+      }
+    }
     val res: TrustNode = nodesCycle.filter(_.id == selfId).head
-    println(s"runWalkFeedbackUpdateSingleNode res: TrustNode ${res} for node $selfId")
+//    println(s"runWalkFeedbackUpdateSingleNode res: TrustNode ${res} for node $selfId")
 
     res
   }

--- a/modules/core/src/test/scala/org/tesselation/trust/TrustCalculationSuite.scala
+++ b/modules/core/src/test/scala/org/tesselation/trust/TrustCalculationSuite.scala
@@ -1,0 +1,24 @@
+package org.tesselation.trust
+
+import org.tesselation.infrastructure.trust.{SelfAvoidingWalk, TrustEdge, TrustNode}
+
+import weaver.FunSuite
+import weaver.scalacheck.Checkers
+
+object TrustCalculationSuite extends FunSuite with Checkers {
+  test("Basic small node network has transitive behavior") {
+
+    val scores = SelfAvoidingWalk.runWalkFeedbackUpdateSingleNode(
+      0,
+      List(
+        TrustNode(0, 0, 0, List(TrustEdge(0, 1, 0.9, isLabel = true), TrustEdge(0, 2, 0.5, isLabel = true))),
+        TrustNode(1, 0, 0, List(TrustEdge(1, 0, 0.7, isLabel = true), TrustEdge(1, 3, 0.5, isLabel = true))),
+        TrustNode(2, 0, 0, List(TrustEdge(2, 1, 0.9, isLabel = true), TrustEdge(2, 0, 0.5, isLabel = true))),
+        TrustNode(3, 0, 0, List(TrustEdge(3, 1, 0.9, isLabel = true), TrustEdge(3, 1, 0.5, isLabel = true)))
+      )
+    )
+    val nonZeroTransitive = scores.edges.find(_.dst == 3).get.trust > 0
+    val originalScores = scores.edges.find(_.dst == 1).get.trust == 0.9
+    expect.all(nonZeroTransitive, originalScores)
+  }
+}


### PR DESCRIPTION
Very basic and simple data, model already has stack error fixed so enabling it should be fine. Data generator will be
ported over separately, this is the minimal verification
that model is producing scores and not overriding labels.