### PR TITLE
feat: keep last N global snapshots in storage for Currency L0

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -22,7 +22,7 @@ import io.constellationnetwork.schema.peer.L0Peer
 
 import com.monovore.decline.Opts
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.NonNegLong
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
 import fs2.io.file.Path
 
 object method {
@@ -32,6 +32,9 @@ object method {
 
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig = AppConfig(
       snapshot = c.snapshot,
+      snapshotConfirmation = SnapshotConfirmationConfig(
+        confirmationWindowSize = PosLong(5L)
+      ),
       globalL0Peer = globalL0Peer,
       peerDiscovery = c.peerDiscovery,
       shared = shared

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/config/types.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/config/types.scala
@@ -3,6 +3,8 @@ package io.constellationnetwork.currency.l0.config
 import io.constellationnetwork.node.shared.config.types._
 import io.constellationnetwork.schema.peer.L0Peer
 
+import eu.timepit.refined.types.numeric.PosLong
+
 object types {
   case class AppConfigReader(
     peerDiscovery: PeerDiscoveryConfig,
@@ -12,6 +14,7 @@ object types {
   case class AppConfig(
     peerDiscovery: PeerDiscoveryConfig,
     snapshot: SnapshotConfig,
+    snapshotConfirmation: SnapshotConfirmationConfig,
     globalL0Peer: L0Peer,
     shared: SharedConfig
   ) {
@@ -24,5 +27,9 @@ object types {
 
   case class PeerDiscoveryConfig(
     delay: PeerDiscoveryDelay
+  )
+
+  case class SnapshotConfirmationConfig(
+    confirmationWindowSize: PosLong
   )
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
@@ -127,7 +127,7 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
       validators.currencyMessageValidator,
       storages.snapshot,
       storages.identifier,
-      storages.lastGlobalSnapshot
+      storages.lastNGlobalSnapshot
     ).publicRoutes
   )
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -78,7 +78,7 @@ object Programs {
       services.globalL0,
       storages.identifier,
       storages.snapshot,
-      storages.lastGlobalSnapshot,
+      storages.lastNGlobalSnapshot,
       services.collateral,
       services.consensus.manager,
       dataApplication

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -71,7 +71,7 @@ object Services {
       stateChannelBinarySender <- StateChannelBinarySender.make(
         storages.identifier,
         storages.globalL0Cluster,
-        storages.lastGlobalSnapshot,
+        storages.lastNGlobalSnapshot,
         p2PClient.stateChannelSnapshot
       )
 
@@ -81,7 +81,7 @@ object Services {
         .make[F](
           keyPair,
           storages.snapshot,
-          storages.lastGlobalSnapshot,
+          storages.lastNGlobalSnapshot,
           jsonBrotliBinarySerializer,
           dataApplicationAcceptanceManager,
           stateChannelBinarySender,
@@ -113,7 +113,7 @@ object Services {
           cfg.collateral.amount,
           storages.cluster,
           storages.node,
-          storages.lastGlobalSnapshot,
+          storages.lastNGlobalSnapshot,
           maybeRewards,
           cfg.snapshot,
           client,
@@ -129,7 +129,7 @@ object Services {
       addressService = AddressService.make[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](cfg.shared.addresses, storages.snapshot)
       collateralService = Collateral.make[F](cfg.collateral, storages.snapshot)
       globalL0Service = GlobalL0Service
-        .make[F](p2PClient.l0GlobalSnapshot, storages.globalL0Cluster, storages.lastGlobalSnapshot, None, maybeMajorityPeerIds)
+        .make[F](p2PClient.l0GlobalSnapshot, storages.globalL0Cluster, storages.lastNGlobalSnapshot, None, maybeMajorityPeerIds)
     } yield
       new Services[F, R](
         localHealthcheck = sharedServices.localHealthcheck,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Storages.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Storages.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import io.constellationnetwork.currency.dataApplication.BaseDataApplicationL0Service
 import io.constellationnetwork.currency.dataApplication.storage.CalculatedStateLocalFileSystemStorage
 import io.constellationnetwork.currency.l0.node.IdentifierStorage
+import io.constellationnetwork.currency.l0.snapshot.storage.LastNGlobalSnapshotStorage
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
@@ -49,7 +50,7 @@ object Storages {
           SnapshotOrdinal.MinValue,
           hasherSelector
         )
-      lastGlobalSnapshotStorage <- LastSnapshotStorage.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+      lastGlobalSnapshotStorage <- LastNGlobalSnapshotStorage.make[F]
       globalL0ClusterStorage <- L0ClusterStorage.make[F](globalL0Peer)
       identifierStorage <- IdentifierStorage.make[F]
       maybeCalculatedStateStorage <- dataApplication.traverse { _ =>
@@ -63,7 +64,7 @@ object Storages {
         session = sharedStorages.session,
         rumor = sharedStorages.rumor,
         snapshot = snapshotStorage,
-        lastGlobalSnapshot = lastGlobalSnapshotStorage,
+        lastNGlobalSnapshot = lastGlobalSnapshotStorage,
         incrementalSnapshotLocalFileSystemStorage = snapshotLocalFileSystemStorage,
         identifier = identifierStorage,
         calculatedStateStorage = maybeCalculatedStateStorage
@@ -77,7 +78,7 @@ sealed abstract class Storages[F[_]] private (
   val session: SessionStorage[F],
   val rumor: RumorStorage[F],
   val snapshot: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo] with LatestBalances[F],
-  val lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+  val lastNGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F],
   val incrementalSnapshotLocalFileSystemStorage: SnapshotLocalFileSystemStorage[F, CurrencyIncrementalSnapshot],
   val identifier: IdentifierStorage[F],
   val calculatedStateStorage: Option[CalculatedStateLocalFileSystemStorage[F]]

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/LastNGlobalSnapshotStorage.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/LastNGlobalSnapshotStorage.scala
@@ -1,0 +1,80 @@
+package io.constellationnetwork.currency.l0.snapshot.storage
+
+import cats.effect.kernel.Async
+import cats.syntax.all._
+import cats.{Applicative, MonadThrow}
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.node.shared.domain.snapshot.Validator.isNextSnapshot
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.schema._
+import io.constellationnetwork.security.Hashed
+
+import fs2.Stream
+import fs2.concurrent.SignallingRef
+
+trait LastNGlobalSnapshotStorage[F[_]] {
+  def get(ordinal: SnapshotOrdinal): F[Option[Hashed[GlobalIncrementalSnapshot]]]
+  def getCombined(ordinal: SnapshotOrdinal): F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
+  def delete(ordinal: SnapshotOrdinal): F[Unit]
+  def deleteBelow(ordinal: SnapshotOrdinal): F[Unit]
+}
+
+object LastNGlobalSnapshotStorage {
+  def make[F[_]: Async]: F[LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F]] =
+    SignallingRef
+      .of[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
+      .map(make[F](_))
+
+  def make[F[_]: Async](
+    snapshotsR: SignallingRef[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
+  ): LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F] =
+    new LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F] {
+
+      def delete(ordinal: SnapshotOrdinal): F[Unit] = snapshotsR.update(_.removed(ordinal))
+
+      def deleteBelow(ordinal: SnapshotOrdinal): F[Unit] = snapshotsR.update {
+        _.filterNot { case (key, _) => key < ordinal }
+      }
+
+      def get(ordinal: SnapshotOrdinal): F[Option[Hashed[GlobalIncrementalSnapshot]]] =
+        getCombined(ordinal).map(_.map { case (snapshot, _) => snapshot })
+
+      def getCombined(ordinal: SnapshotOrdinal): F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
+        snapshotsR.get.map(_.get(ordinal))
+
+      def set(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+        snapshotsR.modify { snapshots =>
+          snapshots.lastOption match {
+            case Some((_, (latest, _))) if isNextSnapshot(latest, snapshot.signed.value) =>
+              (snapshots.updated(snapshot.ordinal, (snapshot, state)), Applicative[F].unit)
+            case _ => (snapshots, MonadThrow[F].raiseError[Unit](new Throwable("Failure during putting new global snapshot!")))
+          }
+        }.flatten
+
+      def setInitial(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+        snapshotsR.modify { snapshots =>
+          if (snapshots.nonEmpty) {
+            (snapshots, MonadThrow[F].raiseError[Unit](new Throwable(s"Failure putting initial snapshot! Storage non empty.")))
+          } else {
+            (snapshots.updated(snapshot.ordinal, (snapshot, state)), Applicative[F].unit)
+          }
+        }.flatten
+
+      def get: F[Option[Hashed[GlobalIncrementalSnapshot]]] = getCombined.map(_.map { case (snapshot, _) => snapshot })
+
+      def getCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = snapshotsR.get.map {
+        _.lastOption.map { case (_, combined) => combined }
+      }
+
+      def getCombinedStream: fs2.Stream[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
+        Stream
+          .eval[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](getCombined)
+          .merge(snapshotsR.discrete.map(_.lastOption.map { case (_, combined) => combined }))
+
+      def getOrdinal: F[Option[SnapshotOrdinal]] = get.map(_.map(_.ordinal))
+
+      def getHeight: F[Option[height.Height]] = get.map(_.map(_.height))
+    }
+}


### PR DESCRIPTION
Regardless of the chosen solution (fixed window / consensus) for selecting the GIS to return as the 'synchronized' one, we need to keep the last N GlobalSnapshots instead of just the latest one. It should also allow for the deletion of stored GIS that are below the 'synchronized' one.