### PR TITLE
Add allowance list for Testnet and IntegrationNet

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/cli/method.scala
@@ -1,6 +1,8 @@
 package org.tessellation.currency.l0.cli
 
+import cats.data.NonEmptySet
 import cats.syntax.contravariantSemigroupal._
+import cats.syntax.option._
 
 import scala.concurrent.duration._
 
@@ -13,7 +15,7 @@ import org.tessellation.ext.decline.WithOpts
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.node.NodeState
-import org.tessellation.schema.peer.L0Peer
+import org.tessellation.schema.peer.{L0Peer, PeerId}
 import org.tessellation.sdk.cli._
 import org.tessellation.sdk.cli.opts.{genesisPathOpts, trustRatingsPathOpts}
 import org.tessellation.sdk.config.types._
@@ -66,9 +68,32 @@ object method {
 
     val stateAfterJoining: NodeState = NodeState.WaitingForDownload
 
-    val stateChannelAllowanceLists = None
+    val stateChannelAllowanceLists: Option[Map[Address, NonEmptySet[PeerId]]] = environment match {
+      case AppEnvironment.Dev     => None
+      case AppEnvironment.Mainnet => None
 
-    val l0SeedlistPath = None
+      case AppEnvironment.Testnet =>
+        makeStateChannelAllowance(
+          Address("DAG8gMagrwoJ4nAMjbGx17WB5D6nqBEPZYChc3zH"),
+          NonEmptySet.of(
+            "1ec3c11867e3cd984a31db77e053c4105c78115ae604503fd9b0ef03399efd41464ac6efdf54cb3cdaa480be5262e7bd3fd2e1b6cc6bdc6dc3cee94f31c90856",
+            "1f1494da3bf0fdf70faff3fd21cebcd322b2b4d0abc5107924a0a70239afe12c480c9ca9f70ec125bee15781e93310f2a5d726c0f26b287785d009ef93bcaa77",
+            "3fd28a8c11a56434b1806abc8f244a0db8896f3eb53951a9712a9e7085af88097290ef8169752b21a0f62f7ae4c5002db9cb46ba791a3253caf41cfa9cb3135a"
+          )
+        ).some
+
+      case AppEnvironment.Integrationnet =>
+        makeStateChannelAllowance(
+          Address("DAG5kfY9GoHF1CYaY8tuRJxmB3JSzAEARJEAkA2C"),
+          NonEmptySet.of(
+            "a2496d09b7325f7e96d0f774c8fd45670779ec0614b672db23d2cf8342c13aaa6a64146996f8aed365eb12412c9b39f2eade3e45f610464212b8f69a660271d5",
+            "49496e22cffa3314958aa12fc16c658ce5ed0a8da032823a6100c39d7ef5198221888350c1d40cd35c8892d779e9d50b4c8a0f542168c6a586967b1c6dd5b153",
+            "d741b547225b6ba6f1ba38be192ab7550b7610ef54e7fee88a9666b79a12a6741d1565241fba5c2a812be66edd878824f927a42430ffba48fa0bd0264a5483bf"
+          )
+        ).some
+    }
+
+    val l0SeedlistPath: Option[SeedListPath] = None
 
   }
 

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
@@ -1,6 +1,8 @@
 package org.tessellation.currency.l1.cli
 
+import cats.data.NonEmptySet
 import cats.syntax.contravariantSemigroupal._
+import cats.syntax.option._
 
 import scala.concurrent.duration.{DurationDouble, DurationInt}
 
@@ -13,7 +15,7 @@ import org.tessellation.dag.l1.domain.consensus.block.config.ConsensusConfig
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.node.NodeState
-import org.tessellation.schema.peer.L0Peer
+import org.tessellation.schema.peer.{L0Peer, PeerId}
 import org.tessellation.sdk.cli.opts.trustRatingsPathOpts
 import org.tessellation.sdk.cli.{CliMethod, CollateralAmountOpts, L0PeerOpts}
 import org.tessellation.sdk.config.types._
@@ -63,9 +65,32 @@ object method {
       collateral = collateralConfig(environment, collateralAmount)
     )
 
-    val stateChannelAllowanceLists = None
+    val stateChannelAllowanceLists: Option[Map[Address, NonEmptySet[PeerId]]] = environment match {
+      case AppEnvironment.Dev     => None
+      case AppEnvironment.Mainnet => None
 
-    val l0SeedlistPath = None
+      case AppEnvironment.Testnet =>
+        makeStateChannelAllowance(
+          Address("DAG8gMagrwoJ4nAMjbGx17WB5D6nqBEPZYChc3zH"),
+          NonEmptySet.of(
+            "d894a728b3c347ea46828eba3f4f69153522cf7c8429656ac736ac38856fd2fcb440803050ac5db90a4255c9d1deddbd42585768806538ea7504e068785c95b9",
+            "c43491168699803ce36649da2b6862249a8f5e8bb7702596dcfbd29228867ecfa35663a067610cce3bc7cc624e617c7c765a0131690a439827655ad88ff4c010",
+            "b907307a13b8c2ba6ebbf5b561cbd39bcf3c2aad83ee691c60038d8e62471066ca5c9853ff996be6750f0a848aa98dfe6c9a032c4a951a24884ebcce598f896a"
+          )
+        ).some
+
+      case AppEnvironment.Integrationnet =>
+        makeStateChannelAllowance(
+          Address("DAG5kfY9GoHF1CYaY8tuRJxmB3JSzAEARJEAkA2C"),
+          NonEmptySet.of(
+            "fe377cfa08f234ae87c5a4966b6fbbfd2ad12bff5b27b852c5eb0b885aeac1abfce7c580a8541df0402bd5ac968f720672864661a932f9bc5e98f6138d2f13bc",
+            "2bc01ce069fc8a23a786a2cd94e36942558d130e0898465e1742833aeb4944d8cb19dada7bfc5f56f64b838e84298436c7cb7fd22114fd8aa70b5fd8e0a7a679",
+            "50707f3fa88cbbc07a64ce274b6cbbfbed98b8c1a836efab81582332493475d27a95dd30ef822f29d862f455988a160223e835c838d24110d2a9038c1d5f4ba7"
+          )
+        ).some
+    }
+
+    val l0SeedlistPath: Option[SeedListPath] = None
 
     val prioritySeedlistPath: Option[SeedListPath]
   }

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
@@ -1,6 +1,8 @@
 package org.tessellation.dag.l1.cli
 
