### PR TITLE
Adjust DTM weights

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/config/types.scala
+++ b/modules/core/src/main/scala/org/tessellation/config/types.scala
@@ -66,8 +66,8 @@ object types {
 
   case class DTMConfig(
     address: Address = Address("DAG0Njmo6JZ3FhkLsipJSppepUHPuTXcSifARfvK"),
-    dtmWeight: NonNegLong = 156L,
-    remainingWeight: NonNegLong = 844L
+    dtmWeight: NonNegLong = 176L,
+    remainingWeight: NonNegLong = 824L
   )
 
   case class StardustConfig(


### PR DESCRIPTION
New distribution reflects ~4.5M in rewards per 30 days of snapshots