### PR TITLE
Updating validate data lifecycle function to remove only invalid updates instead of the entire batch

### DIFF
--- a/.github/templates/project_template/modules/data_l1/src/main/scala/com/my/project_template/data_l1/Main.scala
+++ b/.github/templates/project_template/modules/data_l1/src/main/scala/com/my/project_template/data_l1/Main.scala
@@ -37,7 +37,7 @@ object Main extends CurrencyL1App(
     new DataApplicationL1Service[IO, UsageUpdate, UsageUpdateState, UsageUpdateCalculatedState] {
       override def validateData(
         state  : DataState[UsageUpdateState, UsageUpdateCalculatedState],
-        updates: NonEmptyList[Signed[UsageUpdate]]
+        update: Signed[UsageUpdate]
       )(implicit context: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
         ().validNec.pure[IO]
 

--- a/.github/templates/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
+++ b/.github/templates/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
@@ -59,7 +59,7 @@ object Main
 
         override def validateData(
           state  : DataState[UsageUpdateState, UsageUpdateCalculatedState],
-          updates: NonEmptyList[Signed[UsageUpdate]]
+          update: Signed[UsageUpdate]
         )(implicit context: L0NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
           ().validNec.pure[IO]
 

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -368,7 +368,11 @@ object Engine {
             }
           } yield result
         case (newState, _) => ().pure[F].tupleLeft(newState)
-      }.getOrElse(logger.warn(s"Couldn't persist proposal").tupleLeft(state))
+      }
+        .getOrElse(logger.warn(s"Couldn't persist proposal").tupleLeft(state))
+        .handleErrorWith { e =>
+          logger.error(e)(s"Error when persisting proposal: ${e}").tupleLeft(state)
+        }
 
     def informAboutInabilityToParticipate(proposal: Proposal, reason: DataCancellationReason): F[Unit] = {
       def cancellation = CancelledCreationRound(

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
@@ -50,7 +50,7 @@ class DummyDataApplicationL1Service extends BaseDataApplicationL1Service[IO] {
 
   override def calculatedStateDecoder: Decoder[DataCalculatedState] = ???
 
-  override def validateData(state: Base, updates: NonEmptyList[Signed[DataUpdate]])(
+  override def validateData(state: Base, update: Signed[DataUpdate])(
     implicit context: L1NodeContext[IO]
   ): IO[DataApplicationValidationErrorOr[Unit]] = ???
 

--- a/modules/node-shared/src/test/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
+++ b/modules/node-shared/src/test/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
@@ -317,7 +317,7 @@ object CurrencyEventsCutterSuite extends MutableIOSuite with Checkers {
 
     override def calculatedStateDecoder: Decoder[DataCalculatedState] = ???
 
-    override def validateData(state: DataState.Base, updates: NonEmptyList[Signed[DataUpdate]])(
+    override def validateData(state: DataState.Base, update: Signed[DataUpdate])(
       implicit context: L0NodeContext[IO]
     ): IO[dataApplication.DataApplicationValidationErrorOr[Unit]] = ???
 


### PR DESCRIPTION
### Changes
+ Fixing the `validateData` lifecycle function to reject only the invalid updates and keep the valid ones
+ Previously, if one of the updates of the batch was invalid, the entire batch was discarded