### PR TITLE
Make transaction validator an abstract class

### DIFF
--- a/modules/dag-shared/src/main/scala/org/tessellation/dag/transaction/TransactionValidator.scala
+++ b/modules/dag-shared/src/main/scala/org/tessellation/dag/transaction/TransactionValidator.scala
@@ -25,12 +25,8 @@ import org.tessellation.security.signature.signature.SignatureProof
 import eu.timepit.refined.auto._
 import io.estatico.newtype.ops._
 
-trait TransactionValidator[F[_]] {
+abstract class TransactionValidator[F[_]: Async: KryoSerializer: SecurityProvider] {
   import TransactionValidator._
-
-  implicit val F: Async[F]
-  implicit val kryoSerializer: KryoSerializer[F]
-  implicit val securityProvider: SecurityProvider[F]
 
   protected def getBalance(address: Address): F[Balance]
 

--- a/modules/dag-shared/src/test/scala/org/tessellation/dag/transaction/TransactionValidatorSuite.scala
+++ b/modules/dag-shared/src/test/scala/org/tessellation/dag/transaction/TransactionValidatorSuite.scala
@@ -44,10 +44,6 @@ object TransactionValidatorSuite extends ResourceSuite with Checkers {
           balancesFn: Address => Balance,
           lastAcceptedTxFn: Address => TransactionReference
         ) = new TransactionValidator[IO] {
-          val F = effect
-          val securityProvider = sp
-          val kryoSerializer = kp
-
           def getBalance(address: Address): IO[Balance] = balancesFn(address).pure[IO]
           def getLastAcceptedTransactionRef(address: Address): IO[TransactionReference] =
             lastAcceptedTxFn(address).pure[IO]


### PR DESCRIPTION
Transaction validator will not be mixed in anywhere I think and working with abstract class with type parameters instead of trait is easier.