### PR TITLE
feat: moving SpendAction and update it to extend SharedArtifact instead of SpendTransaction

### DIFF
--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -20,7 +20,7 @@ object artifact {
   sealed trait SharedArtifact
 
   @derive(decoder, encoder, order, ordering, show)
-  sealed trait SpendTransaction extends SharedArtifact
+  sealed trait SpendTransaction
 
   @derive(decoder, encoder, order, show)
   @newtype
@@ -29,6 +29,9 @@ object artifact {
   @derive(decoder, encoder, order, show)
   @newtype
   case class SpendTransactionReference(hash: Hash)
+
+  @derive(decoder, encoder, order, ordering, show)
+  case class SpendAction(input: SpendTransaction, output: SpendTransaction) extends SharedArtifact
 
   object SpendTransactionReference {
     def of[F[_]: Async](spendTransaction: SpendTransaction)(implicit hasher: Hasher[F]): F[SpendTransactionReference] =

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
@@ -14,7 +14,6 @@ import io.constellationnetwork.ext.codecs._
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.ext.derevo.ordering
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.artifact.SpendTransaction
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.round.RoundId
@@ -155,9 +154,4 @@ object swap {
   @derive(decoder, encoder, order, show)
   @newtype
   case class SwapReference(value: Address)
-
-  sealed trait SwapAction
-
-  @derive(decoder, encoder, order, show)
-  case class SpendAction(pending: SpendTransaction, transaction: SpendTransaction) extends SwapAction
 }


### PR DESCRIPTION
### Changes
* Update Artifacts to Use List[SpendAction]: Modified the artifact structure to use List[SpendAction] instead of List[SpendTransaction], aligning with recent updates in the Notion documentation.
* SpendAction as Atomic Action:
  * Input (SpendTransaction): Represents the user’s input, such as the primary declared currency for staking or the “Allow spend” transaction.
  * Output (SpendTransaction): Represents the AMM’s output, either as “spending” funds or the staking pair currency determined by the AMM.
* Updated Functionality: Now sending a SpendAction instead of a single SpendTransaction to reflect the new schema requirements.