### PR TITLE
fix: adding retry mechanism to fetch global snapshots from another peer if it fails during rollback

### DIFF
--- a/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/DataApplicationTraverse.scala
+++ b/modules/shared/src/main/scala/org/tessellation/currency/dataApplication/DataApplicationTraverse.scala
@@ -150,7 +150,8 @@ object DataApplicationTraverse {
                         }
 
                       case _ =>
-                        updateCache(snapshot).as(tail.asLeft[Output])
+                        logger.info(s"Could not get calculated state of ordinal: ${snapshot.ordinal}, updating cache") >>
+                          updateCache(snapshot).as(tail.asLeft[Output])
                     }
               } >>= {
               case Some((state, ordinal)) =>
@@ -169,7 +170,8 @@ object DataApplicationTraverse {
                   )).raiseError[F, Either[Acc, Output]]
                 case Validated.Valid(snapshots) =>
                   logger.info(
-                    s"Found ${snapshots.size.show} snapshots at global snapshot ordinal=${globalSnapshot.ordinal.show}, performing nested recursion."
+                    s"Found ${snapshots.size.show} snapshots at global snapshot ordinal=${globalSnapshot.ordinal.show}, Ordinals: ${snapshots
+                        .map(_.ordinal)} performing nested recursion."
                   ) >> nestedRecursion(snapshots).flatMap {
                     case Right(Some((state, ordinal))) => (state, ordinal).some.asRight[Acc].pure[F]
                     case _ =>


### PR DESCRIPTION
### Changes
+ Adding a retry mechanism of 10 times when not find the snapshot in a peer, during rollback.
+ This error was finishing the metagraph restart when we fetch from a peer that might not contain the global snapshot per hash
+ I've also added more logs to follow during the traverse.

### Tests
It's working as expected
<img width="1965" alt="Captura de Tela 2024-08-10 às 09 25 57" src="https://github.com/user-attachments/assets/5d357f1a-cf1e-4a3a-a5a6-c384af5750d0">
<img width="2501" alt="Captura de Tela 2024-08-10 às 09 39 29" src="https://github.com/user-attachments/assets/3a1f6541-9480-4145-ba9e-fb86fd535f35">
