### PR TITLE
fix: update epoch progress one time reward to around 16 UTC 2024-08-08

### DIFF
--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/config/types.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/config/types.scala
@@ -93,9 +93,9 @@ object types {
       // as of the last minting it received awards (Epoch 1352274)
       OneTimeReward(EpochProgress(1353745L), stardustNewPrimary, TransactionAmount(4_343_029_488_479_231L)),
       // One-time minting to treasure wallets according to new metanomics
-      OneTimeReward(EpochProgress(1927873L), treasureWalletMetanomics1, TransactionAmount(150_000_000_000_000_00L)),
-      OneTimeReward(EpochProgress(1927873L), treasureWalletMetanomics2, TransactionAmount(150_000_000_000_000_00L)),
-      OneTimeReward(EpochProgress(1927873L), treasureWalletMetanomics3, TransactionAmount(150_000_000_000_000_00L)),
+      OneTimeReward(EpochProgress(1928500L), treasureWalletMetanomics1, TransactionAmount(150_000_000_000_000_00L)),
+      OneTimeReward(EpochProgress(1928500L), treasureWalletMetanomics2, TransactionAmount(150_000_000_000_000_00L)),
+      OneTimeReward(EpochProgress(1928500L), treasureWalletMetanomics3, TransactionAmount(150_000_000_000_000_00L)),
     )
   )
 


### PR DESCRIPTION
### Changes
+ Updating one time rewards to the metanomics treasure wallets to be around 16 UTC 2024-08-08