### PR TITLE
Fix fluctuating retry mode when Global L0 is faster than Metagraph

### DIFF
--- a/modules/currency-l0/src/test/scala/org/tessellation/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
+++ b/modules/currency-l0/src/test/scala/org/tessellation/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
@@ -7,7 +7,6 @@ import cats.syntax.all._
 import scala.collection.immutable.SortedMap
 
 import org.tessellation.currency.l0.node.IdentifierStorage
-import org.tessellation.currency.l0.snapshot.services._
 import org.tessellation.currency.schema.currency.SnapshotFee
 import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.generators.nonEmptyStringGen
@@ -185,7 +184,7 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
     }
   }
 
-  test("retry mode - should switch to normal mode if cap reached than enqueued count and all sent at least once") { res =>
+  test("retry mode - should switch to normal mode if cap >= enqueued count, all sent and no stalled") { res =>
     implicit val (_, hs, sp) = res
 
     forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
@@ -203,22 +202,31 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
         hashed <- binaries.traverse(_.toHashed)
         _ <- hashed.traverse(sender.process)
 
-        globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp.getPublic.toAddress, List.empty)
-
+        globalSnapshot <- mkSnapshot(SnapshotOrdinal(5L), kp.getPublic.toAddress, List.empty)
         _ <- sender.confirm(globalSnapshot)
-        reachedButNotSentAtLeastOnce <- stateRef.get
+        capReachedButNoSendsSoFar <- stateRef.get
 
         _ <- stateRef.update { state =>
           state.copy(
-            pending = state.pending.map(t => t.copy(sendsSoFar = NonNegLong(1L))),
-            cap = NonNegLong.unsafeFrom(binaries.length.toLong)
+            pending = state.pending.map(t => t.copy(sendsSoFar = NonNegLong(1L), enqueuedAtOrdinal = SnapshotOrdinal(0L))),
+            cap = NonNegLong.unsafeFrom(state.pending.length.toLong)
           )
         }
-
         _ <- sender.confirm(globalSnapshot)
-        reachedButAllSentAtLeastOnce <- stateRef.get
+        capReachedAllSentButHasStalled <- stateRef.get
 
-      } yield expect(reachedButNotSentAtLeastOnce.retryMode).and(expect(!reachedButAllSentAtLeastOnce.retryMode))
+        _ <- stateRef.update { state =>
+          state.copy(
+            pending = state.pending.map(t => t.copy(sendsSoFar = NonNegLong(1L), enqueuedAtOrdinal = SnapshotOrdinal(1L))),
+            cap = NonNegLong.unsafeFrom(state.pending.length.toLong)
+          )
+        }
+        _ <- sender.confirm(globalSnapshot)
+        capReachedAllSentAndNoStalled <- stateRef.get
+      } yield
+        expect(capReachedButNoSendsSoFar.retryMode)
+          .and(expect(capReachedAllSentButHasStalled.retryMode))
+          .and(expect(!capReachedAllSentAndNoStalled.retryMode))
     }
   }
 


### PR DESCRIPTION
The issue was observed while working on different issues. Reducing the time-trigger delays on Global L0 makes producing global snapshots much faster than metagraph enqueues binaries. Such a situation can trigger the "Retry mode" when the number of pending binaries on Metagraph is lower than the initial `cap`. 

It causes the  "Retry mode" to fluctuate so it will constantly enter and exit the retry mode and reset the cap to 3 over and over. The additional condition for exiting the "Retry mode" has been introduced in that PR and unit tests are adjusted accordingly