### PR TITLE
feat: getLastSynchronizedGlobalSnapshot support for L0NodeContext

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -22,7 +22,7 @@ import io.constellationnetwork.schema.peer.L0Peer
 
 import com.monovore.decline.Opts
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
+import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
 import fs2.io.file.Path
 
 object method {
@@ -33,7 +33,7 @@ object method {
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig = AppConfig(
       snapshot = c.snapshot,
       snapshotConfirmation = SnapshotConfirmationConfig(
-        confirmationWindowSize = PosLong(5L)
+        fixedWindowSize = PosInt(5)
       ),
       globalL0Peer = globalL0Peer,
       peerDiscovery = c.peerDiscovery,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/config/types.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/config/types.scala
@@ -3,7 +3,7 @@ package io.constellationnetwork.currency.l0.config
 import io.constellationnetwork.node.shared.config.types._
 import io.constellationnetwork.schema.peer.L0Peer
 
-import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.types.numeric.PosInt
 
 object types {
   case class AppConfigReader(
@@ -30,6 +30,6 @@ object types {
   )
 
   case class SnapshotConfirmationConfig(
-    confirmationWindowSize: PosLong
+    fixedWindowSize: PosInt
   )
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -61,19 +61,21 @@ object Services {
       jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[F]
       implicit0(hasher: Hasher[F]) = hasherSelector.getCurrent
 
-      l0NodeContext = L0NodeContext.make[F](storages.snapshot, hasherSelector, storages.identifier)
+      stateChannelBinarySender <- StateChannelBinarySender.make(
+        storages.identifier,
+        storages.globalL0Cluster,
+        storages.lastNGlobalSnapshot,
+        p2PClient.stateChannelSnapshot,
+        cfg.snapshotConfirmation
+      )
+
+      l0NodeContext = L0NodeContext
+        .make[F](storages.snapshot, hasherSelector, stateChannelBinarySender, storages.lastNGlobalSnapshot, storages.identifier)
 
       dataApplicationAcceptanceManager = (maybeDataApplication, storages.calculatedStateStorage).mapN {
         case (service, storage) =>
           DataApplicationSnapshotAcceptanceManager.make[F](service, l0NodeContext, storage)
       }
-
-      stateChannelBinarySender <- StateChannelBinarySender.make(
-        storages.identifier,
-        storages.globalL0Cluster,
-        storages.lastNGlobalSnapshot,
-        p2PClient.stateChannelSnapshot
-      )
 
       feeCalculator = FeeCalculator.make(cfg.shared.feeConfigs)
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
@@ -5,16 +5,20 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.L0NodeContext
+import io.constellationnetwork.currency.l0.snapshot.services.StateChannelBinarySender
+import io.constellationnetwork.currency.l0.snapshot.storage.LastNGlobalSnapshotStorage
 import io.constellationnetwork.currency.schema.currency._
-import io.constellationnetwork.node.shared.domain.snapshot.storage.SnapshotStorage
-import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSnapshotStorage, SnapshotStorage}
 import io.constellationnetwork.schema.swap.CurrencyId
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security._
 
 object L0NodeContext {
   def make[F[_]: SecurityProvider: Async](
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     hasherSelector: HasherSelector[F],
+    stateChannelBinarySender: StateChannelBinarySender[F],
+    lastNGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F],
     identifierStorage: IdentifierStorage[F]
   ): L0NodeContext[F] = new L0NodeContext[F] {
     def getCurrencyId: F[CurrencyId] =
@@ -37,5 +41,14 @@ object L0NodeContext {
         case (snapshot, info) => hasherSelector.forOrdinal(snapshot.ordinal)(implicit hasher => snapshot.toHashed).map((_, info))
       }.value
 
+    def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] =
+      getLastSynchronizedGlobalSnapshotCombined.map(_.map { case (snapshot, _) => snapshot })
+
+    def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
+      stateChannelBinarySender.getLastConfirmedWithinFixedWindow.flatMap { lastConfirmed =>
+        lastConfirmed
+          .map(_.confirmationProof.globalOrdinal)
+          .flatTraverse(lastNGlobalSnapshotStorage.getCombined)
+      }
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 
 import scala.collection.immutable.SortedMap
 
+import io.constellationnetwork.currency.l0.config.types.SnapshotConfirmationConfig
 import io.constellationnetwork.currency.l0.node.IdentifierStorage
 import io.constellationnetwork.currency.schema.currency.SnapshotFee
 import io.constellationnetwork.ext.cats.effect.ResourceIO
@@ -34,7 +35,7 @@ import io.constellationnetwork.statechannel.StateChannelSnapshotBinary
 
 import com.comcast.ip4s.{Host, Port}
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.NonNegLong
+import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
 import org.scalacheck.Gen
 import weaver.MutableIOSuite
 import weaver.scalacheck.Checkers
@@ -99,6 +100,8 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
         def getHeight: StateChannelBinarySenderSuite.F[Option[height.Height]] = ???
       }
 
+      snapshotConfirmationConfig = SnapshotConfirmationConfig(PosInt.MaxValue)
+
       postedRef <- Ref.of[IO, List[Hashed[StateChannelSnapshotBinary]]](List.empty)
       stateChannelSnapshotClient = new StateChannelSnapshotClient[F] {
         def send(
@@ -117,7 +120,8 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
         identifierStorage,
         globalL0ClusterStorage,
         lastSnapshotStorage,
-        stateChannelSnapshotClient
+        stateChannelSnapshotClient,
+        snapshotConfirmationConfig
       )
     } yield (sender, stateRef, postedRef)
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -540,6 +540,8 @@ trait L1NodeContext[F[_]] {
 }
 
 trait L0NodeContext[F[_]] {
+  def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]]
+  def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
   def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getCurrencySnapshot(ordinal: SnapshotOrdinal): F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]]


### PR DESCRIPTION
Based on the "fixed-window" solution the following algorithm is implemented:

1. Confirm pending sent binaries (just as it was working before).
2. Take the highest confirmed binary index and subtract the fixed window size from it to get the highest Currency Snapshot (binary) that is still within the window. Remove all confirmed binaries that are older, as these are out of the fixed window bounds.
3. Take the global snapshot in which the fixed window's Currency Snapshot (binary) was confirmed and provide it to the Data Application. Remove all stored global snapshots that are older, as these will no longer be returned.

It needs to be tested on the cluster and may have some edge cases, so I would treat it as a proof of concept (PoC).