### PR TITLE
Adding validations to reject repeated owner or staking address

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/HttpApi.scala
@@ -121,7 +121,13 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
   private val targetRoutes = HasherSelector[F].withCurrent(implicit hasher => TargetRoutes[F](services.cluster).publicRoutes)
 
   private val currencyMessageRoutes = HasherSelector[F].withCurrent(implicit hasher =>
-    new CurrencyMessageRoutes[F](mkCell, validators.currencyMessageValidator, storages.snapshot, storages.identifier).publicRoutes
+    new CurrencyMessageRoutes[F](
+      mkCell,
+      validators.currencyMessageValidator,
+      storages.snapshot,
+      storages.identifier,
+      storages.lastGlobalSnapshot
+    ).publicRoutes
   )
 
   private val openRoutes: HttpRoutes[F] =

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/Main.scala
@@ -155,8 +155,7 @@ object Main
             programs.rollbackLoader.load(m.rollbackHash).flatMap {
               case (snapshotInfo, snapshot) =>
                 hasherSelector.forOrdinal(snapshot.ordinal) { implicit hasher =>
-                  storages.globalSnapshot
-                    .prepend(snapshot, snapshotInfo)
+                  storages.globalSnapshot.prepend(snapshot, snapshotInfo)
                 } >>
                   services.consensus.manager.startFacilitatingAfterRollback(
                     snapshot.ordinal,

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Services.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Services.scala
@@ -85,7 +85,10 @@ object Services {
       addressService = AddressService.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo](storages.globalSnapshot)
       collateralService = Collateral.make[F](cfg.collateral, storages.globalSnapshot)
       stateChannelService = StateChannelService
-        .make[F](L0Cell.mkL0Cell(queues.l1Output, queues.stateChannelOutput), validators.stateChannelValidator)
+        .make[F](
+          L0Cell.mkL0Cell(queues.l1Output, queues.stateChannelOutput),
+          validators.stateChannelValidator
+        )
       getOrdinal = storages.globalSnapshot.headSnapshot.map(_.map(_.ordinal))
       trustUpdaterService = TrustStorageUpdater.make(getOrdinal, sharedServices.gossip, storages.trust)
     } yield

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Storages.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Storages.scala
@@ -19,11 +19,7 @@ import org.tessellation.node.shared.domain.seedlist.SeedlistEntry
 import org.tessellation.node.shared.domain.snapshot.storage.SnapshotStorage
 import org.tessellation.node.shared.domain.trust.storage.TrustStorage
 import org.tessellation.node.shared.infrastructure.gossip.RumorStorage
-import org.tessellation.node.shared.infrastructure.snapshot.storage.{
-  SnapshotInfoLocalFileSystemStorage,
-  SnapshotLocalFileSystemStorage,
-  SnapshotStorage
-}
+import org.tessellation.node.shared.infrastructure.snapshot.storage._
 import org.tessellation.node.shared.modules.SharedStorages
 import org.tessellation.schema._
 import org.tessellation.schema.trust.PeerObservationAdjustmentUpdateBatch
@@ -76,6 +72,7 @@ object Storages {
           incrementalKryoGlobalSnapshotInfoLocalFileSystemStorage,
           hashSelect
         )
+
     } yield
       new Storages[F](
         cluster = sharedStorages.cluster,

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/domain/statechannel/StateChannelServiceSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/domain/statechannel/StateChannelServiceSuite.scala
@@ -13,9 +13,8 @@ import org.tessellation.dag.l0.domain.cell.L0Cell
 import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.json.JsonSerializer
 import org.tessellation.kryo.KryoSerializer
-import org.tessellation.node.shared.domain.statechannel.StateChannelValidator
+import org.tessellation.node.shared.domain.statechannel.{SnapshotFeesInfo, StateChannelValidator}
 import org.tessellation.schema._
-import org.tessellation.schema.balance.Balance
 import org.tessellation.schema.epoch.EpochProgress
 import org.tessellation.schema.height.{Height, SubHeight}
 import org.tessellation.schema.peer.PeerId
@@ -71,11 +70,17 @@ object StateChannelServiceSuite extends MutableIOSuite {
 
   def mkService(failed: Option[StateChannelValidator.StateChannelValidationError] = None) = {
     val validator = new StateChannelValidator[IO] {
-      def validate(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
+      def validate(
+        output: StateChannelOutput,
+        globalOrdinal: SnapshotOrdinal,
+        snapshotFeesInfo: SnapshotFeesInfo
+      )(implicit hasher: Hasher[IO]) =
         IO.pure(failed.fold[StateChannelValidator.StateChannelValidationErrorOr[StateChannelOutput]](output.validNec)(_.invalidNec))
 
-      def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
-        validate(output, globalOrdinal, staked)
+      def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, snapshotFeesInfo: SnapshotFeesInfo)(
+        implicit hasher: Hasher[IO]
+      ) =
+        validate(output, globalOrdinal, snapshotFeesInfo)
     }
 
     for {

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -16,12 +16,12 @@ import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.node.shared.config.types.SnapshotSizeConfig
-import org.tessellation.node.shared.domain.statechannel.{FeeCalculator, StateChannelAcceptanceResult, StateChannelValidator}
+import org.tessellation.node.shared.domain.statechannel._
 import org.tessellation.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import org.tessellation.node.shared.infrastructure.snapshot._
 import org.tessellation.node.shared.modules.SharedValidators
 import org.tessellation.schema.address.Address
-import org.tessellation.schema.balance.{Amount, Balance}
+import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.{GlobalSnapshotInfo, SnapshotOrdinal}
 import org.tessellation.security._
@@ -55,11 +55,18 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
     for {
       _ <- IO.unit
       validator = new StateChannelValidator[IO] {
-        def validate(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
+        def validate(
+          output: StateChannelOutput,
+          globalOrdinal: SnapshotOrdinal,
+          snapshotFeesInfo: SnapshotFeesInfo
+        )(implicit hasher: Hasher[IO]) =
           IO.pure(failed.filter(f => f._1 == output.address).map(_._2.invalidNec).getOrElse(output.validNec))
-        def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
-          validate(output, globalOrdinal, staked)(hasher)
+        def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, snapshotFeesInfo: SnapshotFeesInfo)(
+          implicit hasher: Hasher[IO]
+        ) =
+          validate(output, globalOrdinal, snapshotFeesInfo)(hasher)
       }
+
       validators = SharedValidators
         .make[IO](None, None, Some(stateChannelAllowanceLists), SortedMap.empty, Long.MaxValue, Hasher.forKryo[IO])
       currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -229,6 +229,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
     val feeCalculator = FeeCalculator.make(SortedMap.empty)
     val validators =
       SharedValidators.make[IO](None, None, Some(Map.empty[Address, NonEmptySet[PeerId]]), SortedMap.empty, Long.MaxValue, txHasher)
+
     val currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
       BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
       Amount(0L),

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/statechannel/FeeCalculator.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/statechannel/FeeCalculator.scala
@@ -10,6 +10,7 @@ import scala.collection.immutable.SortedMap
 
 import org.tessellation.currency.schema.currency.SnapshotFee
 import org.tessellation.schema.SnapshotOrdinal
+import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Balance
 
 import derevo.cats.eqv
@@ -27,6 +28,17 @@ case class FeeCalculatorConfig(
   computationalCost: NonNegLong,
   proWeight: NonNegBigDecimal
 )
+
+case class SnapshotFeesInfo(
+  allFeesAddresses: Map[Address, Set[Address]],
+  stakingBalance: Balance,
+  ownerAddress: Option[Address],
+  stakingAddress: Option[Address]
+)
+
+object SnapshotFeesInfo {
+  def empty: SnapshotFeesInfo = SnapshotFeesInfo(Map.empty, Balance.empty, none, none)
+}
 
 object FeeCalculatorConfig {
   val noFee: FeeCalculatorConfig =

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -18,7 +18,6 @@ import org.tessellation.security.Hasher
 import org.tessellation.security.signature.Signed
 import org.tessellation.syntax.sortedCollection._
 
-import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegLong
 
 case class CurrencyMessagesAcceptanceResult(
@@ -107,7 +106,7 @@ object CurrencySnapshotAcceptanceManager {
           .sorted(msgOrdering)
           .foldLeftM((lastMessages, List.empty[Signed[CurrencyMessage]], List.empty[Signed[CurrencyMessage]])) {
             case ((lastMsgs, toAdd, toReject), message) =>
-              messageValidator.validate(message, lastMsgs, lastSnapshotContext.address).map {
+              messageValidator.validate(message, lastMsgs, lastSnapshotContext.address, Map.empty).map {
                 case Validated.Valid(_) =>
                   val updatedLastMsgs = lastMsgs.updated(message.messageType, message)
                   val updatedToAdd = message :: toAdd
@@ -118,6 +117,7 @@ object CurrencySnapshotAcceptanceManager {
 
                   (lastMsgs, toAdd, updatedToReject)
               }
+
           }
 
       messagesAcceptanceResult = CurrencyMessagesAcceptanceResult(


### PR DESCRIPTION
### Changes
+ Added new storage to store all metagraphs and fee addresses in both layers: Global and Metagraph.
+ Implemented validation in StateChannel validations to reject snapshots with existing addresses.
+ Updated the validation function to accept not only staking balances but also addresses.
+ Added new validation in StateChannel validation to reject duplicate entries.
+ Updated the current tests to ensure compatibility with the updates.
+ Added validation on the endpoint to reject existing wallets. This provides an additional layer of validation, rejecting messages of existing wallets directly at the endpoint, resulting in two layers of validation.
+ Added code to populate existing metagraphs and addresses based on the lastGlobalSnapshot, and to fill values as snapshots are accepted.
+ We decided to not change the schema to add the addresses OWNER and STAKING, so we are deserializing the binary to read those information

### Tests
I've made tests in both scenarios, genesis and rollback in global layer