### PR TITLE
Adding canStartOwnDataConsensus to avoid error during the data-l1 consensus and halting the streaming

### DIFF
--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/CurrencyL1App.scala
@@ -237,9 +237,11 @@ abstract class CurrencyL1App(
         hasherSelector.withCurrent { implicit hasher =>
           DataApplication
             .run(
+              cfg.dataConsensus,
               storages.cluster,
               storages.l0Cluster,
               storages.lastGlobalSnapshot,
+              storages.node,
               p2pClient.l0BlockOutputClient,
               p2pClient.consensusClient,
               services,

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/cli/method.scala
@@ -28,7 +28,7 @@ object method {
     val identifier: Address
 
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig =
-      AppConfig(c.consensus, c.transactionLimit, shared)
+      AppConfig(c.consensus, c.dataConsensus, c.transactionLimit, shared)
 
     val stateChannelAllowanceLists = None
 

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -14,6 +14,7 @@ import org.tessellation.currency.dataApplication.ConsensusInput._
 import org.tessellation.currency.dataApplication.ConsensusOutput.Noop
 import org.tessellation.currency.dataApplication._
 import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
+import org.tessellation.dag.l1.domain.consensus.block.config.DataConsensusConfig
 import org.tessellation.effects.GenUUID
 import org.tessellation.fsm.FSM
 import org.tessellation.node.shared.domain.cluster.storage.ClusterStorage
@@ -84,6 +85,7 @@ object Engine {
   type State = ConsensusState
 
   def fsm[F[_]: Async: Random: SecurityProvider: Hasher: L1NodeContext](
+    dataConsensusCfg: DataConsensusConfig,
     dataApplication: BaseDataApplicationL1Service[F],
     clusterStorage: ClusterStorage[F],
     lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
@@ -95,9 +97,9 @@ object Engine {
 
     implicit val dataEncoder = dataApplication.dataEncoder
 
-    def peersCount = 2
-    def timeout = 10.seconds
-    def maxDataUpdatesToDequeue = 50
+    def peersCount = dataConsensusCfg.peersCount.value
+    def timeout = dataConsensusCfg.timeout
+    def maxDataUpdatesToDequeue = dataConsensusCfg.maxDataUpdatesToDequeue.value
 
     def logger = Slf4jLogger.getLogger[F]
     def getTime: F[FiniteDuration] = Clock[F].monotonic

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Validator.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/domain/dataApplication/consensus/Validator.scala
@@ -1,0 +1,86 @@
+package org.tessellation.currency.l1.domain.dataApplication.consensus
+
+import cats.effect.Async
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.{Applicative, Monad}
+
+import org.tessellation.currency.dataApplication.{BaseDataApplicationL1Service, ConsensusInput}
+import org.tessellation.node.shared.domain.cluster.storage.ClusterStorage
+import org.tessellation.node.shared.domain.node.NodeStorage
+import org.tessellation.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import org.tessellation.schema.node.NodeState
+import org.tessellation.schema.node.NodeState.Ready
+import org.tessellation.schema.peer.PeerId
+import org.tessellation.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import org.tessellation.security.signature.Signed
+import org.tessellation.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object Validator {
+
+  private def logger[F[_]: Async] = Slf4jLogger.getLogger
+
+  private def isReadyForConsensus(state: NodeState): Boolean = state == Ready
+
+  def isLastGlobalSnapshotPresent[F[_]: Async](
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+  ): F[Boolean] =
+    lastGlobalSnapshot.getOrdinal.map(_.isDefined)
+
+  private def enoughPeersForConsensus[F[_]: Monad](
+    clusterStorage: ClusterStorage[F],
+    peersCount: PosInt
+  ): F[Boolean] =
+    clusterStorage.getResponsivePeers
+      .map(_.filter(p => isReadyForConsensus(p.state)))
+      .map(_.size >= peersCount.value)
+
+  def isPeerInputValid[F[_]: Async: SecurityProvider: Hasher](
+    input: Signed[ConsensusInput.PeerConsensusInput],
+    dataApplicationService: BaseDataApplicationL1Service[F]
+  ): F[Boolean] =
+    for {
+      validSignature <- input.value match {
+        case proposal: ConsensusInput.Proposal =>
+          implicit val e: Encoder[ConsensusInput.Proposal] = ConsensusInput.Proposal.encoder(dataApplicationService.dataEncoder)
+          Signed(proposal, input.proofs).hasValidSignature
+
+        case signatureProposal: ConsensusInput.SignatureProposal =>
+          implicit val e: Encoder[ConsensusInput.SignatureProposal] = deriveEncoder
+          Signed(signatureProposal, input.proofs).hasValidSignature
+
+        case cancellation: ConsensusInput.CancelledCreationRound =>
+          implicit val e: Encoder[ConsensusInput.CancelledCreationRound] = deriveEncoder
+          Signed(cancellation, input.proofs).hasValidSignature
+      }
+
+      signedExclusively = input.isSignedExclusivelyBy(PeerId._Id.get(input.value.senderId))
+    } yield validSignature && signedExclusively
+
+  def canStartOwnDataConsensus[F[_]: Async](
+    nodeStorage: NodeStorage[F],
+    clusterStorage: ClusterStorage[F],
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    peersCount: PosInt
+  ): F[Boolean] =
+    for {
+      stateReadyForConsensus <- nodeStorage.getNodeState.map(isReadyForConsensus)
+      enoughPeers <- enoughPeersForConsensus(clusterStorage, peersCount)
+      lastGlobalSnapshotPresent <- isLastGlobalSnapshotPresent(lastGlobalSnapshot)
+      res = stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent
+      _ <-
+        Applicative[F].whenA(!res) {
+          val reason = Seq(
+            if (!stateReadyForConsensus) "State not ready for consensus" else "",
+            if (!enoughPeers) "Not enough peers" else "",
+            if (!lastGlobalSnapshotPresent) "No global snapshot" else ""
+          ).filter(_.nonEmpty).mkString(", ")
+          logger.debug(s"Cannot start data own consensus: ${reason}")
+        }
+    } yield res
+}

--- a/modules/dag-l1/src/main/resources/application.conf
+++ b/modules/dag-l1/src/main/resources/application.conf
@@ -7,6 +7,12 @@ consensus {
   pull-txs-count = 100
 }
 
+data-consensus {
+  peers-count = 2
+  timeout = 10 seconds
+  max-data-updates-to-dequeue = 50
+}
+
 transaction-limit {
   base-balance = 100000000
   time-trigger-interval = 43 seconds

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/cli/method.scala
@@ -21,6 +21,7 @@ object method {
 
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig = AppConfig(
       c.consensus,
+      c.dataConsensus,
       c.transactionLimit,
       shared
     )

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/config/types.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/config/types.scala
@@ -1,6 +1,6 @@
 package org.tessellation.dag.l1.config
 
-import org.tessellation.dag.l1.domain.consensus.block.config.ConsensusConfig
+import org.tessellation.dag.l1.domain.consensus.block.config.{ConsensusConfig, DataConsensusConfig}
 import org.tessellation.dag.l1.domain.transaction.TransactionLimitConfig
 import org.tessellation.node.shared.config.types._
 
@@ -8,11 +8,13 @@ object types {
 
   case class AppConfigReader(
     consensus: ConsensusConfig,
+    dataConsensus: DataConsensusConfig,
     transactionLimit: TransactionLimitConfig
   )
 
   case class AppConfig(
     consensus: ConsensusConfig,
+    dataConsensus: DataConsensusConfig,
     transactionLimit: TransactionLimitConfig,
     shared: SharedConfig
   ) {

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/Validator.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/Validator.scala
@@ -2,7 +2,6 @@ package org.tessellation.dag.l1.domain.consensus.block
 
 import cats.effect.Async
 import cats.syntax.flatMap._
-import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.{Applicative, Monad}
 

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/config/DataConsensusConfig.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/domain/consensus/block/config/DataConsensusConfig.scala
@@ -1,0 +1,7 @@
+package org.tessellation.dag.l1.domain.consensus.block.config
+
+import scala.concurrent.duration.FiniteDuration
+
+import eu.timepit.refined.types.numeric.PosInt
+
+case class DataConsensusConfig(peersCount: PosInt, timeout: FiniteDuration, maxDataUpdatesToDequeue: PosInt)


### PR DESCRIPTION
### Changes
+ We had a bug that the data-l1 consensus was being stopped when the lastGlobalSnapshot wasn't present. This error was halting the streaming and blocking the node from starting the own consensus
+ I've followed the pattern of the currency layer and added a validation to the data consensus before trying to start the own consensus

### Tests
It was working as expected, as the image below illustrates 
<img width="2538" alt="Captura de Tela 2024-07-10 às 11 04 43" src="https://github.com/Constellation-Labs/tessellation/assets/22091534/9af0832a-7f36-4c0d-bc4b-3bdf7fb98a4e">
