### PR TITLE
Fix isSignedBy method naming

### DIFF
--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/Validator.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/Validator.scala
@@ -80,8 +80,6 @@ object Validator {
   ): F[Boolean] =
     for {
       hasValidSignature <- input.hasValidSignature
-      isSignedBy = input.isSignedBy(
-        Set(PeerId._Id.get(input.value.senderId))
-      )
+      isSignedBy = input.isSignedExclusivelyBy(PeerId._Id.get(input.value.senderId))
     } yield hasValidSignature && isSignedBy
 }

--- a/modules/shared/src/main/scala/org/tessellation/security/signature/Signed.scala
+++ b/modules/shared/src/main/scala/org/tessellation/security/signature/Signed.scala
@@ -77,7 +77,14 @@ object Signed {
         Signed(signed.value, signed.proofs.add(sp))
       }
 
+    def isSignedBy(signer: Id): Boolean = isSignedBy(Set(signer))
+
     def isSignedBy(signers: Set[Id]): Boolean =
+      signers.forall(signed.proofs.map(_.id).contains(_))
+
+    def isSignedExclusivelyBy(signer: Id): Boolean = isSignedExclusivelyBy(Set(signer))
+
+    def isSignedExclusivelyBy(signers: Set[Id]): Boolean =
       signed.proofs.map(_.id).toSortedSet.unsorted === signers
 
     def hasValidSignature[F[_]: Async: SecurityProvider: KryoSerializer]: F[Boolean] =


### PR DESCRIPTION
`isSignedBy` method name was misleading because it worked exclusively.
Instead, we decided to support two methods for exclusive and non-exclusive check.