### PR TITLE
Handle block storing error in DAG L1

### DIFF
--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/StateChannel.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/StateChannel.scala
@@ -127,7 +127,9 @@ class StateChannel[F[_]: Async: KryoSerializer: SecurityProvider: Random](
     }
 
   private val storeBlock: Pipe[F, FinalBlock, Unit] =
-    _.evalMap(fb => blockStorage.store(fb.hashedBlock))
+    _.evalMap { fb =>
+      blockStorage.store(fb.hashedBlock).handleErrorWith(e => logger.debug(e)("Error storing block!"))
+    }
 
   private val blockAcceptance: Stream[F, Unit] = Stream
     .awakeEvery(1.seconds)


### PR DESCRIPTION
Lack of error handling caused the DAG block creation stream to fail.