### PR TITLE
Add disk persistence from snapshot to TrustStorage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ ThisBuild / organizationName := "tessellation"
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / scalafixDependencies += Libraries.organizeImports
 
+ThisBuild  / envFileName := ".sbtenv"
+
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 val scalafixCommonSettings = inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest))

--- a/modules/core/src/main/scala/org/tessellation/Main.scala
+++ b/modules/core/src/main/scala/org/tessellation/Main.scala
@@ -44,7 +44,7 @@ object Main
         _ <- IO.unit.asResource
         p2pClient = P2PClient.make[IO](sdkP2PClient, sdkResources.client, sdkServices.session)
         queues <- Queues.make[IO](sdkQueues).asResource
-        storages <- Storages.make[IO](sdkStorages, cfg.snapshot).asResource
+        storages <- Storages.make[IO](sdkStorages, cfg.snapshot, cfg.trust).asResource
         services <- Services.make[IO](sdkServices, queues, storages, sdk.nodeId, keyPair, cfg).asResource
         programs = Programs.make[IO](sdkPrograms, storages, services)
         validators = Validators.make[IO](cfg.snapshot)

--- a/modules/core/src/main/scala/org/tessellation/cli/method.scala
+++ b/modules/core/src/main/scala/org/tessellation/cli/method.scala
@@ -41,7 +41,8 @@ object method {
       trust = TrustConfig(
         TrustDaemonConfig(
           10.minutes
-        )
+        ),
+        Path("tmp/trust")
       ),
       healthCheck = healthCheckConfig,
       snapshot = snapshotConfig
@@ -85,14 +86,15 @@ object method {
     dbConfig: DBConfig,
     httpConfig: HttpConfig,
     environment: AppEnvironment,
-    snapshotConfig: SnapshotConfig
+    snapshotConfig: SnapshotConfig,
+    trustConfig: TrustConfig
   ) extends Run
 
   object RunValidator extends WithOpts[RunValidator] {
 
     val opts = Opts.subcommand("run-validator", "Run validator mode") {
-      (StorePath.opts, KeyAlias.opts, Password.opts, db.opts, http.opts, AppEnvironment.opts, snapshot.opts)
-        .mapN(RunValidator.apply(_, _, _, _, _, _, _))
+      (StorePath.opts, KeyAlias.opts, Password.opts, db.opts, http.opts, AppEnvironment.opts, snapshot.opts, trust.opts)
+        .mapN(RunValidator.apply(_, _, _, _, _, _, _, _))
     }
   }
 

--- a/modules/core/src/main/scala/org/tessellation/cli/trust.scala
+++ b/modules/core/src/main/scala/org/tessellation/cli/trust.scala
@@ -1,0 +1,18 @@
+package org.tessellation.cli
+
+import scala.concurrent.duration.DurationInt
+
+import org.tessellation.config.types.{TrustConfig, TrustDaemonConfig}
+import org.tessellation.ext.decline.decline._
+
+import com.monovore.decline._
+import fs2.io.file.Path
+
+object trust {
+
+  val trustPath: Opts[Path] = Opts
+    .env[Path]("CL_TRUST_STORED_PATH", help = "Path to store trust related data")
+    .withDefault(Path("tmp/trust"))
+
+  val opts = trustPath.map(TrustConfig(TrustDaemonConfig(10.minutes), _))
+}

