### PR TITLE
Observe majority fork

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/Main.scala
+++ b/modules/core/src/main/scala/org/tessellation/Main.scala
@@ -64,7 +64,7 @@ object Main
           cfg
         )
         .asResource
-      programs = Programs.make[IO](sdkPrograms, storages, services, keyPair, cfg)
+      programs = Programs.make[IO](sdkPrograms, storages, services, keyPair, cfg, p2pClient.l0GlobalSnapshotClient)
       healthChecks <- HealthChecks
         .make[IO](
           storages,

--- a/modules/core/src/main/scala/org/tessellation/http/p2p/P2PClient.scala
+++ b/modules/core/src/main/scala/org/tessellation/http/p2p/P2PClient.scala
@@ -13,7 +13,8 @@ object P2PClient {
       sdkP2PClient.sign,
       sdkP2PClient.cluster,
       sdkP2PClient.gossip,
-      sdkP2PClient.node
+      sdkP2PClient.node,
+      sdkP2PClient.l0GlobalSnapshotClient
     ) {}
 }
 
@@ -21,5 +22,6 @@ sealed abstract class P2PClient[F[_]] private (
   val sign: SignClient[F],
   val cluster: ClusterClient[F],
   val gossip: GossipClient[F],
-  val node: NodeClient[F]
+  val node: NodeClient[F],
+  val l0GlobalSnapshotClient: L0GlobalSnapshotClient[F]
 )

--- a/modules/core/src/main/scala/org/tessellation/modules/Programs.scala
+++ b/modules/core/src/main/scala/org/tessellation/modules/Programs.scala
@@ -3,30 +3,37 @@ package org.tessellation.modules
 import java.security.KeyPair
 
 import cats.effect.Async
