### PR TITLE
Implement basic sybil attack test on weak edge

### DIFF
--- a/modules/core/src/test/scala/org/tessellation/trust/DataGenerator.scala
+++ b/modules/core/src/test/scala/org/tessellation/trust/DataGenerator.scala
@@ -26,6 +26,18 @@ class DataGenerator[F[_]: Monad: Random] {
       } else None
     }
 
+  def randomPositiveEdge(
+    logic: Double => F[Boolean] = randomEdgeLogic
+  )(n: TrustNode, n2: TrustNode): F[Option[TrustEdge]] =
+    for {
+      result <- logic(n.id.toDouble)
+      trustZeroToOne <- Random[F].nextDouble
+    } yield {
+      if (result) {
+        Some(TrustEdge(n.id, n2.id, trustZeroToOne, isLabel = true))
+      } else None
+    }
+
   def seedCliqueLogic(maxSeedNodeIdx: Int = 1)(id: Double): F[Boolean] =
     Applicative[F].pure(id <= maxSeedNodeIdx)
 

--- a/modules/core/src/test/scala/org/tessellation/trust/SybilAttackSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/trust/SybilAttackSuite.scala
@@ -1,0 +1,55 @@
+package org.tessellation.trust
+
+import cats.effect.IO
+import cats.effect.std.Random
+
+import org.tessellation.infrastructure.trust.{SelfAvoidingWalk, TrustEdge}
+
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object SybilAttackSuite extends SimpleIOSuite with Checkers {
+  test("Simple positive double network with weak edge sybil attack") {
+    val numNodes = 30
+
+    val maliciousInviteNodeId = 0
+    val maliciousEdgeId = 40
+
+    val generator = Random.scalaUtilRandom[IO].map { implicit rnd =>
+      new DataGenerator[IO]
+    }
+    for {
+      gen <- generator
+      data <- gen.generateData(numNodes = numNodes, edgeLogic = gen.randomPositiveEdge()).map { nodes =>
+        nodes.map { node =>
+          // Add a single strong edge between networks.
+          if (node.id == maliciousInviteNodeId)
+            node.copy(edges = node.edges.appended(TrustEdge(node.id, maliciousEdgeId, 1.0, isLabel = true)))
+          else node
+        }
+      }
+      attackData <- gen.generateData(numNodes = numNodes).map { nodes =>
+        nodes.map { tn =>
+          val node = tn.copy(tn.id + numNodes, edges = tn.edges.map { e =>
+            e.copy(src = e.src + numNodes, dst = e.dst + numNodes)
+          })
+          // Add a single strong edge between networks.
+          if (node.id == maliciousEdgeId)
+            node.copy(edges = node.edges.appended(TrustEdge(node.id, maliciousInviteNodeId, 1.0, isLabel = true)))
+          else node
+        }
+      }
+    } yield {
+      val allData = data ++ attackData
+      val scores = SelfAvoidingWalk.runWalkFeedbackUpdateSingleNode(
+        0,
+        allData
+      )
+      val relativeLocalTrust = scores.edges.filter(_.dst < numNodes).map(_.trust).sum
+      val relativeMaliciousTrust = scores.edges.filter(_.dst >= numNodes).map(_.trust).sum
+
+      val defensiveFactor = relativeLocalTrust / relativeMaliciousTrust
+      expect(defensiveFactor > 2)
+    }
+  }
+}


### PR DESCRIPTION
This is a very 'weak' test in the sense that new variations of it should be proposed, but it demonstrates an example of where SAW beats conventional EigenTrust for 2 equivalent networks with a relative local scoring function.

This isn't deterministic but it's most likely always going to yield some defensive factor above 5, may need to reduce assertion depending but subject to change.

I typically see defensive factor of around ~5-10 in random tests. Plan to add example with EigenTrust but EigenTrust here should almost always yield ~ defense factor of 1 since the networks are otherwise randomly initialized with only a single edge.