### PR TITLE
refactor!: restrict function scope of DataApp lifecycle methods

### DIFF
--- a/.github/templates/project_template/modules/data_l1/src/main/scala/com/my/project_template/data_l1/Main.scala
+++ b/.github/templates/project_template/modules/data_l1/src/main/scala/com/my/project_template/data_l1/Main.scala
@@ -35,12 +35,6 @@ object Main extends CurrencyL1App(
     calculatedStateService: CalculatedStateService[IO]
   ): BaseDataApplicationL1Service[IO] = BaseDataApplicationL1Service(
     new DataApplicationL1Service[IO, UsageUpdate, UsageUpdateState, UsageUpdateCalculatedState] {
-      override def validateData(
-        state  : DataState[UsageUpdateState, UsageUpdateCalculatedState],
-        updates: NonEmptyList[Signed[UsageUpdate]]
-      )(implicit context: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
-        ().validNec.pure[IO]
-
       override def validateUpdate(
         update: UsageUpdate
       )(implicit context: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
@@ -50,12 +44,6 @@ object Main extends CurrencyL1App(
         implicit context: L1NodeContext[IO], A: Applicative[IO]
       ): IO[DataApplicationValidationErrorOr[Unit]] =
         ().validNec.pure[IO]
-
-      override def combine(
-        state  : DataState[UsageUpdateState, UsageUpdateCalculatedState],
-        updates: List[Signed[UsageUpdate]]
-      )(implicit context: L1NodeContext[IO]): IO[DataState[UsageUpdateState, UsageUpdateCalculatedState]] =
-        state.pure[IO]
 
       override def routes(implicit context: L1NodeContext[IO]): HttpRoutes[IO] =
         HttpRoutes.empty
@@ -104,20 +92,6 @@ object Main extends CurrencyL1App(
         bytes: Array[Byte]
       ): IO[Either[Throwable, UsageUpdate]] =
         IO(Deserializers.deserializeUpdate(bytes))
-
-      override def getCalculatedState(implicit context: L1NodeContext[IO]): IO[(SnapshotOrdinal, UsageUpdateCalculatedState)] =
-        calculatedStateService.getCalculatedState.map(calculatedState => (calculatedState.ordinal, calculatedState.state))
-
-      override def setCalculatedState(
-        ordinal: SnapshotOrdinal,
-        state  : UsageUpdateCalculatedState
-      )(implicit context: L1NodeContext[IO]): IO[Boolean] =
-        calculatedStateService.setCalculatedState(ordinal, state)
-
-      override def hashCalculatedState(
-        state: UsageUpdateCalculatedState
-      )(implicit context: L1NodeContext[IO]): IO[Hash] =
-        calculatedStateService.hashCalculatedState(state)
 
       override def serializeCalculatedState(
         state: UsageUpdateCalculatedState

--- a/.github/templates/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
+++ b/.github/templates/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
@@ -46,11 +46,6 @@ object Main
         override def genesis: DataState[UsageUpdateState, UsageUpdateCalculatedState] =
           DataState(UsageUpdateState(List.empty), UsageUpdateCalculatedState(Map.empty))
 
-        override def validateUpdate(
-          update: UsageUpdate
-        )(implicit context: L0NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
-          ().validNec.pure[IO]
-
         override def validateFee(gsOrdinal: SnapshotOrdinal)(update: Signed[UsageUpdate])(
           implicit context: L0NodeContext[IO],
           A: Applicative[IO]

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
@@ -1,15 +1,12 @@
 package org.tessellation.currency.l1
 
 import cats.Applicative
-import cats.data.NonEmptyList
 import cats.effect.IO
 
-import org.tessellation.currency.dataApplication.DataState.Base
 import org.tessellation.currency.dataApplication._
 import org.tessellation.currency.dataApplication.dataApplication.{DataApplicationBlock, DataApplicationValidationErrorOr}
 import org.tessellation.routes.internal.ExternalUrlPrefix
 import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.hash.Hash
 import org.tessellation.security.signature.Signed
 
 import io.circe.{Decoder, Encoder}
@@ -50,26 +47,12 @@ class DummyDataApplicationL1Service extends BaseDataApplicationL1Service[IO] {
 
   override def calculatedStateDecoder: Decoder[DataCalculatedState] = ???
 
-  override def validateData(state: Base, updates: NonEmptyList[Signed[DataUpdate]])(
-    implicit context: L1NodeContext[IO]
-  ): IO[DataApplicationValidationErrorOr[Unit]] = ???
-
   override def validateUpdate(update: DataUpdate)(implicit context: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] = ???
 
   override def validateFee(gsOrdinal: SnapshotOrdinal)(update: Signed[DataUpdate])(
     implicit context: L1NodeContext[IO],
     A: Applicative[IO]
   ): IO[dataApplication.DataApplicationValidationErrorOr[Unit]] = ???
-
-  override def combine(state: Base, updates: List[Signed[DataUpdate]])(implicit context: L1NodeContext[IO]): IO[Base] = ???
-
-  override def getCalculatedState(implicit context: L1NodeContext[IO]): IO[(SnapshotOrdinal, DataCalculatedState)] = ???
-
-  override def setCalculatedState(ordinal: SnapshotOrdinal, state: DataCalculatedState)(
-    implicit context: L1NodeContext[IO]
-  ): IO[Boolean] = ???
-
-  override def hashCalculatedState(state: DataCalculatedState)(implicit context: L1NodeContext[IO]): IO[Hash] = ???
 
   override def routes(implicit context: L1NodeContext[IO]): HttpRoutes[IO] = ???
 

--- a/modules/node-shared/src/test/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
+++ b/modules/node-shared/src/test/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
@@ -322,10 +322,6 @@ object CurrencyEventsCutterSuite extends MutableIOSuite with Checkers {
       implicit context: L0NodeContext[IO]
     ): IO[dataApplication.DataApplicationValidationErrorOr[Unit]] = ???
 
-    override def validateUpdate(update: DataUpdate)(
-      implicit context: L0NodeContext[IO]
-    ): IO[dataApplication.DataApplicationValidationErrorOr[Unit]] = ???
-
     override def validateFee(gsOrdinal: SnapshotOrdinal)(update: Signed[DataUpdate])(
       implicit context: L0NodeContext[IO],
       A: Applicative[IO]


### PR DESCRIPTION
## Purpose
The previous definition of `DataApplicationContextualOps` was shared between L0 and L1 services which led to metagraph developers needing to provide implementations for functions that were not invoked by the underlying `TessellationIOApp`. For example, Data-L1 nodes were forced to provide definitions for `combine` and `validateData` but these methods are only invoked for L0 nodes. This led to dummy implementations being provided simply to satisfy inheritance constraints for all Data Applications such as [Dor](https://github.com/Constellation-Labs/dor-metagraph/blob/d85e808d12bbb491fce8e789fe72f2d736cc4328/metagraph/modules/data_l1/src/main/scala/com/my/dor_metagraph/data_l1/Main.scala#L51). 

This PR introduces `SharedContextualOps, L0ContextualOps, & L1ContextualOps` to restrict the scope of contextual operations to the layer where they are needed. This allows for metagraph developers to avoid the dummy implementations that were previously needed.

## Changes
- Updates `dataApplication` package definitions to distinguish between shared, L0, & L1 contextual operations
- Updated unit test mocks and integration test implementations for CurrencyL0 and CurrencyL1 

## Testing
- All unit tests passing locally
- A metagraph-example was modified to depend on the updated DataApplication and compiled successfully
- verified expected behavior of an end to end example will be performed to ensure expected behavior