### PR TITLE
L0 peers discovery functionality

### DIFF
--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
@@ -9,7 +9,8 @@ import org.tessellation.dag.block.config.BlockValidatorConfig
 import org.tessellation.dag.l1.config.TipsConfig
 import org.tessellation.dag.l1.config.types.{AppConfig, DBConfig}
 import org.tessellation.dag.l1.domain.consensus.block.config.ConsensusConfig
-import org.tessellation.sdk.cli.CliMethod
+import org.tessellation.schema.peer.L0Peer
+import org.tessellation.sdk.cli.{CliMethod, L0PeerOpts}
 import org.tessellation.sdk.config.AppEnvironment
 import org.tessellation.sdk.config.types._
 
@@ -20,6 +21,7 @@ object method {
 
   sealed trait Run extends CliMethod {
     val dbConfig: DBConfig
+    val l0Peer: L0Peer
 
     val appConfig: AppConfig = AppConfig(
       environment = environment,
@@ -67,14 +69,15 @@ object method {
     password: Password,
     environment: AppEnvironment,
     httpConfig: HttpConfig,
-    dbConfig: DBConfig
+    dbConfig: DBConfig,
+    l0Peer: L0Peer
   ) extends Run
 
   object RunInitialValidator {
 
     val opts = Opts.subcommand("run-initial-validator", "Run initial validator mode") {
-      (StorePath.opts, KeyAlias.opts, Password.opts, AppEnvironment.opts, http.opts, db.opts)
-        .mapN(RunInitialValidator(_, _, _, _, _, _))
+      (StorePath.opts, KeyAlias.opts, Password.opts, AppEnvironment.opts, http.opts, db.opts, L0PeerOpts.opts)
+        .mapN(RunInitialValidator(_, _, _, _, _, _, _))
     }
   }
 
@@ -84,14 +87,15 @@ object method {
     password: Password,
     environment: AppEnvironment,
     httpConfig: HttpConfig,
-    dbConfig: DBConfig
+    dbConfig: DBConfig,
+    l0Peer: L0Peer
   ) extends Run
 
   object RunValidator {
 
     val opts = Opts.subcommand("run-validator", "Run validator mode") {
-      (StorePath.opts, KeyAlias.opts, Password.opts, AppEnvironment.opts, http.opts, db.opts)
-        .mapN(RunValidator(_, _, _, _, _, _))
+      (StorePath.opts, KeyAlias.opts, Password.opts, AppEnvironment.opts, http.opts, db.opts, L0PeerOpts.opts)
+        .mapN(RunValidator(_, _, _, _, _, _, _))
     }
   }
 

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/http/p2p/P2PClient.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/http/p2p/P2PClient.scala
@@ -1,17 +1,18 @@
 package org.tessellation.dag.l1.http.p2p
 
-import cats.effect.Sync
+import cats.effect.Async
 
 import org.tessellation.dag.l1.domain.consensus.block.http.p2p.clients.BlockConsensusClient
 import org.tessellation.sdk.http.p2p.SdkP2PClient
-import org.tessellation.sdk.http.p2p.clients.{ClusterClient, NodeClient, SignClient}
+import org.tessellation.sdk.http.p2p.clients._
 import org.tessellation.sdk.infrastructure.gossip.p2p.GossipClient
+import org.tessellation.security.SecurityProvider
 
 import org.http4s.client._
 
 object P2PClient {
 
-  def make[F[_]: Sync](
+  def make[F[_]: Async: SecurityProvider](
     sdkP2PClient: SdkP2PClient[F],
     client: Client[F]
   ): P2PClient[F] =
@@ -19,6 +20,7 @@ object P2PClient {
       sdkP2PClient.sign,
       sdkP2PClient.node,
       sdkP2PClient.cluster,
+      L0ClusterClient.make(client),
       sdkP2PClient.gossip,
       BlockConsensusClient.make(client)
     ) {}
@@ -28,6 +30,7 @@ sealed abstract class P2PClient[F[_]] private (
   val sign: SignClient[F],
   val node: NodeClient[F],
   val cluster: ClusterClient[F],
+  val l0Cluster: L0ClusterClient[F],
   val gossip: GossipClient[F],
   val blockConsensus: BlockConsensusClient[F]
 )

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/HttpApi.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/HttpApi.scala
@@ -11,7 +11,6 @@ import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.sdk.http.p2p.middleware.{PeerAuthMiddleware, `X-Id-Middleware`}
 import org.tessellation.sdk.http.routes._
-import org.tessellation.sdk.modules.SdkPrograms
 import org.tessellation.security.SecurityProvider
 
 import com.comcast.ip4s.Host
@@ -26,10 +25,10 @@ object HttpApi {
     queues: Queues[F],
     privateKey: PrivateKey,
     services: Services[F],
-    sdkPrograms: SdkPrograms[F],
+    programs: Programs[F],
     selfId: PeerId
   ): HttpApi[F] =
-    new HttpApi[F](storages, queues, privateKey, services, sdkPrograms, selfId) {}
+    new HttpApi[F](storages, queues, privateKey, services, programs, selfId) {}
 }
 
 sealed abstract class HttpApi[F[_]: Async: KryoSerializer: SecurityProvider] private (
@@ -37,11 +36,11 @@ sealed abstract class HttpApi[F[_]: Async: KryoSerializer: SecurityProvider] pri
   queues: Queues[F],
   privateKey: PrivateKey,
   services: Services[F],
-  sdkPrograms: SdkPrograms[F],
+  programs: Programs[F],
   selfId: PeerId
 ) {
   private val clusterRoutes =
-    ClusterRoutes[F](sdkPrograms.joining, sdkPrograms.peerDiscovery, storages.cluster, services.cluster)
+    ClusterRoutes[F](programs.joining, programs.peerDiscovery, storages.cluster, services.cluster)
   private val registrationRoutes = RegistrationRoutes[F](services.cluster)
   private val gossipRoutes = GossipRoutes[F](storages.rumor, queues.rumor, services.gossip)
   private val dagRoutes = Routes[F](services.transaction, queues.peerBlockConsensusInput)

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/Programs.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/Programs.scala
@@ -1,0 +1,22 @@
+package org.tessellation.dag.l1.modules
+
+import cats.effect.Sync
+
+import org.tessellation.dag.l1.http.p2p.P2PClient
+import org.tessellation.sdk.domain.cluster.programs.{Joining, L0PeerDiscovery, PeerDiscovery}
+import org.tessellation.sdk.modules.SdkPrograms
+
+object Programs {
+
+  def make[F[_]: Sync](sdkPrograms: SdkPrograms[F], p2pClient: P2PClient[F], storages: Storages[F]): Programs[F] = {
+    val l0PeerDiscovery = L0PeerDiscovery.make(p2pClient.l0Cluster, storages.l0Cluster)
+
+    new Programs[F](sdkPrograms.peerDiscovery, l0PeerDiscovery, sdkPrograms.joining) {}
+  }
+}
+
+sealed abstract class Programs[F[_]] private (
+  val peerDiscovery: PeerDiscovery[F],
+  val l0PeerDiscovery: L0PeerDiscovery[F],
+  val joining: Joining[F]
+)

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/Storages.scala
@@ -11,20 +11,24 @@ import org.tessellation.dag.l1.domain.consensus.block.storage.ConsensusStorage
 import org.tessellation.dag.l1.domain.transaction.TransactionStorage
 import org.tessellation.dag.l1.infrastructure.address.storage.AddressStorage
 import org.tessellation.dag.l1.infrastructure.db.Database
-import org.tessellation.sdk.domain.cluster.storage.{ClusterStorage, SessionStorage}
+import org.tessellation.schema.peer.L0Peer
+import org.tessellation.sdk.domain.cluster.storage.{ClusterStorage, L0ClusterStorage, SessionStorage}
 import org.tessellation.sdk.domain.gossip.RumorStorage
 import org.tessellation.sdk.domain.node.NodeStorage
+import org.tessellation.sdk.infrastructure.cluster.storage.L0ClusterStorage
 import org.tessellation.sdk.modules.SdkStorages
 
 object Storages {
 
   def make[F[_]: Async: Database](
     tipsConfig: TipsConfig,
-    sdkStorages: SdkStorages[F]
+    sdkStorages: SdkStorages[F],
+    l0Peer: L0Peer
   ): F[Storages[F]] =
     for {
       blockStorage <- BlockStorage.make[F](tipsConfig)
       consensusStorage <- ConsensusStorage.make[F]
+      l0ClusterStorage <- L0ClusterStorage.make[F](l0Peer)
       transactionStorage <- TransactionStorage.make[F]
       addressStorage = AddressStorage.make[F]
     } yield
@@ -33,6 +37,7 @@ object Storages {
         block = blockStorage,
         consensus = consensusStorage,
         cluster = sdkStorages.cluster,
+        l0Cluster = l0ClusterStorage,
         node = sdkStorages.node,
         session = sdkStorages.session,
         rumor = sdkStorages.rumor,
@@ -45,6 +50,7 @@ sealed abstract class Storages[F[_]] private (
   val block: BlockStorage[F],
   val consensus: ConsensusStorage[F],
   val cluster: ClusterStorage[F],
+  val l0Cluster: L0ClusterStorage[F],
   val node: NodeStorage[F],
   val session: SessionStorage[F],
   val rumor: RumorStorage[F],

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/cli/L0PeerOpts.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/cli/L0PeerOpts.scala
@@ -1,0 +1,29 @@
+package org.tessellation.sdk.cli
+
+import cats.syntax.contravariantSemigroupal._
+
+import org.tessellation.ext.decline.decline.{coercibleArgument, hostArgument, portArgument}
+import org.tessellation.schema.peer.{L0Peer, PeerId}
+
+import com.comcast.ip4s.{Host, IpLiteralSyntax, Port}
+import com.monovore.decline.Opts
+
+object L0PeerOpts {
+
+  val l0PeerIdOpts: Opts[PeerId] = Opts
+    .option[PeerId]("l0-peer-id", help = "L0 peer Id")
+    .orElse(Opts.env[PeerId]("CL_L0_PEER_ID", help = "L0 peer Id"))
+
+  val l0PeerHostOpts: Opts[Host] = Opts
+    .option[Host]("l0-peer-host", help = "L0 peer HTTP host")
+    .orElse(Opts.env[Host]("CL_L0_PEER_HTTP_HOST", help = "L0 peer HTTP host"))
+
+  val l0PeerPortOpts: Opts[Port] = Opts
+    .option[Port]("l0-peer-port", help = "L0 peer HTTP port")
+    .orElse(Opts.env[Port]("CL_L0_PEER_HTTP_PORT", help = "L0 peer HTTP port"))
+    .withDefault(port"9000")
+
+  val opts: Opts[L0Peer] =
+    (l0PeerIdOpts, l0PeerHostOpts, l0PeerPortOpts)
+      .mapN(L0Peer(_, _, _))
+}

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/domain/cluster/programs/L0PeerDiscovery.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/domain/cluster/programs/L0PeerDiscovery.scala
@@ -1,0 +1,47 @@
+package org.tessellation.sdk.domain.cluster.programs
+
+import cats.MonadThrow
+import cats.effect.Sync
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import scala.util.control.NoStackTrace
+
+import org.tessellation.schema.peer.{L0Peer, P2PContext}
+import org.tessellation.sdk.domain.cluster.programs.L0PeerDiscovery.L0PeerDiscoveryError
+import org.tessellation.sdk.domain.cluster.storage.L0ClusterStorage
+import org.tessellation.sdk.http.p2p.clients.L0ClusterClient
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object L0PeerDiscovery {
+
+  def make[F[_]: Sync](
+    l0ClusterClient: L0ClusterClient[F],
+    l0ClusterStorage: L0ClusterStorage[F]
+  ): L0PeerDiscovery[F] =
+    new L0PeerDiscovery[F](l0ClusterClient, l0ClusterStorage) {}
+
+  case object L0PeerDiscoveryError extends NoStackTrace {
+    override def getMessage: String = s"Error during L0 peer discovery!"
+  }
+}
+
+sealed abstract class L0PeerDiscovery[F[_]: Sync] private (
+  l0ClusterClient: L0ClusterClient[F],
+  l0ClusterStorage: L0ClusterStorage[F]
+) {
+
+  val logger = Slf4jLogger.getLogger[F]
+
+  def discoverFrom(peer: P2PContext): F[Unit] =
+    l0ClusterClient.getPeers
+      .run(peer)
+      .map(_.map(L0Peer.fromPeer))
+      .flatMap(l0ClusterStorage.addPeers)
+      .handleErrorWith { e =>
+        logger.error(e)("Error during L0 peer discovery!") >>
+          MonadThrow[F].raiseError[Unit](L0PeerDiscoveryError)
+      }
+}

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/domain/cluster/storage/L0ClusterStorage.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/domain/cluster/storage/L0ClusterStorage.scala
@@ -1,0 +1,11 @@
+package org.tessellation.sdk.domain.cluster.storage
+
+import cats.data.NonEmptySet
+
+import org.tessellation.schema.peer.{L0Peer, PeerId}
+
+trait L0ClusterStorage[F[_]] {
+  def getPeers: F[NonEmptySet[L0Peer]]
+  def getPeer(id: PeerId): F[Option[L0Peer]]
+  def addPeers(l0Peers: Set[L0Peer]): F[Unit]
+}

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/http/p2p/clients/L0ClusterClient.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/http/p2p/clients/L0ClusterClient.scala
@@ -1,0 +1,25 @@
+package org.tessellation.sdk.http.p2p.clients
+
+import cats.effect.Async
+
+import org.tessellation.schema.peer.Peer
+import org.tessellation.sdk.http.p2p.PeerResponse
+import org.tessellation.sdk.http.p2p.PeerResponse.PeerResponse
+import org.tessellation.security.SecurityProvider
+
+import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+import org.http4s.client.Client
+
+trait L0ClusterClient[F[_]] {
+  def getPeers: PeerResponse[F, Set[Peer]]
+}
+
+object L0ClusterClient {
+
+  def make[F[_]: Async: SecurityProvider](client: Client[F]): L0ClusterClient[F] =
+    new L0ClusterClient[F] {
+
+      def getPeers: PeerResponse[F, Set[Peer]] =
+        PeerResponse[F, Set[Peer]]("cluster/info")(client)
+    }
+}

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/cluster/storage/L0ClusterStorage.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/cluster/storage/L0ClusterStorage.scala
@@ -1,0 +1,39 @@
+package org.tessellation.sdk.infrastructure.cluster.storage
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.{Ref, Sync}
+import cats.syntax.contravariant._
+import cats.syntax.functor._
+import cats.{Monad, Order}
+
+import org.tessellation.ext.cats.data.NonEmptyMapOps
+import org.tessellation.schema.peer.{L0Peer, PeerId}
+import org.tessellation.sdk.domain.cluster.storage.L0ClusterStorage
+
+object L0ClusterStorage {
+
+  implicit val order: Order[L0Peer] = Order[PeerId].contramap(_.id)
+  implicit val ordering: Ordering[L0Peer] = order.toOrdering
+
+  def make[F[_]: Sync](l0Peer: L0Peer): F[L0ClusterStorage[F]] =
+    Ref
+      .of[F, NonEmptyMap[PeerId, L0Peer]](NonEmptyMap.one(l0Peer.id, l0Peer))
+      .map(make(_))
+
+  def make[F[_]: Monad](peers: Ref[F, NonEmptyMap[PeerId, L0Peer]]): L0ClusterStorage[F] =
+    new L0ClusterStorage[F] {
+
+      def getPeers: F[NonEmptySet[L0Peer]] =
+        peers.get.map(_.values)
+
+      def getPeer(id: PeerId): F[Option[L0Peer]] =
+        peers.get.map(_.lookup(id))
+
+      def addPeers(l0Peers: Set[L0Peer]): F[Unit] =
+        peers.modify { current =>
+          val updated = l0Peers.map(p => p.id -> p).toMap.foldLeft(current)(_.add(_))
+
+          (updated, ())
+        }
+    }
+}

--- a/modules/shared/src/main/scala/org/tessellation/ext/cats/data/package.scala
+++ b/modules/shared/src/main/scala/org/tessellation/ext/cats/data/package.scala
@@ -1,0 +1,13 @@
+package org.tessellation.ext.cats
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+
+import scala.collection.immutable.SortedSet
+
+package object data {
+  implicit class NonEmptyMapOps[K, A](value: NonEmptyMap[K, A]) {
+
+    def values(implicit ordering: Ordering[A]): NonEmptySet[A] =
+      NonEmptySet.fromSetUnsafe(SortedSet.from(value.toSortedMap.values))
+  }
+}

--- a/modules/shared/src/main/scala/org/tessellation/schema/peer.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/peer.scala
@@ -60,6 +60,17 @@ object peer {
     val _State: Lens[Peer, NodeState] = GenLens[Peer](_.state)
   }
 
+  @derive(eqv, encoder, decoder, show)
+  case class L0Peer(id: PeerId, ip: Host, port: Port)
+
+  object L0Peer {
+    implicit def toP2PContext(l0Peer: L0Peer): P2PContext =
+      P2PContext(l0Peer.ip, l0Peer.port, l0Peer.id)
+
+    def fromPeer(p: Peer): L0Peer =
+      L0Peer(p.id, p.ip, p.publicPort)
+  }
+
   @derive(eqv, show)
   case class FullPeer(
     data: Peer


### PR DESCRIPTION
I will still look into whether L0 nodes can be discovered from L1 peers (except for the initial node starting L1 layer). But this is a working and tested implementation of L0 peers discovery based on declaring initial L0 peer during node startup. Doing it that way also seems correct to me.