### PR TITLE
Adding new metagraph info endpoint

### DIFF
--- a/.github/assets/basic_rewards_implementation.txt
+++ b/.github/assets/basic_rewards_implementation.txt
@@ -16,6 +16,7 @@ import org.tessellation.security.SecurityProvider
 import org.tessellation.security.signature.Signed
 import eu.timepit.refined.auto._
 import cats.syntax.applicative._
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import java.util.UUID
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -25,8 +26,8 @@ object Main
     "custom-rewards-l0",
     "custom-rewards L0 node",
     ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-    tessellationVersion = BuildInfo.version,
-    metagraphVersion = BuildInfo.version
+    tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+    metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
   ) {
 
   override def rewards(implicit sp: SecurityProvider[IO]): Some[Rewards[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]] =

--- a/.github/assets/basic_rewards_implementation.txt
+++ b/.github/assets/basic_rewards_implementation.txt
@@ -25,7 +25,8 @@ object Main
     "custom-rewards-l0",
     "custom-rewards L0 node",
     ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-    version = BuildInfo.version
+    tessellationVersion = BuildInfo.version,
+    metagraphVersion = BuildInfo.version
   ) {
 
   override def rewards(implicit sp: SecurityProvider[IO]): Some[Rewards[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]] =

--- a/.github/templates/project_template/modules/l0/src/main/scala/com/my/currency/l0/Main.scala
+++ b/.github/templates/project_template/modules/l0/src/main/scala/com/my/currency/l0/Main.scala
@@ -3,6 +3,7 @@ package com.my.currency.l0
 import org.tessellation.BuildInfo
 import org.tessellation.currency.l0.CurrencyL0App
 import org.tessellation.schema.cluster.ClusterId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import java.util.UUID
 
@@ -11,6 +12,6 @@ object Main
     "custom-project-l0",
     "custom-project L0 node",
     ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-    tessellationVersion = BuildInfo.version,
-    metagraphVersion = BuildInfo.version
+    tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+    metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
   ) {}

--- a/.github/templates/project_template/modules/l0/src/main/scala/com/my/currency/l0/Main.scala
+++ b/.github/templates/project_template/modules/l0/src/main/scala/com/my/currency/l0/Main.scala
@@ -11,5 +11,6 @@ object Main
     "custom-project-l0",
     "custom-project L0 node",
     ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-    version = BuildInfo.version
+    tessellationVersion = BuildInfo.version,
+    metagraphVersion = BuildInfo.version
   ) {}

--- a/.github/templates/project_template/modules/l1/src/main/scala/com/my/currency/l1/Main.scala
+++ b/.github/templates/project_template/modules/l1/src/main/scala/com/my/currency/l1/Main.scala
@@ -10,5 +10,6 @@ object Main
       "custom-project-l1",
       "custom-project L1 node",
       ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      version = BuildInfo.version
+      tessellationVersion = BuildInfo.version,
+      metagraphVersion = BuildInfo.version
     ) {}

--- a/.github/templates/project_template/modules/l1/src/main/scala/com/my/currency/l1/Main.scala
+++ b/.github/templates/project_template/modules/l1/src/main/scala/com/my/currency/l1/Main.scala
@@ -4,12 +4,13 @@ import java.util.UUID
 import org.tessellation.BuildInfo
 import org.tessellation.currency.l1.CurrencyL1App
 import org.tessellation.schema.cluster.ClusterId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 object Main
     extends CurrencyL1App(
       "custom-project-l1",
       "custom-project L1 node",
       ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      tessellationVersion = BuildInfo.version,
-      metagraphVersion = BuildInfo.version
+      tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
     ) {}

--- a/.github/templates/project_template/project/Dependencies.scala
+++ b/.github/templates/project_template/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object V {
     //Default version of tessellation develop branch
-    val tessellation = "github-action-test-version"
+    val tessellation = "99.99.99"
     val decline = "2.4.1"
   }
   def tessellation(artifact: String): ModuleID = "org.constellation" %% s"tessellation-$artifact" % V.tessellation

