### PR TITLE
Fix rosetta publish error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "tessellation"
   )
-  .aggregate(keytool, kernel, shared, dagL0, testShared, wallet, nodeShared, dagL1, rosetta, currencyL0, currencyL1, tools, sdk)
+  .aggregate(testShared, shared, keytool, kernel, wallet, nodeShared, sdk, dagL0, dagL1, currencyL0, currencyL1, tools, rosetta)
 
 lazy val kernel = (project in file("modules/kernel"))
   .enablePlugins(AshScriptPlugin)

--- a/modules/rosetta/src/main/scala/org/tessellation/rosetta/domain/Amount.scala
+++ b/modules/rosetta/src/main/scala/org/tessellation/rosetta/domain/Amount.scala
@@ -11,15 +11,13 @@ import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
-import eu.timepit.refined.numeric.Interval.OpenClosed
-import eu.timepit.refined.numeric.{NonNegative, Positive}
+import eu.timepit.refined.numeric.{Negative, NonNegative, Positive}
 import eu.timepit.refined.predicates.all.Or
 import io.circe.refined._
 import io.estatico.newtype.macros.newtype
 
 object amount {
-  type NegatedPositive = OpenClosed[W.`Long.MinValue`.T, -1L]
-  type AmountValuePredicate = Positive Or NegatedPositive
+  type AmountValuePredicate = Positive Or Negative
   type AmountValueRefined = Long Refined AmountValuePredicate
 
   @derive(eqv, decoder, encoder, show)


### PR DESCRIPTION
When executing `publishLocal` the sbt task ends due to a scaladoc error in _rosetta_, so not all the modules are published. This PR

1. Fixes the error
2. Reorders the _aggregate_ list to closer match dependencies so the error wouldn't affect publishing of required artifacts