+import cats.effect.std.Random
 
 import org.tessellation.config.types.AppConfig
 import org.tessellation.domain.cluster.programs.TrustPush
 import org.tessellation.infrastructure.snapshot.programs.RollbackLoader
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.sdk.domain.cluster.programs.{Joining, PeerDiscovery}
+import org.tessellation.sdk.domain.snapshot.PeerSelect
+import org.tessellation.sdk.http.p2p.clients.L0GlobalSnapshotClient
+import org.tessellation.sdk.infrastructure.snapshot.MajorityPeerSelect
 import org.tessellation.sdk.infrastructure.snapshot.programs.Download
 import org.tessellation.sdk.modules.SdkPrograms
 import org.tessellation.security.SecurityProvider
 
 object Programs {
 
-  def make[F[_]: Async: KryoSerializer: SecurityProvider](
+  def make[F[_]: Async: KryoSerializer: SecurityProvider: Random](
     sdkPrograms: SdkPrograms[F],
     storages: Storages[F],
     services: Services[F],
     keyPair: KeyPair,
-    config: AppConfig
+    config: AppConfig,
+    l0GlobalSnapshotClient: L0GlobalSnapshotClient[F]
   ): Programs[F] = {
     val trustPush = TrustPush.make(storages.trust, services.gossip)
+    val peerSelect: PeerSelect[F] = MajorityPeerSelect.make(storages.cluster, l0GlobalSnapshotClient)
     val download = Download
       .make(
         storages.node,
-        services.consensus
+        services.consensus,
+        peerSelect
       )
     val rollbackLoader = RollbackLoader.make(
       keyPair,

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
@@ -11,7 +11,9 @@ import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.peer.{L0Peer, PeerId}
 import org.tessellation.sdk.domain.cluster.programs.{Joining, L0PeerDiscovery, PeerDiscovery}
+import org.tessellation.sdk.domain.snapshot.PeerSelect
 import org.tessellation.sdk.infrastructure.genesis.{Loader => GenesisLoader}
+import org.tessellation.sdk.infrastructure.snapshot.MajorityPeerSelect
 import org.tessellation.sdk.infrastructure.snapshot.programs.Download
 import org.tessellation.sdk.modules.SdkPrograms
 import org.tessellation.security.SecurityProvider
@@ -28,10 +30,12 @@ object Programs {
     services: Services[F],
     p2pClient: P2PClient[F]
   ): Programs[F] = {
+    val peerSelect: PeerSelect[F] = MajorityPeerSelect.make(storages.cluster, p2pClient.l0GlobalSnapshot)
     val download = Download
       .make(
         storages.node,
-        services.consensus
+        services.consensus,
+        peerSelect
       )
 
     val globalL0PeerDiscovery = L0PeerDiscovery.make(

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/domain/consensus/ConsensusManager.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/domain/consensus/ConsensusManager.scala
@@ -1,11 +1,12 @@
 package org.tessellation.sdk.domain.consensus
 
+import org.tessellation.schema.peer.Peer
 import org.tessellation.sdk.infrastructure.consensus.ConsensusResources
 import org.tessellation.security.signature.Signed
 
 trait ConsensusManager[F[_], Key, Artifact, Context] {
 
-  def startObserving: F[Unit]
+  def startObserving(peerToObserve: Peer): F[Unit]
   def startFacilitatingAfter(lastKey: Key, lastArtifact: Signed[Artifact], lastContext: Context): F[Unit]
 
   def withdrawFromConsensus: F[Unit]

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/domain/snapshot/PeerSelect.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/domain/snapshot/PeerSelect.scala
@@ -1,0 +1,7 @@
+package org.tessellation.sdk.domain.snapshot
+
+import org.tessellation.schema.peer.Peer
+
+trait PeerSelect[F[_]] {
+  def select: F[Peer]
+}

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/http/p2p/SdkP2PClient.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/http/p2p/SdkP2PClient.scala
@@ -18,7 +18,8 @@ object SdkP2PClient {
       ClusterClient.make[F](client, session),
       GossipClient.make[F](client, session),
       NodeClient.make[F](client, session),
-      TrustClient.make[F](client, session)
+      TrustClient.make[F](client, session),
+      L0GlobalSnapshotClient.make[F](client)
     ) {}
 
 }
@@ -28,5 +29,6 @@ sealed abstract class SdkP2PClient[F[_]] private (
   val cluster: ClusterClient[F],
   val gossip: GossipClient[F],
   val node: NodeClient[F],
-  val trust: TrustClient[F]
+  val trust: TrustClient[F],
+  val l0GlobalSnapshotClient: L0GlobalSnapshotClient[F]
 )

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/MajorityPeerSelect.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/MajorityPeerSelect.scala
@@ -1,0 +1,77 @@
+package org.tessellation.sdk.infrastructure.snapshot
+
+import cats.data.NonEmptyList
+import cats.effect.Async
+import cats.effect.std.Random
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.eq._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.list._
+
+import scala.util.control.NoStackTrace
+
+import org.tessellation.kryo.KryoSerializer
+import org.tessellation.schema.node.NodeState.Ready
+import org.tessellation.schema.peer.Peer
+import org.tessellation.schema.peer.Peer.toP2PContext
+import org.tessellation.sdk.domain.cluster.storage.ClusterStorage
+import org.tessellation.sdk.domain.snapshot.PeerSelect
+import org.tessellation.sdk.http.p2p.clients.L0GlobalSnapshotClient
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object MajorityPeerSelect {
+
+  case object NoPeersToSelect extends NoStackTrace
+
+  def make[F[_]: Async: KryoSerializer: Random](
+    storage: ClusterStorage[F],
+    snapshotClient: L0GlobalSnapshotClient[F]
+  ): PeerSelect[F] = new PeerSelect[F] {
+
+    val logger = Slf4jLogger.getLoggerFromClass[F](MajorityPeerSelect.getClass)
+
+    def select: F[Peer] = storage.getResponsivePeers
+      .map(_.filter(_.state === Ready))
+      .flatMap(getPeerSublist)
+      .flatMap { peers =>
+        peers.toNel match {
+          case Some(value) => value.pure[F]
+          case None =>
+            logger.error("No Ready peers were found to be selected.") >>
+              NoPeersToSelect.raiseError[F, NonEmptyList[Peer]]
+        }
+      }
+      .flatMap(filterPeerList)
+      .map(_.toList)
+      .flatMap(Random[F].elementOf)
+
+    def filterPeerList(peers: NonEmptyList[Peer]): F[NonEmptyList[Peer]] =
+      peers
+        .traverse(snapshotClient.getLatestOrdinal(_))
+        .map {
+          _.groupBy(identity).maxBy { case (_, ordinals) => ordinals.size }
+        }
+        .flatMap {
+          case (majorityOrdinal, _) =>
+            peers.traverse(snapshotClient.get(majorityOrdinal).run(_).flatMap(_.toHashed.map(_.hash)))
+        }
+        .map(_.zip(peers))
+        .map(_.groupMap { case (hash, _) => hash } { case (_, ps) => ps })
+        .map(_.maxBy { case (_, peers) => peers.size })
+        .map { case (_, peerCandidates) => peerCandidates }
+
+    def getPeerSublist(peers: Set[Peer]): F[List[Peer]] = {
+      val maxSublistPercent = 0.25
+      val maxSublistSize = Math.max((peers.size * maxSublistPercent).toInt, 1)
+
+      Random[F].nextIntBounded(maxSublistSize).flatMap { peerCount =>
+        Random[F]
+          .shuffleList(peers.toList)
+          .map(_.take(peerCount))
+      }
+    }
+  }
+}

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/programs/Download.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/programs/Download.scala
@@ -5,26 +5,30 @@ import cats.syntax.flatMap._
 
 import org.tessellation.schema.node.NodeState
 import org.tessellation.sdk.domain.node.NodeStorage
+import org.tessellation.sdk.domain.snapshot.PeerSelect
 import org.tessellation.sdk.infrastructure.snapshot.SnapshotConsensus
 
 object Download {
 
   def make[F[_]: Async](
     nodeStorage: NodeStorage[F],
-    consensus: SnapshotConsensus[F, _, _, _, _, _]
+    consensus: SnapshotConsensus[F, _, _, _, _, _],
+    peerSelecter: PeerSelect[F]
   ): Download[F] =
     new Download[F](
       nodeStorage,
-      consensus
+      consensus,
+      peerSelecter
     ) {}
 }
 
 sealed abstract class Download[F[_]: Async] private (
   nodeStorage: NodeStorage[F],
-  consensus: SnapshotConsensus[F, _, _, _, _, _]
+  consensus: SnapshotConsensus[F, _, _, _, _, _],
+  peerSelect: PeerSelect[F]
 ) {
 
   def download(): F[Unit] =
     nodeStorage.tryModifyState(NodeState.WaitingForDownload, NodeState.WaitingForObserving) >>
-      consensus.manager.startObserving
+      peerSelect.select.flatMap(consensus.manager.startObserving(_))
 }


### PR DESCRIPTION
When choosing which peer to observe, select a peer on the majority fork. This PR implements the code needed to select a peer on the majority fork for observation. It supersedes PR https://github.com/Constellation-Labs/tessellation/pull/616 and is related to PR https://github.com/Constellation-Labs/tessellation/pull/629.