--- a/.github/workflows/test-metagraph-rewards.yml
+++ b/.github/workflows/test-metagraph-rewards.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Update version.sbt to github-action-test-version
         shell: bash
         run: |
-          echo 'ThisBuild / version := "github-action-test-version"' > version.sbt
+          echo 'ThisBuild / version := "99.99.99"' > version.sbt
 
       - name: Generating Metagraph dependencies
         env:

--- a/.github/workflows/test-transactions.yml
+++ b/.github/workflows/test-transactions.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Update version.sbt to github-action-test-version
         shell: bash
         run: |
-          echo 'ThisBuild / version := "github-action-test-version"' > version.sbt
+          echo 'ThisBuild / version := "99.99.99"' > version.sbt
 
       - name: Generating Metagraph dependencies
         env:

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
@@ -3,7 +3,6 @@ package org.tessellation.currency.l0
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 
-import org.tessellation.BuildInfo
 import org.tessellation.currency.dataApplication.{BaseDataApplicationL0Service, L0NodeContext}
 import org.tessellation.currency.l0.cli.method
 import org.tessellation.currency.l0.cli.method._
@@ -30,12 +29,13 @@ abstract class CurrencyL0App(
   name: String,
   header: String,
   clusterId: ClusterId,
-  version: String
+  tessellationVersion: String,
+  metagraphVersion: String
 ) extends TessellationIOApp[Run](
       name,
       header,
       clusterId,
-      version = version
+      version = tessellationVersion
     ) {
 
   val opts: Opts[Run] = method.opts
@@ -128,9 +128,10 @@ abstract class CurrencyL0App(
           keyPair.getPrivate,
           cfg.environment,
           nodeShared.nodeId,
-          BuildInfo.version,
+          tessellationVersion,
           cfg.http,
-          services.dataApplication
+          services.dataApplication,
+          metagraphVersion.some
         )
       _ <- MkHttpServer[IO].newEmber(ServerName("public"), cfg.http.publicHttp, api.publicApp)
       _ <- MkHttpServer[IO].newEmber(ServerName("p2p"), cfg.http.p2pHttp, api.p2pApp)

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
@@ -21,6 +21,7 @@ import org.tessellation.node.shared.snapshot.currency.CurrencySnapshotEvent
 import org.tessellation.node.shared.{NodeSharedOrSharedRegistrationIdRange, nodeSharedKryoRegistrar}
 import org.tessellation.schema.cluster.ClusterId
 import org.tessellation.schema.node.NodeState
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 import org.tessellation.security.SecurityProvider
 
 import com.monovore.decline.Opts
@@ -29,8 +30,8 @@ abstract class CurrencyL0App(
   name: String,
   header: String,
   clusterId: ClusterId,
-  tessellationVersion: String,
-  metagraphVersion: String
+  tessellationVersion: TessellationVersion,
+  metagraphVersion: MetagraphVersion
 ) extends TessellationIOApp[Run](
       name,
       header,

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/Main.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/Main.scala
@@ -10,5 +10,6 @@ object Main
       "Currency-l0",
       "Currency L0 node",
       ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      version = BuildInfo.version
-    ) {}
+      tessellationVersion = BuildInfo.version,
+      metagraphVersion = ""
+    )

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/Main.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/Main.scala
@@ -4,12 +4,13 @@ import java.util.UUID
 
 import org.tessellation.BuildInfo
 import org.tessellation.schema.cluster.ClusterId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 object Main
     extends CurrencyL0App(
       "Currency-l0",
       "Currency L0 node",
       ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      tessellationVersion = BuildInfo.version,
-      metagraphVersion = ""
+      tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
     )

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/HttpApi.scala
@@ -21,6 +21,7 @@ import org.tessellation.node.shared.infrastructure.healthcheck.ping.PingHealthCh
 import org.tessellation.node.shared.infrastructure.metrics.Metrics
 import org.tessellation.schema.SnapshotOrdinal
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 import org.tessellation.security.{Hasher, SecurityProvider}
 
 import eu.timepit.refined.auto._
