### PR TITLE
Fix short format for Hex class

### DIFF
--- a/modules/shared/src/main/scala/org/tessellation/security/Hex.scala
+++ b/modules/shared/src/main/scala/org/tessellation/security/Hex.scala
@@ -52,7 +52,7 @@ object hex {
         }
       } yield pk
 
-    def shortValue: String = value.substring(0, 8)
+    def shortValue: String = value.take(8)
   }
 
   object Hex {


### PR DESCRIPTION
Before this change, there was a possibility that calling `.shortValue` would throw an error.