### PR TITLE
Allow signing using node keys via L0/L1 node context

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
@@ -64,7 +64,7 @@ abstract class CurrencyL0App(
       storages <- Storages.make[IO](sharedStorages, cfg.snapshot, method.globalL0Peer, dataApplicationService).asResource
       p2pClient = P2PClient.make[IO](sharedP2PClient, sharedResources.client, sharedServices.session)
       validators = Validators.make[IO](seedlist)
-      implicit0(nodeContext: L0NodeContext[IO]) = L0NodeContext.make[IO](storages.snapshot)
+      implicit0(nodeContext: L0NodeContext[IO]) = L0NodeContext.make[IO](storages.snapshot)(keyPair)
       maybeMajorityPeerIds <- getMajorityPeerIds[IO](
         nodeShared.prioritySeedlist,
         method.nodeSharedConfig.priorityPeerIds,

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Services.scala
@@ -55,7 +55,7 @@ object Services {
     for {
       jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[F]
 
-      l0NodeContext = L0NodeContext.make[F](storages.snapshot)
+      l0NodeContext = L0NodeContext.make[F](storages.snapshot)(keyPair)
 
       dataApplicationAcceptanceManager = (maybeDataApplication, storages.calculatedStateStorage).mapN {
         case (service, storage) =>

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -151,7 +151,7 @@ abstract class CurrencyL1App(
         .start(storages, services, healthChecks)
         .asResource
 
-      implicit0(nodeContext: L1NodeContext[IO]) = L1NodeContext.make[IO](storages.lastGlobalSnapshot, storages.lastSnapshot)
+      implicit0(nodeContext: L1NodeContext[IO]) = L1NodeContext.make[IO](storages.lastGlobalSnapshot, storages.lastSnapshot)(keyPair)
 
       api = HttpApi
         .make[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](

--- a/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
@@ -14,6 +14,7 @@ import org.tessellation.schema.round.RoundId
 import org.tessellation.schema.{GlobalIncrementalSnapshot, SnapshotOrdinal}
 import org.tessellation.security.hash.Hash
 import org.tessellation.security.signature.Signed
+import org.tessellation.security.signature.signature.SignatureProof
 import org.tessellation.security.{Encodable, Hashed, SecurityProvider}
 
 import eu.timepit.refined.auto._
@@ -472,6 +473,7 @@ trait L1NodeContext[F[_]] {
   def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]]
   def securityProvider: SecurityProvider[F]
+  def signWithNodeKey(input: Hash): F[SignatureProof]
 }
 
 trait L0NodeContext[F[_]] {
@@ -479,4 +481,5 @@ trait L0NodeContext[F[_]] {
   def getCurrencySnapshot(ordinal: SnapshotOrdinal): F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]]
   def securityProvider: SecurityProvider[F]
+  def signWithNodeKey(input: Hash): F[SignatureProof]
 }


### PR DESCRIPTION
## Summary
Added method `Hash => F[SignatureProof]` to `L0NodeContext` and `L1NodeContext` to allow for signing data using the node key pair within the Data Application scope.

## Changes
- Updated node context traits, implementations, and calling locations to include `KeyPair` argument

## Testing
- unit tests pass
- integration tests pass

## Tickets
PROT-577