### PR TITLE
Fixing collateral check in currency modules

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/cli/method.scala
@@ -2,6 +2,8 @@ package org.tessellation.currency.l0.cli
 
 import cats.syntax.all._
 
+import scala.collection.immutable.SortedMap
+
 import org.tessellation.currency.cli.{GlobalL0PeerOpts, L0TokenIdentifierOpts}
 import org.tessellation.currency.l0.cli.http.{opts => httpOpts}
 import org.tessellation.currency.l0.config.types._
@@ -18,6 +20,7 @@ import org.tessellation.schema.peer.L0Peer
 
 import com.monovore.decline.Opts
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
 import fs2.io.file.Path
 
 object method {
@@ -36,6 +39,22 @@ object method {
 
     val l0SeedlistPath = None
 
+    override def nodeSharedConfig(c: SharedConfigReader): SharedConfig = SharedConfig(
+      environment,
+      c.gossip,
+      httpConfig,
+      c.leavingDelay,
+      c.stateAfterJoining,
+      CollateralConfig(
+        amount = collateralAmount.getOrElse(Amount(NonNegLong.MinValue))
+      ),
+      c.trust.storage,
+      c.priorityPeerIds.get(environment),
+      c.snapshot.size,
+      c.feeConfigs.get(environment).map(SortedMap.from(_)).getOrElse(SortedMap.empty),
+      c.forkInfoStorage,
+      c.lastKryoHashOrdinal
+    )
   }
 
   case class CreateGenesis(

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
@@ -2,6 +2,8 @@ package org.tessellation.currency.l1.cli
 
 import cats.syntax.all._
 
+import scala.collection.immutable.SortedMap
+
 import org.tessellation.currency.cli.{GlobalL0PeerOpts, L0TokenIdentifierOpts}
 import org.tessellation.dag.l1.cli.http
 import org.tessellation.dag.l1.config.types.{AppConfig, AppConfigReader}
@@ -15,6 +17,7 @@ import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.peer.L0Peer
 
 import com.monovore.decline.Opts
+import eu.timepit.refined.types.numeric.NonNegLong
 import fs2.io.file.Path
 
 object method {
@@ -32,6 +35,23 @@ object method {
     val l0SeedlistPath = None
 
     val prioritySeedlistPath: Option[SeedListPath]
+
+    override def nodeSharedConfig(c: SharedConfigReader): SharedConfig = SharedConfig(
+      environment,
+      c.gossip,
+      httpConfig,
+      c.leavingDelay,
+      c.stateAfterJoining,
+      CollateralConfig(
+        amount = collateralAmount.getOrElse(Amount(NonNegLong.MinValue))
+      ),
+      c.trust.storage,
+      c.priorityPeerIds.get(environment),
+      c.snapshot.size,
+      c.feeConfigs.get(environment).map(SortedMap.from(_)).getOrElse(SortedMap.empty),
+      c.forkInfoStorage,
+      c.lastKryoHashOrdinal
+    )
   }
 
   case class RunInitialValidator(

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/app/TessellationIOApp.scala
@@ -106,6 +106,7 @@ abstract class TessellationIOApp[A <: CliMethod](
                 LoggerConfigurator.configureLogger[IO](cfg.environment) >>
                 logger.info(s"App environment: ${cfg.environment}") >>
                 logger.info(s"App version: ${version.show}") >>
+                logger.info(s"App collateral: ${cfg.collateral.amount.show}") >>
                 KryoSerializer.forAsync[IO](registrar).use { implicit _kryoPool =>
                   JsonSerializer.forSync[IO].asResource.use { implicit _jsonSerializer =>
                     implicit val _hasherSelector = HasherSelector.forSync[IO](Hasher.forJson, Hasher.forKryo, _hashSelect)


### PR DESCRIPTION
### Changes
+ Fixing the collateral check in currency modules to be independent of the global checker.
+ Currently, in the global layer mainnet, it's required to have 250K Tokens (DAG for the global layer and L0 Token for the currency layer). So, I've fixed this to use the CL_COLLATERAL parameter or be 0 if not provided (ONLY IN CURRENCY LAYER, THE GLOBAL LAYER KEEP WITH THE SAME BEHAVIOR)