@@ -40,10 +41,10 @@ object HttpApi {
     privateKey: PrivateKey,
     environment: AppEnvironment,
     selfId: PeerId,
-    nodeVersion: String,
+    nodeVersion: TessellationVersion,
     httpCfg: HttpConfig,
     maybeDataApplication: Option[BaseDataApplicationL0Service[F]],
-    maybeMetagraphVersion: Option[String]
+    maybeMetagraphVersion: Option[MetagraphVersion]
   ): HttpApi[F] =
     new HttpApi[F](
       storages,
@@ -70,10 +71,10 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: KryoSerializer: Has
   privateKey: PrivateKey,
   environment: AppEnvironment,
   selfId: PeerId,
-  nodeVersion: String,
+  nodeVersion: TessellationVersion,
   httpCfg: HttpConfig,
   maybeDataApplication: Option[BaseDataApplicationL0Service[F]],
-  maybeMetagraphVersion: Option[String]
+  maybeMetagraphVersion: Option[MetagraphVersion]
 ) {
 
   private val mkCell = (event: CurrencySnapshotEvent) => L0Cell.mkL0Cell(queues.l1Output).apply(L0CellInput.HandleL1Block(event))

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -1,13 +1,13 @@
 package org.tessellation.currency.l1
 
 import cats.effect.{IO, Resource}
+import cats.implicits.catsSyntaxOptionId
 import cats.syntax.applicativeError._
 import cats.syntax.semigroupk._
 import cats.syntax.traverse._
 
 import scala.concurrent.duration._
 
-import org.tessellation.BuildInfo
 import org.tessellation.currency.dataApplication.{BaseDataApplicationL1Service, L1NodeContext}
 import org.tessellation.currency.l1.cli.method
 import org.tessellation.currency.l1.cli.method.{Run, RunInitialValidator, RunValidator}
@@ -46,12 +46,13 @@ abstract class CurrencyL1App(
   name: String,
   header: String,
   clusterId: ClusterId,
-  version: String
+  tessellationVersion: String,
+  metagraphVersion: String
 ) extends TessellationIOApp[Run](
       name,
       header,
       clusterId,
-      version = version
+      version = tessellationVersion
     ) {
 
   val opts: Opts[Run] = method.opts
@@ -161,8 +162,9 @@ abstract class CurrencyL1App(
           programs,
           healthChecks,
           nodeShared.nodeId,
-          BuildInfo.version,
-          cfg.http
+          tessellationVersion,
+          cfg.http,
+          metagraphVersion.some
         )
       _ <- MkHttpServer[IO].newEmber(ServerName("public"), cfg.http.publicHttp, api.publicApp)
       _ <- MkHttpServer[IO].newEmber(ServerName("p2p"), cfg.http.p2pHttp, api.p2pApp)

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -1,8 +1,8 @@
 package org.tessellation.currency.l1
 
 import cats.effect.{IO, Resource}
-import cats.implicits.catsSyntaxOptionId
 import cats.syntax.applicativeError._
+import cats.syntax.option._
 import cats.syntax.semigroupk._
 import cats.syntax.traverse._
 
@@ -37,6 +37,7 @@ import org.tessellation.schema.cluster.ClusterId
 import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.node.NodeState.SessionStarted
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import com.monovore.decline.Opts
 import eu.timepit.refined.boolean.Or
@@ -46,8 +47,8 @@ abstract class CurrencyL1App(
   name: String,
   header: String,
   clusterId: ClusterId,
-  tessellationVersion: String,
-  metagraphVersion: String
+  tessellationVersion: TessellationVersion,
+  metagraphVersion: MetagraphVersion
 ) extends TessellationIOApp[Run](
       name,
       header,

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/Main.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/Main.scala
@@ -7,8 +7,9 @@ import org.tessellation.schema.cluster.ClusterId
 
 object Main
     extends CurrencyL1App(
-      s"Currency-l1",
-      s"Currency L1 node",
+      "Currency-l1",
+      "Currency L1 node",
       ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      version = BuildInfo.version
+      tessellationVersion = BuildInfo.version,
+      metagraphVersion = ""
     )

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/Main.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/Main.scala
@@ -4,12 +4,13 @@ import java.util.UUID
 
 import org.tessellation.BuildInfo
 import org.tessellation.schema.cluster.ClusterId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 object Main
     extends CurrencyL1App(
       "Currency-l1",
       "Currency L1 node",
       ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      tessellationVersion = BuildInfo.version,
-      metagraphVersion = ""
+      tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
     )

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/modules/HttpApi.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/modules/HttpApi.scala
@@ -19,6 +19,7 @@ import org.tessellation.node.shared.http.routes._
 import org.tessellation.node.shared.infrastructure.healthcheck.ping.PingHealthCheckRoutes
 import org.tessellation.node.shared.infrastructure.metrics.Metrics
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 import org.tessellation.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import org.tessellation.security.{Hasher, SecurityProvider}
 
@@ -58,9 +59,9 @@ object HttpApi {
     ],
     healthchecks: HealthChecks[F],
     selfId: PeerId,
-    nodeVersion: String,
+    nodeVersion: TessellationVersion,
     httpCfg: HttpConfig,
-    maybeMetagraphVersion: Option[String]
+    maybeMetagraphVersion: Option[MetagraphVersion]
   ): HttpApi[F] =
     new HttpApi[F](
       maybeDataApplication,
@@ -88,9 +89,9 @@ sealed abstract class HttpApi[
   programs: Programs[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
   healthchecks: HealthChecks[F],
   selfId: PeerId,
-  nodeVersion: String,
+  nodeVersion: TessellationVersion,
   httpCfg: HttpConfig,
-  maybeMetagraphVersion: Option[String]
+  maybeMetagraphVersion: Option[MetagraphVersion]
 ) {
 
   private val clusterRoutes =

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/Main.scala
@@ -21,6 +21,7 @@ import org.tessellation.node.shared.resources.MkHttpServer
 import org.tessellation.node.shared.resources.MkHttpServer.ServerName
 import org.tessellation.schema.cluster.ClusterId
 import org.tessellation.schema.node.NodeState
+import org.tessellation.schema.semver.TessellationVersion
 import org.tessellation.schema.{GlobalIncrementalSnapshot, GlobalSnapshot}
 import org.tessellation.security.signature.Signed
 
@@ -31,7 +32,7 @@ object Main
     extends TessellationIOApp[Run](
       name = "dag-l0",
       header = "Tessellation Node",
-      version = BuildInfo.version,
+      version = TessellationVersion.unsafeFrom(BuildInfo.version),
       clusterId = ClusterId("6d7f1d6a-213a-4148-9d45-d7200f555ecf")
     ) {
 
@@ -117,7 +118,7 @@ object Main
           keyPair.getPrivate,
           cfg.environment,
           nodeShared.nodeId,
-          BuildInfo.version,
+          TessellationVersion.unsafeFrom(BuildInfo.version),
           cfg.http
         )
       _ <- MkHttpServer[IO].newEmber(ServerName("public"), cfg.http.publicHttp, api.publicApp)

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/HttpApi.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/HttpApi.scala
@@ -18,6 +18,7 @@ import org.tessellation.node.shared.infrastructure.healthcheck.ping.PingHealthCh
 import org.tessellation.node.shared.infrastructure.metrics.Metrics
 import org.tessellation.schema._
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.TessellationVersion
 import org.tessellation.security.signature.Signed
 import org.tessellation.security.{Hasher, SecurityProvider}
 
@@ -38,7 +39,7 @@ object HttpApi {
     privateKey: PrivateKey,
     environment: AppEnvironment,
     selfId: PeerId,
-    nodeVersion: String,
+    nodeVersion: TessellationVersion,
     httpCfg: HttpConfig
   ): HttpApi[F] =
     new HttpApi[F](
@@ -64,7 +65,7 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: KryoSerializer: Has
   privateKey: PrivateKey,
   environment: AppEnvironment,
   selfId: PeerId,
-  nodeVersion: String,
+  nodeVersion: TessellationVersion,
   httpCfg: HttpConfig
 ) {
 

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/Main.scala
@@ -19,6 +19,7 @@ import org.tessellation.node.shared.resources.MkHttpServer.ServerName
 import org.tessellation.schema.cluster.ClusterId
 import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.node.NodeState.SessionStarted
+import org.tessellation.schema.semver.TessellationVersion
 import org.tessellation.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, GlobalSnapshotStateProof}
 import org.tessellation.shared.{SharedKryoRegistrationIdRange, sharedKryoRegistrar}
 
@@ -31,7 +32,7 @@ object Main
       "dag-l1",
       "DAG L1 node",
       ClusterId("17e78993-37ea-4539-a4f3-039068ea1e92"),
-      version = BuildInfo.version
+      version = TessellationVersion.unsafeFrom(BuildInfo.version)
     ) {
   val opts: Opts[Run] = cli.method.opts
 
@@ -117,7 +118,7 @@ object Main
           programs,
           healthChecks,
           nodeShared.nodeId,
-          BuildInfo.version,
+          TessellationVersion.unsafeFrom(BuildInfo.version),
           cfg.http
         )
       _ <- MkHttpServer[IO].newEmber(ServerName("public"), cfg.http.publicHttp, api.publicApp)

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/HttpApi.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/HttpApi.scala
@@ -14,6 +14,7 @@ import org.tessellation.node.shared.http.routes._
 import org.tessellation.node.shared.infrastructure.healthcheck.ping.PingHealthCheckRoutes
 import org.tessellation.node.shared.infrastructure.metrics.Metrics
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.TessellationVersion
 import org.tessellation.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import org.tessellation.security.{Hasher, SecurityProvider}
 
@@ -37,7 +38,7 @@ object HttpApi {
     programs: Programs[F, P, S, SI],
     healthchecks: HealthChecks[F],
     selfId: PeerId,
-    nodeVersion: String,
+    nodeVersion: TessellationVersion,
     httpCfg: HttpConfig
   ): HttpApi[F, P, S, SI] =
     new HttpApi[F, P, S, SI](storages, queues, privateKey, services, programs, healthchecks, selfId, nodeVersion, httpCfg) {}
@@ -56,7 +57,7 @@ sealed abstract class HttpApi[
   programs: Programs[F, P, S, SI],
   healthchecks: HealthChecks[F],
   selfId: PeerId,
-  nodeVersion: String,
+  nodeVersion: TessellationVersion,
   httpCfg: HttpConfig
 ) {
   private val clusterRoutes =

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/app/TessellationIOApp.scala
@@ -27,6 +27,7 @@ import org.tessellation.node.shared.resources.SharedResources
 import org.tessellation.schema.cluster.ClusterId
 import org.tessellation.schema.generation.Generation
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.TessellationVersion
 import org.tessellation.security.{Hasher, SecurityProvider}
 
 import com.monovore.decline.Opts
@@ -43,12 +44,12 @@ abstract class TessellationIOApp[A <: CliMethod](
   header: String,
   clusterId: ClusterId,
   helpFlag: Boolean = true,
-  version: String = ""
+  version: TessellationVersion = TessellationVersion.unsafeFrom("0.0.1")
 ) extends CommandIOApp(
       name,
       header,
       helpFlag,
-      version
+      version.version.value
     ) {
 
   /** Command-line opts

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/http/routes/MetagraphRoutes.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/http/routes/MetagraphRoutes.scala
@@ -10,6 +10,7 @@ import org.tessellation.node.shared.domain.node.NodeStorage
 import org.tessellation.routes.internal._
 import org.tessellation.schema.node.MetagraphNodeInfo
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import eu.timepit.refined.auto._
 import org.http4s.HttpRoutes
@@ -22,8 +23,8 @@ final case class MetagraphRoutes[F[_]: Async](
   clusterStorage: ClusterStorage[F],
   httpCfg: HttpConfig,
   selfId: PeerId,
-  tessellationVersion: String,
-  metagraphVersion: String
+  tessellationVersion: TessellationVersion,
+  metagraphVersion: MetagraphVersion
 ) extends Http4sDsl[F]
     with PublicRoutes[F]
     with P2PRoutes[F] {

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/http/routes/MetagraphRoutes.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/http/routes/MetagraphRoutes.scala
@@ -1,0 +1,50 @@
+package org.tessellation.node.shared.http.routes
+
+import cats.effect.Async
+import cats.syntax.contravariantSemigroupal._
+import cats.syntax.flatMap._
+
+import org.tessellation.node.shared.config.types.HttpConfig
+import org.tessellation.node.shared.domain.cluster.storage.{ClusterStorage, SessionStorage}
+import org.tessellation.node.shared.domain.node.NodeStorage
+import org.tessellation.routes.internal._
+import org.tessellation.schema.node.MetagraphNodeInfo
+import org.tessellation.schema.peer.PeerId
+
+import eu.timepit.refined.auto._
+import org.http4s.HttpRoutes
+import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
+import org.http4s.dsl.Http4sDsl
+
+final case class MetagraphRoutes[F[_]: Async](
+  nodeStorage: NodeStorage[F],
+  sessionStorage: SessionStorage[F],
+  clusterStorage: ClusterStorage[F],
+  httpCfg: HttpConfig,
+  selfId: PeerId,
+  tessellationVersion: String,
+  metagraphVersion: String
+) extends Http4sDsl[F]
+    with PublicRoutes[F]
+    with P2PRoutes[F] {
+  protected[routes] val prefixPath: InternalUrlPrefix = "/metagraph"
+
+  protected val p2p: HttpRoutes[F] = HttpRoutes.empty
+
+  protected val public: HttpRoutes[F] = HttpRoutes.of[F] {
+    case GET -> Root / "info" =>
+      (nodeStorage.getNodeState, sessionStorage.getToken, clusterStorage.getToken).mapN { (state, session, clusterSession) =>
+        MetagraphNodeInfo(
+          state,
+          session,
+          clusterSession,
+          httpCfg.externalIp,
+          httpCfg.publicHttp.port,
+          httpCfg.p2pHttp.port,
+          selfId,
+          tessellationVersion,
+          metagraphVersion
+        )
+      }.flatMap(Ok(_))
+  }
+}

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/http/routes/NodeRoutes.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/http/routes/NodeRoutes.scala
@@ -10,6 +10,7 @@ import org.tessellation.node.shared.domain.node.NodeStorage
 import org.tessellation.routes.internal._
 import org.tessellation.schema.node.NodeInfo
 import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.semver.TessellationVersion
 
 import eu.timepit.refined.auto._
 import org.http4s.HttpRoutes
@@ -20,7 +21,7 @@ final case class NodeRoutes[F[_]: Async](
   nodeStorage: NodeStorage[F],
   sessionStorage: SessionStorage[F],
   clusterStorage: ClusterStorage[F],
-  version: String,
+  version: TessellationVersion,
   httpCfg: HttpConfig,
   selfId: PeerId
 ) extends Http4sDsl[F]
@@ -42,7 +43,16 @@ final case class NodeRoutes[F[_]: Async](
   protected val public: HttpRoutes[F] = HttpRoutes.of[F] {
     case GET -> Root / "info" =>
       (nodeStorage.getNodeState, sessionStorage.getToken, clusterStorage.getToken).mapN { (state, session, clusterSession) =>
-        NodeInfo(state, session, clusterSession, version, httpCfg.externalIp, httpCfg.publicHttp.port, httpCfg.p2pHttp.port, selfId)
+        NodeInfo(
+          state,
+          session,
+          clusterSession,
+          version.version.value,
+          httpCfg.externalIp,
+          httpCfg.publicHttp.port,
+          httpCfg.p2pHttp.port,
+          selfId
+        )
       }.flatMap(Ok(_))
 
     case GET -> Root / "state" =>

--- a/modules/shared/src/main/scala/org/tessellation/routes/internal.scala
+++ b/modules/shared/src/main/scala/org/tessellation/routes/internal.scala
@@ -66,6 +66,7 @@ object internal {
       :: Equal["/network"]
       :: Equal["/snapshots"]
       :: Equal["/global-snapshots"]
+      :: Equal["/metagraph"]
       :: HNil
   ]
 

--- a/modules/shared/src/main/scala/org/tessellation/schema/node.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/node.scala
@@ -103,4 +103,16 @@ object node {
     id: PeerId
   )
 
+  @derive(encoder)
+  case class MetagraphNodeInfo(
+    state: NodeState,
+    session: Option[SessionToken],
+    clusterSession: Option[ClusterSessionToken],
+    host: Host,
+    publicPort: Port,
+    p2pPort: Port,
+    id: PeerId,
+    tessellationVersion: String,
+    metagraphVersion: String
+  )
 }

--- a/modules/shared/src/main/scala/org/tessellation/schema/node.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/node.scala
@@ -6,6 +6,7 @@ import scala.util.Try
 
 import org.tessellation.schema.cluster.{ClusterSessionToken, SessionToken}
 import org.tessellation.schema.peer.{Peer, PeerId}
+import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import com.comcast.ip4s.{Host, Port}
 import derevo.cats.{eqv, show}
@@ -112,7 +113,7 @@ object node {
     publicPort: Port,
     p2pPort: Port,
     id: PeerId,
-    tessellationVersion: String,
-    metagraphVersion: String
+    tessellationVersion: TessellationVersion,
+    metagraphVersion: MetagraphVersion
   )
 }

--- a/modules/shared/src/main/scala/org/tessellation/schema/semver.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/semver.scala
@@ -7,6 +7,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.boolean.And
 import eu.timepit.refined.cats._
 import eu.timepit.refined.generic.Equal
+import eu.timepit.refined.refineV
 import eu.timepit.refined.string.MatchesRegex
 import io.circe.refined._
 import io.estatico.newtype.macros.newtype
@@ -20,4 +21,20 @@ object semver {
   @derive(encoder, decoder, show, order)
   @newtype
   case class SnapshotVersion(version: String Refined (SemVer And Equal["0.0.1"]))
+
+  @derive(encoder, decoder, show, order)
+  @newtype
+  case class TessellationVersion(version: String Refined SemVer)
+
+  object TessellationVersion {
+    def unsafeFrom(str: String): TessellationVersion = TessellationVersion(refineV[SemVer].unsafeFrom(str))
+  }
+
+  @derive(encoder, decoder, show, order)
+  @newtype
+  case class MetagraphVersion(version: String Refined SemVer)
+
+  object MetagraphVersion {
+    def unsafeFrom(str: String): MetagraphVersion = MetagraphVersion(refineV[SemVer].unsafeFrom(str))
+  }
 }


### PR DESCRIPTION
### Changes
+ Adding new `metagraph/info` endpoint that can be accessed on currencyL0 and currencyL1 modules
+ Here is one print of the response
<img width="1718" alt="Captura de Tela 2024-01-25 às 12 37 54" src="https://github.com/Constellation-Labs/tessellation/assets/22091534/396f6fc3-ccc4-404d-b536-7dc45c05fce1">
*Ignore the version of tessellation as `adding-metagraph-info`, I've hardcoded this to test on Euclid*

### JIRA
[PROT-567](https://constellationnetwork.atlassian.net/browse/PROT-567)