### PR TITLE
feat: adding additional features that will be used by amm metagraph

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -102,7 +102,13 @@ abstract class CurrencyL0App(
         )
         .asResource
       implicit0(nodeContext: L0NodeContext[IO]) = L0NodeContext
-        .make[IO](storages.snapshot, hasherSelectorAlwaysCurrent, services.stateChannelBinarySender, storages.lastNGlobalSnapshot)
+        .make[IO](
+          storages.snapshot,
+          hasherSelectorAlwaysCurrent,
+          services.stateChannelBinarySender,
+          storages.lastNGlobalSnapshot,
+          storages.identifier
+        )
       programs = Programs.make[IO, Run](
         keyPair,
         nodeShared.nodeId,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -69,7 +69,8 @@ object Services {
         cfg.snapshotConfirmation
       )
 
-      l0NodeContext = L0NodeContext.make[F](storages.snapshot, hasherSelector, stateChannelBinarySender, storages.lastNGlobalSnapshot)
+      l0NodeContext = L0NodeContext
+        .make[F](storages.snapshot, hasherSelector, stateChannelBinarySender, storages.lastNGlobalSnapshot, storages.identifier)
 
       dataApplicationAcceptanceManager = (maybeDataApplication, storages.calculatedStateStorage).mapN {
         case (service, storage) =>

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
@@ -9,6 +9,7 @@ import io.constellationnetwork.currency.l0.snapshot.services.StateChannelBinaryS
 import io.constellationnetwork.currency.l0.snapshot.storage.LastNGlobalSnapshotStorage
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSnapshotStorage, SnapshotStorage}
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security.{Hashed, HasherSelector, SecurityProvider}
 
@@ -17,8 +18,12 @@ object L0NodeContext {
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     hasherSelector: HasherSelector[F],
     stateChannelBinarySender: StateChannelBinarySender[F],
-    lastNGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F]
+    lastNGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastNGlobalSnapshotStorage[F],
+    identifierStorage: IdentifierStorage[F]
   ): L0NodeContext[F] = new L0NodeContext[F] {
+    def getMetagraphId: F[Address] =
+      identifierStorage.get
+
     def securityProvider: SecurityProvider[F] = SecurityProvider[F]
 
     def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]] =

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -13,6 +13,7 @@ import io.constellationnetwork.currency.dataApplication.dataApplication.{DataApp
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import io.constellationnetwork.currency.schema.feeTransaction.FeeTransaction
 import io.constellationnetwork.routes.internal.ExternalUrlPrefix
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.round.RoundId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
@@ -545,4 +546,5 @@ trait L0NodeContext[F[_]] {
   def getCurrencySnapshot(ordinal: SnapshotOrdinal): F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]]
   def securityProvider: SecurityProvider[F]
+  def getMetagraphId: F[Address]
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -34,7 +34,7 @@ object artifact {
     def of[F[_]: Async](spendTransaction: SpendTransaction)(implicit hasher: Hasher[F]): F[SpendTransactionReference] =
       hasher.hash(spendTransaction).map(SpendTransactionReference(_))
   }
-  @derive(decoder, encoder, order, show)
+  @derive(decoder, encoder, order, ordering, show)
   case class PendingSpendTransaction(
     fee: SpendTransactionFee,
     lastValidEpochProgress: EpochProgress,
@@ -43,7 +43,7 @@ object artifact {
     amount: SwapAmount
   ) extends SpendTransaction
 
-  @derive(decoder, encoder, order, show)
+  @derive(decoder, encoder, order, ordering, show)
   case class ConcludedSpendTransaction(
     spendTransactionRef: SpendTransactionReference
   ) extends SpendTransaction

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
@@ -49,7 +49,7 @@ object swap {
     implicit def toAmount(fee: AllowSpendFee): Amount = Amount(fee.value)
   }
 
-  @derive(decoder, encoder, order, show)
+  @derive(decoder, encoder, order, show, ordering)
   @newtype
   case class CurrencyId(value: Address)
 
@@ -90,7 +90,7 @@ object swap {
   case class AllowSpend(
     source: Address,
     destination: Address,
-    currency: CurrencyId,
+    currency: Option[CurrencyId],
     amount: SwapAmount,
     fee: AllowSpendFee,
     parent: AllowSpendReference,


### PR DESCRIPTION
### Changes
+ Additional parts that should be used by amm metagraph, such as:
-> getMetagraphId: We will use this to get the AllowSpends aggregated in GlobalSnapshotInfo to the current metagraph
-> allowSpend - currency: Changed to optional since we need it as none to represent DAG
-> ordering: adding ordering to the missing parts that we need in amm metagraph

### Note
+ This PR references the branch that adds lastGlobalSnapshotSync, and not directly the allow-spend branch