### PR TITLE
Fixing data-l1 consensus when lastGlobalSnapshot isn't available yet

### DIFF
--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/HttpApi.scala
@@ -121,7 +121,13 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
   private val targetRoutes = HasherSelector[F].withCurrent(implicit hasher => TargetRoutes[F](services.cluster).publicRoutes)
 
   private val currencyMessageRoutes = HasherSelector[F].withCurrent(implicit hasher =>
-    new CurrencyMessageRoutes[F](mkCell, validators.currencyMessageValidator, storages.snapshot, storages.identifier).publicRoutes
+    new CurrencyMessageRoutes[F](
+      mkCell,
+      validators.currencyMessageValidator,
+      storages.snapshot,
+      storages.identifier,
+      storages.lastGlobalSnapshot
+    ).publicRoutes
   )
 
   private val openRoutes: HttpRoutes[F] =

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -237,9 +237,11 @@ abstract class CurrencyL1App(
         hasherSelector.withCurrent { implicit hasher =>
           DataApplication
             .run(
+              cfg.dataConsensus,
               storages.cluster,
               storages.l0Cluster,
               storages.lastGlobalSnapshot,
+              storages.node,
               p2pClient.l0BlockOutputClient,
               p2pClient.consensusClient,
               services,

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
@@ -28,7 +28,7 @@ object method {
     val identifier: Address
 
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig =
-      AppConfig(c.consensus, c.transactionLimit, shared)
+      AppConfig(c.consensus, c.dataConsensus, c.transactionLimit, shared)
 
     val stateChannelAllowanceLists = None
 

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -14,6 +14,7 @@ import org.tessellation.currency.dataApplication.ConsensusInput._
 import org.tessellation.currency.dataApplication.ConsensusOutput.Noop
 import org.tessellation.currency.dataApplication._
 import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
+import org.tessellation.dag.l1.domain.consensus.block.config.DataConsensusConfig
 import org.tessellation.effects.GenUUID
 import org.tessellation.fsm.FSM
 import org.tessellation.node.shared.domain.cluster.storage.ClusterStorage
@@ -84,6 +85,7 @@ object Engine {
   type State = ConsensusState
 
   def fsm[F[_]: Async: Random: SecurityProvider: Hasher: L1NodeContext](
+    dataConsensusCfg: DataConsensusConfig,
     dataApplication: BaseDataApplicationL1Service[F],
     clusterStorage: ClusterStorage[F],
     lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
@@ -95,9 +97,9 @@ object Engine {
 
     implicit val dataEncoder = dataApplication.dataEncoder
 
-    def peersCount = 2
-    def timeout = 10.seconds
-    def maxDataUpdatesToDequeue = 50
+    def peersCount = dataConsensusCfg.peersCount.value
+    def timeout = dataConsensusCfg.timeout
+    def maxDataUpdatesToDequeue = dataConsensusCfg.maxDataUpdatesToDequeue.value
 
     def logger = Slf4jLogger.getLogger[F]
     def getTime: F[FiniteDuration] = Clock[F].monotonic

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Validator.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Validator.scala
@@ -1,0 +1,86 @@
+package org.tessellation.currency.l1.domain.dataApplication.consensus
+
+import cats.effect.Async
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.{Applicative, Monad}
+
+import org.tessellation.currency.dataApplication.{BaseDataApplicationL1Service, ConsensusInput}
+import org.tessellation.node.shared.domain.cluster.storage.ClusterStorage
+import org.tessellation.node.shared.domain.node.NodeStorage
+import org.tessellation.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import org.tessellation.schema.node.NodeState
+import org.tessellation.schema.node.NodeState.Ready
+import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import org.tessellation.security.signature.Signed
+import org.tessellation.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object Validator {
+
+  private def logger[F[_]: Async] = Slf4jLogger.getLogger
+
+  private def isReadyForConsensus(state: NodeState): Boolean = state == Ready
+
+  def isLastGlobalSnapshotPresent[F[_]: Async](
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+  ): F[Boolean] =
+    lastGlobalSnapshot.getOrdinal.map(_.isDefined)
+
+  private def enoughPeersForConsensus[F[_]: Monad](
+    clusterStorage: ClusterStorage[F],
+    peersCount: PosInt
+  ): F[Boolean] =
+    clusterStorage.getResponsivePeers
+      .map(_.filter(p => isReadyForConsensus(p.state)))
+      .map(_.size >= peersCount.value)
+
+  def isPeerInputValid[F[_]: Async: SecurityProvider: Hasher](
+    input: Signed[ConsensusInput.PeerConsensusInput],
+    dataApplicationService: BaseDataApplicationL1Service[F]
+  ): F[Boolean] =
+    for {
+      validSignature <- input.value match {
+        case proposal: ConsensusInput.Proposal =>
+          implicit val e: Encoder[ConsensusInput.Proposal] = ConsensusInput.Proposal.encoder(dataApplicationService.dataEncoder)
+          Signed(proposal, input.proofs).hasValidSignature
+
+        case signatureProposal: ConsensusInput.SignatureProposal =>
+          implicit val e: Encoder[ConsensusInput.SignatureProposal] = deriveEncoder
+          Signed(signatureProposal, input.proofs).hasValidSignature
+
+        case cancellation: ConsensusInput.CancelledCreationRound =>
+          implicit val e: Encoder[ConsensusInput.CancelledCreationRound] = deriveEncoder
+          Signed(cancellation, input.proofs).hasValidSignature
+      }
+
+      signedExclusively = input.isSignedExclusivelyBy(PeerId._Id.get(input.value.senderId))
+    } yield validSignature && signedExclusively
+
+  def canStartOwnDataConsensus[F[_]: Async](
+    nodeStorage: NodeStorage[F],
+    clusterStorage: ClusterStorage[F],
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    peersCount: PosInt
+  ): F[Boolean] =
+    for {
+      stateReadyForConsensus <- nodeStorage.getNodeState.map(isReadyForConsensus)
+      enoughPeers <- enoughPeersForConsensus(clusterStorage, peersCount)
+      lastGlobalSnapshotPresent <- isLastGlobalSnapshotPresent(lastGlobalSnapshot)
+      res = stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent
+      _ <-
+        Applicative[F].whenA(!res) {
+          val reason = Seq(
+            if (!stateReadyForConsensus) "State not ready for consensus" else "",
+            if (!enoughPeers) "Not enough peers" else "",
+            if (!lastGlobalSnapshotPresent) "No global snapshot" else ""
+          ).filter(_.nonEmpty).mkString(", ")
+          logger.debug(s"Cannot start data own consensus: ${reason}")
+        }
+    } yield res
+}

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/Main.scala
@@ -155,8 +155,7 @@ object Main
             programs.rollbackLoader.load(m.rollbackHash).flatMap {
               case (snapshotInfo, snapshot) =>
                 hasherSelector.forOrdinal(snapshot.ordinal) { implicit hasher =>
-                  storages.globalSnapshot
-                    .prepend(snapshot, snapshotInfo)
+                  storages.globalSnapshot.prepend(snapshot, snapshotInfo)
                 } >>
                   services.consensus.manager.startFacilitatingAfterRollback(
                     snapshot.ordinal,

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Services.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Services.scala
@@ -85,7 +85,10 @@ object Services {
       addressService = AddressService.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo](storages.globalSnapshot)
       collateralService = Collateral.make[F](cfg.collateral, storages.globalSnapshot)
       stateChannelService = StateChannelService
-        .make[F](L0Cell.mkL0Cell(queues.l1Output, queues.stateChannelOutput), validators.stateChannelValidator)
+        .make[F](
+          L0Cell.mkL0Cell(queues.l1Output, queues.stateChannelOutput),
+          validators.stateChannelValidator
+        )
       getOrdinal = storages.globalSnapshot.headSnapshot.map(_.map(_.ordinal))
       trustUpdaterService = TrustStorageUpdater.make(getOrdinal, sharedServices.gossip, storages.trust)
     } yield

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Storages.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Storages.scala
@@ -19,11 +19,7 @@ import org.tessellation.node.shared.domain.seedlist.SeedlistEntry
 import org.tessellation.node.shared.domain.snapshot.storage.SnapshotStorage
 import org.tessellation.node.shared.domain.trust.storage.TrustStorage
 import org.tessellation.node.shared.infrastructure.gossip.RumorStorage
-import org.tessellation.node.shared.infrastructure.snapshot.storage.{
-  SnapshotInfoLocalFileSystemStorage,
-  SnapshotLocalFileSystemStorage,
-  SnapshotStorage
-}
+import org.tessellation.node.shared.infrastructure.snapshot.storage._
 import org.tessellation.node.shared.modules.SharedStorages
 import org.tessellation.schema._
 import org.tessellation.schema.trust.PeerObservationAdjustmentUpdateBatch
@@ -76,6 +72,7 @@ object Storages {
           incrementalKryoGlobalSnapshotInfoLocalFileSystemStorage,
           hashSelect
         )
+
     } yield
       new Storages[F](
         cluster = sharedStorages.cluster,

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/domain/statechannel/StateChannelServiceSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/domain/statechannel/StateChannelServiceSuite.scala
@@ -13,9 +13,8 @@ import org.tessellation.dag.l0.domain.cell.L0Cell
 import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.json.JsonSerializer
 import org.tessellation.kryo.KryoSerializer
-import org.tessellation.node.shared.domain.statechannel.StateChannelValidator
+import org.tessellation.node.shared.domain.statechannel.{SnapshotFeesInfo, StateChannelValidator}
 import org.tessellation.schema._
-import org.tessellation.schema.balance.Balance
 import org.tessellation.schema.epoch.EpochProgress
 import org.tessellation.schema.height.{Height, SubHeight}
 import org.tessellation.schema.peer.PeerId
@@ -71,11 +70,17 @@ object StateChannelServiceSuite extends MutableIOSuite {
 
   def mkService(failed: Option[StateChannelValidator.StateChannelValidationError] = None) = {
     val validator = new StateChannelValidator[IO] {
-      def validate(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
+      def validate(
+        output: StateChannelOutput,
+        globalOrdinal: SnapshotOrdinal,
+        snapshotFeesInfo: SnapshotFeesInfo
+      )(implicit hasher: Hasher[IO]) =
         IO.pure(failed.fold[StateChannelValidator.StateChannelValidationErrorOr[StateChannelOutput]](output.validNec)(_.invalidNec))
 
-      def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
-        validate(output, globalOrdinal, staked)
+      def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, snapshotFeesInfo: SnapshotFeesInfo)(
+        implicit hasher: Hasher[IO]
+      ) =
+        validate(output, globalOrdinal, snapshotFeesInfo)
     }
 
     for {

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -16,12 +16,12 @@ import org.tessellation.ext.cats.effect.ResourceIO
 import org.tessellation.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import org.tessellation.kryo.KryoSerializer
 import org.tessellation.node.shared.config.types.SnapshotSizeConfig
-import org.tessellation.node.shared.domain.statechannel.{FeeCalculator, StateChannelAcceptanceResult, StateChannelValidator}
+import org.tessellation.node.shared.domain.statechannel._
 import org.tessellation.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import org.tessellation.node.shared.infrastructure.snapshot._
 import org.tessellation.node.shared.modules.SharedValidators
 import org.tessellation.schema.address.Address
-import org.tessellation.schema.balance.{Amount, Balance}
+import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.peer.PeerId
 import org.tessellation.schema.{GlobalSnapshotInfo, SnapshotOrdinal}
 import org.tessellation.security._
@@ -55,11 +55,18 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
     for {
       _ <- IO.unit
       validator = new StateChannelValidator[IO] {
-        def validate(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
+        def validate(
+          output: StateChannelOutput,
+          globalOrdinal: SnapshotOrdinal,
+          snapshotFeesInfo: SnapshotFeesInfo
+        )(implicit hasher: Hasher[IO]) =
           IO.pure(failed.filter(f => f._1 == output.address).map(_._2.invalidNec).getOrElse(output.validNec))
-        def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, staked: Balance)(implicit hasher: Hasher[IO]) =
-          validate(output, globalOrdinal, staked)(hasher)
+        def validateHistorical(output: StateChannelOutput, globalOrdinal: SnapshotOrdinal, snapshotFeesInfo: SnapshotFeesInfo)(
+          implicit hasher: Hasher[IO]
+        ) =
+          validate(output, globalOrdinal, snapshotFeesInfo)(hasher)
       }
+
       validators = SharedValidators
         .make[IO](None, None, Some(stateChannelAllowanceLists), SortedMap.empty, Long.MaxValue, Hasher.forKryo[IO])
       currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -229,6 +229,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
     val feeCalculator = FeeCalculator.make(SortedMap.empty)
     val validators =
       SharedValidators.make[IO](None, None, Some(Map.empty[Address, NonEmptySet[PeerId]]), SortedMap.empty, Long.MaxValue, txHasher)
+
     val currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
       BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
       Amount(0L),

--- a/modules/dag-l1/src/main/resources/application.conf
+++ b/modules/dag-l1/src/main/resources/application.conf
@@ -7,6 +7,12 @@ consensus {
   pull-txs-count = 100
 }
 
+data-consensus {
+  peers-count = 2
+  timeout = 10 seconds
+  max-data-updates-to-dequeue = 50
+}
+
 transaction-limit {
   base-balance = 100000000
   time-trigger-interval = 43 seconds

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
@@ -21,6 +21,7 @@ object method {
 
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig = AppConfig(
       c.consensus,
+      c.dataConsensus,
       c.transactionLimit,
       shared
     )

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/config/types.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/config/types.scala
@@ -1,6 +1,6 @@
 package org.tessellation.dag.l1.config
 
-import org.tessellation.dag.l1.domain.consensus.block.config.ConsensusConfig
+import org.tessellation.dag.l1.domain.consensus.block.config.{ConsensusConfig, DataConsensusConfig}
 import org.tessellation.dag.l1.domain.transaction.TransactionLimitConfig
 import org.tessellation.node.shared.config.types._
 
@@ -8,11 +8,13 @@ object types {
 
   case class AppConfigReader(
     consensus: ConsensusConfig,
+    dataConsensus: DataConsensusConfig,
     transactionLimit: TransactionLimitConfig
   )
 
   case class AppConfig(
     consensus: ConsensusConfig,
+    dataConsensus: DataConsensusConfig,
     transactionLimit: TransactionLimitConfig,
     shared: SharedConfig
   ) {

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/Validator.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/Validator.scala
@@ -2,7 +2,6 @@ package org.tessellation.dag.l1.domain.consensus.block
 
 import cats.effect.Async
 import cats.syntax.flatMap._
-import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.{Applicative, Monad}
 

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/config/DataConsensusConfig.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/config/DataConsensusConfig.scala
@@ -1,0 +1,7 @@
+package org.tessellation.dag.l1.domain.consensus.block.config
+
+import scala.concurrent.duration.FiniteDuration
+
+import eu.timepit.refined.types.numeric.PosInt
+
+case class DataConsensusConfig(peersCount: PosInt, timeout: FiniteDuration, maxDataUpdatesToDequeue: PosInt)

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -83,7 +83,7 @@ fee-configs {
     }
   }
   integrationnet: {
-    1573000: {
+    1618500: {
       base-fee: 100000,
       staking-weight: 2e-15,
       computational-cost: 1,

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/statechannel/FeeCalculator.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/statechannel/FeeCalculator.scala
@@ -10,6 +10,7 @@ import scala.collection.immutable.SortedMap
 
 import org.tessellation.currency.schema.currency.SnapshotFee
 import org.tessellation.schema.SnapshotOrdinal
+import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Balance
 
 import derevo.cats.eqv
@@ -27,6 +28,17 @@ case class FeeCalculatorConfig(
   computationalCost: NonNegLong,
   proWeight: NonNegBigDecimal
 )
+
+case class SnapshotFeesInfo(
+  allFeesAddresses: Map[Address, Set[Address]],
+  stakingBalance: Balance,
+  ownerAddress: Option[Address],
+  stakingAddress: Option[Address]
+)
+
+object SnapshotFeesInfo {
+  def empty: SnapshotFeesInfo = SnapshotFeesInfo(Map.empty, Balance.empty, none, none)
+}
 
 object FeeCalculatorConfig {
   val noFee: FeeCalculatorConfig =

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -18,7 +18,6 @@ import org.tessellation.security.Hasher
 import org.tessellation.security.signature.Signed
 import org.tessellation.syntax.sortedCollection._
 
-import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegLong
 
 case class CurrencyMessagesAcceptanceResult(
@@ -107,7 +106,7 @@ object CurrencySnapshotAcceptanceManager {
           .sorted(msgOrdering)
           .foldLeftM((lastMessages, List.empty[Signed[CurrencyMessage]], List.empty[Signed[CurrencyMessage]])) {
             case ((lastMsgs, toAdd, toReject), message) =>
-              messageValidator.validate(message, lastMsgs, lastSnapshotContext.address).map {
+              messageValidator.validate(message, lastMsgs, lastSnapshotContext.address, Map.empty).map {
                 case Validated.Valid(_) =>
                   val updatedLastMsgs = lastMsgs.updated(message.messageType, message)
                   val updatedToAdd = message :: toAdd
@@ -118,6 +117,7 @@ object CurrencySnapshotAcceptanceManager {
 
                   (lastMsgs, toAdd, updatedToReject)
               }
+
           }
 
       messagesAcceptanceResult = CurrencyMessagesAcceptanceResult(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.7.4"
+ThisBuild / version := "2.7.5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.7.4-SNAPSHOT"
+ThisBuild / version := "2.7.4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.7.5-SNAPSHOT"
+ThisBuild / version := "2.7.6-SNAPSHOT"


### PR DESCRIPTION
### Changes
+ We had a bug that the data-l1 consensus was being stopped when the lastGlobalSnapshot wasn't present. This error was halting the streaming and blocking the node from starting the own consensus
+ I've followed the pattern of the currency layer and added a validation to the data consensus before trying to start the own consensus

### Tests
It was working as expected, as the image below illustrates 
<img width="2538" alt="Captura de Tela 2024-07-10 às 11 04 43" src="https://github.com/Constellation-Labs/tessellation/assets/22091534/9af0832a-7f36-4c0d-bc4b-3bdf7fb98a4e">
