### PR TITLE
Setting global snapshot after running currency rollback

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/CurrencyL0App.scala
@@ -165,6 +165,8 @@ abstract class CurrencyL0App(
 
         case other =>
           for {
+            _ <- StateChannel.performGlobalL0PeerDiscovery[IO](storages, programs)
+
             innerProgram <- other match {
               case rv: RunValidator =>
                 storages.identifier.setInitial(rv.identifier) >>

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
@@ -77,6 +77,7 @@ object Programs {
       services.globalL0,
       storages.identifier,
       storages.snapshot,
+      storages.lastGlobalSnapshot,
       services.collateral,
       services.consensus.manager,
       dataApplication


### PR DESCRIPTION
### Problem
When we rollback an existing metagraph, and then send the snapshot fee `owner` message, the first global snapshot is set to 0 because wasn't being set before the first consensus round.
You can check the image below with some custom logs I've added to debug
<img width="2446" alt="Captura de Tela 2024-06-18 às 13 13 36" src="https://github.com/Constellation-Labs/tessellation/assets/22091534/adf4d53b-ee68-4b5e-b5e0-f32044b03bf3">

### Solution
I'm filling the lastGlobalSnapshot when running as rollback, I've already tested and it's working as expected

### NOTE
This PR was already created for the hotfix branch so we can deploy it as soon as we fix it. The DOR Metagraph in Testnet are already fixed because I've generated a custom version locally to unlock