### PR TITLE
feat: adding features required by amm metagraph

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -77,7 +77,8 @@ abstract class CurrencyL0App(
       p2pClient = P2PClient.make[IO](sharedP2PClient, sharedResources.client, sharedServices.session)
       maybeAllowanceList = StateChannelAllowanceLists.get(cfg.environment)
       validators = Validators.make[IO](cfg.shared, seedlist, maybeAllowanceList, Hasher.forKryo[IO])
-      implicit0(nodeContext: L0NodeContext[IO]) = L0NodeContext.make[IO](storages.snapshot, hasherSelectorAlwaysCurrent)
+      implicit0(nodeContext: L0NodeContext[IO]) = L0NodeContext
+        .make[IO](storages.snapshot, hasherSelectorAlwaysCurrent, storages.identifier)
       maybeMajorityPeerIds <- getMajorityPeerIds[IO](
         nodeShared.prioritySeedlist,
         sharedConfig.priorityPeerIds,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -61,7 +61,7 @@ object Services {
       jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[F]
       implicit0(hasher: Hasher[F]) = hasherSelector.getCurrent
 
-      l0NodeContext = L0NodeContext.make[F](storages.snapshot, hasherSelector)
+      l0NodeContext = L0NodeContext.make[F](storages.snapshot, hasherSelector, storages.identifier)
 
       dataApplicationAcceptanceManager = (maybeDataApplication, storages.calculatedStateStorage).mapN {
         case (service, storage) =>

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
@@ -2,19 +2,24 @@ package io.constellationnetwork.currency.l0.node
 
 import cats.data.OptionT
 import cats.effect.Async
-import cats.syntax.functor._
+import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.L0NodeContext
-import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
+import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.node.shared.domain.snapshot.storage.SnapshotStorage
 import io.constellationnetwork.schema.SnapshotOrdinal
-import io.constellationnetwork.security.{Hashed, HasherSelector, SecurityProvider}
+import io.constellationnetwork.schema.swap.CurrencyId
+import io.constellationnetwork.security._
 
 object L0NodeContext {
   def make[F[_]: SecurityProvider: Async](
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
-    hasherSelector: HasherSelector[F]
+    hasherSelector: HasherSelector[F],
+    identifierStorage: IdentifierStorage[F]
   ): L0NodeContext[F] = new L0NodeContext[F] {
+    def getCurrencyId: F[CurrencyId] =
+      identifierStorage.get.map(_.toCurrencyId)
+
     def securityProvider: SecurityProvider[F] = SecurityProvider[F]
 
     def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]] =

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -15,6 +15,7 @@ import io.constellationnetwork.currency.schema.feeTransaction.FeeTransaction
 import io.constellationnetwork.routes.internal.ExternalUrlPrefix
 import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -543,4 +544,5 @@ trait L0NodeContext[F[_]] {
   def getCurrencySnapshot(ordinal: SnapshotOrdinal): F[Option[Hashed[CurrencyIncrementalSnapshot]]]
   def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]]
   def securityProvider: SecurityProvider[F]
+  def getCurrencyId: F[CurrencyId]
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/address.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/address.scala
@@ -3,6 +3,7 @@ package io.constellationnetwork.schema
 import io.constellationnetwork.ext.cats.data.OrderBasedOrdering
 import io.constellationnetwork.ext.refined._
 import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.security.Base58
 import io.constellationnetwork.security.hash.Hash
 
@@ -22,6 +23,9 @@ object address {
   case class Address(value: DAGAddress)
 
   object Address {
+    implicit class AddressOps(address: Address) {
+      def toCurrencyId: CurrencyId = CurrencyId(address)
+    }
 
     def fromBytes(bytes: Array[Byte]): Address = {
       val hashCode = Hash.hashCodeFromBytes(bytes)

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -34,7 +34,7 @@ object artifact {
     def of[F[_]: Async](spendTransaction: SpendTransaction)(implicit hasher: Hasher[F]): F[SpendTransactionReference] =
       hasher.hash(spendTransaction).map(SpendTransactionReference(_))
   }
-  @derive(decoder, encoder, order, show)
+  @derive(decoder, encoder, order, ordering, show)
   case class PendingSpendTransaction(
     fee: SpendTransactionFee,
     lastValidEpochProgress: EpochProgress,
@@ -43,7 +43,7 @@ object artifact {
     amount: SwapAmount
   ) extends SpendTransaction
 
-  @derive(decoder, encoder, order, show)
+  @derive(decoder, encoder, order, ordering, show)
   case class ConcludedSpendTransaction(
     spendTransactionRef: SpendTransactionReference
   ) extends SpendTransaction

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
@@ -49,7 +49,7 @@ object swap {
     implicit def toAmount(fee: AllowSpendFee): Amount = Amount(fee.value)
   }
 
-  @derive(decoder, encoder, order, show)
+  @derive(decoder, encoder, order, show, ordering)
   @newtype
   case class CurrencyId(value: Address)
 
@@ -90,7 +90,7 @@ object swap {
   case class AllowSpend(
     source: Address,
     destination: Address,
-    currency: CurrencyId,
+    currency: Option[CurrencyId],
     amount: SwapAmount,
     fee: AllowSpendFee,
     parent: AllowSpendReference,


### PR DESCRIPTION
### Changes
+ Additional parts that should be used by amm metagraph, such as:
-> getMetagraphId: We will use this to get the AllowSpends aggregated in GlobalSnapshotInfo to the current metagraph
-> allowSpend - currency: Changed to optional since we need it as none to represent DAG
-> ordering: adding ordering to the missing parts that we need in amm metagraph
