### PR TITLE
Viewable queue exposed in Data Application Routes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -495,7 +495,7 @@ lazy val dagL0 = (project in file("modules/dag-l0"))
   )
 
 lazy val currencyL1 = (project in file("modules/currency-l1"))
-  .dependsOn(dagL1, nodeShared, shared)
+  .dependsOn(dagL1, shared % "compile->compile;test->test", testShared % Test, nodeShared)
   .settings(
     name := "tessellation-currency-l1",
     Defaults.itSettings,

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -5,7 +5,7 @@ import java.security.KeyPair
 import cats.Applicative
 import cats.data.NonEmptyList
 import cats.effect.kernel.{Async, Clock}
-import cats.effect.std.{Queue, Random}
+import cats.effect.std.Random
 import cats.syntax.all._
 
 import scala.concurrent.duration._
@@ -13,9 +13,11 @@ import scala.concurrent.duration._
 import org.tessellation.currency.dataApplication.ConsensusInput._
 import org.tessellation.currency.dataApplication.ConsensusOutput.Noop
 import org.tessellation.currency.dataApplication._
+import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
 import org.tessellation.effects.GenUUID
 import org.tessellation.fsm.FSM
 import org.tessellation.node.shared.domain.cluster.storage.ClusterStorage
+import org.tessellation.node.shared.domain.queue.ViewableQueue
 import org.tessellation.schema.node.NodeState
 import org.tessellation.schema.peer.{Peer, PeerId}
 import org.tessellation.schema.round.RoundId
@@ -26,8 +28,6 @@ import org.tessellation.security.{Hasher, SecurityProvider}
 import io.circe.Encoder
 import monocle.syntax.all._
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-
-import dataApplication.DataApplicationBlock
 
 case class RoundData(
   roundId: RoundId,
@@ -85,7 +85,7 @@ object Engine {
     dataApplication: BaseDataApplicationL1Service[F],
     clusterStorage: ClusterStorage[F],
     consensusClient: ConsensusClient[F],
-    dataUpdates: Queue[F, Signed[DataUpdate]],
+    dataUpdates: ViewableQueue[F, Signed[DataUpdate]],
     selfId: PeerId,
     selfKeyPair: KeyPair
   ): FSM[F, State, In, Out] = {

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/modules/Queues.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/modules/Queues.scala
@@ -9,6 +9,7 @@ import org.tessellation.currency.dataApplication.dataApplication.DataApplication
 import org.tessellation.currency.dataApplication.{ConsensusInput, DataUpdate}
 import org.tessellation.dag.l1.domain.consensus.block.BlockConsensusInput.PeerBlockConsensusInput
 import org.tessellation.dag.l1.modules.{Queues => DAGL1Queues}
+import org.tessellation.node.shared.domain.queue.ViewableQueue
 import org.tessellation.schema.Block
 import org.tessellation.schema.gossip.RumorRaw
 import org.tessellation.security.Hashed
@@ -17,10 +18,9 @@ import org.tessellation.security.signature.Signed
 object Queues {
   def make[F[_]: Concurrent](dagL1Queues: DAGL1Queues[F]): F[Queues[F]] =
     for {
-
       dataApplicationPeerConsensusInputQueue <- Queue.unbounded[F, Signed[ConsensusInput.PeerConsensusInput]]
       dataApplicationBlockQueue <- Queue.unbounded[F, Signed[DataApplicationBlock]]
-      dataUpdatesQueue <- Queue.unbounded[F, Signed[DataUpdate]]
+      dataUpdatesQueue <- ViewableQueue.make[F, Signed[DataUpdate]]
     } yield
       new Queues[F] {
         val rumor = dagL1Queues.rumor
@@ -38,5 +38,5 @@ sealed abstract class Queues[F[_]] private {
   val peerBlock: Queue[F, Signed[Block]]
   val dataApplicationPeerConsensusInput: Queue[F, Signed[ConsensusInput.PeerConsensusInput]]
   val dataApplicationBlock: Queue[F, Signed[DataApplicationBlock]]
-  val dataUpdates: Queue[F, Signed[DataUpdate]]
+  val dataUpdates: ViewableQueue[F, Signed[DataUpdate]]
 }

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
@@ -1,0 +1,75 @@
+package org.tessellation.currency.l1
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+
+import org.tessellation.currency.dataApplication.DataState.Base
+import org.tessellation.currency.dataApplication._
+import org.tessellation.currency.dataApplication.dataApplication.{DataApplicationBlock, DataApplicationValidationErrorOr}
+import org.tessellation.routes.internal.ExternalUrlPrefix
+import org.tessellation.schema.SnapshotOrdinal
+import org.tessellation.security.hash.Hash
+import org.tessellation.security.signature.Signed
+
+import io.circe.{Decoder, Encoder}
+import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+import org.http4s.circe.jsonEncoderOf
+import org.http4s.{EntityDecoder, EntityEncoder, HttpRoutes}
+
+object DummyDataApplicationL1Service {
+  def make[F[_]]: IO[BaseDataApplicationL1Service[IO]] = IO.pure {
+    new BaseDataApplicationL1Service[IO] {
+      override def serializeState(state: DataOnChainState): IO[Array[Byte]] = ???
+
+      override def deserializeState(bytes: Array[Byte]): IO[Either[Throwable, DataOnChainState]] = ???
+
+      override def serializeUpdate(update: DataUpdate): IO[Array[Byte]] = ???
+
+      override def deserializeUpdate(bytes: Array[Byte]): IO[Either[Throwable, DataUpdate]] = ???
+
+      override def serializeBlock(block: Signed[DataApplicationBlock]): IO[Array[Byte]] = ???
+
+      override def deserializeBlock(bytes: Array[Byte]): IO[Either[Throwable, Signed[DataApplicationBlock]]] = ???
+
+      override def serializeCalculatedState(state: DataCalculatedState): IO[Array[Byte]] = ???
+
+      override def deserializeCalculatedState(bytes: Array[Byte]): IO[Either[Throwable, DataCalculatedState]] = ???
+
+      override def dataEncoder: Encoder[DataUpdate] = DummyDataApplicationState.dataUpateEncoder
+
+      override def dataDecoder: Decoder[DataUpdate] = DummyDataApplicationState.dataUpdateDecoder
+
+      override def signedDataEntityEncoder: EntityEncoder[IO, Signed[DataUpdate]] =
+        jsonEncoderOf[IO, Signed[DataUpdate]](Signed.encoder[DataUpdate](dataEncoder))
+
+      override def signedDataEntityDecoder: EntityDecoder[IO, Signed[DataUpdate]] = {
+        implicit val signedDecoder: Decoder[Signed[DataUpdate]] = Signed.decoder[DataUpdate](dataDecoder)
+        circeEntityDecoder
+      }
+
+      override def calculatedStateEncoder: Encoder[DataCalculatedState] = ???
+
+      override def calculatedStateDecoder: Decoder[DataCalculatedState] = ???
+
+      override def validateData(state: Base, updates: NonEmptyList[Signed[DataUpdate]])(
+        implicit context: L1NodeContext[IO]
+      ): IO[DataApplicationValidationErrorOr[Unit]] = ???
+
+      override def validateUpdate(update: DataUpdate)(implicit context: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] = ???
+
+      override def combine(state: Base, updates: List[Signed[DataUpdate]])(implicit context: L1NodeContext[IO]): IO[Base] = ???
+
+      override def getCalculatedState(implicit context: L1NodeContext[IO]): IO[(SnapshotOrdinal, DataCalculatedState)] = ???
+
+      override def setCalculatedState(ordinal: SnapshotOrdinal, state: DataCalculatedState)(
+        implicit context: L1NodeContext[IO]
+      ): IO[Boolean] = ???
+
+      override def hashCalculatedState(state: DataCalculatedState)(implicit context: L1NodeContext[IO]): IO[Hash] = ???
+
+      override def routes(implicit context: L1NodeContext[IO]): HttpRoutes[IO] = ???
+
+      override def routesPrefix: ExternalUrlPrefix = ???
+    }
+  }
+}

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationState.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationState.scala
@@ -1,0 +1,30 @@
+package org.tessellation.currency.l1
+
+import org.tessellation.currency.dataApplication.DataUpdate
+
+import derevo.cats.show
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import io.circe._
+import io.circe.syntax.EncoderOps
+import org.scalacheck.Gen
+
+object DummyDataApplicationState {
+
+  implicit val dataUpateEncoder: Encoder[DataUpdate] = {
+    case event: DummyUpdate => event.asJson
+    case _                 => Json.Null
+  }
+
+  implicit val dataUpdateDecoder: Decoder[DataUpdate] =
+    (c: HCursor) => c.as[DummyUpdate]
+
+  @derive(encoder, decoder, show)
+  case class DummyUpdate(key: String, value: Long) extends DataUpdate
+
+  val dummyUpdateGen: Gen[DummyUpdate] = for {
+    key <- Gen.alphaStr
+    value <- Gen.posNum[Long]
+  } yield DummyUpdate(key, value)
+
+}

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/http/DataApplicationRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/http/DataApplicationRoutesSuite.scala
@@ -1,0 +1,142 @@
+package org.tessellation.currency.l1.http
+
+import cats.data.NonEmptySet
+import cats.effect.std.{Queue, Random, Supervisor}
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import org.tessellation.currency.dataApplication.{ConsensusInput, DataUpdate, L1NodeContext}
+import org.tessellation.currency.l1.DummyDataApplicationL1Service
+import org.tessellation.currency.l1.DummyDataApplicationState.{DummyUpdate, dummyUpdateGen}
+import org.tessellation.currency.l1.node.L1NodeContext
+import org.tessellation.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
+import org.tessellation.ext.cats.effect.ResourceIO
+import org.tessellation.json.JsonSerializer
+import org.tessellation.kryo.KryoSerializer
+import org.tessellation.node.shared.domain.cluster.storage.L0ClusterStorage
+import org.tessellation.node.shared.domain.queue.ViewableQueue
+import org.tessellation.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import org.tessellation.schema._
+import org.tessellation.schema.generators.signedOf
+import org.tessellation.schema.peer.L0Peer
+import org.tessellation.schema.snapshot.{Snapshot, SnapshotInfo}
+import org.tessellation.security._
+import org.tessellation.security.signature.Signed
+import org.tessellation.shared.sharedKryoRegistrar
+
+import org.http4s.Method.GET
+import org.http4s._
+import org.http4s.client.dsl.io._
+import org.http4s.implicits.http4sLiteralsSyntax
+import org.scalacheck.Gen
+import suite.HttpSuite
+
+object DataApplicationRoutesSuite extends HttpSuite {
+
+  type Res = (SecurityProvider[IO], Hasher[IO], Supervisor[IO], Random[IO])
+
+  def construct(updateQueue: ViewableQueue[F, Signed[DataUpdate]]): IO[HttpRoutes[IO]] =
+    sharedResource.use { res =>
+      implicit val (sp, h, sv, r) = res
+      for {
+        lastGlobalSnapshotStorage <- mockLastSnapshotStorage[GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+        lastCurrencySnapshotStorage <- mockLastSnapshotStorage[CurrencyIncrementalSnapshot, CurrencySnapshotInfo]
+        implicit0(ctx: L1NodeContext[IO]) = L1NodeContext.make[IO](lastGlobalSnapshotStorage, lastCurrencySnapshotStorage)
+        consensusQueue <- Queue.unbounded[F, Signed[ConsensusInput.PeerConsensusInput]]
+        l0ClusterStorage <- mockL0ClusterStorage
+        l1Service <- DummyDataApplicationL1Service.make[IO]
+        dataApi = DataApplicationRoutes(
+          consensusQueue,
+          l0ClusterStorage,
+          l1Service,
+          updateQueue,
+          lastGlobalSnapshotStorage,
+          lastCurrencySnapshotStorage
+        )
+      } yield dataApi.publicRoutes
+    }
+
+  def sharedResource: Resource[IO, Res] = for {
+    implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(json2bin: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h: Hasher[IO] <- IO(Hasher.forSync[IO](_ => JsonHash)).asResource
+    sv <- Supervisor[IO]
+    r <- Random.scalaUtilRandom.asResource
+  } yield (sp, h, sv, r)
+
+  def mockLastSnapshotStorage[A <: Snapshot, B <: SnapshotInfo[_]]: IO[LastSnapshotStorage[IO, A, B]] = IO.pure(
+    new LastSnapshotStorage[IO, A, B] {
+      override def set(snapshot: Hashed[A], state: B): IO[Unit] = ???
+
+      override def setInitial(snapshot: Hashed[A], state: B): IO[Unit] = ???
+
+      override def get: IO[Option[Hashed[A]]] = ???
+
+      override def getCombined: IO[Option[(Hashed[A], B)]] = ???
+
+      override def getCombinedStream: fs2.Stream[IO, Option[(Hashed[A], B)]] = ???
+
+      override def getOrdinal: IO[Option[SnapshotOrdinal]] = ???
+
+      override def getHeight: IO[Option[height.Height]] = ???
+    }
+  )
+
+  def mockL0ClusterStorage: IO[L0ClusterStorage[IO]] = IO.pure(
+    new L0ClusterStorage[IO] {
+      override def getPeers: IO[NonEmptySet[L0Peer]] = ???
+
+      override def getPeer(id: peer.PeerId): IO[Option[L0Peer]] = ???
+
+      override def getRandomPeer: IO[L0Peer] = ???
+
+      override def addPeers(l0Peers: Set[L0Peer]): IO[Unit] = ???
+
+      override def setPeers(l0Peers: NonEmptySet[L0Peer]): IO[Unit] = ???
+    }
+  )
+
+  test("GET returns Http Status code 200 with empty array") {
+    val req: Request[IO] = GET(uri"/data")
+
+    for {
+      dataQueue <- ViewableQueue.make[F, Signed[DataUpdate]]
+      endpoint <- construct(dataQueue)
+      testResult <- expectHttpBodyAndStatus(endpoint, req)(List.empty[Signed[DummyUpdate]], Status.Ok)
+    } yield testResult
+  }
+
+  test("GET returns single value") {
+    val req: Request[IO] = GET(uri"/data")
+
+    forall(signedOf(dummyUpdateGen)) { update =>
+      for {
+        dataQueue <- ViewableQueue.make[F, Signed[DataUpdate]]
+        _ <- dataQueue.offer(update)
+        endpoint <- construct(dataQueue)
+        testResult <- expectHttpBodyAndStatus(endpoint, req)(List(update), Status.Ok)
+      } yield testResult
+    }
+  }
+
+  test("GET returns multiple values") {
+    val req: Request[IO] = GET(uri"/data")
+
+    val gen = for {
+      size <- Gen.chooseNum(1, 1)
+      updates <- Gen.listOfN(size, signedOf(dummyUpdateGen))
+    } yield updates
+
+    forall(gen) { updates =>
+      for {
+        dataQueue <- ViewableQueue.make[F, Signed[DataUpdate]]
+        _ <- dataQueue.tryOfferN(updates).flatMap { rejected =>
+          IO.raiseError(new RuntimeException("Updates failed to enter queue")).whenA(rejected.nonEmpty)
+        }
+        endpoint <- construct(dataQueue)
+        testResult <- expectHttpBodyAndStatus(endpoint, req)(updates, Status.Ok)
+      } yield testResult
+    }
+  }
+}

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/queue/ViewableQueue.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/queue/ViewableQueue.scala
@@ -1,0 +1,48 @@
+package org.tessellation.node.shared.domain.queue
+
+import cats.effect.Ref
+import cats.effect.kernel.Concurrent
+import cats.syntax.functor._
+
+import scala.collection.immutable.Queue
+
+trait ViewableQueue[F[_], A] {
+  def offer(item: A): F[Unit]
+
+  def take: F[A]
+
+  def tryOfferN(items: List[A]): F[List[A]]
+
+  def tryTakeN(n: Option[Int]): F[List[A]]
+
+  def view: F[List[A]]
+}
+
+object ViewableQueue {
+
+  def make[F[_]: Concurrent, A]: F[ViewableQueue[F, A]] =
+    Ref[F].of(Queue.empty[A]).map { queue =>
+      new ViewableQueue[F, A] {
+        def offer(item: A): F[Unit] =
+          queue.update(_.enqueue(item))
+
+        def take: F[A] =
+          queue.modify { q =>
+            val (head, tail) = q.dequeue
+            (tail, head)
+          }
+
+        def tryOfferN(items: List[A]): F[List[A]] =
+          queue.update(_ ++ items).as(List.empty[A])
+
+        def tryTakeN(n: Option[Int]): F[List[A]] =
+          queue.modify { q =>
+            val (taken, remaining) = q.splitAt(n.getOrElse(0))
+            (remaining, taken.toList)
+          }
+
+        def view: F[List[A]] =
+          queue.get.map(_.toList)
+      }
+    }
+}

--- a/modules/node-shared/src/test/scala/org/tessellation/node/shared/domain/queue/ViewableQueueSuite.scala
+++ b/modules/node-shared/src/test/scala/org/tessellation/node/shared/domain/queue/ViewableQueueSuite.scala
@@ -1,0 +1,118 @@
+package org.tessellation.node.shared.domain.queue
+
+import cats.effect.IO
+import cats.effect.implicits._
+import cats.syntax.all._
+
+import scala.concurrent.duration.DurationDouble
+
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object ViewableQueueSuite extends SimpleIOSuite with Checkers {
+
+  test("Offer and take with single element") {
+    forall(Gen.chooseNum(1, 1000)) { item =>
+      for {
+        viewQueue <- ViewableQueue.make[IO, Int]
+        _ <- viewQueue.offer(item)
+        takenItem <- viewQueue.take
+        remainingItems <- viewQueue.view
+      } yield expect(takenItem == item) && expect(remainingItems.isEmpty)
+    }
+  }
+
+  test("Insert multiple items at once using tryOfferN") {
+    forall(Gen.listOfN(100, Gen.chooseNum(1, 1000))) { items =>
+      for {
+        viewQueue <- ViewableQueue.make[IO, Int]
+        _ <- viewQueue.tryOfferN(items)
+        viewResult <- viewQueue.view
+      } yield expect(viewResult.sorted == items.sorted)
+    }
+  }
+
+  test("Take a single item and validate the remaining queue") {
+    forall(Gen.listOfN(100, Gen.chooseNum(1, 1000)).map(_.distinct)) { items =>
+      for {
+        viewQueue <- ViewableQueue.make[IO, Int]
+        _ <- items.traverse(viewQueue.offer)
+        takenItem <- viewQueue.take
+        remainingItems <- viewQueue.view
+      } yield expect(remainingItems.size == items.size - 1).and(expect(!remainingItems.contains(takenItem)))
+    }
+  }
+
+  test("Insert and retrieve many Int from single fiber") {
+    forall(Gen.chooseNum(0, 20000)) { numItems =>
+      for {
+        viewQueue <- ViewableQueue.make[IO, Int]
+        _ <- List.range(0, numItems).map(i => viewQueue.offer(i)).parSequence
+        viewResult <- viewQueue.view
+        takeResult <- viewQueue.tryTakeN(Some(numItems))
+      } yield expect(viewResult.sorted == takeResult.sorted)
+    }
+  }
+
+  test("Insert and retrieve many Int via multiple fibers") {
+
+    val gen = for {
+      numFibers <- Gen.chooseNum(1, 100)
+      numItems <- Gen.chooseNum(0, 200)
+    } yield (numFibers, numItems)
+
+    forall(gen) {
+      case (numFibers, numItems) =>
+        for {
+          viewQueue <- ViewableQueue.make[IO, Int]
+          actions = List
+            .range(0, numFibers)
+            .map(i => List.range(i * numItems, (i + 1) * numItems))
+            .flatMap(list => list.map(item => IO.sleep((math.random() * 2).millisecond) *> viewQueue.offer(item)))
+          fibers <- actions.parTraverseN(numFibers)(_.start)
+          _ <- fibers.traverse(_.join)
+          viewResult <- viewQueue.view
+          takeResult <- viewQueue.tryTakeN(Some(numFibers * numItems))
+        } yield expect(viewResult.sorted == takeResult.sorted)
+    }
+  }
+
+  test("Take when the queue is empty") {
+    forall(Gen.const(())) { _ =>
+      for {
+        viewQueue <- ViewableQueue.make[IO, Int]
+        _ <- viewQueue.take.attempt
+      } yield expect(true)
+    }
+  }
+
+  test("tryTakeN edge cases") {
+    val gen = for {
+      items <- Gen.listOfN(100, Gen.chooseNum(1, 1000))
+      n <- Gen.oneOf(0, 1, items.size + 1)
+    } yield (items, n)
+
+    forall(gen) {
+      case (items, n) =>
+        for {
+          viewQueue <- ViewableQueue.make[IO, Int]
+          _ <- items.traverse(viewQueue.offer)
+          takenItems <- viewQueue.tryTakeN(Some(n))
+        } yield
+          if (n <= items.size) expect(takenItems.size == n)
+          else expect(takenItems.size == items.size) // If n is larger than the queue size, it should return all items.
+    }
+  }
+
+  test("Multi-step interaction between offer, take and tryOfferN with single element") {
+    forall(Gen.chooseNum(1, 1000)) { item =>
+      for {
+        viewQueue <- ViewableQueue.make[IO, Int]
+        _ <- viewQueue.offer(item)
+        _ <- viewQueue.tryOfferN(List(item))
+        takenItem <- viewQueue.take
+      } yield expect(takenItem == item)
+    }
+  }
+}

--- a/modules/node-shared/src/test/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
+++ b/modules/node-shared/src/test/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
@@ -30,7 +30,7 @@ import derevo.derive
 import eu.timepit.refined.auto._
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
-import org.http4s.{EntityDecoder, HttpRoutes}
+import org.http4s.{EntityDecoder, EntityEncoder, HttpRoutes}
 import org.scalacheck.Gen
 import weaver.MutableIOSuite
 import weaver.scalacheck.Checkers
@@ -309,6 +309,8 @@ object CurrencyEventsCutterSuite extends MutableIOSuite with Checkers {
 
     override def dataDecoder: Decoder[DataUpdate] = ???
 
+    override def signedDataEntityEncoder: EntityEncoder[IO, Signed[DataUpdate]] = ???
+
     override def signedDataEntityDecoder: EntityDecoder[IO, Signed[DataUpdate]] = ???
 
     override def calculatedStateEncoder: Encoder[DataCalculatedState] = ???
@@ -342,7 +344,6 @@ object CurrencyEventsCutterSuite extends MutableIOSuite with Checkers {
     override def genesis: DataState.Base = ???
 
     override def onSnapshotConsensusResult(snapshot: Hashed[currency.CurrencyIncrementalSnapshot]): IO[Unit] = ???
-
   }
 
 }

--- a/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/package.scala
@@ -22,6 +22,7 @@ import io.circe._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
 import org.http4s._
+import org.http4s.circe.jsonEncoderOf
 import org.http4s.server.Router
 
 trait DataUpdate
@@ -61,6 +62,8 @@ trait BaseDataApplicationService[F[_]] {
 
   def dataEncoder: Encoder[DataUpdate]
   def dataDecoder: Decoder[DataUpdate]
+
+  def signedDataEntityEncoder: EntityEncoder[F, Signed[DataUpdate]]
 
   def signedDataEntityDecoder: EntityDecoder[F, Signed[DataUpdate]]
 
@@ -286,6 +289,9 @@ object BaseDataApplicationService {
 
       def dataDecoder: Decoder[DataUpdate] = service.dataDecoder.widen[DataUpdate]
 
+      def signedDataEntityEncoder: EntityEncoder[F, Signed[DataUpdate]] =
+        jsonEncoderOf[F, Signed[DataUpdate]](Signed.encoder[DataUpdate](dataEncoder))
+
       def signedDataEntityDecoder: EntityDecoder[F, Signed[DataUpdate]] =
         service.signedDataEntityDecoder.widen[Signed[DataUpdate]]
 
@@ -331,6 +337,8 @@ object BaseDataApplicationL0Service {
       def dataEncoder: Encoder[DataUpdate] = base.dataEncoder
 
       def dataDecoder: Decoder[DataUpdate] = base.dataDecoder
+
+      def signedDataEntityEncoder: EntityEncoder[F, Signed[DataUpdate]] = base.signedDataEntityEncoder
 
       def signedDataEntityDecoder: EntityDecoder[F, Signed[DataUpdate]] = base.signedDataEntityDecoder
 
@@ -397,6 +405,8 @@ object BaseDataApplicationL1Service {
       def dataEncoder: Encoder[DataUpdate] = base.dataEncoder
 
       def dataDecoder: Decoder[DataUpdate] = base.dataDecoder
+
+      def signedDataEntityEncoder: EntityEncoder[F, Signed[DataUpdate]] = base.signedDataEntityEncoder
 
       def signedDataEntityDecoder: EntityDecoder[F, Signed[DataUpdate]] = base.signedDataEntityDecoder
 

--- a/modules/shared/src/main/scala/org/tessellation/ext/codecs.scala
+++ b/modules/shared/src/main/scala/org/tessellation/ext/codecs.scala
@@ -4,11 +4,14 @@ import scala.collection.immutable.SortedSet
 
 import _root_.cats.Order
 import _root_.cats.data.NonEmptySet
-import io.circe.Decoder
+import io.circe.{Decoder, Encoder}
 
 object codecs {
 
   object NonEmptySetCodec {
+
+    def encoder[A: Encoder]: Encoder[NonEmptySet[A]] =
+      Encoder.encodeNonEmptySet[A](Encoder[A])
 
     def decoder[A: Decoder: Ordering]: Decoder[NonEmptySet[A]] =
       Decoder.decodeNonEmptySet[A](Decoder[A], Order.fromOrdering).map { nes =>

--- a/modules/shared/src/main/scala/org/tessellation/security/signature/Signed.scala
+++ b/modules/shared/src/main/scala/org/tessellation/security/signature/Signed.scala
@@ -40,6 +40,8 @@ object Signed {
 
   implicit def encoder[A: Encoder]: Encoder[Signed[A]] = deriveEncoder
 
+  implicit val proofsEncoder: Encoder[NonEmptySet[SignatureProof]] = NonEmptySetCodec.encoder[SignatureProof]
+
   implicit val proofsDecoder: Decoder[NonEmptySet[SignatureProof]] = NonEmptySetCodec.decoder[SignatureProof]
 
   implicit def decoder[A: Decoder]: Decoder[Signed[A]] = deriveDecoder

--- a/modules/test-shared/src/main/scala/suite/HttpSuite.scala
+++ b/modules/test-shared/src/main/scala/suite/HttpSuite.scala
@@ -12,9 +12,9 @@ import org.http4s._
 import org.http4s.circe._
 import org.http4s.headers.Location
 import weaver.scalacheck.Checkers
-import weaver.{Expectations, SimpleIOSuite}
+import weaver.{Expectations, MutableIOSuite}
 
-trait HttpSuite extends SimpleIOSuite with Checkers {
+trait HttpSuite extends MutableIOSuite with Checkers {
   case object DummyError extends NoStackTrace
 
   def expectHttpBodyAndStatus[A: Encoder](routes: HttpRoutes[IO], req: Request[IO])(


### PR DESCRIPTION
## Summary
This PR introduces a `ViewableQueue` trait and implementation in order to expose pending data updates via a `GET` public HTTP route. This work is motivated to provide a "mempool" equivalent at the metagraph layer while maintaining atomicity, minimizing changes to existing usages of `currency.l1.modules.Queues`, and reusing the available API of Cats standard `Queue`.

Additionally, smaller changes were incorporated to facilitate encoding and decoding of `DataUpdates` and  `HttpSuite` was updated to `MutableIOSuite` as the override of `Res` and `def sharedResource` were causing compilation errors.

## Changes
- Updated `currencyL1` project definition to include test dependencies
- Updated usages of `dataUpdates: Queue -> ViewableQueue`
- Added `GET` route at `/data` to return the latest view of pending updates
- Added `MockDataApplicationService` and `...State` to facilitate testing
- Added `EntityEncoder[F, Signed[DataUpdate]]` in `DataApplication` package 
- Updated `HttpSuite` from `SimpleIOSuite -> MutableIOSuite`

## Testing
- Added `ViewbleQueueSuite` unit tests
- Added `DataApplicationRoutesSuite` integration tests cases handling
  - empty queue
  - single element
  - multiple elements