### PR TITLE
Add delay to download to discover peers

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/modules/Programs.scala
+++ b/modules/core/src/main/scala/org/tessellation/modules/Programs.scala
@@ -33,7 +33,8 @@ object Programs {
       .make(
         storages.node,
         services.consensus,
-        peerSelect
+        peerSelect,
+        () => storages.cluster.getPeers
       )
     val rollbackLoader = RollbackLoader.make(
       keyPair,

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
@@ -35,7 +35,8 @@ object Programs {
       .make(
         storages.node,
         services.consensus,
-        peerSelect
+        peerSelect,
+        () => storages.cluster.getPeers
       )
 
     val globalL0PeerDiscovery = L0PeerDiscovery.make(

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/programs/Download.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/programs/Download.scala
@@ -2,33 +2,63 @@ package org.tessellation.sdk.infrastructure.snapshot.programs
 
 import cats.effect.Async
 import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import scala.concurrent.duration.DurationInt
 
 import org.tessellation.schema.node.NodeState
+import org.tessellation.schema.peer.Peer
 import org.tessellation.sdk.domain.node.NodeStorage
 import org.tessellation.sdk.domain.snapshot.PeerSelect
 import org.tessellation.sdk.infrastructure.snapshot.SnapshotConsensus
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import retry.{RetryPolicies, noop, retryingOnFailures}
 
 object Download {
 
   def make[F[_]: Async](
     nodeStorage: NodeStorage[F],
     consensus: SnapshotConsensus[F, _, _, _, _, _],
-    peerSelecter: PeerSelect[F]
+    peerSelecter: PeerSelect[F],
+    getPeers: () => F[Set[Peer]]
   ): Download[F] =
     new Download[F](
       nodeStorage,
       consensus,
-      peerSelecter
+      peerSelecter,
+      getPeers
     ) {}
 }
 
 sealed abstract class Download[F[_]: Async] private (
   nodeStorage: NodeStorage[F],
   consensus: SnapshotConsensus[F, _, _, _, _, _],
-  peerSelect: PeerSelect[F]
+  peerSelect: PeerSelect[F],
+  getPeers: () => F[Set[Peer]]
 ) {
+
+  val logger = Slf4jLogger.getLoggerFromClass[F](Download.getClass)
+
+  private val timeout = 15.seconds
+  private val minKnownPeers = 50
+  private val delayBetweenPeerCountChecks = 1.second
+
+  private def waitUntilMinPeersFound: F[Unit] = {
+    val retryPolicy = RetryPolicies.limitRetriesByCumulativeDelay(
+      timeout,
+      RetryPolicies.constantDelay(delayBetweenPeerCountChecks)
+    )
+
+    val wasSuccessful = (n: Int) => Async[F].pure(n >= minKnownPeers)
+
+    retryingOnFailures(retryPolicy, wasSuccessful, noop)(getPeers().map(_.size)).flatMap(numFoundPeers =>
+      logger.debug(s"Found $numFoundPeers, need at least $minKnownPeers")
+    )
+  }
 
   def download(): F[Unit] =
     nodeStorage.tryModifyState(NodeState.WaitingForDownload, NodeState.WaitingForObserving) >>
+      waitUntilMinPeersFound >>
       peerSelect.select.flatMap(consensus.manager.startObserving(_))
 }


### PR DESCRIPTION
Added a delay to the download process to block the start of observation until peer discovery had been given time to run and discover some peers.