### PR TITLE
Adjust ProgramsDistributionConfig for future epoch

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/config/types.scala
+++ b/modules/core/src/main/scala/org/tessellation/config/types.scala
@@ -9,8 +9,10 @@ import org.tessellation.config.types.RewardsConfig._
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.epoch.EpochProgress
+import org.tessellation.schema.transaction.TransactionAmount
 import org.tessellation.sdk.config.AppEnvironment
 import org.tessellation.sdk.config.types._
+import org.tessellation.sdk.domain.transaction.TransactionValidator.stardustPrimary
 
 import ciris.Secret
 import eu.timepit.refined.auto._
@@ -61,17 +63,21 @@ object types {
     remainingWeight: Weight
   )
 
+  case class OneTimeReward(epoch: EpochProgress, address: Address, amount: TransactionAmount)
+
   case class RewardsConfig(
     programs: EpochProgress => ProgramsDistributionConfig = mainnetProgramsDistributionConfig,
-    rewardsPerEpoch: SortedMap[EpochProgress, Amount] = mainnetRewardsPerEpoch
+    rewardsPerEpoch: SortedMap[EpochProgress, Amount] = mainnetRewardsPerEpoch,
+    oneTimeRewards: List[OneTimeReward] = List.empty
   )
 
   object RewardsConfig {
-    val stardustPrimary: Address = Address("DAGSTARDUSTCOLLECTIVEHZOIPHXZUBFGNXWJETZVSPAPAHMLXS")
+    val stardustNewPrimary = Address("DAG8vD8BUhCpTnYXEadQVGhHjgxEZZiafbzwmKKh")
     val stardustSecondary: Address = Address("DAG8VT7bxjs1XXBAzJGYJDaeyNxuThikHeUTp9XY")
     val softStaking: Address = Address("DAG77VVVRvdZiYxZ2hCtkHz68h85ApT5b2xzdTkn")
     val testnet: Address = Address("DAG0qE5tkz6cMUD5M2dkqgfV4TQCzUUdAP5MFM9P")
     val dataPool: Address = Address("DAG3RXBWBJq1Bf38rawASakLHKYMbRhsDckaGvGu")
+    val integrationNet: Address = Address("DAG8jE4CHy9T2izWFEv8K6rp5hNJq11SyLEVYnt8")
 
     val mainnetProgramsDistributionConfig: EpochProgress => ProgramsDistributionConfig = {
       case epoch if epoch < EpochProgress(1336392L) =>
@@ -85,7 +91,7 @@ object types {
           ),
           remainingWeight = Weight(4L) // facilitators
         )
-      case _ =>
+      case epoch if epoch < EpochProgress(1352274L) =>
         ProgramsDistributionConfig(
           weights = Map(
             stardustPrimary -> Weight(5L),
@@ -94,6 +100,17 @@ object types {
             dataPool -> Weight(55L)
           ),
           remainingWeight = Weight(30L) // facilitators
+        )
+      case _ =>
+        ProgramsDistributionConfig(
+          weights = Map(
+            stardustNewPrimary -> Weight(5L),
+            stardustSecondary -> Weight(5L),
+            testnet -> Weight(3L),
+            dataPool -> Weight(55L),
+            integrationNet -> Weight(15L)
+          ),
+          remainingWeight = Weight(17L) // facilitators
         )
     }
 

--- a/modules/core/src/main/scala/org/tessellation/domain/dag/DagService.scala
+++ b/modules/core/src/main/scala/org/tessellation/domain/dag/DagService.scala
@@ -9,6 +9,7 @@ trait DAGService[F[_]] {
   def getBalance(ordinal: SnapshotOrdinal, address: Address): F[Option[(Balance, SnapshotOrdinal)]]
 
   def getTotalSupply: F[Option[(BigInt, SnapshotOrdinal)]]
+  def getFilteredOutTotalSupply: F[Option[(BigInt, SnapshotOrdinal)]]
   def getTotalSupply(ordinal: SnapshotOrdinal): F[Option[(BigInt, SnapshotOrdinal)]]
 
   def getWalletCount: F[Option[(Int, SnapshotOrdinal)]]

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/dag/DAGService.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/dag/DAGService.scala
@@ -8,6 +8,7 @@ import org.tessellation.domain.snapshot.SnapshotStorage
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Balance
 import org.tessellation.schema.{GlobalSnapshot, SnapshotOrdinal}
+import org.tessellation.sdk.domain.transaction.TransactionValidator.lockedAddresses
 import org.tessellation.security.signature.Signed
 
 import io.estatico.newtype.ops._
@@ -16,7 +17,6 @@ object DAGService {
 
   def make[F[_]: Async](globalSnapshotStorage: SnapshotStorage[F, GlobalSnapshot]): DAGService[F] =
     new DAGService[F] {
-
       private def getBalance(snapshot: Signed[GlobalSnapshot], address: Address): (Balance, SnapshotOrdinal) = {
         val balance = snapshot.value.info.balances.getOrElse(address, Balance.empty)
         val ordinal = snapshot.value.ordinal
@@ -34,25 +34,31 @@ object DAGService {
           _.map(getBalance(_, address))
         }
 
-      private def getTotalSupply(snapshot: Signed[GlobalSnapshot]): (BigInt, SnapshotOrdinal) = {
+      private def calculateTotalSupply(balances: Iterable[Balance], ordinal: SnapshotOrdinal): (BigInt, SnapshotOrdinal) = {
         val empty = BigInt(Balance.empty.coerce.value)
-        val supply = snapshot.value.info.balances.values
+        val supply = balances
           .foldLeft(empty) { (acc, b) =>
             acc + BigInt(b.coerce.value)
           }
-        val ordinal = snapshot.value.ordinal
 
         (supply, ordinal)
       }
 
       def getTotalSupply: F[Option[(BigInt, SnapshotOrdinal)]] =
         globalSnapshotStorage.head.map {
-          _.map(getTotalSupply)
+          _.map(s => calculateTotalSupply(s.info.balances.values, s.ordinal))
+        }
+
+      def getFilteredOutTotalSupply: F[Option[(BigInt, SnapshotOrdinal)]] =
+        globalSnapshotStorage.head.map { maybeSignedSnapshot =>
+          maybeSignedSnapshot.map { snapshot =>
+            calculateTotalSupply(snapshot.info.balances.filterNot { case (a, _) => lockedAddresses.contains(a) }.values, snapshot.ordinal)
+          }
         }
 
       def getTotalSupply(ordinal: SnapshotOrdinal): F[Option[(BigInt, SnapshotOrdinal)]] =
         globalSnapshotStorage.get(ordinal).map {
-          _.map(getTotalSupply)
+          _.map(s => calculateTotalSupply(s.info.balances.values, s.ordinal))
         }
 
       private def getWalletCount(snapshot: Signed[GlobalSnapshot]): (Int, SnapshotOrdinal) = {

--- a/modules/core/src/test/scala/org/tessellation/trust/SybilAttackSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/trust/SybilAttackSuite.scala
@@ -37,7 +37,6 @@ object SybilAttackSuite extends SimpleIOSuite with Checkers {
 
   def benchmark(allData: List[TrustNode], filterGood: Int => Boolean): ModelBenchmark = {
 
-    val numNodes = allData.size / 2
     val scores = SelfAvoidingWalk.runWalkFeedbackUpdateSingleNode(
       0,
       allData

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/domain/transaction/TransactionValidator.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/domain/transaction/TransactionValidator.scala
@@ -22,17 +22,16 @@ trait TransactionValidator[F[_], T <: Transaction] {
 }
 
 object TransactionValidator {
+  val stardustPrimary: Address = Address("DAGSTARDUSTCOLLECTIVEHZOIPHXZUBFGNXWJETZVSPAPAHMLXS")
+  val lockedAddresses: Set[Address] = Set(
+    Address("DAG0qgcEbMk8vQL6VrnbhMreNeEFXk12v1BvERCb"),
+    Address("DAG2KQrN97LpA5gRerJAQ5mDuy6kjC2dDtMr58fe")
+  )
 
   def make[F[_]: Async, T <: Transaction](
     signedValidator: SignedValidator[F]
   ): TransactionValidator[F, T] =
     new TransactionValidator[F, T] {
-
-      val lockedAddresses: Set[Address] = Set(
-        Address("DAG0qgcEbMk8vQL6VrnbhMreNeEFXk12v1BvERCb"),
-        Address("DAG2KQrN97LpA5gRerJAQ5mDuy6kjC2dDtMr58fe")
-      )
-
       def validate(
         signedTransaction: Signed[T]
       ): F[TransactionValidationErrorOr[Signed[T]]] =


### PR DESCRIPTION
UPDATE 2: The only effective change for this PR will be to introduce a new rewards distribution. The majority of the other changes described below will be in a follow-up release.

We're also adding the _Stardust Primary_ address to the set of locked addresses.

UPDATE: As per Ryle's comment we recalculated the expected Epoch to be `1352274` rather than using the computation below.

Calculation for the added `EpochProgress` is based on the recently added epoch progress value of `1349352` estimated to happen on July 1st, 10am UTC. Using the _1 snapshopt / minute_ guideline,
```
scala> val July1st = Instant.parse("2023-07-01T10:00:00Z")
val July1st: java.time.Instant = 2023-07-01T10:00:00Z

scala> val July10th = Instant.parse("2023-07-10T10:00:00Z")
val July10th: java.time.Instant = 2023-07-10T10:00:00Z

scala> ChronoUnit.MINUTES.between(July1st, July10th)
val res0: Long = 12960

scala> 1336392L + 22000 // We increased to 22,000 because EpochProgress seems to be increasing faster than expected
val res1: Long = 1358392
```