### PR TITLE
Enrich snapshot value passed into onSnapshotConsensusResult

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
@@ -56,7 +56,9 @@ object CurrencySnapshotConsensusFunctions {
     ): F[Unit] =
       stateChannelSnapshotService.consume(signedArtifact, context) >>
         gossipForkInfo(gossip, signedArtifact) >>
-        maybeDataApplication.traverse_(_.onSnapshotConsensusResult(signedArtifact))
+        maybeDataApplication.traverse_ { da =>
+          signedArtifact.toHashed >>= da.onSnapshotConsensusResult
+        }
 
     def validateArtifact(
       lastSignedArtifact: Signed[CurrencySnapshotArtifact],

--- a/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
@@ -91,7 +91,7 @@ trait BaseDataApplicationL0Service[F[_]] extends BaseDataApplicationService[F] w
 
   final def serializedOnChainGenesis: F[Array[Byte]] = serializeState(genesis.onChain)
 
-  def onSnapshotConsensusResult(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit]
+  def onSnapshotConsensusResult(snapshot: Hashed[CurrencyIncrementalSnapshot]): F[Unit]
 }
 
 trait BaseDataApplicationL1Service[F[_]] extends BaseDataApplicationService[F] with BaseDataApplicationContextualOps[F, L1NodeContext[F]]
@@ -143,7 +143,7 @@ trait DataApplicationL0Service[F[_], D <: DataUpdate, DON <: DataOnChainState, D
     with DataApplicationContextualOps[F, D, DON, DOF, L0NodeContext[F]] {
   def genesis: DataState[DON, DOF]
 
-  def onSnapshotConsensusResult(snapshot: Signed[CurrencyIncrementalSnapshot])(implicit A: Applicative[F]): F[Unit] = A.unit
+  def onSnapshotConsensusResult(snapshot: Hashed[CurrencyIncrementalSnapshot])(implicit A: Applicative[F]): F[Unit] = A.unit
 }
 
 trait DataApplicationL1Service[F[_], D <: DataUpdate, DON <: DataOnChainState, DOF <: DataCalculatedState]
@@ -364,7 +364,7 @@ object BaseDataApplicationL0Service {
 
       def routesPrefix: ExternalUrlPrefix = base.routesPrefix
 
-      def onSnapshotConsensusResult(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit] = service.onSnapshotConsensusResult(snapshot)
+      def onSnapshotConsensusResult(snapshot: Hashed[CurrencyIncrementalSnapshot]): F[Unit] = service.onSnapshotConsensusResult(snapshot)
     }
   }
 }


### PR DESCRIPTION
## Summary
Metagraphs that utilize the `onSnapshotConsensusResult` hook may wish to interact with additional storage and third-party APIs using a reproducible hash value. By passing the `Hashed[CurrencyIncrementalSnapshot]` we retain the original functionality without any additional imports needed during the `consumeMajorityArtifact` evaluation.

While it is possible to import the required dependencies within the data application implementations and create the needed `KryoSerializer` to produce the `Hashed[_]` value locally, this is a common use-case where boilerplate infrastructure code may be simplified by incorporation into the underlying framework. 

## Changes
- modified function signature of `onSnapshotConsensusResult` to take an argument of `Hashed[CurrencyIncrementalSnapshot]` 

## Testing
** work in progress **

## Tickets
- none
