### PR TITLE
fix: catch exceptions during DataApp onSnapshotConsensusResult

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -294,7 +294,7 @@ object CurrencySnapshotConsensusStateAdvancer {
                         gossipForkInfo(gossip, signedMajorityArtifact) >>
                         maybeDataApplication.traverse_ { da =>
                           signedMajorityArtifact.toHashed >>= da.onSnapshotConsensusResult
-                        }
+                        }.handleErrorWith(logger.error(_)("Unhandled exception during onSnapshotConsensusResult"))
 
                       newState = state.copy(status =
                         identity[CurrencySnapshotStatus](


### PR DESCRIPTION
## Summary
Invocation of `onSnapshotConsensusResult` may throw an exception due to improper error handling by the metagraph developer. If an exception is thrown the underlying consensus process enters a stalled state and the ML0 application must be restarted to recover.

## Changes
- Add error handling to log the exception and return an effect for the state advancement

## Testing
- Tested against a local metagraph with exceptions during `onSnapshotConsensusResult` and consensus process is no longer stalled