### PR TITLE
feat: adding update hash to the schema of estimate fee endpoint response

### DIFF
--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/http/EstimatedFeeResponse.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/http/EstimatedFeeResponse.scala
@@ -6,17 +6,18 @@ import org.tessellation.currency.schema.EstimatedFee
 import org.tessellation.currency.schema.EstimatedFee.{Estimated, Zero}
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
+import org.tessellation.security.hash.Hash
 
 import derevo.circe.magnolia.encoder
 import derevo.derive
 
 @derive(encoder)
-case class EstimatedFeeResponse(fee: Amount, address: Option[Address])
+case class EstimatedFeeResponse(fee: Amount, address: Option[Address], updateHash: Hash)
 
 object EstimatedFeeResponse {
-  def apply(ef: EstimatedFee): EstimatedFeeResponse =
+  def apply(ef: EstimatedFee, updateHash: Hash): EstimatedFeeResponse =
     ef match {
-      case Zero            => EstimatedFeeResponse(fee = Amount.empty, address = none)
-      case Estimated(f, a) => EstimatedFeeResponse(fee = f, address = a.some)
+      case Zero            => EstimatedFeeResponse(fee = Amount.empty, address = none, updateHash)
+      case Estimated(f, a) => EstimatedFeeResponse(fee = f, address = a.some, updateHash)
     }
 }

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/DummyDataApplicationL1Service.scala
@@ -5,6 +5,7 @@ import cats.effect.IO
 
 import org.tessellation.currency.dataApplication._
 import org.tessellation.currency.dataApplication.dataApplication.{DataApplicationBlock, DataApplicationValidationErrorOr}
+import org.tessellation.json.JsonBinarySerializer
 import org.tessellation.routes.internal.ExternalUrlPrefix
 import org.tessellation.schema.SnapshotOrdinal
 import org.tessellation.security.signature.Signed
@@ -19,7 +20,7 @@ class DummyDataApplicationL1Service extends BaseDataApplicationL1Service[IO] {
 
   override def deserializeState(bytes: Array[Byte]): IO[Either[Throwable, DataOnChainState]] = ???
 
-  override def serializeUpdate(update: DataUpdate): IO[Array[Byte]] = ???
+  override def serializeUpdate(update: DataUpdate): IO[Array[Byte]] = IO.delay(JsonBinarySerializer.serialize(update)(dataEncoder))
 
   override def deserializeUpdate(bytes: Array[Byte]): IO[Either[Throwable, DataUpdate]] = ???
 

--- a/modules/shared/src/main/scala/org/tessellation/currency/schema/EstimatedFee.scala
+++ b/modules/shared/src/main/scala/org/tessellation/currency/schema/EstimatedFee.scala
@@ -1,7 +1,12 @@
 package org.tessellation.currency.schema
 
+import cats.effect.Async
+import cats.syntax.functor._
+
+import org.tessellation.currency.dataApplication.DataUpdate
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
+import org.tessellation.security.hash.Hash
 
 import derevo.cats.show
 import derevo.derive
@@ -17,4 +22,7 @@ object EstimatedFee {
 
   def apply(fee: Amount, address: Address): EstimatedFee =
     Estimated(fee, address)
+
+  def getUpdateHash[F[_]: Async](dataUpdate: DataUpdate, toBytes: DataUpdate => F[Array[Byte]]): F[Hash] =
+    toBytes(dataUpdate).map(Hash.fromBytes)
 }


### PR DESCRIPTION
### Changes
+ Adding the `update hash` as part of the response schema of `estimate-fee` data route
+ Updated the tests to this new field and behavior