### PR TITLE
PeerSelect gracefully handles no snapshot errors

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/Main.scala
+++ b/modules/core/src/main/scala/org/tessellation/Main.scala
@@ -64,7 +64,7 @@ object Main
           cfg
         )
         .asResource
-      programs = Programs.make[IO](sdkPrograms, storages, services, keyPair, cfg, p2pClient.l0GlobalSnapshotClient)
+      programs = Programs.make[IO](sdkPrograms, storages, services, keyPair, cfg, p2pClient.l0GlobalSnapshot)
       healthChecks <- HealthChecks
         .make[IO](
           storages,

--- a/modules/core/src/main/scala/org/tessellation/http/p2p/P2PClient.scala
+++ b/modules/core/src/main/scala/org/tessellation/http/p2p/P2PClient.scala
@@ -14,7 +14,7 @@ object P2PClient {
       sdkP2PClient.cluster,
       sdkP2PClient.gossip,
       sdkP2PClient.node,
-      sdkP2PClient.l0GlobalSnapshotClient
+      sdkP2PClient.l0GlobalSnapshot
     ) {}
 }
 
@@ -23,5 +23,5 @@ sealed abstract class P2PClient[F[_]] private (
   val cluster: ClusterClient[F],
   val gossip: GossipClient[F],
   val node: NodeClient[F],
-  val l0GlobalSnapshotClient: L0GlobalSnapshotClient[F]
+  val l0GlobalSnapshot: L0GlobalSnapshotClient[F]
 )

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/http/p2p/SdkP2PClient.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/http/p2p/SdkP2PClient.scala
@@ -30,5 +30,5 @@ sealed abstract class SdkP2PClient[F[_]] private (
   val gossip: GossipClient[F],
   val node: NodeClient[F],
   val trust: TrustClient[F],
-  val l0GlobalSnapshotClient: L0GlobalSnapshotClient[F]
+  val l0GlobalSnapshot: L0GlobalSnapshotClient[F]
 )

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/MajorityPeerSelect.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/MajorityPeerSelect.scala
@@ -1,8 +1,10 @@
 package org.tessellation.sdk.infrastructure.snapshot
 
+import cats.MonadThrow
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.effect.std.Random
+import cats.effect.syntax.concurrent._
 import cats.syntax.applicative._
 import cats.syntax.applicativeError._
 import cats.syntax.eq._
@@ -13,16 +15,22 @@ import cats.syntax.list._
 import scala.util.control.NoStackTrace
 
 import org.tessellation.kryo.KryoSerializer
+import org.tessellation.schema.SnapshotOrdinal
 import org.tessellation.schema.node.NodeState.Ready
 import org.tessellation.schema.peer.Peer
 import org.tessellation.schema.peer.Peer.toP2PContext
 import org.tessellation.sdk.domain.cluster.storage.ClusterStorage
 import org.tessellation.sdk.domain.snapshot.PeerSelect
 import org.tessellation.sdk.http.p2p.clients.L0GlobalSnapshotClient
+import org.tessellation.security.hash.Hash
 
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object MajorityPeerSelect {
+
+  val maxConcurrentPeerInquiries = 10
+  val peerSampleRatio = 0.25
+  val minSampleSize = 20
 
   case object NoPeersToSelect extends NoStackTrace
 
@@ -33,7 +41,9 @@ object MajorityPeerSelect {
 
     val logger = Slf4jLogger.getLoggerFromClass[F](MajorityPeerSelect.getClass)
 
-    def select: F[Peer] = storage.getResponsivePeers
+    def select: F[Peer] = selectPeer
+
+    def selectPeer: F[Peer] = storage.getResponsivePeers
       .map(_.filter(_.state === Ready))
       .flatMap(getPeerSublist)
       .flatMap { peers =>
@@ -50,28 +60,32 @@ object MajorityPeerSelect {
 
     def filterPeerList(peers: NonEmptyList[Peer]): F[NonEmptyList[Peer]] =
       peers
-        .traverse(snapshotClient.getLatestOrdinal(_))
-        .map {
-          _.groupBy(identity).maxBy { case (_, ordinals) => ordinals.size }
+        .parTraverseN(maxConcurrentPeerInquiries)(snapshotClient.getLatestOrdinal(_))
+        .map(_.groupBy(identity).maxBy { case (_, ordinals) => ordinals.size })
+        .map { case (majorityOrdinal, _) => majorityOrdinal }
+        .flatMap { majorityOrdinal =>
+          peers
+            .parTraverseN(maxConcurrentPeerInquiries)(peer => getSnapshotHashByPeer(peer, majorityOrdinal).attempt)
         }
-        .flatMap {
-          case (majorityOrdinal, _) =>
-            peers.traverse(snapshotClient.get(majorityOrdinal).run(_).flatMap(_.toHashed.map(_.hash)))
+        .flatMap { peerSnapshotHashes =>
+          MonadThrow[F].fromOption(
+            peerSnapshotHashes.collect { case Right(peerSnapshot) => peerSnapshot }.toNel,
+            NoPeersToSelect
+          )
         }
-        .map(_.zip(peers))
-        .map(_.groupMap { case (hash, _) => hash } { case (_, ps) => ps })
-        .map(_.maxBy { case (_, peers) => peers.size })
-        .map { case (_, peerCandidates) => peerCandidates }
+        .map(_.groupMap { case (_, hash) => hash } { case (peer, _) => peer })
+        .map(_.values.toList.sortBy(-_.size))
+        .map(_.head)
 
     def getPeerSublist(peers: Set[Peer]): F[List[Peer]] = {
-      val maxSublistPercent = 0.25
-      val maxSublistSize = Math.max((peers.size * maxSublistPercent).toInt, 1)
+      val sampleSize = (peers.size * peerSampleRatio).toInt
 
-      Random[F].nextIntBounded(maxSublistSize).flatMap { peerCount =>
-        Random[F]
-          .shuffleList(peers.toList)
-          .map(_.take(peerCount))
-      }
+      Random[F]
+        .shuffleList(peers.toList)
+        .map(_.take(Math.max(sampleSize, minSampleSize)))
     }
+
+    def getSnapshotHashByPeer(peer: Peer, ordinal: SnapshotOrdinal): F[(Peer, Hash)] =
+      snapshotClient.get(ordinal).run(peer).flatMap(_.toHashed).map(snapshot => (peer, snapshot.hash))
   }
 }

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/programs/Download.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/programs/Download.scala
@@ -13,12 +13,12 @@ object Download {
   def make[F[_]: Async](
     nodeStorage: NodeStorage[F],
     consensus: SnapshotConsensus[F, _, _, _, _, _],
-    peerSelecter: PeerSelect[F]
+    peerSelect: PeerSelect[F]
   ): Download[F] =
     new Download[F](
       nodeStorage,
       consensus,
-      peerSelecter
+      peerSelect
     ) {}
 }
 


### PR DESCRIPTION
The current `PeerSelect` doesn't gracefully handles errors that are the result of it querying a `Peer` for the snapshot for a `SnapshotOrdinal` value that doesn't exist. This fixes that. It also parallelizes the queries to other `Peer`s and addresses comments that were not addressed prior to merging PR https://github.com/Constellation-Labs/tessellation/pull/630.