### PR TITLE
Implement compound model - EigenTrust / DATT / SAW & Tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,9 @@ lazy val commonSettings = Seq(
   scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
   scalafmtOnCompile := true,
   scalafixOnCompile := true,
-  resolvers += Resolver.sonatypeRepo("snapshots")
+  resolvers ++= List(
+    Resolver.sonatypeRepo("snapshots")
+  )
 )
 
 lazy val commonTestSettings = Seq(

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/DATT.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/DATT.scala
@@ -1,0 +1,59 @@
+package org.tessellation.infrastructure.trust
+
+/**
+  * Directed Acyclic Transitive Trust Scores
+  */
+object DATT {
+
+  def calculate[K](
+    trust: Map[K, Map[K, Double]],
+    selfPeerId: K,
+    expansionThreshold: Double = 1e-7
+  ): Map[K, Double] = {
+
+    val selfTrust = trust(selfPeerId)
+    val scores = scala.collection.mutable.HashMap.from[K, Double](selfTrust)
+    // Scores always populated/available for current neighbor expansion
+    var currentNeighborExpansion = scala.collection.mutable.HashSet.from(scores.keys)
+
+    while (currentNeighborExpansion.nonEmpty) {
+      val nextNeighborExpansion = scala.collection.mutable.HashSet.empty[K]
+      val dotScores = scala.collection.mutable.HashMap.empty[K, scala.collection.mutable.HashMap[K, Double]]
+      for (neighbor <- currentNeighborExpansion) {
+        scores.get(neighbor).foreach { neighborScore =>
+          if (neighborScore > expansionThreshold && neighborScore > 0) {
+            trust.get(neighbor).foreach { outerLabels =>
+              outerLabels.foreach {
+                case (outerNeighbor, v) =>
+                  if (!scores.contains(outerNeighbor)) {
+                    val outerTransitiveScore = neighborScore * v
+                    val dotUpdate = dotScores.getOrElse(outerNeighbor, scala.collection.mutable.HashMap.empty)
+                    dotUpdate.update(neighbor, outerTransitiveScore)
+                    dotScores(outerNeighbor) = dotUpdate
+                    nextNeighborExpansion.add(outerNeighbor)
+                  }
+              }
+            }
+          }
+        }
+      }
+      dotScores.foreach {
+        case (k, v) =>
+          val totalWeight = v.map { case (weightingPeer, _) => scores(weightingPeer) }.sum
+          val weightedMean = v.map {
+            case (weightingPeer, transitiveScore) =>
+              val weight = scores(weightingPeer)
+              val weightNormalized = weight / totalWeight
+              transitiveScore * weightNormalized
+          }.sum
+          scores(k) = weightedMean
+      }
+      currentNeighborExpansion = nextNeighborExpansion
+    }
+    scores.toMap
+  }
+
+  def convert(nodes: List[TrustNode]): Map[Int, Map[Int, Double]] =
+    nodes.map(tn => tn.id -> tn.edges.map(e => e.dst -> e.trust).toMap).toMap
+
+}

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/EigenTrust.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/EigenTrust.scala
@@ -1,0 +1,109 @@
+package org.tessellation.infrastructure.trust
+
+import scala.collection.immutable.Map
+
+/**
+  * See example usage here : https://github.com/djelenc/alpha-testbed/blob/83e669e69463872aa84017051392c885d4183d1d/src/test/java/atb/trustmodel/EigenTrustTMTest.java#L24
+  * Reimplemented from atb.trustmodel.EigenTrust
+  * https://nlp.stanford.edu/pubs/eigentrust.pdf
+  *
+  * This uses only a subset of code -- ignores the opinion / experience code implemented by raw example
+  * and expects a raw C_ij trust matrix to be supplied. Also mostly ignores pre-trust vector
+  *
+  * Code can be optimized with use of breeze matrix
+  *
+  */
+object EigenTrust {
+
+  def calculate(trustMatrix: Array[Array[Double]]): Map[Int, Double] = {
+    val trustMatrixNormalized = trustMatrix.map { row =>
+      val sum = row.sum
+      row.map(_ / sum)
+    }
+
+    computeFromTrustMatrix(trustMatrixNormalized, Array.empty)
+  }
+
+  def calculate(trustNodes: List[TrustNode]): Map[Int, Double] = calculate(convert(trustNodes))
+
+  def convert(trustNodes: List[TrustNode]): Array[Array[Double]] = {
+    val size = trustNodes.size
+    trustNodes
+      .sortBy(_.id)
+      .map { tn =>
+        val array = Array.fill(size)(0d)
+        tn.edges.foreach { e =>
+          // Disregard negative edges as EigenTrust doesn't support it.
+          if (e.trust > 0) {
+            array(e.dst) = e.trust
+          }
+        }
+        // Ensure self trust is one
+        array(tn.id) = 1
+        array
+      }
+      .toArray
+  }
+
+  def hasConverged(
+    t_new: Array[Double],
+    t_old: Array[Double],
+    epsilon: Double = 0.01
+  ): Boolean = {
+    var sum = 0d
+    for (i <- t_old.indices) {
+      sum += (t_new(i) - t_old(i)) * (t_new(i) - t_old(i))
+    }
+    Math.sqrt(sum) < epsilon
+  }
+
+  def computeFromTrustMatrix(
+    trustMatrixCij: Array[Array[Double]],
+    preTrustVectorInput: Array[Double],
+    preTrustWeight: Double = 0d,
+    epsilon: Double = 0.01d
+  ): Map[Int, Double] = { // execute algorithm
+
+    var preTrustVector = preTrustVectorInput
+    if (preTrustVector.isEmpty) {
+      val length = trustMatrixCij.length
+      preTrustVector = Array.fill(length)(0d)
+      trustMatrixCij.foreach {
+        _.zipWithIndex.foreach {
+          case (col, j) =>
+            preTrustVector(j) += col
+        }
+      }
+      preTrustVector = preTrustVector.map { _ / length }
+    }
+    val length = preTrustVector.length
+    val t_new = new Array[Double](length)
+    val t_old = new Array[Double](length)
+    // t_new = p
+    System.arraycopy(preTrustVector, 0, t_new, 0, preTrustVector.length)
+    do { // t_old = t_new
+      System.arraycopy(t_new, 0, t_old, 0, t_new.length)
+      // t_new = C * t_old
+      for (row <- t_old.indices) {
+        var sum = 0d
+        for (col <- t_old.indices) {
+          sum += trustMatrixCij(row)(col) * t_old(col)
+        }
+        t_new(row) = sum
+      }
+      // t_new = (1 - weight) * t_new + weight * p
+      for (i <- t_old.indices) {
+        val weighted = preTrustWeight * preTrustVector(i)
+        t_new(i) = (1 - preTrustWeight) * t_new(i) + weighted
+      }
+    } while ({
+      !hasConverged(t_new, t_old, epsilon)
+    })
+    val trust = new scala.collection.mutable.HashMap[Int, Double]
+    for (i <- t_old.indices) {
+      trust.put(i, t_new(i))
+    }
+    trust.toMap
+  }
+
+}

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/SelfAvoidingWalk.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/SelfAvoidingWalk.scala
@@ -214,7 +214,7 @@ object SelfAvoidingWalk extends StrictLogging {
     val negativeScores = merged.zipWithIndex.filterNot { _._2 == selfId }.flatMap {
       case (score, id) =>
         val negativeEdges = others.get(id).map(_.negativeEdges).getOrElse(Seq())
-        logger.debug(s"runWalkBatchesFeedback - negativeScores - selfId: $selfId - negativeEdges: $negativeEdges")
+//        logger.debug(s"runWalkBatchesFeedback - negativeScores - selfId: $selfId - negativeEdges: $negativeEdges")
         negativeEdges.filterNot { _.dst == selfId }.map { ne =>
           val nanTest = (ne.trust * score / negativeEdges.size)
 //          println("nanTest =>" + nanTest)

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/TrustDaemon.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/TrustDaemon.scala
@@ -33,27 +33,8 @@ object TrustDaemon {
         _ <- Spawn[F].start(modelUpdate.foreverM).void
       } yield ()
 
-    private def calculatePredictedTrust(trust: Map[PeerId, TrustInfo]): Map[PeerId, Double] = {
-      val selfTrustLabels = trust.flatMap { case (peerId, trustInfo) => trustInfo.publicTrust.map(peerId -> _) }
-      val allNodesTrustLabels = trust.view.mapValues(_.peerLabels).toMap + (selfPeerId -> selfTrustLabels)
-
-      val peerIdToIdx = allNodesTrustLabels.keys.zipWithIndex.toMap
-      val idxToPeerId = peerIdToIdx.map(_.swap)
-
-      val trustNodes = allNodesTrustLabels.map {
-        case (peerId, labels) =>
-          TrustNode(peerIdToIdx(peerId), 0, 0, labels.map {
-            case (pid, label) =>
-              TrustEdge(peerIdToIdx(peerId), peerIdToIdx(pid), label, peerId == selfPeerId)
-          }.toList)
-      }.toList
-
-      SelfAvoidingWalk
-        .runWalkFeedbackUpdateSingleNode(peerIdToIdx(selfPeerId), trustNodes)
-        .edges
-        .map(e => idxToPeerId(e.dst) -> e.trust)
-        .toMap
-    }
+    private def calculatePredictedTrust(trust: Map[PeerId, TrustInfo]): Map[PeerId, Double] =
+      TrustModel.calculateTrust(trust, selfPeerId)
 
     private def modelUpdate: F[Unit] =
       for {

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/TrustModel.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/TrustModel.scala
@@ -1,0 +1,45 @@
+package org.tessellation.infrastructure.trust
+
+import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.trust.TrustInfo
+
+object TrustModel {
+
+  def calculateTrust(trustNodes: List[TrustNode], selfPeerIdx: Int): Map[Int, Double] = {
+
+    val eigenTrustScores = EigenTrust.calculate(trustNodes)
+
+    val dattScores = DATT.calculate(DATT.convert(trustNodes), selfPeerIdx)
+
+    val walkScores = SelfAvoidingWalk
+      .runWalkFeedbackUpdateSingleNode(selfPeerIdx, trustNodes)
+      .edges
+      .map(e => e.dst -> e.trust)
+      .toMap
+
+    walkScores.map {
+      case (id, score) =>
+        id ->
+          ((score + dattScores.getOrElse(id, 0d) + eigenTrustScores.getOrElse(id, 0d)) / 3)
+    }
+  }
+
+  def calculateTrust(trust: Map[PeerId, TrustInfo], selfPeerId: PeerId): Map[PeerId, Double] = {
+    val selfTrustLabels = trust.flatMap { case (peerId, trustInfo) => trustInfo.publicTrust.map(peerId -> _) }
+    val allNodesTrustLabels = trust.view.mapValues(_.peerLabels).toMap + (selfPeerId -> selfTrustLabels)
+
+    val peerIdToIdx = allNodesTrustLabels.keys.zipWithIndex.toMap
+    val idxToPeerId = peerIdToIdx.map(_.swap)
+    val selfPeerIdx = peerIdToIdx(selfPeerId)
+
+    val trustNodes = allNodesTrustLabels.map {
+      case (peerId, labels) =>
+        TrustNode(peerIdToIdx(peerId), 0, 0, labels.map {
+          case (pid, label) =>
+            TrustEdge(peerIdToIdx(peerId), peerIdToIdx(pid), label, peerId == selfPeerId)
+        }.toList)
+    }.toList
+    calculateTrust(trustNodes, selfPeerIdx).map { case (k, v) => idxToPeerId(k) -> v }
+  }
+
+}

--- a/modules/core/src/test/scala/org/tessellation/trust/TrustCalculationSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/trust/TrustCalculationSuite.scala
@@ -1,24 +1,48 @@
 package org.tessellation.trust
 
-import org.tessellation.infrastructure.trust.{SelfAvoidingWalk, TrustEdge, TrustNode}
+import org.tessellation.infrastructure.trust._
 
 import weaver.FunSuite
 import weaver.scalacheck.Checkers
 
 object TrustCalculationSuite extends FunSuite with Checkers {
-  test("Basic small node network has transitive behavior") {
 
+  val smallTestNetwork = List(
+    TrustNode(0, 0, 0, List(TrustEdge(0, 1, 0.9, isLabel = true), TrustEdge(0, 2, 0.5, isLabel = true))),
+    TrustNode(1, 0, 0, List(TrustEdge(1, 0, 0.7, isLabel = true), TrustEdge(1, 3, 0.5, isLabel = true))),
+    TrustNode(2, 0, 0, List(TrustEdge(2, 1, 0.9, isLabel = true), TrustEdge(2, 0, 0.5, isLabel = true))),
+    TrustNode(3, 0, 0, List(TrustEdge(3, 1, 0.9, isLabel = true), TrustEdge(3, 1, 0.5, isLabel = true)))
+  )
+
+  test("Basic small node network has transitive behavior") {
     val scores = SelfAvoidingWalk.runWalkFeedbackUpdateSingleNode(
       0,
-      List(
-        TrustNode(0, 0, 0, List(TrustEdge(0, 1, 0.9, isLabel = true), TrustEdge(0, 2, 0.5, isLabel = true))),
-        TrustNode(1, 0, 0, List(TrustEdge(1, 0, 0.7, isLabel = true), TrustEdge(1, 3, 0.5, isLabel = true))),
-        TrustNode(2, 0, 0, List(TrustEdge(2, 1, 0.9, isLabel = true), TrustEdge(2, 0, 0.5, isLabel = true))),
-        TrustNode(3, 0, 0, List(TrustEdge(3, 1, 0.9, isLabel = true), TrustEdge(3, 1, 0.5, isLabel = true)))
-      )
+      smallTestNetwork
     )
     val nonZeroTransitive = scores.edges.find(_.dst == 3).get.trust > 0
     val originalScores = scores.edges.find(_.dst == 1).get.trust == 0.9
     expect.all(nonZeroTransitive, originalScores)
+  }
+  test("DATT scores calculate basic network properly") {
+    val dattNetwork = Map(
+      0 -> Map(
+        1 -> 0.1,
+        2 -> 0.9,
+        3 -> 0.8,
+        4 -> 0.5
+      ),
+      1 -> Map(5 -> 0.5), // 5 is the weighted node here -- this contributes *.1*.5
+      2 -> Map(6 -> 0.9), // 6 is an isolated non-weighting edge
+      3 -> Map(5 -> 0.3), // weighting -- 0.8 * .3 = 0.24
+      4 -> Map(5 -> 0.5), // 0.5 * 0.5 = 0.25
+      // Three weighting values to node 5 -> yielding 0.1 ( 0.05), .8 (.24), .5 (.25)
+      5 -> Map.empty[Int, Double],
+      6 -> Map.empty[Int, Double]
+    )
+    val result = DATT.calculate(
+      dattNetwork,
+      0
+    )
+    expect.all(result(5) == 0.22999999999999998, result(6) == 0.81)
   }
 }


### PR DESCRIPTION
This demonstrates sybil attack weakness of EigenTrust and
benefits of the two other models. DATT code covers weighted
and non weighted test examples.

EigenTrust code has a build conflict with this and we can't
easily port over the alpha testbed version. Adapted it quickly
to scala ignoring experiences / opinions (which we need to
do anyways.) Mainly used for comparison purposes here
in demonstration of defense factor for this test.

Implemented an average model between these three to cover
future proximity test which SAW / DATT are currently
weak against, will be demonstrated in separate PR.


Note, in developing this and debugging, I found the data generator code was broken from before and was not generating proper edges. The invocation of random was yielding the same distance value for all edges, also the edge logic was not properly respecting distance (it wasn't using cartesian distance and just using the node id, so very few edges were even being generated.) 

I didn't update this whole class to deal with it, instead just invoked random directly in 1 place required. Is there better pattern for `List[Random[F].nextDouble] => F[List[Double]]` appropriate here?

Next PRs will cover proximity tests showing reason why EigenTrust used here in compound model (as a defense), until SAW replacement fixes.