### PR TITLE
feat: extracting spend transactions to schema

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotValidator.scala
@@ -154,7 +154,12 @@ object CurrencySnapshotValidator {
               maybeDataApplication match {
                 case Some(_) => creationResult
                 case None =>
-                  creationResult.focus(_.artifact.dataApplication).replace(expected.dataApplication)
+                  creationResult
+                    .focus(_.artifact.dataApplication)
+                    .replace(expected.dataApplication)
+                    .focus(_.artifact.artifacts)
+                    .replace(expected.artifacts)
+
               }
             }.map { creationResult =>
               if (creationResult.artifact =!= expected)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
@@ -14,6 +14,7 @@ import cats.syntax.semigroup._
 import cats.syntax.show._
 import cats.syntax.traverse._
 
+import scala.collection.immutable.SortedSet
 import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.currency.dataApplication._
@@ -24,6 +25,7 @@ import io.constellationnetwork.currency.schema.feeTransaction.FeeTransaction
 import io.constellationnetwork.ext.cats.syntax.partialPrevious.catsSyntaxPartialPrevious
 import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotArtifact
 import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 
@@ -46,7 +48,8 @@ trait DataApplicationSnapshotAcceptanceManager[F[_]] {
 case class DataApplicationAcceptanceResult(
   dataApplicationPart: DataApplicationPart,
   calculatedState: DataCalculatedState,
-  feeTransactions: Seq[Signed[FeeTransaction]] = Seq.empty
+  feeTransactions: Seq[Signed[FeeTransaction]] = Seq.empty,
+  sharedArtifacts: SortedSet[SharedArtifact] = SortedSet.empty[SharedArtifact]
 )
 
 object DataApplicationSnapshotAcceptanceManager {
@@ -192,7 +195,8 @@ object DataApplicationSnapshotAcceptanceManager {
         DataApplicationAcceptanceResult(
           DataApplicationPart(serializedOnChainState, serializedBlocks, calculatedStateProof),
           newDataState.calculated,
-          feeTransactions
+          feeTransactions,
+          newDataState.sharedArtifacts
         )
 
       newDataState.value.handleErrorWith { err =>

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
@@ -10,6 +10,7 @@ import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.currencyMessage.{CurrencyMessage, MessageType}
 import io.constellationnetwork.schema.epoch.EpochProgress
@@ -162,7 +163,7 @@ object currency {
     dataApplication: Option[DataApplicationPart] = None,
     messages: Option[SortedSet[Signed[CurrencyMessage]]] = None,
     feeTransactions: Option[SortedSet[Signed[FeeTransaction]]] = None,
-    spendTransactions: Option[SortedSet[SpendTransaction]] = None,
+    artifacts: Option[SortedSet[SharedArtifact]] = SortedSet.empty[SharedArtifact].some,
     version: SnapshotVersion = SnapshotVersion("0.0.1")
   ) extends IncrementalSnapshot[CurrencySnapshotStateProof]
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -1,0 +1,50 @@
+package io.constellationnetwork.schema
+
+import cats.effect.kernel.Async
+import cats.syntax.functor._
+
+import io.constellationnetwork.ext.derevo.ordering
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap.{CurrencyId, SwapAmount}
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.hash.Hash
+
+import derevo.cats.{order, show}
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import eu.timepit.refined.types.numeric.PosLong
+import io.estatico.newtype.macros.newtype
+
+object artifact {
+  @derive(decoder, encoder, order, ordering, show)
+  sealed trait SharedArtifact
+
+  @derive(decoder, encoder, order, ordering, show)
+  sealed trait SpendTransaction extends SharedArtifact
+
+  @derive(decoder, encoder, order, show)
+  @newtype
+  case class SpendTransactionFee(value: PosLong)
+
+  @derive(decoder, encoder, order, show)
+  @newtype
+  case class SpendTransactionReference(hash: Hash)
+
+  object SpendTransactionReference {
+    def of[F[_]: Async](spendTransaction: SpendTransaction)(implicit hasher: Hasher[F]): F[SpendTransactionReference] =
+      hasher.hash(spendTransaction).map(SpendTransactionReference(_))
+  }
+  @derive(decoder, encoder, order, show)
+  case class PendingSpendTransaction(
+    fee: SpendTransactionFee,
+    lastValidEpochProgress: EpochProgress,
+    allowSpendRef: Hash,
+    currency: Option[CurrencyId],
+    amount: SwapAmount
+  ) extends SpendTransaction
+
+  @derive(decoder, encoder, order, show)
+  case class ConcludedSpendTransaction(
+    spendTransactionRef: SpendTransactionReference
+  ) extends SpendTransaction
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.ext.codecs._
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.ext.derevo.ordering
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.SpendTransaction
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.round.RoundId
@@ -154,35 +155,6 @@ object swap {
   @derive(decoder, encoder, order, show)
   @newtype
   case class SwapReference(value: Address)
-
-  @derive(decoder, encoder, order, show)
-  @newtype
-  case class SpendTransactionFee(value: PosLong)
-
-  @derive(decoder, encoder, order, ordering, show)
-  sealed trait SpendTransaction
-
-  @derive(decoder, encoder, order, show)
-  @newtype
-  case class SpendTransactionReference(hash: Hash)
-
-  object SpendTransactionReference {
-    def of[F[_]: Async](spendTransaction: SpendTransaction)(implicit hasher: Hasher[F]): F[SpendTransactionReference] =
-      hasher.hash(spendTransaction).map(SpendTransactionReference(_))
-  }
-  @derive(decoder, encoder, order, show)
-  case class PendingSpendTransaction(
-    fee: SpendTransactionFee,
-    lastValidEpochProgress: EpochProgress,
-    allowSpendRef: Hash,
-    currency: Option[CurrencyId],
-    amount: SwapAmount
-  ) extends SpendTransaction
-
-  @derive(decoder, encoder, order, show)
-  case class ConcludedSpendTransaction(
-    spendTransactionRef: SpendTransactionReference
-  ) extends SpendTransaction
 
   sealed trait SwapAction
 


### PR DESCRIPTION
Changes
+ This ticket introduces a new field in the CIS schema: `artifacts`.
+ The `artifacts` field is of type: Option[SortedSet[SharedArtifact]].
+ SharedArtifact is a sealed trait defined in a new schema file called `artifact`.
+ Initially, the SpendTransaction class extends this trait. We have also added two additional implementations: `PendingSpendTransaction` and `ConcludedSpendTransaction`, which will now be included as artifacts in CIS.
+ I’ve moved SpendTransaction from the swap schema to the new artifact schema.
+ The DataState case class has been updated:
**Previous:**
```
case class DataState[A <: DataOnChainState, B <: DataCalculatedState](
  onChain: A,
  calculated: B
)
```
**Updated:**
```
case class DataState[A <: DataOnChainState, B <: DataCalculatedState](
  onChain: A,
  calculated: B,
  sharedArtifacts: Option[SortedSet[SharedArtifact]] = None
)
```
This change ensures that the `combine` function now returns the `sharedArtifacts` in the output.


### JIRA
[PROT-844](https://constellationnetwork.atlassian.net/browse/PROT-844)

### Tests
+ I have tested this implementation locally by sending `PendingSpendTransaction` instances as output from the `combine` function. Below is an example:
```
    val pendingSpendTransaction: SortedSet[SharedArtifacts] = SortedSet(PendingSpendTransaction(
      SpendTransactionFee(PosLong.MinValue),
      EpochProgress.MaxValue,
      Hash.empty,
      none,
      SwapAmount(PosLong.MinValue)
    ))

    val newStateF = DataState(
      NFTUpdatesState(List.empty),
      state.calculated,
      pendingSpendTransaction.some
    ).pure[F]
```
+ In both endpoints: global/combined and currency we can check the new field:
<img width="2131" alt="Screenshot 2024-10-16 at 11 51 14" src="https://github.com/user-attachments/assets/7c7a92b9-0974-4925-84d6-ddb9e649ad29">
<img width="2056" alt="Screenshot 2024-10-16 at 11 51 26" src="https://github.com/user-attachments/assets/ca8aa1ce-3c8c-4b7a-b0eb-c01b9fb2afa0">

## Notes
+ I’m unsure about the name `sharedArtifacts`. Should we consider changing it to something more appropriate? @ryle-goehausen  @AlexBrandes
+ The logic for extracting these artifacts into the global snapshot state will be handled in a separate ticket.
+ The validation of spend transactions will also be covered in another ticket.
    