### PR TITLE
Fix checking parent acceptance in DAG L1

### DIFF
--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/block/BlockStorage.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/block/BlockStorage.scala
@@ -31,7 +31,7 @@ class BlockStorage[F[_]: Sync](blocks: MapRef[F, ProofsHash, Option[StoredBlock]
   def areParentsAccepted(block: DAGBlock): F[Map[BlockReference, Boolean]] =
     block.parent.traverse { ref =>
       isBlockAccepted(ref).map(ref -> _)
-    }.map(_.toNem.toSortedMap)
+    }.map(_.toList.toMap)
 
   private[block] def accept(hashedBlock: Hashed[DAGBlock]): F[Unit] =
     blocks(hashedBlock.proofsHash)


### PR DESCRIPTION
Currently going through NonEmptyMap resulted in unwanted deduplication because of the way Order is defined for BlockReference - to be revised and possibly fixed in another PR.