### PR TITLE
Inject handle to update dataUpdate queue

### DIFF
--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -149,7 +149,7 @@ abstract class CurrencyL1App(
         .start(storages, services, healthChecks)
         .asResource
 
-      implicit0(nodeContext: L1NodeContext[IO]) = L1NodeContext.make[IO](storages.lastGlobalSnapshot, storages.lastSnapshot)
+      implicit0(nodeContext: L1NodeContext[IO]) = L1NodeContext.make[IO](storages.lastGlobalSnapshot, storages.lastSnapshot, queues)
 
       api = HttpApi
         .make[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/node/L1NodeContext.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/node/L1NodeContext.scala
@@ -1,17 +1,22 @@
 package org.tessellation.currency.l1.node
 
-import org.tessellation.currency.dataApplication.L1NodeContext
+import org.tessellation.currency.dataApplication.{DataUpdate, L1NodeContext}
+import org.tessellation.currency.l1.modules.Queues
 import org.tessellation.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import org.tessellation.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import org.tessellation.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import org.tessellation.security.signature.Signed
 import org.tessellation.security.{Hashed, SecurityProvider}
 
 object L1NodeContext {
   def make[F[_]: SecurityProvider](
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
-    lastCurrencySnapshotStorage: LastSnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo]
+    lastCurrencySnapshotStorage: LastSnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
+    queues: Queues[F]
   ): L1NodeContext[F] =
     new L1NodeContext[F] {
+      def addDataUpdate(update: Signed[DataUpdate]): F[Unit] = queues.dataUpdates.offer(update)
+
       def getLastGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = lastGlobalSnapshotStorage.get
 
       def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]] = lastCurrencySnapshotStorage.get

--- a/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
@@ -94,7 +94,9 @@ trait BaseDataApplicationL0Service[F[_]] extends BaseDataApplicationService[F] w
   def onSnapshotConsensusResult(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit]
 }
 
-trait BaseDataApplicationL1Service[F[_]] extends BaseDataApplicationService[F] with BaseDataApplicationContextualOps[F, L1NodeContext[F]]
+trait BaseDataApplicationL1Service[F[_]] extends BaseDataApplicationService[F] with BaseDataApplicationContextualOps[F, L1NodeContext[F]] {
+  def addDataUpdate(update: Signed[DataUpdate])(implicit context: L1NodeContext[F]): F[Unit] = context.addDataUpdate(update)
+}
 
 trait DataApplicationService[F[_], D <: DataUpdate, DON <: DataOnChainState, DOF <: DataCalculatedState] {
   def serializeState(state: DON): F[Array[Byte]]
@@ -467,6 +469,7 @@ object dataApplication {
 }
 
 trait L1NodeContext[F[_]] {
+  def addDataUpdate(update: Signed[DataUpdate]): F[Unit]
   def getLastGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]]
   def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]]


### PR DESCRIPTION
## Purpose
For the Flight Tracker application, we need the ability to submit updates to the Data L1. This approach adds an `addDataUpdate` function into the `BaseDataApplicationL1Service` definition that is injected via the `L1NodeContext`. 

## Changes
- add `Queue[IO]` dependency into `L1NodeContext` instatiation
- add `addDataUpdate` function into `L1NodeContext` and `BaseDataApplicationL1Service`

## Testing
- dependency builds and new function is available via Data Application

## Tickets