### PR TITLE
fix path portability for windows

### DIFF
--- a/modules/sdk/src/test/scala/org/tessellation/sdk/infrastructure/seedlist/LoaderSuite.scala
+++ b/modules/sdk/src/test/scala/org/tessellation/sdk/infrastructure/seedlist/LoaderSuite.scala
@@ -1,5 +1,7 @@
 package org.tessellation.sdk.infrastructure.seedlist
 
+import java.nio.file.Paths
+
 import cats.effect.IO
 import cats.syntax.option._
 
@@ -34,8 +36,8 @@ object LoaderSuite extends SimpleIOSuite with Checkers {
   }
 
   test("load old-format seedlist csv") {
-    val testFileLocation = getClass.getResource("/seedlists/seedlist.1field.sample").getPath
-    val inFile = Path(testFileLocation)
+    val testFileLocation = getClass.getResource("/seedlists/seedlist.1field.sample")
+    val inFile = Path.fromNioPath(Paths.get(testFileLocation.toURI))
 
     val expected = Seq(
       mkSeedlistEntry(
@@ -60,8 +62,8 @@ object LoaderSuite extends SimpleIOSuite with Checkers {
   }
 
   test("load new-format seedlist csv") {
-    val testFileLocation = getClass.getResource("/seedlists/seedlist.4fields.sample").getPath
-    val inFile = Path(testFileLocation)
+    val testFileLocation = getClass.getResource("/seedlists/seedlist.4fields.sample")
+    val inFile = Path.fromNioPath(Paths.get(testFileLocation.toURI))
 
     val expected = Seq(
       mkSeedlistEntry(
@@ -98,8 +100,8 @@ object LoaderSuite extends SimpleIOSuite with Checkers {
   }
 
   test("load mixed-format seedlist csv") {
-    val testFileLocation = getClass.getResource("/seedlists/seedlist.mixedFields.sample").getPath
-    val inFile = Path(testFileLocation)
+    val testFileLocation = getClass.getResource("/seedlists/seedlist.mixedFields.sample")
+    val inFile = Path.fromNioPath(Paths.get(testFileLocation.toURI))
 
     val expected = Seq(
       mkSeedlistEntry(
@@ -130,8 +132,8 @@ object LoaderSuite extends SimpleIOSuite with Checkers {
   }
 
   test("load invalid-format seedlist csv") {
-    val testFileLocation = getClass.getResource("/seedlists/seedlist.invalid.sample").getPath
-    val inFile = Path(testFileLocation)
+    val testFileLocation = getClass.getResource("/seedlists/seedlist.invalid.sample")
+    val inFile = Path.fromNioPath(Paths.get(testFileLocation.toURI))
 
     for {
       loader <- Loader.make[IO].load(SeedListPath(inFile)).attempt

--- a/modules/sdk/src/test/scala/org/tessellation/sdk/infrastructure/trust/TrustRatingCsvLoaderSuite.scala
+++ b/modules/sdk/src/test/scala/org/tessellation/sdk/infrastructure/trust/TrustRatingCsvLoaderSuite.scala
@@ -1,5 +1,7 @@
 package org.tessellation.sdk.infrastructure.trust
 
+import java.nio.file.Paths
+
 import cats.effect.IO
 
 import org.tessellation.schema.peer.PeerId
@@ -13,8 +15,8 @@ import weaver.scalacheck._
 
 object TrustRatingCsvLoaderSuite extends SimpleIOSuite with Checkers {
   test("load trust ratings from csv") {
-    val testFileLocation = getClass.getResource("/ratings.sample.csv").getPath
-    val inFile = Path(testFileLocation)
+    val testFileLocation = getClass.getResource("/ratings.sample.csv")
+    val inFile = Path.fromNioPath(Paths.get(testFileLocation.toURI))
 
     val expectedRatings = List(
       "3458a688925a4bd89f2ac2c695362e44d2e0c2903bdbb41b341a4d39283b22d8c85b487bd33cc5d36dbe5e31b5b00a10a6eab802718ead4ed7192ade5a5d1941" -> -1.0,


### PR DESCRIPTION
closes #762

This is a quick-fix that took several hours of trial&error to come up.

It looks like only `Paths.get(URI)` returns a correct path that starts with the drive-letter on windows.

I could not find `Paths.get` functionality within `fs2 Paths`, nor any other method that returns the correct path. Thus using `Paths.get()`.

(This should be possibly moved into an helper/shared function to avoid the duplication. But this PR works as-is fine on windows, tests pass now.)

### General Notes

An object of the class `Path` should naturally be working on the platform. This feels like a flaw/bug in the underlying java library.