### PR TITLE
Enable global snapshot processing if Data is enabled

### DIFF
--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -224,6 +224,7 @@ abstract class CurrencyL1App(
             storages.lastSnapshot
           )
           .merge(globalL0PeerDiscovery)
+          .merge(stateChannel.globalSnapshotProcessing)
           .compile
           .drain
           .handleErrorWith { error =>

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/StateChannel.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/StateChannel.scala
@@ -216,7 +216,7 @@ class StateChannel[
       )
     }
 
-  private val globalSnapshotProcessing: Stream[F, Unit] = Stream
+  val globalSnapshotProcessing: Stream[F, Unit] = Stream
     .awakeEvery(10.seconds)
     .evalMap(_ => services.globalL0.pullGlobalSnapshots)
     .evalTap { snapshots =>


### PR DESCRIPTION
@marcinwadon @IPadawans if fixes custom endpoints because previously Currency L1 was not syncing with Global L0 if Data was enabled