### PR TITLE
Update trust info via gossip.

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/infrastructure/trust/handler.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/trust/handler.scala
@@ -1,6 +1,5 @@
 package org.tessellation.infrastructure.trust
 
-import cats.Applicative
 import cats.effect.Async
 import cats.syntax.flatMap._
 import cats.syntax.show._
@@ -23,8 +22,7 @@ object handler {
     RumorHandler.fromPeerRumorConsumer[F, PublicTrust](IgnoreSelfOrigin) {
       case PeerRumor(origin, _, trust) =>
         logger.info(s"Received trust=${trust} from id=${origin.show}") >> {
-          // Placeholder for updating trust scores
-          Applicative[F].unit
+          trustStorage.updatePeerPublicTrustInfo(origin, trust)
         }
     }
   }


### PR DESCRIPTION
Trust ratings transmitted via gossip are now persisted instead of ignored.