### PR TITLE
feat: add cluster session to PeerInfo

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
@@ -197,6 +197,7 @@ class Joining[
         registrationRequest.ip,
         registrationRequest.publicPort,
         registrationRequest.p2pPort,
+        registrationRequest.clusterSession,
         registrationRequest.session,
         registrationRequest.state,
         Responsive,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/cluster/services/Cluster.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/cluster/services/Cluster.scala
@@ -92,6 +92,7 @@ object Cluster {
             req.ip,
             req.publicPort,
             req.p2pPort,
+            req.clusterSession.value.toString,
             req.session.value.toString,
             req.state,
             req.jar

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/peer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/peer.scala
@@ -107,6 +107,7 @@ object peer {
     ip: Host,
     publicPort: Port,
     p2pPort: Port,
+    clusterSession: ClusterSessionToken,
     session: SessionToken,
     state: NodeState,
     responsiveness: PeerResponsiveness,
@@ -130,6 +131,7 @@ object peer {
     ip: Host,
     publicPort: Port,
     p2pPort: Port,
+    clusterSession: String,
     session: String,
     state: NodeState,
     jar: Hash
@@ -137,7 +139,16 @@ object peer {
 
   object PeerInfo {
     def fromPeer(peer: Peer): PeerInfo =
-      PeerInfo(peer.id, peer.ip, peer.publicPort, peer.p2pPort, peer.session.value.toString, peer.state, peer.jar)
+      PeerInfo(
+        peer.id,
+        peer.ip,
+        peer.publicPort,
+        peer.p2pPort,
+        peer.clusterSession.toString,
+        peer.session.value.toString,
+        peer.state,
+        peer.jar
+      )
   }
 
   @derive(eqv, encoder, decoder, order, ordering, show)

--- a/modules/shared/src/test/scala/io/constellationnetwork/schema/generators.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/schema/generators.scala
@@ -8,7 +8,7 @@ import io.constellationnetwork.generators.nesGen
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.{Address, DAGAddressRefined}
 import io.constellationnetwork.schema.balance.Balance
-import io.constellationnetwork.schema.cluster.SessionToken
+import io.constellationnetwork.schema.cluster.{ClusterSessionToken, SessionToken}
 import io.constellationnetwork.schema.generation.Generation
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer._
@@ -70,11 +70,12 @@ object generators {
       h <- hostGen
       p <- portGen
       p2 <- portGen
+      cs <- generationGen.map(ClusterSessionToken.apply)
       s <- generationGen.map(SessionToken.apply)
       st <- nodeStateGen
       r <- peerResponsivenessGen
       j <- Arbitrary.arbitrary[Hash]
-    } yield Peer(i, h, p, p2, s, st, r, j)
+    } yield Peer(i, h, p, p2, cs, s, st, r, j)
 
   def peersGen(n: Option[Int] = None): Gen[Set[Peer]] =
     n.map(Gen.const).getOrElse(Gen.chooseNum(1, 20)).flatMap { n =>


### PR DESCRIPTION
Returns clusterSession on each node reported in "cluster/info". Required by https://github.com/Constellation-Labs/cllb/pull/18