### PR TITLE
fix: remove javax.xml.crypto.jsr105-api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -488,7 +488,6 @@ lazy val dagL0 = (project in file("modules/dag-l0"))
       Libraries.http4sJwtAuth,
       Libraries.httpSignerCore,
       Libraries.httpSignerHttp4s,
-      Libraries.javaxCrypto,
       Libraries.log4cats,
       Libraries.logback % Runtime,
       Libraries.logstashLogbackEncoder % Runtime,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -158,8 +158,6 @@ object Dependencies {
     val log4cats = "org.typelevel" %% "log4cats-slf4j" % V.log4cats
     val newtype = "io.estatico" %% "newtype" % V.newtype
 
-    val javaxCrypto = "javax.xml.crypto" % "jsr105-api" % V.javaxCrypto
-
     val redis4catsEffects = "dev.profunktor" %% "redis4cats-effects" % V.redis4cats
     val redis4catsLog4cats = "dev.profunktor" %% "redis4cats-log4cats" % V.redis4cats
 


### PR DESCRIPTION
`jsr105-api` is declared as a dependency of `dagL0` in `build.sbt`, but for some reason it's not used.