### PR TITLE
refactor: deprecate Guava

### DIFF
--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/address.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/address.scala
@@ -24,8 +24,8 @@ object address {
   object Address {
 
     def fromBytes(bytes: Array[Byte]): Address = {
-      val hashCode = Hash.hashCodeFromBytes(bytes)
-      val encoded = Base58.encode(hashCode.asBytes().toIndexedSeq)
+      val sha256Digest = Hash.sha256DigestFromBytes(bytes)
+      val encoded = Base58.encode(sha256Digest.toIndexedSeq)
       val end = encoded.slice(encoded.length - 36, encoded.length)
       val validInt = end.filter(Character.isDigit)
       val ints = validInt.map(_.toString.toInt)

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Hash.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Hash.scala
@@ -1,8 +1,9 @@
 package io.constellationnetwork.security
 
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 
-import cats.Show
+import cats.{Eq, Show}
 
 import io.constellationnetwork.ext.derevo.ordering
 
@@ -10,7 +11,6 @@ import com.google.common.hash.{HashCode, Hashing}
 import derevo.cats.{order, show}
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import eu.timepit.refined.auto._
 import io.estatico.newtype.macros.newtype
 import io.estatico.newtype.ops._
 import org.scalacheck.{Arbitrary, Gen}
@@ -24,12 +24,39 @@ object hash {
   }
 
   object Hash {
+    private val hexDigits = "0123456789abcdef".toCharArray
+    private val sha256 = MessageDigest.getInstance("SHA-256")
 
+    case class Sha256Digest(private val bytes: Array[Byte]) {
+      def toByteArray: Array[Byte] = Array.copyOf(bytes, bytes.length)
+
+      def toHexString: String =
+        bytes
+          .foldLeft(new StringBuilder(bytes.length * 2)) { (sb, b) =>
+            sb.append(hexDigits((b >> 4) & 0xf)).append(hexDigits(b & 0xf))
+          }
+          .toString
+
+      def toIndexedSeq: IndexedSeq[Byte] = bytes.toIndexedSeq
+    }
+
+    object Sha256Digest {
+      implicit val show: Show[Sha256Digest] = Show.show(s => s"Sha256Digest(${s.toHexString})")
+      implicit val eq: Eq[Sha256Digest] = Eq.instance((a, b) => a.bytes.sameElements(b.bytes))
+    }
+
+    @deprecated("Use sha256DigestFromBytes() instead", since = "3.0")
     def hashCodeFromBytes(bytes: Array[Byte]): HashCode =
       Hashing.sha256().hashBytes(bytes)
 
+    def sha256DigestFromBytes(bytes: Array[Byte]): Sha256Digest = {
+      val md = sha256.clone().asInstanceOf[MessageDigest]
+      md.update(bytes)
+      Sha256Digest(md.digest())
+    }
+
     def fromBytes(bytes: Array[Byte]): Hash =
-      Hash(hashCodeFromBytes(bytes).toString)
+      Hash(sha256DigestFromBytes(bytes).toHexString)
 
     def empty: Hash = Hash(s"%064d".format(0))
 


### PR DESCRIPTION
This PR deprecates the Guava version of `Hash.fromBytes()` method. 

It doesn't remove Guava from the dependency list, and provides compatibility tests.