### PR TITLE
Fix memory leak in L0 consensus storage

### DIFF
--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/consensus/ConsensusStorage.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/consensus/ConsensusStorage.scala
@@ -184,7 +184,7 @@ object ConsensusStorage {
         private def cleanupStateAndResource(key: Key): F[Unit] =
           condModifyState[Unit](key) { _ =>
             (none[ConsensusState[Key, Artifact]], ()).some.pure[F]
-          }.void
+          }.void >> cleanResources(key)
 
         def containsTriggerEvent: F[Boolean] =
           eventsR.keys.flatMap { keys =>
@@ -311,6 +311,9 @@ object ConsensusStorage {
           resourcesR(key).updateAndGet { maybeResource =>
             f(maybeResource.getOrElse(ConsensusResources.empty)).some
           }.flatMap(_.liftTo[F](new RuntimeException("Should never happen")))
+
+        private def cleanResources(key: Key): F[Unit] =
+          resourcesR(key).set(none)
 
         def getOwnRegistration: F[Option[Key]] = ownRegistrationR.get
 


### PR DESCRIPTION
FYI: this also impacts the way the healthcheck will work from now on for the corner case of checking proposal for an obsolete snapshot consensus. Example: if some slower node starts consensus for snapshot 10 when our node has already finished consensus for snapshot 11 we will respond with not required even if we had a proposal at height 10 originally - we will have those proposals cleaned up already. After analyzing it it doesn't seem like something we should be concerned about in the algorithm logic.