### PR TITLE
Process currency snapshots in correct order on GL0

### DIFF
--- a/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessor.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessor.scala
@@ -92,7 +92,7 @@ object GlobalSnapshotStateChannelEventsProcessor {
                 (Option[(Option[Signed[CurrencyIncrementalSnapshot]], CurrencySnapshotInfo)], List[Signed[StateChannelSnapshotBinary]])
               type Result = Option[Success]
 
-              (lastGlobalSnapshotInfo.lastCurrencySnapshots.get(address), binaries.toList)
+              (lastGlobalSnapshotInfo.lastCurrencySnapshots.get(address), binaries.toList.reverse)
                 .tailRecM[F, Result] {
                   case (state, Nil) => state.asRight[Agg].pure[F]
 


### PR DESCRIPTION
Already merged to 2.0.0-alpha.6, missing on develop