### PR TITLE
Fix duplicated consensus logs

### DIFF
--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/consensus/ConsensusManager.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/consensus/ConsensusManager.scala
@@ -74,8 +74,8 @@ object ConsensusManager {
                   consensusStorage
                     .tryUpdateLastKeyAndArtifactWithCleanup(state.lastKeyAndArtifact, keyAndArtifact)
                     .ifM(
-                      logger.info(s"Consensus for key ${key.show} finished") >> checkAllForTrigger(keyAndArtifact),
-                      logger.info(s"Consensus for key ${key.show} finished, skip trying to trigger another")
+                      checkAllForTrigger(keyAndArtifact),
+                      logger.info("Skip triggering another consensus")
                     )
                 case _ =>
                   internalCheckForStateUpdate(key, state, resources)


### PR DESCRIPTION
Successful finish is already logged  by the `ConsensusStateUpdater`