### PR TITLE
Include currencyL0 and currencyL1 into sdk module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -533,7 +533,7 @@ lazy val sdk = (project in file("modules/sdk"))
   .enablePlugins(AshScriptPlugin)
   .enablePlugins(BuildInfoPlugin)
   .enablePlugins(JavaAppPackaging)
-  .dependsOn(keytool, kernel, shared % "compile->compile;test->test", testShared % Test, nodeShared)
+  .dependsOn(keytool, kernel, shared % "compile->compile;test->test", testShared % Test, nodeShared, currencyL0, currencyL1)
   .settings(
     name := "tessellation-sdk",
     Defaults.itSettings,


### PR DESCRIPTION
## Purpose
@marcinwadon has mentioned in a couple of the example PR's that a single dependency of `tessellation-sdk` is the preferred import by metagraph projects. This PR updates the tessellation build to have the `sdk` package depend on the `currencyL1` and `currencyL0` modules.

## Changes
- Updated `sdk` module definition in `build-sbt`

## Testing
- Locally published updated Tessellation deps and ensured a metagraph was able to only import `tessellation-sdk` and still compile