--- a/modules/core/src/main/scala/org/tessellation/config/types.scala
+++ b/modules/core/src/main/scala/org/tessellation/config/types.scala
@@ -34,7 +34,8 @@ object types {
   )
 
   case class TrustConfig(
-    daemon: TrustDaemonConfig
+    daemon: TrustDaemonConfig,
+    trustStorePath: Path
   )
 
   case class SnapshotConfig(

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/handler.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/handler.scala
@@ -1,6 +1,5 @@
 package org.tessellation.infrastructure.trust
 
-import cats.Applicative
 import cats.effect.Async
 import cats.syntax.flatMap._
 import cats.syntax.show._
@@ -23,8 +22,7 @@ object handler {
     RumorHandler.fromPeerRumorConsumer[F, PublicTrust](IgnoreSelfOrigin) {
       case PeerRumor(origin, _, trust) =>
         logger.info(s"Received trust=${trust} from id=${origin.show}") >> {
-          // Placeholder for updating trust scores
-          Applicative[F].unit
+          trustStorage.updatePeerPublicTrustInfo(origin, trust)
         }
     }
   }

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/storage/TrustStorage.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/storage/TrustStorage.scala
@@ -1,53 +1,94 @@
 package org.tessellation.infrastructure.trust.storage
 
-import cats.Monad
-import cats.effect.Ref
+import cats.Applicative
+import cats.effect.{Async, Ref}
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.functorFilter._
 
-import org.tessellation.domain.trust.storage.TrustStorage
+import org.tessellation.domain.trust.storage.{TrustStorage => TST}
+import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.peer.PeerId
-import org.tessellation.schema.trust.{InternalTrustUpdateBatch, PublicTrust, TrustInfo}
+import org.tessellation.schema.trust._
+import org.tessellation.storage.LocalFileSystemStorage
+
+import fs2.io.file.Path
+
+final class TrustStorage[F[_]: Async: KryoSerializer] private (
+  path: Path,
+  val trust: Ref[F, Map[PeerId, TrustInfo]],
+  diskEnabled: Boolean = false
+) extends LocalFileSystemStorage[F, TrustStorageData](path)
+    with TST[F] {
+
+  def writeData(): F[Unit] =
+    Option
+      .when(diskEnabled) {
+        getTrust.flatMap { t =>
+          val data = TrustStorageData(t)
+          write("data", data).rethrowT.handleErrorWith { e =>
+            Applicative[F].pure(())
+          }
+        }
+      }
+      .getOrElse(Applicative[F].pure(()))
+
+  def readInitial(): F[Unit] =
+    read("data").rethrowT
+      .flatMap(data => trust.update(_ => data.trustInfo))
+      .handleErrorWith { e =>
+        Applicative[F].pure(())
+      }
+
+  def updateTrust(trustUpdates: InternalTrustUpdateBatch): F[Unit] =
+    trust.update { t =>
+      t ++ trustUpdates.updates.map { trustUpdate =>
+        val capped = Math.max(Math.min(trustUpdate.trust, 1), -1)
+        val updated = t.getOrElse(trustUpdate.id, TrustInfo()).copy(trustLabel = Some(capped))
+        trustUpdate.id -> updated
+      }.toMap
+    }.flatTap(_ => writeData())
+
+  def getTrust: F[Map[PeerId, TrustInfo]] = trust.get
+
+  def getPublicTrust: F[PublicTrust] = getTrust.map { trust =>
+    PublicTrust(trust.mapFilter { _.publicTrust })
+  }
+
+  def updatePeerPublicTrustInfo(peerId: PeerId, publicTrust: PublicTrust): F[Unit] =
+    trust.update { t =>
+      t.updatedWith(peerId) { trustInfo =>
+        trustInfo
+          .orElse(Some(TrustInfo()))
+          .map(_.copy(peerLabels = publicTrust.labels))
+      }
+    }.flatTap(_ => writeData())
+
+  override def updatePredictedTrust(trustUpdates: Map[PeerId, Double]): F[Unit] =
+    trust.update { t =>
+      t ++ trustUpdates.map {
+        case (k, v) =>
+          k -> t.getOrElse(k, TrustInfo()).copy(predictedTrust = Some(v))
+      }
+    }.flatTap(_ => writeData())
+
+}
 
 object TrustStorage {
 
-  def make[F[_]: Monad: Ref.Make]: F[TrustStorage[F]] =
-    for {
+  def make[F[_]: Async: KryoSerializer](path: Path, diskEnabled: Boolean = false): F[TrustStorage[F]] = {
+    val res = for {
       trust <- Ref[F].of[Map[PeerId, TrustInfo]](Map.empty)
-    } yield make(trust)
-
-  def make[F[_]: Monad](trust: Ref[F, Map[PeerId, TrustInfo]]): TrustStorage[F] =
-    new TrustStorage[F] {
-
-      def updateTrust(trustUpdates: InternalTrustUpdateBatch): F[Unit] =
-        trust.update { t =>
-          t ++ trustUpdates.updates.map { trustUpdate =>
-            val capped = Math.max(Math.min(trustUpdate.trust, 1), -1)
-            val updated = t.getOrElse(trustUpdate.id, TrustInfo()).copy(trustLabel = Some(capped))
-            trustUpdate.id -> updated
-          }.toMap
-        }
-
-      def getTrust: F[Map[PeerId, TrustInfo]] = trust.get
-
-      def getPublicTrust: F[PublicTrust] = getTrust.map { trust =>
-        PublicTrust(trust.mapFilter { _.publicTrust })
-      }
-
-      def updatePeerPublicTrustInfo(peerId: PeerId, publicTrust: PublicTrust): F[Unit] = trust.update { t =>
-        t.updatedWith(peerId) { trustInfo =>
-          trustInfo
-            .orElse(Some(TrustInfo()))
-            .map(_.copy(peerLabels = publicTrust.labels))
-        }
-      }
-
-      override def updatePredictedTrust(trustUpdates: Map[PeerId, Double]): F[Unit] = trust.update { t =>
-        t ++ trustUpdates.map {
-          case (k, v) =>
-            k -> t.getOrElse(k, TrustInfo()).copy(predictedTrust = Some(v))
-        }
-      }
+      t = new TrustStorage[F](path, trust, diskEnabled = diskEnabled)
+    } yield {
+      t
     }
 
+    res.flatTap { storage =>
+      if (diskEnabled) {
+        storage.readInitial().flatMap(_ => storage.createDirectoryIfNotExists().rethrowT)
+      } else Applicative[F].pure(())
+    }
+  }
 }

--- a/modules/core/src/main/scala/org/tessellation/modules/Storages.scala
+++ b/modules/core/src/main/scala/org/tessellation/modules/Storages.scala
@@ -4,10 +4,10 @@ import cats.effect.kernel.Async
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
-import org.tessellation.config.types.SnapshotConfig
+import org.tessellation.config.types.{SnapshotConfig, TrustConfig}
 import org.tessellation.domain.cluster.storage.AddressStorage
 import org.tessellation.domain.snapshot.GlobalSnapshotStorage
-import org.tessellation.domain.trust.storage.TrustStorage
+import org.tessellation.domain.trust.storage.{TrustStorage => TrustStorageDomain}
 import org.tessellation.infrastructure.cluster.storage.AddressStorage
 import org.tessellation.infrastructure.db.Database
 import org.tessellation.infrastructure.snapshot.{GlobalSnapshotLocalFileSystemStorage, GlobalSnapshotStorage}
@@ -22,11 +22,12 @@ object Storages {
 
   def make[F[_]: Async: Database: KryoSerializer](
     sdkStorages: SdkStorages[F],
-    snapshotConfig: SnapshotConfig
+    snapshotConfig: SnapshotConfig,
+    trustConfig: TrustConfig
   ): F[Storages[F]] =
     for {
       addressStorage <- AddressStorage.make[F]
-      trustStorage <- TrustStorage.make[F]
+      trustStorage <- TrustStorage.make[F](trustConfig.trustStorePath)
       globalSnapshotLocalFileSystemStorage <- GlobalSnapshotLocalFileSystemStorage.make(
         snapshotConfig.globalSnapshotPath
       )
@@ -50,6 +51,6 @@ sealed abstract class Storages[F[_]] private (
   val node: NodeStorage[F],
   val session: SessionStorage[F],
   val rumor: RumorStorage[F],
-  val trust: TrustStorage[F],
+  val trust: TrustStorageDomain[F],
   val globalSnapshot: GlobalSnapshotStorage[F]
 )

--- a/modules/core/src/test/scala/org/tessellation/http/routes/TrustRoutesSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/http/routes/TrustRoutesSuite.scala
@@ -10,11 +10,11 @@ import org.tessellation.domain.cluster.programs.TrustPush
 import org.tessellation.infrastructure.trust.storage.TrustStorage
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.generators._
-import org.tessellation.schema.peer.PeerId
-import org.tessellation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
+import org.tessellation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch}
 import org.tessellation.sdk.domain.gossip.Gossip
 import org.tessellation.sdk.sdkKryoRegistrar
 
+import fs2.io.file.Path
 import org.http4s.Method._
 import org.http4s._
 import org.http4s.client.dsl.io._
@@ -32,8 +32,7 @@ object TrustRoutesSuite extends HttpSuite {
       .forAsync[IO](sdkKryoRegistrar ++ coreKryoRegistrar)
       .use { implicit kryoPool =>
         for {
-          trust <- Ref[IO].of(Map.empty[PeerId, TrustInfo])
-          ts = TrustStorage.make[IO](trust)
+          ts <- TrustStorage.make[IO](Path("tmp/test"), diskEnabled = false)
           gossip = new Gossip[IO] {
             override def spread[A <: AnyRef: TypeTag](rumorContent: A): IO[Unit] = IO.unit
             override def spreadCommon[A <: AnyRef: TypeTag](rumorContent: A): IO[Unit] = IO.unit

--- a/modules/core/src/test/scala/org/tessellation/infrastructure/trust/storage/TrustStorageSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/infrastructure/trust/storage/TrustStorageSuite.scala
@@ -1,26 +1,53 @@
 package org.tessellation.infrastructure.trust.storage
 
-import cats.effect.{IO, Ref}
+import cats.effect.IO
 
+import org.tessellation.coreKryoRegistrar
+import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.generators._
-import org.tessellation.schema.peer.PeerId
-import org.tessellation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch, TrustInfo}
+import org.tessellation.schema.trust.{InternalTrustUpdate, InternalTrustUpdateBatch}
+import org.tessellation.sdk.sdkKryoRegistrar
 
+import fs2.io.file.Path
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers
 
 object TrustStorageSuite extends SimpleIOSuite with Checkers {
 
   test("trust update is applied") {
-    forall(peerGen) { peer =>
-      for {
-        trust <- Ref[IO].of(Map.empty[PeerId, TrustInfo])
-        cs = TrustStorage.make[IO](trust)
-        _ <- cs.updateTrust(
-          InternalTrustUpdateBatch(List(InternalTrustUpdate(peer.id, 0.5)))
-        )
-        updatedTrust <- cs.getTrust
-      } yield expect(updatedTrust(peer.id).trustLabel.get == 0.5)
-    }
+    KryoSerializer
+      .forAsync[IO](sdkKryoRegistrar ++ coreKryoRegistrar)
+      .use { implicit kryoPool =>
+        forall(peerGen) { peer =>
+          for {
+            cs <- TrustStorage.make[IO](Path("tmp/test2"), diskEnabled = false)
+            _ <- cs.updateTrust(
+              InternalTrustUpdateBatch(List(InternalTrustUpdate(peer.id, 0.5)))
+            )
+            updatedTrust <- cs.getTrust
+          } yield expect(updatedTrust(peer.id).trustLabel.get == 0.5)
+        }
+      }
   }
+
+  test("trust update is applied to disk") {
+    KryoSerializer
+      .forAsync[IO](sdkKryoRegistrar ++ coreKryoRegistrar)
+      .use { implicit kryoPool =>
+        Path("./data").toNioPath.toFile.delete()
+        val peer = peerGen.sample.get
+        for {
+          cs <- TrustStorage.make[IO](Path("."), diskEnabled = true)
+          _ <- cs.updateTrust(
+            InternalTrustUpdateBatch(List(InternalTrustUpdate(peer.id, 0.5)))
+          )
+          cs2 <- TrustStorage.make[IO](Path("."), diskEnabled = true)
+          updatedTrust <- cs2.getTrust
+        } yield {
+          Path("./data").toNioPath.toFile.delete()
+          expect(updatedTrust(peer.id).trustLabel.get == 0.5)
+        }
+      }
+  }
+
 }

--- a/modules/shared/src/main/scala/org/tessellation/schema/trust.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/trust.scala
@@ -33,4 +33,9 @@ object trust {
     labels: Map[PeerId, Double]
   )
 
+  @derive(decoder, encoder, show)
+  case class TrustStorageData(
+    trustInfo: Map[PeerId, TrustInfo]
+  )
+
 }

--- a/modules/shared/src/main/scala/org/tessellation/shared/package.scala
+++ b/modules/shared/src/main/scala/org/tessellation/shared/package.scala
@@ -10,7 +10,7 @@ import org.tessellation.schema.gossip._
 import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.peer.SignRequest
 import org.tessellation.schema.transaction.{Transaction, TransactionReference}
-import org.tessellation.schema.trust.PublicTrust
+import org.tessellation.schema.trust.{PublicTrust, TrustInfo, TrustStorageData}
 import org.tessellation.security.signature.Signed
 import org.tessellation.security.signature.signature.SignatureProof
 
@@ -46,7 +46,9 @@ package object shared {
     classOf[Transaction] -> 324,
     classOf[TransactionReference] -> 325,
     classOf[Refined[_, _]] -> 326,
-    classOf[BigInt] -> 327
+    classOf[BigInt] -> 327,
+    classOf[TrustStorageData] -> 328,
+    classOf[TrustInfo] -> 329
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.30")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")
+addSbtPlugin("au.com.onegeek" % "sbt-dotenv" % "2.1.204")
 addDependencyTreePlugin


### PR DESCRIPTION
Will eventually be replaced with SQL tables for label and
predictions management but performance is not a criteria
for repeated updates here given the tiny amount of data.

Data is read on initial storage creation once, otherwise
updated on every write. CLI option provided for path
following exact same format as snapshot CLI.

Future CLI options will require similar configurations, so
that part should remain even with SQL table.

Test demonstrates successful disk persistence by creating a
storage once, updating it, and creating a new one. Manually
verified across multiple tests that large amount of data
accumulates as well.