### PR TITLE
Extract block validator config and allow overriding signers count

### DIFF
--- a/modules/dag-shared/src/main/scala/org/tessellation/dag/block/config/BlockValidatorConfig.scala
+++ b/modules/dag-shared/src/main/scala/org/tessellation/dag/block/config/BlockValidatorConfig.scala
@@ -1,0 +1,6 @@
+package org.tessellation.dag.block.config
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
+
+case class BlockValidatorConfig(requiredUniqueSigners: PosInt = 3)


### PR DESCRIPTION
Needed to fix an issue with block validation during DAG L1 block consensus.