### PR TITLE
One-time reward transfer to new Stardust Primary

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/config/types.scala
+++ b/modules/core/src/main/scala/org/tessellation/config/types.scala
@@ -68,7 +68,11 @@ object types {
   case class RewardsConfig(
     programs: EpochProgress => ProgramsDistributionConfig = mainnetProgramsDistributionConfig,
     rewardsPerEpoch: SortedMap[EpochProgress, Amount] = mainnetRewardsPerEpoch,
-    oneTimeRewards: List[OneTimeReward] = List.empty
+    oneTimeRewards: List[OneTimeReward] = List(
+      // Transferring final balance of 4,343,029,488,479,231 from DAGSTARDUSTCOLLECTIVEHZOIPHXZUBFGNXWJETZVSPAPAHMLXS
+      // as of the last minting it received awards (Epoch 1352274)
+      OneTimeReward(EpochProgress(1353745L), stardustNewPrimary, TransactionAmount(4_343_029_488_479_231L))
+    )
   )
 
   object RewardsConfig {

--- a/modules/core/src/main/scala/org/tessellation/http/routes/DagRoutes.scala
+++ b/modules/core/src/main/scala/org/tessellation/http/routes/DagRoutes.scala
@@ -32,7 +32,7 @@ final case class DagRoutes[F[_]: Async](dagService: DAGService[F], mkDagCell: L0
         }
 
     case GET -> Root / "total-supply" =>
-      dagService.getTotalSupply.flatMap {
+      dagService.getFilteredOutTotalSupply.flatMap {
         case Some((supply, ordinal)) =>
           Ok(("total" ->> supply) :: ("ordinal" ->> ordinal.value.value) :: HNil)
         case _ => NotFound()

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/domain/transaction/TransactionValidator.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/domain/transaction/TransactionValidator.scala
@@ -25,7 +25,8 @@ object TransactionValidator {
   val stardustPrimary: Address = Address("DAGSTARDUSTCOLLECTIVEHZOIPHXZUBFGNXWJETZVSPAPAHMLXS")
   val lockedAddresses: Set[Address] = Set(
     Address("DAG0qgcEbMk8vQL6VrnbhMreNeEFXk12v1BvERCb"),
-    Address("DAG2KQrN97LpA5gRerJAQ5mDuy6kjC2dDtMr58fe")
+    Address("DAG2KQrN97LpA5gRerJAQ5mDuy6kjC2dDtMr58fe"),
+    stardustPrimary
   )
 
   def make[F[_]: Async, T <: Transaction](


### PR DESCRIPTION
Transfer old stardust primary balance to new address
Add old stardust primary to locked addresses set
Exclude locked addresses from `total-supply` endpoint

Note that the balance shown in [DAG Explorer for `DAGSTARDUSTCOLLECTIVEHZOIPHXZUBFGNXWJETZVSPAPAHMLXS`](https://mainnet.dagexplorer.io/address/DAGSTARDUSTCOLLECTIVEHZOIPHXZUBFGNXWJETZVSPAPAHMLXS)
is `43,430,294.88479231 DAG`. The balance transferred in this PR is the value taken from the global snapshot `4343029488479231`, which is the same value with the decimal point moved eight places to the right.