### PR TITLE
Move TrustPush and related classes to new trust module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -284,9 +284,32 @@ lazy val dagL1 = (project in file("modules/dag-l1"))
       Libraries.refinedCore
     )
   )
+
+
+lazy val trust = (project in file("modules/trust"))
+  .dependsOn(shared, sdk)
+  .settings(
+    name := "tessellation-trust",
+    Defaults.itSettings,
+    scalafixCommonSettings,
+    commonSettings,
+    commonTestSettings,
+    makeBatScripts := Seq(),
+    libraryDependencies ++= Seq(
+      CompilerPlugin.kindProjector,
+      CompilerPlugin.betterMonadicFor,
+      CompilerPlugin.semanticDB,
+      Libraries.cats,
+      Libraries.catsEffect,
+      Libraries.refinedCats,
+      Libraries.log4cats,
+      Libraries.logback % Runtime
+    )
+  )
+
 lazy val core = (project in file("modules/core"))
   .enablePlugins(AshScriptPlugin)
-  .dependsOn(keytool, kernel, shared % "compile->compile;test->test", testShared % Test, dagShared, sdk)
+  .dependsOn(keytool, kernel, shared % "compile->compile;test->test", testShared % Test, dagShared, sdk, trust)
   .settings(
     name := "tessellation-core",
     Defaults.itSettings,

--- a/modules/core/src/main/scala/org/tessellation/Main.scala
+++ b/modules/core/src/main/scala/org/tessellation/Main.scala
@@ -13,7 +13,6 @@ import org.tessellation.http.p2p.P2PClient
 import org.tessellation.infrastructure.db.Database
 import org.tessellation.infrastructure.genesis.{Loader => GenesisLoader}
 import org.tessellation.infrastructure.logs.LoggerConfigurator
-import org.tessellation.infrastructure.trust.handler.trustHandler
 import org.tessellation.keytool.KeyStoreUtils
 import org.tessellation.kryo.{KryoSerializer, coreKryoRegistrar}
 import org.tessellation.modules._
@@ -23,6 +22,7 @@ import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.sdk.infrastructure.gossip.RumorHandlers
 import org.tessellation.security.SecurityProvider
+import org.tessellation.trust.infrastructure.handler.trustHandler
 
 import com.monovore.decline.Opts
 import com.monovore.decline.effect.CommandIOApp

--- a/modules/core/src/main/scala/org/tessellation/http/routes/ClusterRoutes.scala
+++ b/modules/core/src/main/scala/org/tessellation/http/routes/ClusterRoutes.scala
@@ -5,8 +5,6 @@ import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
-import org.tessellation.domain.cluster.programs.TrustPush
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.ext.http4s.refined._
 import org.tessellation.schema.cluster._
 import org.tessellation.schema.peer.JoinRequest
@@ -14,6 +12,8 @@ import org.tessellation.schema.peer.Peer.toP2PContext
 import org.tessellation.schema.trust.InternalTrustUpdateBatch
 import org.tessellation.sdk.domain.cluster.programs.{Joining, PeerDiscovery}
 import org.tessellation.sdk.domain.cluster.storage.ClusterStorage
+import org.tessellation.trust.domain.storage.TrustStorage
+import org.tessellation.trust.programs.TrustPush
 
 import com.comcast.ip4s.Host
 import org.http4s.HttpRoutes

--- a/modules/core/src/main/scala/org/tessellation/http/routes/TrustRoutes.scala
+++ b/modules/core/src/main/scala/org/tessellation/http/routes/TrustRoutes.scala
@@ -3,9 +3,9 @@ package org.tessellation.http.routes
 import cats.effect.Async
 import cats.syntax.flatMap._
 
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.ext.codecs.BinaryCodec._
 import org.tessellation.kryo.KryoSerializer
+import org.tessellation.trust.domain.storage.TrustStorage
 
 import org.http4s._
 import org.http4s.circe.CirceEntityCodec.circeEntityEncoder

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/TrustDaemon.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/TrustDaemon.scala
@@ -7,12 +7,12 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 
 import org.tessellation.config.types.TrustDaemonConfig
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.trust.TrustInfo
 import org.tessellation.sdk.domain.Daemon
 import org.tessellation.security.SecurityProvider
+import org.tessellation.trust.domain.storage.TrustStorage
 
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/modules/core/src/main/scala/org/tessellation/modules/Programs.scala
+++ b/modules/core/src/main/scala/org/tessellation/modules/Programs.scala
@@ -5,12 +5,12 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 
 import org.tessellation.config.types.AppConfig
-import org.tessellation.domain.cluster.programs.TrustPush
 import org.tessellation.http.p2p.P2PClient
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.sdk.domain.cluster.programs.{Joining, PeerDiscovery}
 import org.tessellation.security.SecurityProvider
+import org.tessellation.trust.programs.TrustPush
 
 object Programs {
 

--- a/modules/core/src/main/scala/org/tessellation/modules/Storages.scala
+++ b/modules/core/src/main/scala/org/tessellation/modules/Storages.scala
@@ -6,16 +6,16 @@ import cats.syntax.functor._
 
 import org.tessellation.config.types.AppConfig
 import org.tessellation.domain.cluster.storage.AddressStorage
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.infrastructure.cluster.storage.AddressStorage
 import org.tessellation.infrastructure.db.Database
-import org.tessellation.infrastructure.trust.storage.TrustStorage
 import org.tessellation.sdk.domain.cluster.storage.{ClusterStorage, SessionStorage}
 import org.tessellation.sdk.domain.gossip.RumorStorage
 import org.tessellation.sdk.domain.node.NodeStorage
 import org.tessellation.sdk.infrastructure.cluster.storage.{ClusterStorage, SessionStorage}
 import org.tessellation.sdk.infrastructure.gossip.RumorStorage
 import org.tessellation.sdk.infrastructure.node.NodeStorage
+import org.tessellation.trust.domain.storage.TrustStorage
+import org.tessellation.trust.infrastructure.storage.TrustStorage
 
 object Storages {
 

--- a/modules/core/src/test/scala/org/tessellation/http/routes/TrustRoutesSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/http/routes/TrustRoutesSuite.scala
@@ -3,11 +3,11 @@ package org.tessellation.http.routes
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 
-import org.tessellation.infrastructure.trust.storage.TrustStorage
 import org.tessellation.kryo.{KryoSerializer, coreKryoRegistrar}
 import org.tessellation.schema.generators._
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
+import org.tessellation.trust.infrastructure.storage.TrustStorage
 
 import org.http4s.Method._
 import org.http4s._

--- a/modules/core/src/test/scala/org/tessellation/infrastructure/trust/storage/TrustStorageSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/infrastructure/trust/storage/TrustStorageSuite.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, Ref}
 import org.tessellation.schema.generators._
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
+import org.tessellation.trust.infrastructure.storage.TrustStorage
 
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers

--- a/modules/trust/src/main/scala/org/tessellation/trust/domain/storage/TrustStorage.scala
+++ b/modules/trust/src/main/scala/org/tessellation/trust/domain/storage/TrustStorage.scala
@@ -1,4 +1,4 @@
-package org.tessellation.domain.trust.storage
+package org.tessellation.trust.domain.storage
 
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.trust.{InternalTrustUpdateBatch, PublicTrust, TrustInfo}

--- a/modules/trust/src/main/scala/org/tessellation/trust/infrastructure/handler.scala
+++ b/modules/trust/src/main/scala/org/tessellation/trust/infrastructure/handler.scala
@@ -1,15 +1,15 @@
-package org.tessellation.infrastructure.trust
+package org.tessellation.trust.infrastructure
 
 import cats.Applicative
 import cats.effect.Async
 import cats.syntax.flatMap._
 import cats.syntax.show._
 
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.gossip.ReceivedRumor
 import org.tessellation.schema.trust.PublicTrust
 import org.tessellation.sdk.infrastructure.gossip.RumorHandler
+import org.tessellation.trust.domain.storage.TrustStorage
 
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/modules/trust/src/main/scala/org/tessellation/trust/infrastructure/storage/TrustStorage.scala
+++ b/modules/trust/src/main/scala/org/tessellation/trust/infrastructure/storage/TrustStorage.scala
@@ -1,13 +1,13 @@
-package org.tessellation.infrastructure.trust.storage
+package org.tessellation.trust.infrastructure.storage
 
 import cats.Monad
 import cats.effect.Ref
 import cats.syntax.functor._
 import cats.syntax.functorFilter._
 
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.trust.{InternalTrustUpdateBatch, PublicTrust, TrustInfo}
+import org.tessellation.trust.domain.storage.TrustStorage
 
 object TrustStorage {
 

--- a/modules/trust/src/main/scala/org/tessellation/trust/programs/TrustPush.scala
+++ b/modules/trust/src/main/scala/org/tessellation/trust/programs/TrustPush.scala
@@ -1,11 +1,10 @@
-package org.tessellation.domain.cluster.programs
+package org.tessellation.trust.programs
 
 import cats.effect.Async
-import cats.syntax.flatMap._
-import cats.syntax.functor._
+import cats.implicits._
 
-import org.tessellation.domain.trust.storage.TrustStorage
 import org.tessellation.sdk.domain.gossip.Gossip
+import org.tessellation.trust.domain.storage.TrustStorage
 
 object TrustPush {
 


### PR DESCRIPTION
Not all trust related classes moved as part of this PR, only main interfaces
to the rest of the code.