+import cats.data.NonEmptySet
 import cats.syntax.contravariantSemigroupal._
+import cats.syntax.option._
 
 import scala.concurrent.duration.{DurationDouble, DurationInt}
 
@@ -8,9 +10,10 @@ import org.tessellation.cli.AppEnvironment
 import org.tessellation.cli.env._
 import org.tessellation.dag.l1.config.types.AppConfig
 import org.tessellation.dag.l1.domain.consensus.block.config.ConsensusConfig
+import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.node.NodeState
-import org.tessellation.schema.peer.L0Peer
+import org.tessellation.schema.peer.{L0Peer, PeerId}
 import org.tessellation.sdk.cli.opts.trustRatingsPathOpts
 import org.tessellation.sdk.cli.{CliMethod, CollateralAmountOpts, L0PeerOpts}
 import org.tessellation.sdk.config.types._
@@ -58,9 +61,32 @@ object method {
       collateral = collateralConfig(environment, collateralAmount)
     )
 
-    val stateChannelAllowanceLists = None
+    val stateChannelAllowanceLists: Option[Map[Address, NonEmptySet[PeerId]]] = environment match {
+      case AppEnvironment.Dev     => None
+      case AppEnvironment.Mainnet => None
 
-    val l0SeedlistPath = None
+      case AppEnvironment.Testnet =>
+        makeStateChannelAllowance(
+          Address("DAG8gMagrwoJ4nAMjbGx17WB5D6nqBEPZYChc3zH"),
+          NonEmptySet.of(
+            "f88874b15da4f772bb8a76936b923b138b83e3035ea23075b88e5bf599ccbb6ca1ee818605f87f5db9bcd4782abe74fa600dbf6f81c63d98c150425e592c27fa",
+            "cf2b0795a4ed0d09b1331ae95bec954e2fe0c25962ad883e74b588e63de5cad1708140f1daf402996b50e79932bdf1e0c9519e09566437bf73ae6e99ac839024",
+            "b0ed7562a3a66ce4ba7f4fd51e0f17fb59d2c7b1dd42dd14d6f57ba47467be5f36bb80fb5999c446f87cb70b8b715311691313c9623e37fb679ccdaf3016e537"
+          )
+        ).some
+
+      case AppEnvironment.Integrationnet =>
+        makeStateChannelAllowance(
+          Address("DAG5kfY9GoHF1CYaY8tuRJxmB3JSzAEARJEAkA2C"),
+          NonEmptySet.of(
+            "197280d110642ff3af86bf846b6ca3a3b5861a0b0691cc376812d10b3ae4e7b3b0d489391e56343377e7efa13299635931961c623c1debaa49e645f31cb1ff1f",
+            "388f6a85155018075047fc197e9e0d1f0101d422c2216a9d7603eee1c3aafa080053e51c835e4a870609de8349e7d0e6e852c5a2dd1e6a3e8b51c24baa8af28f",
+            "e288f7cab826ea0c27fad7b0700171e60e96a68dcee1e7a942bc8a9950929c1c6a609d08ffc7114f17bc841e6d261972fcc862eadd08c81fe17bf99a1d9218e5"
+          )
+        ).some
+    }
+
+    val l0SeedlistPath: Option[SeedListPath] = None
 
     val prioritySeedlistPath: Option[SeedListPath]
   }

--- a/modules/sdk/src/main/scala/org/tessellation/sdk/cli/CliMethod.scala
+++ b/modules/sdk/src/main/scala/org/tessellation/sdk/cli/CliMethod.scala
@@ -14,6 +14,7 @@ import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.sdk.PriorityPeerIds
 import org.tessellation.sdk.config.types._
+import org.tessellation.security.hex.Hex
 
 import eu.timepit.refined.auto._
 import fs2.io.file.Path
@@ -101,4 +102,6 @@ trait CliMethod {
     PriorityPeerIds.get(environment)
   )
 
+  def makeStateChannelAllowance(metagraphId: Address, peerIdValues: NonEmptySet[String]): Map[Address, NonEmptySet[PeerId]] =
+    Map(metagraphId -> peerIdValues.map(s => PeerId(Hex(s))))
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-alpha.18"
+ThisBuild / version := "2.0.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-alpha.18"


### PR DESCRIPTION
Created using the following metagraph ids:

Testnet: DAG8gMagrwoJ4nAMjbGx17WB5D6nqBEPZYChc3zH
Integrationnet: DAG5kfY9GoHF1CYaY8tuRJxmB3JSzAEARJEAkA2C

and peer ids taken from

Testnet
http://34.212.38.215:7000/cluster/info for Metagraph L0
http://34.212.38.215:8000/cluster/info for Currency L1
http://34.212.38.215:9000/cluster/info for Data L1

Integrationnet
http://54.218.46.24:7000/cluster/info for Metagraph L0
http://54.218.46.24:8000/cluster/info for Currency L1
http://54.218.46.24:9000/cluster/info for Data L1