### PR TITLE
Fix IntelliJ compile errors

### DIFF
--- a/modules/shared/src/main/scala/org/tessellation/ext/crypto.scala
+++ b/modules/shared/src/main/scala/org/tessellation/ext/crypto.scala
@@ -7,7 +7,7 @@ import org.tessellation.security.hash.Hash
 import org.tessellation.security.signature.Signed
 import org.tessellation.security.{Hashable, SecurityProvider}
 
-import _root_.cats.MonadThrow
+import _root_.cats._
 import _root_.cats.data.NonEmptyList
 import _root_.cats.effect.kernel.Async
 import _root_.cats.syntax.either._

--- a/modules/shared/src/main/scala/org/tessellation/ext/kryo.scala
+++ b/modules/shared/src/main/scala/org/tessellation/ext/kryo.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 
 import org.tessellation.kryo.KryoSerializer
 
-import _root_.cats.MonadThrow
+import _root_.cats._
 import _root_.cats.syntax.either._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
@@ -40,8 +40,8 @@ object kryo {
 
   implicit class MapRegistrationId[C1](mapa: Map[Class[_], KryoRegistrationId[C1]]) {
 
-    def union[C2](mapb: Map[Class[_], KryoRegistrationId[C2]]) =
-      mapa.view.mapValues[KryoRegistrationId[C1 Or C2]](identity).toMap ++
-        mapb.view.mapValues[KryoRegistrationId[C1 Or C2]](identity).toMap
+    def union[C2](mapb: Map[Class[_], KryoRegistrationId[C2]]): Map[Class[_], KryoRegistrationId[Or[C1, C2]]] =
+      mapa.view.mapValues[KryoRegistrationId[C1 Or C2]](c => c).toMap ++
+        mapb.view.mapValues[KryoRegistrationId[C1 Or C2]](c => c).toMap
   }
 }


### PR DESCRIPTION
This PR fixes a problem for IntelliJ users; there are no functionality changes.

For some reason I haven't been able to solve, the IDE sees usages of `.toBinaryF` and `.hashF` as errors; this is because for some reason it doesn't see `MonadThrow`. (In the kryo module it doesn't see `identity` either.) However, if we use both `MonadThrow` and `ApplicativeThrow` then they're seen. Alternatively, importing `_root_.cats._` fixes the problem so that I didn't have to change the code.

`sbt` has no problem with them but there's something about these modules that IntelliJ can't solve which causes problems during development. If anyone knows how to adjust IntelliJ w/o these changes I'd be happy to withdraw this PR.