### PR TITLE
fix: changed /data response to match /transactions

### DIFF
--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/http/DataApplicationRoutes.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/http/DataApplicationRoutes.scala
@@ -19,6 +19,7 @@ import org.tessellation.security.signature.Signed
 import org.tessellation.security.{Hasher, SecurityProvider}
 
 import eu.timepit.refined.auto._
+import io.circe.shapes._
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder}
 import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder}
@@ -26,6 +27,8 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.{EntityDecoder, HttpRoutes, Response}
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import shapeless._
+import shapeless.syntax.singleton._
 
 final case class DataApplicationRoutes[F[_]: Async: Hasher: SecurityProvider: L1NodeContext](
   dataApplicationPeerConsensusInput: Queue[F, Signed[ConsensusInput.PeerConsensusInput]],
@@ -84,7 +87,7 @@ final case class DataApplicationRoutes[F[_]: Async: Hasher: SecurityProvider: L1
             case Left(_) => BadRequest(InvalidSignature.toApplicationError)
             case Right(hashed) =>
               validate(hashed.signed) {
-                dataUpdatesQueue.offer(hashed.signed) >> Ok(("hash" -> hashed.hash.value).asJson)
+                dataUpdatesQueue.offer(hashed.signed) >> Ok(("hash" ->> hashed.hash.value) :: HNil)
               }
           }
         }


### PR DESCRIPTION
The current implementation of the `/data` response produces a JSON array of two elements:
```
["hash","047e9423a1e6f9ee53596abf787884d007c82e1ec898a599f2048961ce5872e2"]
```
but I think the intention was to produce an object similar to the `/transactions` endpoint:
```
{"hash":"4ee922ad6b244df6ec5b84a54cb9024d92607cba3cbc2c7b283e0b2fa053cf5e"}
```
