### PR TITLE
Fix purging snapshots from persisted storage

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/domain/snapshot/programs/Download.scala
+++ b/modules/core/src/main/scala/org/tessellation/domain/snapshot/programs/Download.scala
@@ -205,7 +205,7 @@ object Download {
                     _.map(
                       _.toHashed[F]
                         .map(_.hash)
-                        .flatMap(snapshotStorage.movePersistedToTmp(_))
+                        .flatMap(snapshotStorage.movePersistedToTmp(_, snapshot.ordinal))
                     ).getOrElse(Applicative[F].unit)
                   } >>
                     snapshotStorage

--- a/modules/core/src/main/scala/org/tessellation/domain/snapshot/storages/SnapshotDownloadStorage.scala
+++ b/modules/core/src/main/scala/org/tessellation/domain/snapshot/storages/SnapshotDownloadStorage.scala
@@ -15,7 +15,7 @@ trait SnapshotDownloadStorage[F[_]] {
 
   def isPersisted(hash: Hash): F[Boolean]
 
-  def movePersistedToTmp(hash: Hash): F[Unit]
+  def movePersistedToTmp(hash: Hash, ordinal: SnapshotOrdinal): F[Unit]
   def moveTmpToPersisted(snapshot: Signed[GlobalIncrementalSnapshot]): F[Unit]
 
   def readGenesis(ordinal: SnapshotOrdinal): F[Option[Signed[GlobalSnapshot]]]

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/snapshot/SnapshotDownloadStorage.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/snapshot/SnapshotDownloadStorage.scala
@@ -27,7 +27,9 @@ object SnapshotDownloadStorage {
 
       def isPersisted(hash: Hash): F[Boolean] = persistedStorage.exists(hash)
 
-      def movePersistedToTmp(hash: Hash): F[Unit] = tmpStorage.getPath(hash).flatMap(persistedStorage.move(hash, _))
+      def movePersistedToTmp(hash: Hash, ordinal: SnapshotOrdinal): F[Unit] =
+        tmpStorage.getPath(hash).flatMap(persistedStorage.move(hash, _) >> persistedStorage.delete(ordinal))
+
       def moveTmpToPersisted(snapshot: Signed[GlobalIncrementalSnapshot]): F[Unit] =
         persistedStorage.getPath(snapshot).flatMap(tmpStorage.moveByOrdinal(snapshot, _) >> persistedStorage.link(snapshot))
 


### PR DESCRIPTION
This fixes removing the forked snapshots when the node joining has the highest ordinal lower than the network it joins to. A fix for purging snapshots above the highest in the network a node joins to is still to be implemented.