### PR TITLE
Add json with brotli compression serializer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,7 @@ lazy val shared = (project in file("modules/shared"))
       Libraries.bc,
       Libraries.bcExtensions,
       Libraries.betterFiles,
+      Libraries.brotli4j,
       Libraries.cats,
       Libraries.catsEffect,
       Libraries.chill,

--- a/modules/core/src/test/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -12,6 +12,8 @@ import cats.syntax.validated._
 import scala.collection.immutable.SortedMap
 
 import org.tessellation.currency.schema.currency._
+import org.tessellation.ext.cats.effect.ResourceIO
+import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
@@ -33,50 +35,56 @@ import eu.timepit.refined.auto._
 import weaver.MutableIOSuite
 object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
 
-  type Res = (KryoSerializer[IO], SecurityProvider[IO])
+  type Res = (KryoSerializer[IO], SecurityProvider[IO], JsonBrotliBinarySerializer[IO])
 
   override def sharedResource: Resource[IO, GlobalSnapshotStateChannelEventsProcessorSuite.Res] =
-    KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { ks =>
-      SecurityProvider.forAsync[IO].map((ks, _))
-    }
+    for {
+      ks <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
+      sp <- SecurityProvider.forAsync[IO]
+      serializer <- JsonBrotliBinarySerializer.make[IO]().asResource
+    } yield (ks, sp, serializer)
 
   def mkProcessor(
     stateChannelAllowanceLists: Map[Address, NonEmptySet[PeerId]],
     failed: Option[(Address, StateChannelValidator.StateChannelValidationError)] = None
-  )(implicit K: KryoSerializer[IO], S: SecurityProvider[IO]) = {
-    val validator = new StateChannelValidator[IO] {
-      def validate(output: StateChannelOutput) =
-        IO.pure(failed.filter(f => f._1 == output.address).map(_._2.invalidNec).getOrElse(output.validNec))
-      def validateHistorical(output: StateChannelOutput) = validate(output)
-    }
-    val validators = SdkValidators.make[IO](None, None, Some(stateChannelAllowanceLists))
-    val currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
-      BlockAcceptanceManager.make[IO](validators.currencyBlockValidator),
-      Amount(0L)
-    )
-    val creator = CurrencySnapshotCreator.make[IO](currencySnapshotAcceptanceManager, None)
-    val currencySnapshotValidator = CurrencySnapshotValidator.make[IO](creator, validators.signedValidator, None, None)
-    val currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
-    val manager = new GlobalSnapshotStateChannelAcceptanceManager[IO] {
-      def accept(ordinal: SnapshotOrdinal, lastGlobalSnapshotInfo: GlobalSnapshotInfo, events: List[StateChannelOutput]): IO[
-        (
-          SortedMap[Address, NonEmptyList[Signed[StateChannelSnapshotBinary]]],
-          Set[StateChannelOutput]
-        )
-      ] = IO.pure((events.groupByNel(_.address).map { case (k, v) => k -> v.map(_.snapshotBinary) }, Set.empty))
-    }
-    GlobalSnapshotStateChannelEventsProcessor.make[IO](validator, manager, currencySnapshotContextFns)
-  }
+  )(implicit K: KryoSerializer[IO], S: SecurityProvider[IO]) =
+    for {
+      _ <- IO.unit
+      validator = new StateChannelValidator[IO] {
+        def validate(output: StateChannelOutput) =
+          IO.pure(failed.filter(f => f._1 == output.address).map(_._2.invalidNec).getOrElse(output.validNec))
+        def validateHistorical(output: StateChannelOutput) = validate(output)
+      }
+      validators = SdkValidators.make[IO](None, None, Some(stateChannelAllowanceLists))
+      currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
+        BlockAcceptanceManager.make[IO](validators.currencyBlockValidator),
+        Amount(0L)
+      )
+      creator = CurrencySnapshotCreator.make[IO](currencySnapshotAcceptanceManager, None)
+      currencySnapshotValidator = CurrencySnapshotValidator.make[IO](creator, validators.signedValidator, None, None)
+      currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
+      manager = new GlobalSnapshotStateChannelAcceptanceManager[IO] {
+        def accept(ordinal: SnapshotOrdinal, lastGlobalSnapshotInfo: GlobalSnapshotInfo, events: List[StateChannelOutput]): IO[
+          (
+            SortedMap[Address, NonEmptyList[Signed[StateChannelSnapshotBinary]]],
+            Set[StateChannelOutput]
+          )
+        ] = IO.pure((events.groupByNel(_.address).map { case (k, v) => k -> v.map(_.snapshotBinary) }, Set.empty))
+      }
+      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.make()
+      processor = GlobalSnapshotStateChannelEventsProcessor
+        .make[IO](validator, manager, currencySnapshotContextFns, jsonBrotliBinarySerializer)
+    } yield processor
 
   test("return new sc event") { res =>
-    implicit val (kryo, sp) = res
+    implicit val (kryo, sp, serializer) = res
 
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       address = keyPair.getPublic().toAddress
-      output <- mkStateChannelOutput(keyPair)
+      output <- mkStateChannelOutput(keyPair, serializer = serializer)
       snapshotInfo = mkGlobalSnapshotInfo()
-      service = mkProcessor(Map(address -> output.snapshotBinary.proofs.map(_.id.toPeerId)))
+      service <- mkProcessor(Map(address -> output.snapshotBinary.proofs.map(_.id.toPeerId)))
       expected = (
         SortedMap((address, NonEmptyList.one(output.snapshotBinary))),
         SortedMap.empty[Address, (Option[Signed[CurrencyIncrementalSnapshot]], CurrencySnapshotInfo)],
@@ -88,17 +96,17 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
   }
 
   test("return sc events for different addresses") { res =>
-    implicit val (kryo, sp) = res
+    implicit val (kryo, sp, serializer) = res
 
     for {
       keyPair1 <- KeyPairGenerator.makeKeyPair[IO]
       address1 = keyPair1.getPublic().toAddress
-      output1 <- mkStateChannelOutput(keyPair1)
+      output1 <- mkStateChannelOutput(keyPair1, serializer = serializer)
       keyPair2 <- KeyPairGenerator.makeKeyPair[IO]
       address2 = keyPair2.getPublic().toAddress
-      output2 <- mkStateChannelOutput(keyPair2)
+      output2 <- mkStateChannelOutput(keyPair2, serializer = serializer)
       snapshotInfo = mkGlobalSnapshotInfo()
-      service = mkProcessor(
+      service <- mkProcessor(
         Map(address1 -> output1.snapshotBinary.proofs.map(_.id.toPeerId), address2 -> output2.snapshotBinary.proofs.map(_.id.toPeerId))
       )
       expected = (
@@ -112,17 +120,17 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
   }
 
   test("return only valid sc events") { res =>
-    implicit val (kryo, sp) = res
+    implicit val (kryo, sp, serializer) = res
 
     for {
       keyPair1 <- KeyPairGenerator.makeKeyPair[IO]
       address1 = keyPair1.getPublic().toAddress
-      output1 <- mkStateChannelOutput(keyPair1)
+      output1 <- mkStateChannelOutput(keyPair1, serializer = serializer)
       keyPair2 <- KeyPairGenerator.makeKeyPair[IO]
       address2 = keyPair2.getPublic().toAddress
-      output2 <- mkStateChannelOutput(keyPair2)
+      output2 <- mkStateChannelOutput(keyPair2, serializer = serializer)
       snapshotInfo = mkGlobalSnapshotInfo()
-      service = mkProcessor(
+      service <- mkProcessor(
         Map(address1 -> output1.snapshotBinary.proofs.map(_.id.toPeerId), address2 -> output2.snapshotBinary.proofs.map(_.id.toPeerId)),
         Some(address1 -> StateChannelValidator.NotSignedExclusivelyByStateChannelOwner)
       )
@@ -136,9 +144,13 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
 
   }
 
-  def mkStateChannelOutput(keyPair: KeyPair, hash: Option[Hash] = None)(implicit S: SecurityProvider[IO], K: KryoSerializer[IO]) = for {
+  def mkStateChannelOutput(keyPair: KeyPair, hash: Option[Hash] = None, serializer: JsonBrotliBinarySerializer[IO])(
+    implicit S: SecurityProvider[IO],
+    K: KryoSerializer[IO]
+  ) = for {
     content <- Random.scalaUtilRandom[IO].flatMap(_.nextString(10))
-    binary <- StateChannelSnapshotBinary(hash.getOrElse(Hash.empty), content.getBytes, SnapshotFee.MinValue).pure[IO]
+    compressedBytes <- serializer.serialize(content)
+    binary <- StateChannelSnapshotBinary(hash.getOrElse(Hash.empty), compressedBytes, SnapshotFee.MinValue).pure[IO]
     signedSC <- forAsyncKryo(binary, keyPair)
   } yield StateChannelOutput(keyPair.getPublic.toAddress, signedSC)
 

--- a/modules/core/src/test/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -15,6 +15,7 @@ import scala.collection.immutable.{SortedMap, SortedSet}
 import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.ext.cats.syntax.next._
 import org.tessellation.infrastructure.snapshot._
+import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema._
 import org.tessellation.schema.address.Address
@@ -170,8 +171,9 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
     val currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
     for {
       stateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L))
+      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.make()
       stateChannelProcessor = GlobalSnapshotStateChannelEventsProcessor
-        .make[IO](stateChannelValidator, stateChannelManager, currencySnapshotContextFns)
+        .make[IO](stateChannelValidator, stateChannelManager, currencySnapshotContextFns, jsonBrotliBinarySerializer)
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make[IO](blockAcceptanceManager, stateChannelProcessor, Amount.empty)
       snapshotContextFunctions = GlobalSnapshotContextFunctions.make[IO](snapshotAcceptanceManager)
     } yield GlobalSnapshotTraverse.make[IO](loadGlobalIncrementalSnapshot, loadGlobalSnapshot, snapshotContextFunctions, rollbackHash)

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Services.scala
@@ -16,6 +16,7 @@ import org.tessellation.currency.l0.node.L0NodeContext
 import org.tessellation.currency.l0.snapshot.services.StateChannelSnapshotService
 import org.tessellation.currency.l0.snapshot.{CurrencySnapshotConsensus, CurrencySnapshotEvent}
 import org.tessellation.currency.schema.currency._
+import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.sdk.domain.cluster.services.{Cluster, Session}
@@ -54,6 +55,7 @@ object Services {
     maybeMajorityPeerIds: Option[NonEmptySet[PeerId]]
   ): F[Services[F]] =
     for {
+      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.make[F]()
       stateChannelSnapshotService <- StateChannelSnapshotService
         .make[F](
           keyPair,
@@ -61,7 +63,8 @@ object Services {
           p2PClient.stateChannelSnapshot,
           storages.globalL0Cluster,
           storages.snapshot,
-          storages.identifier
+          storages.identifier,
+          jsonBrotliBinarySerializer
         )
         .pure[F]
 

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -26,6 +26,7 @@ import org.tessellation.dag.l1.modules.{
 import org.tessellation.dag.l1.{DagL1KryoRegistrationIdRange, StateChannel, dagL1KryoRegistrar}
 import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.ext.kryo.{KryoRegistrationId, MapRegistrationId}
+import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.schema.cluster.ClusterId
 import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.node.NodeState.SessionStarted
@@ -105,6 +106,7 @@ abstract class CurrencyL1App(
           dataApplication,
           maybeMajorityPeerIds
         )
+      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.make[IO]().asResource
       snapshotProcessor = CurrencySnapshotProcessor.make(
         method.identifier,
         storages.address,
@@ -113,7 +115,8 @@ abstract class CurrencyL1App(
         storages.lastSnapshot,
         storages.transaction,
         sdkServices.globalSnapshotContextFns,
-        sdkServices.currencySnapshotContextFns
+        sdkServices.currencySnapshotContextFns,
+        jsonBrotliBinarySerializer
       )
       programs = Programs
         .make[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](

--- a/modules/dag-l1/src/test/scala/org/tessellation/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/org/tessellation/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -21,6 +21,7 @@ import org.tessellation.dag.l1.domain.transaction.TransactionStorage.{Accepted, 
 import org.tessellation.dag.transaction.TransactionGenerator
 import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.ext.collection.MapRefUtils._
+import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.{Amount, Balance}
@@ -90,10 +91,16 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
             currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
             globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L)).asResource
+            jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.make[IO]().asResource
             globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
               BlockAcceptanceManager.make[IO](validators.blockValidator),
               GlobalSnapshotStateChannelEventsProcessor
-                .make[IO](validators.stateChannelValidator, globalSnapshotStateChannelManager, currencySnapshotContextFns),
+                .make[IO](
+                  validators.stateChannelValidator,
+                  globalSnapshotStateChannelManager,
+                  currencySnapshotContextFns,
+                  jsonBrotliBinarySerializer
+                ),
               Amount(0L)
             )
             globalSnapshotContextFns = GlobalSnapshotContextFunctions.make[IO](globalSnapshotAcceptanceManager)

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/modules/SdkServices.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/modules/SdkServices.scala
@@ -9,6 +9,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 
 import org.tessellation.cli.AppEnvironment
+import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.generation.Generation
@@ -86,10 +87,16 @@ object SdkServices {
         currencySnapshotValidator
       )
       globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make(stateChannelAllowanceLists)
+      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.make()
       globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
         BlockAcceptanceManager.make[F](validators.blockValidator),
         GlobalSnapshotStateChannelEventsProcessor
-          .make[F](validators.stateChannelValidator, globalSnapshotStateChannelManager, currencySnapshotContextFns),
+          .make[F](
+            validators.stateChannelValidator,
+            globalSnapshotStateChannelManager,
+            currencySnapshotContextFns,
+            jsonBrotliBinarySerializer
+          ),
         collateral.amount
       )
       globalSnapshotContextFns = GlobalSnapshotContextFunctions.make(globalSnapshotAcceptanceManager)

--- a/modules/shared/src/main/scala/org/tessellation/json/JsonBrotliBinarySerializer.scala
+++ b/modules/shared/src/main/scala/org/tessellation/json/JsonBrotliBinarySerializer.scala
@@ -1,0 +1,36 @@
+package org.tessellation.json
+
+import cats.effect.kernel.Sync
+import cats.syntax.functor._
+
+import com.aayushatharva.brotli4j.Brotli4jLoader
+import com.aayushatharva.brotli4j.decoder.{Decoder => BrotliDecoder}
+import com.aayushatharva.brotli4j.encoder.Encoder.Parameters
+import com.aayushatharva.brotli4j.encoder.{Encoder => BrotliEncoder}
+import io.circe.jawn.JawnParser
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
+
+trait JsonBrotliBinarySerializer[F[_]] {
+  def serialize[A: Encoder](content: A): F[Array[Byte]]
+  def deserialize[A: Decoder](content: Array[Byte]): F[Either[Throwable, A]]
+}
+
+object JsonBrotliBinarySerializer {
+  private val compressionLevel = 2
+
+  def make[F[_]: Sync](): F[JsonBrotliBinarySerializer[F]] =
+    Sync[F].delay(Brotli4jLoader.ensureAvailability()).map { _ =>
+      new JsonBrotliBinarySerializer[F] {
+        def serialize[A: Encoder](content: A): F[Array[Byte]] = {
+          val params = new Parameters().setQuality(compressionLevel)
+          Sync[F].delay(BrotliEncoder.compress(content.asJson.noSpaces.getBytes("UTF-8"), params))
+        }
+
+        def deserialize[A: Decoder](content: Array[Byte]): F[Either[Throwable, A]] =
+          Sync[F]
+            .delay(BrotliDecoder.decompress(content).getDecompressedData)
+            .map(JawnParser(false).decodeByteArray[A](_))
+      }
+    }
+}

--- a/modules/shared/src/test/scala/org/tessellation/json/JsonBinarySerializerSuite.scala
+++ b/modules/shared/src/test/scala/org/tessellation/json/JsonBinarySerializerSuite.scala
@@ -45,7 +45,7 @@ object JsonBinarySerializerSuite extends MutableIOSuite {
     }
   }
 
-  private def currencyIncrementalSnapshot[F[_]: MonadThrow: KryoSerializer](
+  private[json] def currencyIncrementalSnapshot[F[_]: MonadThrow: KryoSerializer](
     hash: Hash,
     currencySnapshotInfo: CurrencySnapshotInfo
   ): F[Signed[CurrencyIncrementalSnapshot]] =

--- a/modules/shared/src/test/scala/org/tessellation/json/JsonBrotliBinarySerializerSuite.scala
+++ b/modules/shared/src/test/scala/org/tessellation/json/JsonBrotliBinarySerializerSuite.scala
@@ -1,0 +1,50 @@
+package org.tessellation.json
+
+import cats.effect.{IO, Resource}
+
+import scala.collection.immutable.SortedMap
+
+import org.tessellation.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshot, CurrencySnapshotInfo}
+import org.tessellation.ext.cats.effect.ResourceIO
+import org.tessellation.kryo.KryoSerializer
+import org.tessellation.schema._
+import org.tessellation.security.hash.Hash
+import org.tessellation.security.signature.Signed
+import org.tessellation.shared.sharedKryoRegistrar
+
+import eu.timepit.refined.auto._
+import weaver.MutableIOSuite
+
+object JsonBrotliBinarySerializerSuite extends MutableIOSuite {
+
+  type Res = (KryoSerializer[IO], JsonBrotliBinarySerializer[IO])
+
+  override def sharedResource: Resource[IO, Res] =
+    KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { kp =>
+      JsonBrotliBinarySerializer.make[IO]().asResource.map((kp, _))
+    }
+
+  test("should deserialize properly serialized object") {
+    case (kryo, serializer) =>
+      implicit val kp = kryo
+
+      for {
+        signedSnapshot <- JsonBinarySerializerSuite
+          .currencyIncrementalSnapshot[IO](Hash.empty, CurrencySnapshotInfo(SortedMap.empty, SortedMap.empty))
+        serialized <- serializer.serialize(signedSnapshot)
+        deserialized <- serializer.deserialize[Signed[CurrencyIncrementalSnapshot]](serialized)
+      } yield expect.same(Right(signedSnapshot), deserialized)
+  }
+
+  test("should not deserialize different serialized object") {
+    case (kryo, serializer) =>
+      implicit val kp = kryo
+
+      for {
+        signedSnapshot <- JsonBinarySerializerSuite
+          .currencyIncrementalSnapshot[IO](Hash.empty, CurrencySnapshotInfo(SortedMap.empty, SortedMap.empty))
+        serialized <- serializer.serialize(signedSnapshot)
+        deserialized <- serializer.deserialize[CurrencySnapshot](serialized)
+      } yield expect.same(true, deserialized.isLeft)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,8 @@ object Dependencies {
 
     val betterFiles = "com.github.pathikrit" %% "better-files" % V.betterFiles
 
+    val brotli4j = "com.aayushatharva.brotli4j" % "brotli4j" % "1.12.0"
+
     val cats = "org.typelevel" %% "cats-core" % V.cats
     val catsEffect = "org.typelevel" %% "cats-effect" % V.catsEffect
     val catsEffectTestkit = "org.typelevel" %% "cats-effect-testkit" % V.catsEffect


### PR DESCRIPTION
A PR introducing the compression for metagraph snapshot binary. Here the implementation with Brotli algorithm. There is a second PR built on top of this one changing the compression algorithm to Gzip.

The reason there is a second one is that there is one caveat with Brotli in java.
The library used in this PR namely brotli4j (https://github.com/hyperxpro/Brotli4j) is the only one I found providing encoding/compressing functionality with Brotli. The way it works though is by using native brotli implementation provided by the host platform and by using JNI (Java Native Interface). The implementation works on macOS for sure and is tested by the library owner on other platforms like Ubuntu 18.04 or Windows Server 2022. We could run some cross platform test with GitHub Actions to check the compatibility with selected platforms and if the compatibility looks widespread enough we could go with this implementation I think. If the compatibility is not sufficient we can go with Gzip (I would then locally squash both commits into one and then merge a single commit).

In general Brotli is much more performant than Gzip, with compression time being much lower and ratio being higher. So from the performance point of view it's better to use Brotli given that it seems widely supported in other popular programming languages. The only question is if it's safe and compatible to a sufficient degree with mutliple platforms to use it.