### PR TITLE
PROT-104: Change env to Mainnet in GlobalSnapshotConsensusFunctionsSuite

### DIFF
--- a/modules/core/src/main/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -8,7 +8,6 @@ import cats.effect.std.{Random, Supervisor}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
-import org.tessellation.cli.AppEnvironment
 import org.tessellation.json.JsonBrotliBinarySerializer
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.schema.address.Address
@@ -53,7 +52,6 @@ object GlobalSnapshotConsensus {
     validators: SdkValidators[F],
     sdkServices: SdkServices[F],
     snapshotConfig: SnapshotConfig,
-    environment: AppEnvironment,
     stateChannelPullDelay: NonNegLong,
     stateChannelPurgeDelay: NonNegLong,
     stateChannelAllowanceLists: Option[Map[Address, NonEmptySet[PeerId]]],
@@ -82,8 +80,7 @@ object GlobalSnapshotConsensus {
           globalSnapshotStorage,
           snapshotAcceptanceManager,
           collateral,
-          rewards,
-          environment
+          rewards
         ),
         gossip,
         selfId,

--- a/modules/core/src/main/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotConsensusFunctions.scala
+++ b/modules/core/src/main/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotConsensusFunctions.scala
@@ -11,8 +11,6 @@ import cats.syntax.order._
 
 import scala.collection.immutable.SortedMap
 
-import org.tessellation.cli.AppEnvironment
-import org.tessellation.cli.AppEnvironment.Mainnet
 import org.tessellation.ext.cats.syntax.next._
 import org.tessellation.ext.crypto._
 import org.tessellation.kryo.KryoSerializer
@@ -48,8 +46,7 @@ object GlobalSnapshotConsensusFunctions {
     globalSnapshotStorage: SnapshotStorage[F, GlobalSnapshotArtifact, GlobalSnapshotContext],
     globalSnapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[F],
     collateral: Amount,
-    rewards: Rewards[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotEvent],
-    environment: AppEnvironment
+    rewards: Rewards[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotEvent]
   ): GlobalSnapshotConsensusFunctions[F] = new GlobalSnapshotConsensusFunctions[F] {
 
     private val logger = Slf4jLogger.getLoggerFromClass(GlobalSnapshotConsensusFunctions.getClass)
@@ -94,9 +91,9 @@ object GlobalSnapshotConsensusFunctions {
       trigger: ConsensusTrigger,
       events: Set[GlobalSnapshotEvent]
     ): F[(GlobalSnapshotArtifact, GlobalSnapshotContext, Set[GlobalSnapshotEvent])] = {
-      val (scEvents: List[StateChannelEvent], dagEvents: List[DAGEvent]) = events.filter { event =>
-        if (environment == Mainnet) event.isRight else true
-      }.toList.partitionMap(identity)
+
+      val (scEvents: List[StateChannelEvent], dagEvents: List[DAGEvent]) =
+        events.toList.partitionMap(identity)
 
       val blocksForAcceptance = dagEvents
         .filter(_.height > lastArtifact.height)

--- a/modules/core/src/main/scala/org/tessellation/modules/Services.scala
+++ b/modules/core/src/main/scala/org/tessellation/modules/Services.scala
@@ -88,7 +88,6 @@ object Services {
           validators,
           sdkServices,
           cfg.snapshot,
-          cfg.environment,
           stateChannelPullDelay = cfg.stateChannelPullDelay,
           stateChannelPurgeDelay = cfg.stateChannelPurgeDelay,
           stateChannelAllowanceLists,

--- a/modules/core/src/test/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/core/src/test/scala/org/tessellation/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -9,7 +9,6 @@ import cats.syntax.list._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 
-import org.tessellation.cli.AppEnvironment
 import org.tessellation.currency.schema.currency.SnapshotFee
 import org.tessellation.ext.cats.syntax.next._
 import org.tessellation.kryo.KryoSerializer
@@ -113,10 +112,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
 
   def mkGlobalSnapshotConsensusFunctions()(implicit ks: KryoSerializer[IO], sp: SecurityProvider[IO], m: Metrics[IO]) = {
     val snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make[IO](bam, scProcessor, collateral)
-    GlobalSnapshotConsensusFunctions.make[IO](gss, snapshotAcceptanceManager, collateral, rewards, env)
+    GlobalSnapshotConsensusFunctions.make[IO](gss, snapshotAcceptanceManager, collateral, rewards)
   }
-
-  val env: AppEnvironment = AppEnvironment.Testnet
 
   test("validateArtifact - returns artifact for correct data") { res =>
     implicit val (_, ks, sp, m) = res


### PR DESCRIPTION
## Overview
Small cleanup of a testing flag that was used during the migration to 2.0

## Approach
- Removed hardcoded testnet definition that is no longer needed in test
- Cleaned up env param that was no longer used

## Testing
- ensured unit tests pass
- all CI checks pass

## Tickets
- closes PROT-104