### PR TITLE
Break Currency L0 validator joining to Currency L0 initial validator

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/http/p2p/P2PClient.scala
+++ b/modules/core/src/main/scala/org/tessellation/http/p2p/P2PClient.scala
@@ -1,7 +1,6 @@
 package org.tessellation.http.p2p
 
 import cats.effect.Async
-import cats.syntax.option._
 
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.sdk.domain.cluster.services.Session
@@ -24,7 +23,7 @@ object P2PClient {
       sdkP2PClient.cluster,
       sdkP2PClient.gossip,
       sdkP2PClient.node,
-      L0GlobalSnapshotClient.make(client, session.some)
+      L0GlobalSnapshotClient.make(client, None)
     ) {}
 }
 

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
@@ -31,7 +31,7 @@ object Programs {
     p2pClient: P2PClient[F],
     currencySnapshotContextFns: CurrencySnapshotContextFunctions[F]
   ): Programs[F] = {
-    val peerSelect: PeerSelect[F] = MajorityPeerSelect.make(storages.cluster, p2pClient.currencySnapshot)
+    val peerSelect: PeerSelect[F] = MajorityPeerSelect.make(storages.cluster, p2pClient.l0GlobalSnapshot)
     val download = Download
       .make(
         p2pClient,


### PR DESCRIPTION
**This PR is not meant to be merged**

It's sole purpose is to see if the automated github actions will fail by reverting a fix done a few PRs ago:
We expect the github actions to fail.

When I ran it locally:

1. Launch Global initial (genesis) node
2. Launch Currency L0 initial validator (c0)
3. Launch Currency L0 validator (c1)
4. Join c1 to c0
5. 404 error reported in the node logs

The error does not happen in the current develop branch

cc: @ryle-goehausen @AlexBrandes 