### PR TITLE
feat: adding token lock endpoints and consensus

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -57,7 +57,8 @@ object method {
       c.forkInfoStorage,
       c.lastKryoHashOrdinal,
       c.addresses,
-      c.allowSpends
+      c.allowSpends,
+      c.tokenLocks
     )
   }
 

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/TokenLock.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/TokenLock.scala
@@ -1,0 +1,136 @@
+package io.constellationnetwork.currency.l1
+
+import java.security.KeyPair
+
+import cats.Applicative
+import cats.effect.kernel.Async
+import cats.effect.std.Random
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.currency.l1.cli.method.Run
+import io.constellationnetwork.currency.l1.domain.dataApplication.consensus.Validator.isLastGlobalSnapshotPresent
+import io.constellationnetwork.currency.l1.modules.{Queues, Services}
+import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo, CurrencySnapshotStateProof}
+import io.constellationnetwork.currency.tokenlock.ConsensusInput.OwnerConsensusInput
+import io.constellationnetwork.currency.tokenlock.{ConsensusInput, ConsensusOutput}
+import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient
+import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage}
+import io.constellationnetwork.node.shared.domain.node.NodeStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.Validator._
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.config.TokenLockConsensusConfig
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.{ConsensusClient, ConsensusState, Engine}
+import io.constellationnetwork.node.shared.domain.tokenlock.{TokenLockStorage, TokenLockValidator}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import fs2.{Pipe, Stream}
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object TokenLock {
+  def run[F[_]: Async: Random: Hasher: SecurityProvider](
+    tokenLockConsensusConfig: TokenLockConsensusConfig,
+    clusterStorage: ClusterStorage[F],
+    l0ClusterStorage: L0ClusterStorage[F],
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    nodeStorage: NodeStorage[F],
+    blockOutputClient: L0BlockOutputClient[F],
+    consensusClient: ConsensusClient[F],
+    services: Services[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, Run],
+    tokenLockStorage: TokenLockStorage[F],
+    queues: Queues[F],
+    tokenLockValidator: TokenLockValidator[F],
+    selfKeyPair: KeyPair,
+    selfId: PeerId
+  ): Stream[F, Unit] = {
+
+    def logger = Slf4jLogger.getLogger[F]
+
+    def inspectionTrigger: Stream[F, OwnerConsensusInput] =
+      Stream
+        .awakeEvery(5.seconds)
+        .evalFilter(_ => isLastGlobalSnapshotPresent(lastGlobalSnapshot))
+        .as(ConsensusInput.InspectionTrigger)
+
+    def ownRoundTrigger: Stream[F, OwnerConsensusInput] =
+      Stream
+        .awakeEvery(5.seconds)
+        .evalFilter { _ =>
+          canStartOwnTokenLockConsensus(
+            nodeStorage,
+            clusterStorage,
+            lastGlobalSnapshot,
+            tokenLockConsensusConfig.peersCount,
+            tokenLockStorage
+          ).handleErrorWith { e =>
+            logger.warn(e)("Failure checking if own consensus can be kicked off!").as(false)
+          }
+        }
+        .as(ConsensusInput.OwnRoundTrigger)
+
+    def ownerBlockConsensusInputs =
+      inspectionTrigger.merge(ownRoundTrigger)
+
+    def peerBlockConsensusInputs =
+      Stream
+        .fromQueueUnterminated(queues.tokenLockPeerConsensusInput)
+        .evalFilter(isPeerInputValid(_))
+        .evalFilter(_ => isLastGlobalSnapshotPresent(lastGlobalSnapshot))
+        .map(_.value)
+
+    def blockConsensusInputs =
+      ownerBlockConsensusInputs.merge(peerBlockConsensusInputs)
+
+    def runConsensus: Pipe[F, ConsensusInput, ConsensusOutput.FinalBlock] =
+      _.evalMapAccumulate(ConsensusState.Empty) {
+        Engine
+          .fsm(
+            tokenLockConsensusConfig,
+            clusterStorage,
+            lastGlobalSnapshot,
+            consensusClient,
+            tokenLockValidator,
+            tokenLockStorage,
+            selfId,
+            selfKeyPair
+          )
+          .run
+      }.handleErrorWith { e =>
+        Stream.eval(logger.error(e)("Error during token lock block creation")) >> Stream.empty
+      }.flatMap {
+        case (_, fb @ ConsensusOutput.FinalBlock(hashedBlock)) =>
+          Stream
+            .eval(logger.debug(s"Token lock block created! Hash=${hashedBlock.hash}, ProofsHash=${hashedBlock.proofsHash}"))
+            .as(fb)
+        case (_, ConsensusOutput.CleanedConsensuses(ids)) =>
+          Stream.eval(logger.debug(s"Cleaned consensuses ids=$ids")) >> Stream.empty
+        case (_, ConsensusOutput.Noop) => Stream.empty
+      }
+
+    def sendBlockToL0: Pipe[F, ConsensusOutput.FinalBlock, ConsensusOutput.FinalBlock] =
+      _.evalTap { fb =>
+        l0ClusterStorage.getPeers
+          .map(_.toNonEmptyList.toList)
+          .flatMap(_.filterA(p => services.collateral.hasCollateral(p.id)))
+          .flatMap(peers => Random[F].shuffleList(peers))
+          .map(peers => peers.headOption)
+          .flatMap { maybeL0Peer =>
+            maybeL0Peer.fold(logger.warn("No available L0 peer")) { l0Peer =>
+              blockOutputClient
+                .sendTokenLockBlock(fb.hashedBlock.signed)(l0Peer)
+                .handleErrorWith(e => logger.error(e)("Error when sending block to L0").as(false))
+                .ifM(Applicative[F].unit, logger.warn("Sending block to L0 failed"))
+            }
+          }
+      }
+
+    blockConsensusInputs
+      .through(runConsensus)
+      .through(sendBlockToL0)
+      .void
+
+  }
+}

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
@@ -30,7 +30,7 @@ object method {
     val identifier: Address
 
     def appConfig(c: AppConfigReader, shared: SharedConfig): AppConfig =
-      AppConfig(c.consensus, c.dataConsensus, c.swap, c.transactionLimit, shared)
+      AppConfig(c.consensus, c.dataConsensus, c.swap, c.tokenLock, c.transactionLimit, shared)
 
     val stateChannelAllowanceLists = None
 
@@ -54,7 +54,8 @@ object method {
       c.forkInfoStorage,
       c.lastKryoHashOrdinal,
       c.addresses,
-      c.allowSpends
+      c.allowSpends,
+      c.tokenLocks
     )
   }
 

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/p2p/L0CurrencyBlockOutputClient.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/p2p/L0CurrencyBlockOutputClient.scala
@@ -6,6 +6,7 @@ import io.constellationnetwork.node.shared.http.p2p.PeerResponse
 import io.constellationnetwork.node.shared.http.p2p.PeerResponse.PeerResponse
 import io.constellationnetwork.schema.Block
 import io.constellationnetwork.schema.swap.AllowSpendBlock
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security.signature.Signed
 
 import io.circe.Encoder
@@ -17,6 +18,7 @@ trait L0CurrencyBlockOutputClient[F[_]] {
   def sendL1Output(output: Signed[Block]): PeerResponse[F, Boolean]
   def sendL1DataOutput(output: Signed[DataApplicationBlock]): PeerResponse[F, Boolean]
   def sendL1AllowSpendOutput(output: Signed[AllowSpendBlock]): PeerResponse[F, Boolean]
+  def sendL1TokenLockOutput(output: Signed[TokenLockBlock]): PeerResponse[F, Boolean]
 }
 
 object L0CurrencyBlockOutputClient {
@@ -31,9 +33,12 @@ object L0CurrencyBlockOutputClient {
         PeerResponse(s"currency/l1-data-output", POST)(client) { (req, c) =>
           c.successful(req.withEntity(output))
         }
-
       def sendL1AllowSpendOutput(output: Signed[AllowSpendBlock]): PeerResponse[F, Boolean] =
         PeerResponse(s"currency/l1-allow-spend-output", POST)(client) { (req, c) =>
+          c.successful(req.withEntity(output))
+        }
+      def sendL1TokenLockOutput(output: Signed[TokenLockBlock]): PeerResponse[F, Boolean] =
+        PeerResponse(s"currency/l1-token-lock-output", POST)(client) { (req, c) =>
           c.successful(req.withEntity(output))
         }
     }

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/p2p/P2PClient.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/p2p/P2PClient.scala
@@ -6,6 +6,7 @@ import io.constellationnetwork.currency.l1.domain.dataApplication.consensus.Cons
 import io.constellationnetwork.dag.l1.domain.consensus.block.http.p2p.clients.BlockConsensusClient
 import io.constellationnetwork.dag.l1.http.p2p.{L0BlockOutputClient, P2PClient => DagL1P2PClient}
 import io.constellationnetwork.node.shared.domain.swap.consensus.{ConsensusClient => SwapConsensusClient}
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.{ConsensusClient => TokenLockConsensusClient}
 import io.constellationnetwork.node.shared.http.p2p.clients._
 import io.constellationnetwork.node.shared.infrastructure.gossip.p2p.GossipClient
 import io.constellationnetwork.security.SecurityProvider
@@ -29,6 +30,7 @@ object P2PClient {
       dagL1P2PClient.l0GlobalSnapshot,
       ConsensusClient.make(client),
       SwapConsensusClient.make(client),
+      TokenLockConsensusClient.make(client),
       L0TrustClient.make(client)
     ) {}
 }
@@ -44,5 +46,6 @@ sealed abstract class P2PClient[F[_]] private (
   val l0GlobalSnapshot: L0GlobalSnapshotClient[F],
   val consensusClient: ConsensusClient[F],
   val swapConsensusClient: SwapConsensusClient[F],
+  val tokenLockConsensusClient: TokenLockConsensusClient[F],
   val l0Trust: L0TrustClient[F]
 )

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Queues.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Queues.scala
@@ -8,12 +8,14 @@ import cats.syntax.functor._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationBlock
 import io.constellationnetwork.currency.dataApplication.{ConsensusInput => DataConsensusInput, DataUpdate}
 import io.constellationnetwork.currency.swap.{ConsensusInput => SwapConsensusInput}
+import io.constellationnetwork.currency.tokenlock.{ConsensusInput => TokenLockConsensusInput}
 import io.constellationnetwork.dag.l1.domain.consensus.block.BlockConsensusInput.PeerBlockConsensusInput
 import io.constellationnetwork.dag.l1.modules.{Queues => DAGL1Queues}
 import io.constellationnetwork.node.shared.domain.queue.ViewableQueue
 import io.constellationnetwork.schema.Block
 import io.constellationnetwork.schema.gossip.RumorRaw
 import io.constellationnetwork.schema.swap.AllowSpendBlock
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security.Hashed
 import io.constellationnetwork.security.signature.Signed
 
@@ -33,6 +35,8 @@ object Queues {
         val dataUpdates = dataUpdatesQueue
         val swapPeerConsensusInput = dagL1Queues.swapPeerConsensusInput
         val allowSpendBlocks = dagL1Queues.allowSpendBlocks
+        val tokenLockPeerConsensusInput = dagL1Queues.tokenLockConsensusInput
+        val tokenLocksBlocks = dagL1Queues.tokenLocksBlocks
       }
 }
 
@@ -45,4 +49,6 @@ sealed abstract class Queues[F[_]] private {
   val dataUpdates: ViewableQueue[F, Signed[DataUpdate]]
   val swapPeerConsensusInput: Queue[F, Signed[SwapConsensusInput.PeerConsensusInput]]
   val allowSpendBlocks: Queue[F, Signed[AllowSpendBlock]]
+  val tokenLockPeerConsensusInput: Queue[F, Signed[TokenLockConsensusInput.PeerConsensusInput]]
+  val tokenLocksBlocks: Queue[F, Signed[TokenLockBlock]]
 }

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Services.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Services.scala
@@ -15,6 +15,7 @@ import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStora
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.swap.AllowSpendService
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockService
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.collateral.Collateral
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
@@ -69,6 +70,11 @@ object Services {
         storages.allowSpend,
         storages.lastSnapshot,
         validators.allowSpend
+      )
+      val tokenLock = TokenLockService.make[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](
+        storages.tokenLock,
+        storages.lastSnapshot,
+        validators.tokenLock
       )
       val collateral = Collateral.make[F](cfg.collateral, storages.lastSnapshot)
       val dataApplication = maybeDataApplication

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
@@ -13,6 +13,7 @@ import io.constellationnetwork.dag.l1.modules.{Storages => BaseStorages}
 import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.swap.{AllowSpendStorage, ContextualAllowSpendValidator}
+import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockStorage}
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.modules.SharedStorages
@@ -20,6 +21,7 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.peer.L0Peer
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.swap.AllowSpendReference
+import io.constellationnetwork.schema.tokenLock.TokenLockReference
 import io.constellationnetwork.schema.transaction.TransactionReference
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
 import io.constellationnetwork.security.Hasher
@@ -37,7 +39,8 @@ object Storages {
     globalL0Peer: L0Peer,
     currencyIdentifier: Address,
     contextualTransactionValidator: ContextualTransactionValidator,
-    contextualAllowSpendValidator: ContextualAllowSpendValidator
+    contextualAllowSpendValidator: ContextualAllowSpendValidator,
+    contextualTokenLockValidator: ContextualTokenLockValidator
   ): F[Storages[F, P, S, SI]] =
     for {
       blockStorage <- BlockStorage.make[F]
@@ -51,6 +54,9 @@ object Storages {
       }
       allowSpendStorage <- AllowSpendReference.emptyCurrency(currencyIdentifier).flatMap {
         AllowSpendStorage.make[F](_, contextualAllowSpendValidator)
+      }
+      tokenLockStorage <- TokenLockReference.emptyCurrency(currencyIdentifier).flatMap {
+        TokenLockStorage.make[F](_, contextualTokenLockValidator)
       }
       addressStorage <- AddressStorage.make[F]
     } yield
@@ -68,6 +74,7 @@ object Storages {
         val rumor = sharedStorages.rumor
         val transaction = transactionStorage
         val allowSpend = allowSpendStorage
+        val tokenLock = tokenLockStorage
       }
 }
 

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
@@ -1,0 +1,222 @@
+package io.constellationnetwork.currency.l1.http
+
+import java.security.KeyPair
+
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.effect.std.{Queue, Random, Supervisor}
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.tokenlock.ConsensusInput
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.config.types.TokenLocksConfig
+import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockValidator.{TokenLockValidationError, TokenLockValidationErrorOr}
+import io.constellationnetwork.node.shared.domain.tokenlock._
+import io.constellationnetwork.node.shared.http.routes.TokenLockRoutes
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.peer.L0Peer
+import io.constellationnetwork.schema.swap.CurrencyId
+import io.constellationnetwork.schema.tokenLock._
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.signature.Signed
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
+import io.chrisdavenport.mapref.MapRef
+import io.circe.Json
+import org.http4s.Method.{GET, POST}
+import org.http4s._
+import org.http4s.client.dsl.io._
+import org.http4s.implicits.http4sLiteralsSyntax
+import suite.HttpSuite
+
+object TokenLockRoutesSuite extends HttpSuite {
+
+  type Res = (SecurityProvider[IO], Hasher[IO], Supervisor[IO], Random[IO])
+  val currencyId: CurrencyId = CurrencyId(Address("DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM"))
+
+  def construct(
+    maybeHashedTokenLock: Option[Hashed[TokenLock]] = none
+  ): IO[HttpRoutes[IO]] =
+    sharedResource.use { res =>
+      implicit val (_, hasher, sv, _) = res
+      for {
+        consensusQueue <- Queue.unbounded[IO, Signed[ConsensusInput.PeerConsensusInput]]
+        l0ClusterStorage <- mockL0ClusterStorage
+        tokenLockStorage <- mockTokenLockStorage(maybeHashedTokenLock)
+        tokenLockService <- mockTokenLockService
+
+        tokenRoutesApi = TokenLockRoutes(
+          consensusQueue,
+          l0ClusterStorage,
+          tokenLockService,
+          tokenLockStorage
+        )
+      } yield tokenRoutesApi.publicRoutes
+    }
+
+  def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(json2bin: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h: Hasher[IO] = Hasher.forJson[IO]
+    sv <- Supervisor[IO]
+    r <- Random.scalaUtilRandom.asResource
+  } yield (sp, h, sv, r)
+
+  def mockL0ClusterStorage: IO[L0ClusterStorage[IO]] = IO.pure(
+    new L0ClusterStorage[IO] {
+      override def getPeers: IO[NonEmptySet[L0Peer]] = ???
+
+      override def getPeer(id: peer.PeerId): IO[Option[L0Peer]] = ???
+
+      override def getRandomPeer: IO[L0Peer] = ???
+
+      override def addPeers(l0Peers: Set[L0Peer]): IO[Unit] = ???
+
+      override def setPeers(l0Peers: NonEmptySet[L0Peer]): IO[Unit] = ???
+    }
+  )
+
+  def mockTokenLockService: IO[TokenLockService[IO]] = IO.pure(
+    new TokenLockService[IO] {
+      override def offer(
+        tokenLock: Hashed[TokenLock]
+      )(implicit hasher: Hasher[IO]): IO[Either[NonEmptyList[ContextualTokenLockValidator.ContextualTokenLockValidationError], Hash]] =
+        tokenLock.hash.asRight.pure[IO]
+    }
+  )
+
+  def mockEmptyMapRef(
+    maybeHashedTokenLock: Option[Hashed[TokenLock]]
+  ): IO[MapRef[IO, Address, Option[SortedMap[TokenLockOrdinal, StoredTokenLock]]]] = {
+    val emptyMap: Map[Address, SortedMap[TokenLockOrdinal, StoredTokenLock]] =
+      maybeHashedTokenLock match {
+        case Some(value) =>
+          Map(
+            value.source -> SortedMap(TokenLockOrdinal(1L) -> WaitingTokenLock(value))
+          )
+        case None => Map.empty
+      }
+
+    MapRef.ofSingleImmutableMap(emptyMap)
+  }
+
+  def mockTokenLockStorage(
+    maybeHashedTokenLock: Option[Hashed[TokenLock]]
+  ): IO[TokenLockStorage[IO]] = mockEmptyMapRef(maybeHashedTokenLock).map { emr =>
+    new TokenLockStorage[IO](
+      emr,
+      TokenLockReference.empty,
+      ContextualTokenLockValidator.make(none, TokenLocksConfig(NonNegLong(100L)))
+    )
+  }
+
+  def mockTokenLockValidator: IO[TokenLockValidator[IO]] = IO.pure(new TokenLockValidator[IO] {
+    override def validate(signedTokenLock: Signed[TokenLock])(
+      implicit hasher: Hasher[IO]
+    ): IO[TokenLockValidationErrorOr[Signed[TokenLock]]] =
+      IO.pure(signedTokenLock.validNec[TokenLockValidationError])
+  })
+
+  def buildSignedLockToken(keyPair: KeyPair)(implicit s: SecurityProvider[IO], h: Hasher[IO]): IO[Signed[TokenLock]] = {
+    val src = keyPair.getPublic.toAddress
+    val amount = TokenLockAmount(1L)
+    val parent = TokenLockReference.empty
+    val lastValidEpochProgress = EpochProgress(500L)
+
+    val tokenLock = TokenLock(
+      src,
+      amount,
+      parent,
+      currencyId,
+      lastValidEpochProgress
+    )
+
+    Signed.forAsyncHasher(tokenLock, keyPair)
+  }
+
+  test("POST /token-locks returns hash") {
+    import org.http4s.circe.CirceEntityEncoder._
+    sharedResource.use { res =>
+      implicit val (sp, h, _, _) = res
+      val req: Request[IO] = POST(uri"/token-locks")
+
+      for {
+        endpoint <- construct()
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        tokenLock <- buildSignedLockToken(keyPair)
+        hashedTokenLock <- tokenLock.toHashed[F]
+        expectedResponse = Json.obj(
+          "hash" -> Json.fromString(hashedTokenLock.hash.value)
+        )
+        testResult <- expectHttpBodyAndStatus(endpoint, req.withEntity(tokenLock))(
+          expectedResponse,
+          Status.Ok
+        )
+      } yield testResult
+    }
+  }
+
+  test("GET /token-locks/:txnHash returns waiting transaction") {
+    sharedResource.use { res =>
+      implicit val (sp, h, _, _) = res
+      for {
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        tokenLock <- buildSignedLockToken(keyPair)
+        hashedTokenLock <- tokenLock.toHashed[F]
+        expectedResponse = Json.obj(
+          "transaction" -> Json.obj(
+            "source" -> Json.fromString(tokenLock.source.value.value),
+            "amount" -> Json.fromLong(tokenLock.amount.value),
+            "parent" -> Json.obj(
+              "ordinal" -> Json.fromLong(0L),
+              "hash" -> Json.fromString(Hash.empty.value)
+            ),
+            "currencyId" -> Json.fromString(currencyId.value.value.value),
+            "unlockEpoch" -> Json.fromLong(500L)
+          ),
+          "hash" -> Json.fromString(hashedTokenLock.hash.value),
+          "status" -> Json.fromString("Waiting")
+        )
+        endpoint <- construct(hashedTokenLock.some)
+        req: Request[IO] = GET(Uri.unsafeFromString(s"/token-locks/${hashedTokenLock.hash.value}"))
+        testResult <- expectHttpBodyAndStatus(endpoint, req)(
+          expectedResponse,
+          Status.Ok
+        )
+      } yield testResult
+    }
+  }
+
+  test("GET /token-locks/:txnHash returns NotFound") {
+    for {
+      endpoint <- construct()
+      req: Request[IO] = GET(Uri.unsafeFromString(s"/token-locks/${Hash.empty.value}"))
+      testResult <- expectHttpStatus(endpoint, req)(Status.NotFound)
+    } yield testResult
+  }
+
+  test("GET /token-locks/last-reference/:address returns last reference") {
+    for {
+      endpoint <- construct()
+      expectedResponse = Json.obj(
+        "ordinal" -> Json.fromLong(0L),
+        "hash" -> Json.fromString(Hash.empty.value)
+      )
+      req: Request[IO] = GET(Uri.unsafeFromString(s"/token-locks/last-reference/DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM"))
+      testResult <- expectHttpBodyAndStatus(endpoint, req)(
+        expectedResponse,
+        Status.Ok
+      )
+    } yield testResult
+  }
+
+}

--- a/modules/dag-l1/src/main/resources/application.conf
+++ b/modules/dag-l1/src/main/resources/application.conf
@@ -19,6 +19,12 @@ swap {
   max-allow-spends-to-dequeue = 50
 }
 
+token-lock {
+  peers-count = 2
+  timeout = 10 seconds
+  max-token-locks-to-dequeue = 50
+}
+
 transaction-limit {
   base-balance = 100000000
   time-trigger-interval = 43 seconds

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/TokenLock.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/TokenLock.scala
@@ -1,0 +1,165 @@
+package io.constellationnetwork.dag.l1
+
+import java.security.KeyPair
+
+import cats.Applicative
+import cats.effect.kernel.Async
+import cats.effect.std.Random
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.currency.tokenlock.ConsensusInput.OwnerConsensusInput
+import io.constellationnetwork.currency.tokenlock.{ConsensusInput, ConsensusOutput}
+import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient
+import io.constellationnetwork.dag.l1.modules.{Queues, Services}
+import io.constellationnetwork.node.shared.cli.CliMethod
+import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage}
+import io.constellationnetwork.node.shared.domain.node.NodeStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.Validator._
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.config.TokenLockConsensusConfig
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.{ConsensusClient, ConsensusState, Engine}
+import io.constellationnetwork.node.shared.domain.tokenlock.{TokenLockStorage, TokenLockValidator}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, GlobalSnapshotStateProof}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import fs2.{Pipe, Stream}
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object TokenLock {
+  def run[
+    F[_]: Async: Hasher: SecurityProvider: Random,
+    R <: CliMethod
+  ](
+    tokenLockConsensusConfig: TokenLockConsensusConfig,
+    clusterStorage: ClusterStorage[F],
+    l0ClusterStorage: L0ClusterStorage[F],
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    nodeStorage: NodeStorage[F],
+    blockOutputClient: L0BlockOutputClient[F],
+    consensusClient: ConsensusClient[F],
+    services: Services[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo, R],
+    tokenLockStorage: TokenLockStorage[F],
+    queues: Queues[F],
+    tokenLockValidator: TokenLockValidator[F],
+    selfKeyPair: KeyPair,
+    selfId: PeerId
+  ): Stream[F, Unit] = {
+
+    def logger = Slf4jLogger.getLogger[F]
+
+    def inspectionTrigger: Stream[F, OwnerConsensusInput] =
+      Stream
+        .awakeEvery(5.seconds)
+        .evalFilter(_ => isLastGlobalSnapshotPresent(lastGlobalSnapshot))
+        .as(ConsensusInput.InspectionTrigger)
+
+    def ownRoundTrigger: Stream[F, OwnerConsensusInput] =
+      Stream
+        .awakeEvery(5.seconds)
+        .evalFilter { _ =>
+          canStartOwnTokenLockConsensus(
+            nodeStorage,
+            clusterStorage,
+            lastGlobalSnapshot,
+            tokenLockConsensusConfig.peersCount,
+            tokenLockStorage
+          ).handleErrorWith { e =>
+            logger.warn(e)("Failure checking if token lock own consensus can be kicked off!").as(false)
+          }
+        }
+        .as(ConsensusInput.OwnRoundTrigger)
+
+    def ownerBlockConsensusInputs =
+      inspectionTrigger.merge(ownRoundTrigger)
+
+    def peerBlockConsensusInputs =
+      Stream
+        .fromQueueUnterminated(queues.tokenLockConsensusInput)
+        .evalFilter(isPeerInputValid(_))
+        .evalFilter(_ => isLastGlobalSnapshotPresent(lastGlobalSnapshot))
+        .map(_.value)
+
+    def blockConsensusInputs =
+      ownerBlockConsensusInputs.merge(peerBlockConsensusInputs)
+
+    def runConsensus: Pipe[F, ConsensusInput, ConsensusOutput.FinalBlock] =
+      _.evalMapAccumulate(ConsensusState.Empty) {
+        Engine
+          .fsm(
+            tokenLockConsensusConfig,
+            clusterStorage,
+            lastGlobalSnapshot,
+            consensusClient,
+            tokenLockValidator,
+            tokenLockStorage,
+            selfId,
+            selfKeyPair
+          )
+          .run
+      }.handleErrorWith { e =>
+        Stream.eval(logger.error(e)("Error during token lock block creation")) >> Stream.empty
+      }.flatMap {
+        case (_, fb @ ConsensusOutput.FinalBlock(hashedBlock)) =>
+          Stream
+            .eval(logger.debug(s"Token lock block created! Hash=${hashedBlock.hash}, ProofsHash=${hashedBlock.proofsHash}"))
+            .as(fb)
+        case (_, ConsensusOutput.CleanedConsensuses(ids)) =>
+          Stream.eval(logger.debug(s"Cleaned consensuses ids=$ids")) >> Stream.empty
+        case (_, ConsensusOutput.Noop) => Stream.empty
+      }
+
+    def sendBlockToL0: Pipe[F, ConsensusOutput.FinalBlock, ConsensusOutput.FinalBlock] =
+      _.evalTap { fb =>
+        l0ClusterStorage.getPeers
+          .map(_.toNonEmptyList.toList)
+          .flatMap(_.filterA(p => services.collateral.hasCollateral(p.id)))
+          .flatMap(peers => Random[F].shuffleList(peers))
+          .map(peers => peers.headOption)
+          .flatMap { maybeL0Peer =>
+            maybeL0Peer.fold(logger.warn("No available L0 peer")) { l0Peer =>
+              blockOutputClient
+                .sendTokenLockBlock(fb.hashedBlock.signed)(l0Peer)
+                .handleErrorWith(e => logger.error(e)("Error when sending block to L0").as(false))
+                .ifM(Applicative[F].unit, logger.warn("Sending block to L0 failed"))
+            }
+          }
+      }
+
+    def gossipBlock: Pipe[F, ConsensusOutput.FinalBlock, ConsensusOutput.FinalBlock] =
+      _.evalTap { fb =>
+        services.gossip
+          .spreadCommon(fb.hashedBlock.signed)
+          .handleErrorWith(e => logger.warn(e)("TokenLockBlock gossip spread failed!"))
+      }
+
+    def peerBlocks: Stream[F, ConsensusOutput.FinalBlock] = Stream
+      .fromQueueUnterminated(queues.tokenLocksBlocks)
+      .evalMap(_.toHashedWithSignatureCheck)
+      .evalTap {
+        case Left(e)  => logger.warn(e)("Received an invalidly signed token lock block!")
+        case Right(_) => Async[F].unit
+      }
+      .collect {
+        case Right(hashedBlock) => ConsensusOutput.FinalBlock(hashedBlock)
+      }
+
+    def storeBlock: Pipe[F, ConsensusOutput.FinalBlock, Unit] =
+      _.evalMap { fb =>
+        logger.debug(s"TODO: Store block! ${fb.hashedBlock.hash}")
+      }
+
+    def blockConsensus: Stream[F, Unit] =
+      blockConsensusInputs
+        .through(runConsensus)
+        .through(gossipBlock)
+        .through(sendBlockToL0)
+        .merge(peerBlocks)
+        .through(storeBlock)
+
+    blockConsensus
+
+  }
+}

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/cli/method.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/cli/method.scala
@@ -25,6 +25,7 @@ object method {
       c.consensus,
       c.dataConsensus,
       c.swap,
+      c.tokenLock,
       c.transactionLimit,
       shared
     )

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/config/types.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/config/types.scala
@@ -4,6 +4,7 @@ import io.constellationnetwork.dag.l1.domain.consensus.block.config.{ConsensusCo
 import io.constellationnetwork.dag.l1.domain.transaction.TransactionLimitConfig
 import io.constellationnetwork.node.shared.config.types._
 import io.constellationnetwork.node.shared.domain.consensus.config.SwapConsensusConfig
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.config.TokenLockConsensusConfig
 
 object types {
 
@@ -11,6 +12,7 @@ object types {
     consensus: ConsensusConfig,
     dataConsensus: DataConsensusConfig,
     swap: SwapConsensusConfig,
+    tokenLock: TokenLockConsensusConfig,
     transactionLimit: TransactionLimitConfig
   )
 
@@ -18,6 +20,7 @@ object types {
     consensus: ConsensusConfig,
     dataConsensus: DataConsensusConfig,
     swap: SwapConsensusConfig,
+    tokenLock: TokenLockConsensusConfig,
     transactionLimit: TransactionLimitConfig,
     shared: SharedConfig
   ) {

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/Routes.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/Routes.scala
@@ -7,6 +7,7 @@ import cats.syntax.functor._
 import cats.syntax.show._
 
 import io.constellationnetwork.currency.swap.{ConsensusInput => SwapConsensusInput}
+import io.constellationnetwork.currency.tokenlock.{ConsensusInput => TokenLockConsensusInput}
 import io.constellationnetwork.dag.l1.domain.consensus.block.BlockConsensusInput.PeerBlockConsensusInput
 import io.constellationnetwork.dag.l1.domain.transaction._
 import io.constellationnetwork.ext.http4s.{AddressVar, HashVar}
@@ -32,6 +33,7 @@ final case class Routes[F[_]: Async](
   l0ClusterStorage: L0ClusterStorage[F],
   peerBlockConsensusInputQueue: Queue[F, Signed[PeerBlockConsensusInput]],
   swapPeerConsensusInputQueue: Queue[F, Signed[SwapConsensusInput.PeerConsensusInput]],
+  tokenLockPeerConsensusInputQueue: Queue[F, Signed[TokenLockConsensusInput.PeerConsensusInput]],
   txHasher: Hasher[F]
 )(implicit S: Supervisor[F])
     extends Http4sDsl[F]

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/L0BlockOutputClient.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/L0BlockOutputClient.scala
@@ -6,6 +6,7 @@ import io.constellationnetwork.node.shared.http.p2p.PeerResponse
 import io.constellationnetwork.node.shared.http.p2p.PeerResponse.PeerResponse
 import io.constellationnetwork.schema.Block
 import io.constellationnetwork.schema.swap.AllowSpendBlock
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security.signature.Signed
 
 import io.circe.Encoder
@@ -19,6 +20,7 @@ trait L0BlockOutputClient[F[_]] {
     implicit encoder: Encoder[DataUpdate]
   ): PeerResponse[F, Boolean]
   def sendAllowSpendBlock(block: Signed[AllowSpendBlock]): PeerResponse[F, Boolean]
+  def sendTokenLockBlock(block: Signed[TokenLockBlock]): PeerResponse[F, Boolean]
 }
 
 object L0BlockOutputClient {
@@ -38,6 +40,11 @@ object L0BlockOutputClient {
 
       def sendAllowSpendBlock(block: Signed[AllowSpendBlock]): PeerResponse[F, Boolean] =
         PeerResponse(s"$pathPrefix/l1-allow-spend-output", POST)(client) { (req, c) =>
+          c.successful(req.withEntity(block))
+        }
+
+      def sendTokenLockBlock(block: Signed[TokenLockBlock]): PeerResponse[F, Boolean] =
+        PeerResponse(s"$pathPrefix/l1-token-lock-output", POST)(client) { (req, c) =>
           c.successful(req.withEntity(block))
         }
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/P2PClient.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/P2PClient.scala
@@ -4,6 +4,7 @@ import cats.effect.Async
 
 import io.constellationnetwork.dag.l1.domain.consensus.block.http.p2p.clients.BlockConsensusClient
 import io.constellationnetwork.node.shared.domain.swap.consensus.{ConsensusClient => SwapConsensusClient}
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.{ConsensusClient => TokenLockConsensusClient}
 import io.constellationnetwork.node.shared.http.p2p.SharedP2PClient
 import io.constellationnetwork.node.shared.http.p2p.clients._
 import io.constellationnetwork.node.shared.infrastructure.gossip.p2p.GossipClient
@@ -28,6 +29,7 @@ object P2PClient {
       BlockConsensusClient.make(client),
       L0GlobalSnapshotClient.make(client),
       SwapConsensusClient.make(client),
+      TokenLockConsensusClient.make(client),
       L0TrustClient.make(client)
     ) {}
 }
@@ -42,5 +44,6 @@ sealed abstract class P2PClient[F[_]] private (
   val blockConsensus: BlockConsensusClient[F],
   val l0GlobalSnapshot: L0GlobalSnapshotClient[F],
   val swapConsensusClient: SwapConsensusClient[F],
+  val tokenLockConsensusClient: TokenLockConsensusClient[F],
   val l0Trust: L0TrustClient[F]
 )

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/HttpApi.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/HttpApi.scala
@@ -75,6 +75,15 @@ sealed abstract class HttpApi[
         storages.allowSpend
       )
     }
+  private val tokenLockRoutes =
+    HasherSelector[F].withCurrent { implicit hasher =>
+      TokenLockRoutes[F](
+        queues.tokenLockConsensusInput,
+        storages.l0Cluster,
+        services.tokenLock,
+        storages.tokenLock
+      )
+    }
   private val dagRoutes =
     Routes[F](
       services.transaction,
@@ -82,6 +91,7 @@ sealed abstract class HttpApi[
       storages.l0Cluster,
       queues.peerBlockConsensusInput,
       queues.swapPeerConsensusInput,
+      queues.tokenLockConsensusInput,
       txHasher
     )
   private val nodeRoutes = NodeRoutes[F](storages.node, storages.session, storages.cluster, nodeVersion, httpCfg, selfId)
@@ -100,7 +110,8 @@ sealed abstract class HttpApi[
           nodeRoutes.publicRoutes <+>
           metricRoutes <+>
           targetRoutes <+>
-          allowSpendRoutes.publicRoutes
+          allowSpendRoutes.publicRoutes <+>
+          tokenLockRoutes.publicRoutes
       }
     }
 
@@ -114,7 +125,8 @@ sealed abstract class HttpApi[
               nodeRoutes.p2pRoutes <+>
               gossipRoutes.p2pRoutes <+>
               dagRoutes.p2pRoutes <+>
-              allowSpendRoutes.p2pRoutes
+              allowSpendRoutes.p2pRoutes <+>
+              tokenLockRoutes.p2pRoutes
           )
         )
     )

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Queues.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Queues.scala
@@ -6,11 +6,13 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 
 import io.constellationnetwork.currency.swap.{ConsensusInput => SwapConsensusInput}
+import io.constellationnetwork.currency.tokenlock.{ConsensusInput => TokenLockConsensusInput}
 import io.constellationnetwork.dag.l1.domain.consensus.block.BlockConsensusInput.PeerBlockConsensusInput
 import io.constellationnetwork.node.shared.modules.SharedQueues
 import io.constellationnetwork.schema.Block
 import io.constellationnetwork.schema.gossip.RumorRaw
 import io.constellationnetwork.schema.swap.AllowSpendBlock
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security.Hashed
 import io.constellationnetwork.security.signature.Signed
 
@@ -22,6 +24,8 @@ object Queues {
       peerBlockQueue <- Queue.unbounded[F, Signed[Block]]
       swapPeerConsensusInputQueue <- Queue.unbounded[F, Signed[SwapConsensusInput.PeerConsensusInput]]
       allowSpendBlocksQueue <- Queue.unbounded[F, Signed[AllowSpendBlock]]
+      tokenLockPeerConsensusInputQueue <- Queue.unbounded[F, Signed[TokenLockConsensusInput.PeerConsensusInput]]
+      tokenLocksQueue <- Queue.unbounded[F, Signed[TokenLockBlock]]
     } yield
       new Queues[F] {
         val rumor: Queue[F, Hashed[RumorRaw]] = sharedQueues.rumor
@@ -29,6 +33,8 @@ object Queues {
         val peerBlock: Queue[F, Signed[Block]] = peerBlockQueue
         val swapPeerConsensusInput = swapPeerConsensusInputQueue
         val allowSpendBlocks = allowSpendBlocksQueue
+        val tokenLockConsensusInput = tokenLockPeerConsensusInputQueue
+        val tokenLocksBlocks = tokenLocksQueue
       }
 }
 
@@ -38,4 +44,6 @@ sealed abstract class Queues[F[_]] private {
   val peerBlock: Queue[F, Signed[Block]]
   val swapPeerConsensusInput: Queue[F, Signed[SwapConsensusInput.PeerConsensusInput]]
   val allowSpendBlocks: Queue[F, Signed[AllowSpendBlock]]
+  val tokenLockConsensusInput: Queue[F, Signed[TokenLockConsensusInput.PeerConsensusInput]]
+  val tokenLocksBlocks: Queue[F, Signed[TokenLockBlock]]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Services.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Services.scala
@@ -16,6 +16,7 @@ import io.constellationnetwork.node.shared.domain.healthcheck.LocalHealthcheck
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.swap.AllowSpendService
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockService
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.collateral.Collateral
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
@@ -62,6 +63,7 @@ object Services {
       val session = sharedServices.session
       val transaction = TransactionService.make[F, P, S, SI](storages.transaction, storages.lastSnapshot, validators.transaction)
       val allowSpend = AllowSpendService.make[F, P, S, SI](storages.allowSpend, storages.lastSnapshot, validators.allowSpend)
+      val tokenLock = TokenLockService.make[F, P, S, SI](storages.tokenLock, storages.lastSnapshot, validators.tokenLock)
       val collateral = Collateral.make[F](cfg.collateral, storages.lastSnapshot)
       val restart = sharedServices.restart
     }
@@ -76,6 +78,7 @@ trait Services[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P], R <:
   val session: Session[F]
   val transaction: TransactionService[F]
   val allowSpend: AllowSpendService[F]
+  val tokenLock: TokenLockService[F]
   val collateral: Collateral[F]
   val restart: RestartService[F, R]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
@@ -15,6 +15,7 @@ import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.swap.{AllowSpendStorage, ContextualAllowSpendValidator}
+import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockStorage}
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.gossip.RumorStorage
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
@@ -22,6 +23,7 @@ import io.constellationnetwork.node.shared.modules.SharedStorages
 import io.constellationnetwork.schema.peer.L0Peer
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.swap.AllowSpendReference
+import io.constellationnetwork.schema.tokenLock.TokenLockReference
 import io.constellationnetwork.schema.transaction.TransactionReference
 
 object Storages {
@@ -30,7 +32,8 @@ object Storages {
     sharedStorages: SharedStorages[F],
     l0Peer: L0Peer,
     contextualTransactionValidator: ContextualTransactionValidator,
-    contextualAllowSpendValidator: ContextualAllowSpendValidator
+    contextualAllowSpendValidator: ContextualAllowSpendValidator,
+    contextualTokenLockValidator: ContextualTokenLockValidator
   ): F[Storages[F, P, S, SI]] =
     for {
       blockStorage <- BlockStorage.make[F]
@@ -40,6 +43,7 @@ object Storages {
       transactionStorage <- TransactionStorage.make[F](TransactionReference.empty, contextualTransactionValidator)
       addressStorage <- AddressStorage.make[F]
       allowSpendStorage <- AllowSpendStorage.make[F](AllowSpendReference.empty, contextualAllowSpendValidator)
+      tokenLockStorage <- TokenLockStorage.make[F](TokenLockReference.empty, contextualTokenLockValidator)
     } yield
       new Storages[F, P, S, SI] {
         val address = addressStorage
@@ -53,6 +57,7 @@ object Storages {
         val rumor = sharedStorages.rumor
         val transaction = transactionStorage
         val allowSpend = allowSpendStorage
+        val tokenLock = tokenLockStorage
       }
 }
 
@@ -68,4 +73,5 @@ trait Storages[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]] {
   val rumor: RumorStorage[F]
   val transaction: TransactionStorage[F]
   val allowSpend: AllowSpendStorage[F]
+  val tokenLock: TokenLockStorage[F]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Validators.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Validators.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.block.processing.BlockValidator
 import io.constellationnetwork.node.shared.domain.seedlist.SeedlistEntry
 import io.constellationnetwork.node.shared.domain.swap.{AllowSpendValidator, ContextualAllowSpendValidator}
+import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockValidator}
 import io.constellationnetwork.node.shared.domain.transaction._
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockValidator
 import io.constellationnetwork.node.shared.infrastructure.gossip.RumorValidator
@@ -48,6 +49,9 @@ object Validators {
     val allowSpend = AllowSpendValidator.make[F](signedValidator)
     val contextualAllowSpendValidator = ContextualAllowSpendValidator.make(None, cfg.allowSpends)
 
+    val tokenLock = TokenLockValidator.make[F](signedValidator)
+    val contextualTokenLockValidator = ContextualTokenLockValidator.make(None, cfg.tokenLocks)
+
     new Validators[F](
       signedValidator,
       blockValidator,
@@ -55,7 +59,9 @@ object Validators {
       contextualTransactionValidator,
       rumorValidator,
       allowSpend,
-      contextualAllowSpendValidator
+      contextualAllowSpendValidator,
+      tokenLock,
+      contextualTokenLockValidator
     ) {}
   }
 }
@@ -67,5 +73,7 @@ sealed abstract class Validators[F[_]] private (
   val transactionContextual: ContextualTransactionValidator,
   val rumorValidator: RumorValidator[F],
   val allowSpend: AllowSpendValidator[F],
-  val allowSpendContextual: ContextualAllowSpendValidator
+  val allowSpendContextual: ContextualAllowSpendValidator,
+  val tokenLock: TokenLockValidator[F],
+  val tokenLockContextual: ContextualTokenLockValidator
 )

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -114,3 +114,7 @@ allow-spends {
     max: 60
   }
 }
+
+token-locks {
+  min-epoch-progresses-to-lock: 100
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
@@ -61,7 +61,8 @@ trait CliMethod {
     c.forkInfoStorage,
     c.lastKryoHashOrdinal,
     c.addresses,
-    c.allowSpends
+    c.allowSpends,
+    c.tokenLocks
   )
 
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -31,7 +31,8 @@ object types {
     priorityPeerIds: Map[AppEnvironment, NonEmptySet[PeerId]],
     lastKryoHashOrdinal: Map[AppEnvironment, SnapshotOrdinal],
     addresses: AddressesConfig,
-    allowSpends: AllowSpendsConfig
+    allowSpends: AllowSpendsConfig,
+    tokenLocks: TokenLocksConfig
   )
 
   case class SharedConfig(
@@ -48,7 +49,8 @@ object types {
     forkInfoStorage: ForkInfoStorageConfig,
     lastKryoHashOrdinal: Map[AppEnvironment, SnapshotOrdinal],
     addresses: AddressesConfig,
-    allowSpends: AllowSpendsConfig
+    allowSpends: AllowSpendsConfig,
+    tokenLocks: TokenLocksConfig
   )
 
   case class SharedTrustConfig(
@@ -152,4 +154,5 @@ object types {
   case class MinMax(min: NonNegLong, max: NonNegLong)
   case class AllowSpendsConfig(lastValidEpochProgress: MinMax)
 
+  case class TokenLocksConfig(minEpochProgressesToLock: NonNegLong)
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidator.scala
@@ -1,0 +1,199 @@
+package io.constellationnetwork.node.shared.domain.tokenlock
+
+import cats.data.ValidatedNec
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.node.shared.config.types.TokenLocksConfig
+import io.constellationnetwork.node.shared.domain.tokenlock.ContextualTokenLockValidator.{
+  ContextualTokenLockValidationErrorOr,
+  CustomValidationError,
+  ValidConflictResolveResult
+}
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockValidator.TokenLockValidationError
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.tokenLock.TokenLockAmount._
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockOrdinal, TokenLockReference}
+import io.constellationnetwork.security.Hashed
+import io.constellationnetwork.security.hash.Hash
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+import eu.timepit.refined.auto._
+
+trait CustomContextualTokenLockValidator {
+  def validate(
+    hashedTokenLock: Hashed[TokenLock],
+    context: TokenLockValidatorContext
+  ): Either[CustomValidationError, Hashed[TokenLock]]
+}
+
+case class TokenLockValidatorContext(
+  sourceTokenLocks: Option[SortedMap[TokenLockOrdinal, StoredTokenLock]],
+  sourceBalance: Balance,
+  sourceLastTokenLocksRef: TokenLockReference,
+  currentOrdinal: SnapshotOrdinal,
+  currentEpochProgress: EpochProgress
+)
+
+trait ContextualTokenLockValidator {
+
+  def validate(
+    hashedTokenLock: Hashed[TokenLock],
+    context: TokenLockValidatorContext
+  ): ContextualTokenLockValidationErrorOr[ValidConflictResolveResult]
+}
+
+object ContextualTokenLockValidator {
+
+  def make(
+    customValidator: Option[CustomContextualTokenLockValidator],
+    tokenLocksConfig: TokenLocksConfig
+  ): ContextualTokenLockValidator =
+    new ContextualTokenLockValidator {
+      def validate(
+        hashedTokenLocks: Hashed[TokenLock],
+        context: TokenLockValidatorContext
+      ): ContextualTokenLockValidationErrorOr[ValidConflictResolveResult] =
+        validateLastTokenLockRef(hashedTokenLocks, context.sourceTokenLocks, context.sourceLastTokenLocksRef)
+          .flatMap(validateEpochProgress(_, context.currentEpochProgress))
+          .flatMap(validateConflictAtOrdinal(_, context.sourceTokenLocks))
+          .flatMap {
+            case (conflictResolveResult, conflictResolvedStoredTxs) =>
+              validateBalances(conflictResolveResult.tx, conflictResolvedStoredTxs, context.sourceBalance)
+                .map(_ => conflictResolveResult)
+          }
+          .flatMap { conflictResolveResult =>
+            customValidator match {
+              case Some(validator) =>
+                validator
+                  .validate(hashedTokenLocks, context)
+                  .leftWiden[ContextualTokenLockValidationError]
+                  .as(conflictResolveResult)
+              case None => conflictResolveResult.asRight
+            }
+          }
+          .toValidatedNec
+
+      private def validateBalances(
+        tokenLock: Hashed[TokenLock],
+        txs: Option[SortedMap[TokenLockOrdinal, StoredTokenLock]],
+        balance: Balance
+      ): Either[ContextualTokenLockValidationError, Hashed[TokenLock]] = {
+        val availableBalance = getBalanceAffectedByTxs(txs, balance)
+        if (tokenLock.amount.value <= availableBalance.value)
+          tokenLock.asRight
+        else
+          InsufficientBalance(tokenLock.amount, availableBalance).asLeft
+      }
+
+      private def validateEpochProgress(
+        tokenLock: Hashed[TokenLock],
+        currentEpochProgress: EpochProgress
+      ): Either[ContextualTokenLockValidationError, Hashed[TokenLock]] = {
+        val validUnlockEpochProgress =
+          tokenLock.unlockEpoch >= (currentEpochProgress |+| EpochProgress(tokenLocksConfig.minEpochProgressesToLock))
+
+        if (validUnlockEpochProgress) {
+          tokenLock.asRight
+        } else
+          TooShortUnlockEpochProgress(tokenLock.unlockEpoch).asLeft
+      }
+
+      private def validateConflictAtOrdinal(
+        tokenLock: Hashed[TokenLock],
+        txs: Option[SortedMap[TokenLockOrdinal, StoredTokenLock]]
+      ): Either[
+        ContextualTokenLockValidationError,
+        (ValidConflictResolveResult, Option[SortedMap[TokenLockOrdinal, StoredTokenLock]])
+      ] =
+        txs match {
+          case Some(txs) =>
+            resolveConflict(tokenLock, txs) match {
+              case noConflict @ NoConflict(_) => (noConflict, txs.some).asRight
+              case canOverride @ CanOverride(_) =>
+                (canOverride, txs.filterNot { case (ordinal, _) => ordinal > tokenLock.ordinal }.some).asRight
+              case CannotOverride(_, existing, current) => Conflict(tokenLock.ordinal, existing.hash, current.hash).asLeft
+            }
+          case None => (NoConflict(tokenLock), none).asRight
+        }
+
+      private def validateLastTokenLockRef(
+        tokenLock: Hashed[TokenLock],
+        txs: Option[SortedMap[TokenLockOrdinal, StoredTokenLock]],
+        lastProcessedTokenLockRef: TokenLockReference
+      ): Either[ContextualTokenLockValidationError, Hashed[TokenLock]] =
+        if (tokenLock.parent.ordinal < lastProcessedTokenLockRef.ordinal)
+          ParentOrdinalLowerThenLastProcessedTxOrdinal(tokenLock.parent.ordinal, lastProcessedTokenLockRef.ordinal).asLeft
+        else if (tokenLock.parent === lastProcessedTokenLockRef) {
+          tokenLock.asRight
+        } else {
+          val hasValidParent = txs.exists(_.exists {
+            case (parentOrdinal, parentTx) => parentTx.ref === tokenLock.parent && parentOrdinal > lastProcessedTokenLockRef.ordinal
+          })
+
+          if (hasValidParent) tokenLock.asRight else HasNoMatchingParent(tokenLock.parent.hash).asLeft
+        }
+
+      private def getBalanceAffectedByTxs(
+        txs: Option[SortedMap[TokenLockOrdinal, StoredTokenLock]],
+        latestBalance: Balance
+      ): Balance =
+        txs match {
+          case Some(txs) =>
+            getTransactionsAboveMajority(txs)
+              .foldLeftM(latestBalance) {
+                case (acc, curr) =>
+                  acc.minus(curr.transaction.amount)
+              }
+              .getOrElse(Balance.empty)
+          case None => latestBalance
+        }
+
+      private def resolveConflict(
+        tokenLock: Hashed[TokenLock],
+        txs: SortedMap[TokenLockOrdinal, StoredTokenLock]
+      ): ConflictResolveResult =
+        txs.get(tokenLock.ordinal) match {
+          case Some(WaitingTokenLock(existing)) if existing.amount < tokenLock.amount => CanOverride(tokenLock)
+          case Some(tx) => CannotOverride(tokenLock, tx.ref, TokenLockReference.of(tokenLock))
+          case None     => NoConflict(tokenLock)
+        }
+
+      private def getTransactionsAboveMajority(
+        txs: SortedMap[TokenLockOrdinal, StoredTokenLock]
+      ): SortedMap[TokenLockOrdinal, NonMajorityTokenLock] =
+        txs.collect {
+          case (ordinal, stored: NonMajorityTokenLock) => (ordinal, stored)
+        }
+    }
+
+  @derive(eqv)
+  sealed trait ConflictResolveResult
+  @derive(eqv)
+  sealed trait ValidConflictResolveResult extends ConflictResolveResult {
+    val tx: Hashed[TokenLock]
+  }
+  case class NoConflict(tx: Hashed[TokenLock]) extends ValidConflictResolveResult
+  case class CanOverride(tx: Hashed[TokenLock]) extends ValidConflictResolveResult
+  case class CannotOverride(tx: Hashed[TokenLock], existingRef: TokenLockReference, newRef: TokenLockReference)
+      extends ConflictResolveResult
+
+  @derive(eqv, show)
+  sealed trait ContextualTokenLockValidationError
+  case class ParentOrdinalLowerThenLastProcessedTxOrdinal(parentOrdinal: TokenLockOrdinal, lastTxOrdinal: TokenLockOrdinal)
+      extends ContextualTokenLockValidationError
+  case class HasNoMatchingParent(parentHash: Hash) extends ContextualTokenLockValidationError
+  case class Conflict(ordinal: TokenLockOrdinal, existingHash: Hash, newHash: Hash) extends ContextualTokenLockValidationError
+  case class InsufficientBalance(amount: Amount, balance: Balance) extends ContextualTokenLockValidationError
+  case class NonContextualValidationError(error: TokenLockValidationError) extends ContextualTokenLockValidationError
+  case class LockedAddressError(address: Address) extends ContextualTokenLockValidationError
+  case class TooShortUnlockEpochProgress(epochProgress: EpochProgress) extends ContextualTokenLockValidationError
+  case class CustomValidationError(message: String) extends ContextualTokenLockValidationError
+
+  type ContextualTokenLockValidationErrorOr[A] = ValidatedNec[ContextualTokenLockValidationError, A]
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockService.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockService.scala
@@ -1,0 +1,60 @@
+package io.constellationnetwork.node.shared.domain.tokenlock
+
+import cats.data.NonEmptyList
+import cats.data.Validated.{Invalid, Valid}
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.ext.cats.syntax.validated.validatedSyntax
+import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.ContextualTokenLockValidator.{
+  ContextualTokenLockValidationError,
+  NonContextualValidationError
+}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
+import io.constellationnetwork.schema.tokenLock.TokenLock
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.{Hashed, Hasher}
+
+import fs2.Stream
+
+trait TokenLockService[F[_]] {
+  def offer(tokenLock: Hashed[TokenLock])(implicit hasher: Hasher[F]): F[Either[NonEmptyList[ContextualTokenLockValidationError], Hash]]
+}
+
+object TokenLockService {
+  def make[F[_]: Async, P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]](
+    tokenLockStorage: TokenLockStorage[F],
+    lastSnapshotStorage: LastSnapshotStorage[F, S, SI] with LatestBalances[F],
+    tokenLockValidator: TokenLockValidator[F]
+  ): TokenLockService[F] = new TokenLockService[F] {
+
+    def offer(
+      tokenLock: Hashed[TokenLock]
+    )(implicit hasher: Hasher[F]): F[Either[NonEmptyList[ContextualTokenLockValidationError], Hash]] =
+      tokenLockValidator
+        .validate(tokenLock.signed)
+        .map(_.errorMap(NonContextualValidationError))
+        .flatMap {
+          case Valid(_) =>
+            lastSnapshotStorage.getCombinedStream.map {
+              case Some((s, si)) => (s.ordinal, s.epochProgress, si.balances.getOrElse(tokenLock.source, Balance.empty))
+              case None          => (SnapshotOrdinal.MinValue, EpochProgress.MinValue, Balance.empty)
+            }.changes.switchMap {
+              case (latestOrdinal, latestEpochProgress, balance) =>
+                Stream.eval(tokenLockStorage.tryPut(tokenLock, latestOrdinal, latestEpochProgress, balance))
+            }.head.compile.last.flatMap {
+              case Some(value) => value.pure[F]
+              case None =>
+                new Exception(s"Unexpected state, stream should always emit the first snapshot")
+                  .raiseError[F, Either[NonEmptyList[ContextualTokenLockValidationError], Hash]]
+            }
+          case Invalid(e) =>
+            e.toNonEmptyList.asLeft[Hash].leftWiden[NonEmptyList[ContextualTokenLockValidationError]].pure[F]
+        }
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockStorage.scala
@@ -1,0 +1,324 @@
+package io.constellationnetwork.node.shared.domain.tokenlock
+
+import cats._
+import cats.data.{NonEmptyList, Validated}
+import cats.effect.Async
+import cats.syntax.all._
+
+import scala.annotation.tailrec
+import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.util.control.NoStackTrace
+
+import io.constellationnetwork.ext.collection.MapRefUtils._
+import io.constellationnetwork.node.shared.domain.tokenlock.ContextualTokenLockValidator.{
+  CanOverride,
+  ContextualTokenLockValidationError,
+  NoConflict
+}
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockStorage._
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockOrdinal, TokenLockReference}
+import io.constellationnetwork.security.Hashed
+import io.constellationnetwork.security.hash.Hash
+
+import derevo.cats.eqv
+import derevo.derive
+import eu.timepit.refined.types.numeric.NonNegLong
+import io.chrisdavenport.mapref.MapRef
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+class TokenLockStorage[F[_]: Async](
+  tokenLocksR: MapRef[F, Address, Option[SortedMap[TokenLockOrdinal, StoredTokenLock]]],
+  initialTokenLockReference: TokenLockReference,
+  contextualTokenLockValidator: ContextualTokenLockValidator
+) {
+
+  private val logger = Slf4jLogger.getLogger[F]
+  private val tokenLockLogger = Slf4jLogger.getLoggerFromName[F](tokenLockLoggerName)
+
+  def getInitialTx: MajorityTokenLock = MajorityTokenLock(initialTokenLockReference, SnapshotOrdinal.MinValue)
+
+  def getState: F[Map[Address, SortedMap[TokenLockOrdinal, StoredTokenLock]]] = tokenLocksR.toMap
+
+  def getLastProcessedTokenLock(source: Address): F[StoredTokenLock] =
+    tokenLocksR(source).get.map {
+      _.flatMap(getLastProcessedTokenLock).getOrElse(getInitialTx)
+    }
+
+  private def getLastProcessedTokenLock(stored: SortedMap[TokenLockOrdinal, StoredTokenLock]): Option[StoredTokenLock] =
+    stored.collect { case tx @ (_, _: AcceptedTokenLock | _: MajorityTokenLock) => tx }.lastOption.map {
+      case (_, tokenLock) => tokenLock
+    }
+
+  def initByRefs(refs: Map[Address, TokenLockReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
+    refs.toList.traverse {
+      case (address, reference) =>
+        tokenLocksR(address)
+          .modify[Either[Error, Unit]] {
+            case curr @ Some(_) =>
+              (curr, new Error("Storage should be empty before download").asLeft)
+            case None =>
+              val initial = SortedMap(reference.ordinal -> MajorityTokenLock(reference, snapshotOrdinal))
+              (initial.some, ().asRight)
+          }
+          .flatMap(_.liftTo[F])
+    }.void
+
+  def replaceByRefs(refs: Map[Address, TokenLockReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
+    refs.toList.traverse_ {
+      case (address, reference) =>
+        val initial = SortedMap(reference.ordinal -> MajorityTokenLock(reference, snapshotOrdinal))
+        tokenLocksR(address).set(initial.some)
+    }
+
+  def advanceMajorityRefs(refs: Map[Address, TokenLockReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
+    refs.toList.traverse_ {
+      case (source, majorityTxRef) =>
+        tokenLocksR(source).modify[Either[MarkingTokenLockReferenceAsMajorityError, Unit]] { maybeStored =>
+          val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
+
+          if (stored.isEmpty && majorityTxRef === TokenLockReference.empty) {
+            val updated = stored + (majorityTxRef.ordinal -> MajorityTokenLock(majorityTxRef, snapshotOrdinal))
+            (updated.some, ().asRight)
+          } else {
+            stored.collectFirst { case (_, a @ AcceptedTokenLock(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
+              val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
+
+              remaining + (majorityTx.ordinal -> MajorityTokenLock(TokenLockReference.of(majorityTx), snapshotOrdinal))
+            } match {
+              case Some(updated) => (updated.some, ().asRight)
+              case None          => (maybeStored, UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, None).asLeft)
+            }
+          }
+        }
+    }
+
+  def accept(hashedTx: Hashed[TokenLock]): F[Unit] = {
+    val parent = hashedTx.signed.value.parent
+    val source = hashedTx.signed.value.source
+    val reference = TokenLockReference(hashedTx.signed.value.ordinal, hashedTx.hash)
+
+    tokenLocksR(source)
+      .modify[Either[TokenLockAcceptanceError, Unit]] { maybeStored =>
+        val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
+        val lastAcceptedRef = getLastProcessedTokenLock(stored)
+
+        if (lastAcceptedRef.exists(_.ref === parent) || (lastAcceptedRef.isEmpty && hashedTx.ordinal == TokenLockOrdinal.first)) {
+          val accepted = stored.updated(hashedTx.ordinal, AcceptedTokenLock(hashedTx))
+
+          val (processed, stillWaitingAboveAccepted) = accepted.partition { case (ordinal, _) => ordinal <= hashedTx.ordinal }
+
+          val updated = stillWaitingAboveAccepted.values.toList.foldLeft(processed) {
+            case (acc, tx) =>
+              val last = acc.last._2
+
+              val maybeStillMatching: Option[StoredTokenLock] = tx match {
+                case w: WaitingTokenLock if w.transaction.parent === last.ref    => w.some
+                case p: ProcessingTokenLock if p.transaction.parent === last.ref => p.some
+                case _                                                           => none[StoredTokenLock]
+              }
+
+              maybeStillMatching.fold(acc)(tx => acc + (tx.ref.ordinal -> tx))
+          }
+
+          (updated.some, ().asRight)
+        } else {
+          (maybeStored, ParentNotAccepted(source, lastAcceptedRef.map(_.ref), reference).asLeft)
+        }
+      }
+      .flatMap(_.liftTo[F])
+  }
+
+  def tryPut(
+    tokenLock: Hashed[TokenLock],
+    lastSnapshotOrdinal: SnapshotOrdinal,
+    lastEpochProgress: EpochProgress,
+    sourceBalance: Balance
+  ): F[Either[NonEmptyList[ContextualTokenLockValidationError], Hash]] =
+    tokenLocksR(tokenLock.source).modify { maybeStored =>
+      val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
+      val lastProcessedTokenLock = getLastProcessedTokenLock(stored).getOrElse(getInitialTx)
+      val validationContext =
+        TokenLockValidatorContext(maybeStored, sourceBalance, lastProcessedTokenLock.ref, lastSnapshotOrdinal, lastEpochProgress)
+      val validation =
+        contextualTokenLockValidator.validate(tokenLock, validationContext)
+
+      validation match {
+        case Validated.Valid(NoConflict(tx)) =>
+          val updated = stored.updated(tokenLock.ordinal, WaitingTokenLock(tx))
+          (updated.some, tokenLock.hash.asRight[NonEmptyList[ContextualTokenLockValidationError]])
+        case Validated.Valid(CanOverride(tx)) =>
+          val updated = stored.updated(tokenLock.ordinal, WaitingTokenLock(tx)).filterNot { case (ordinal, _) => ordinal > tx.ordinal }
+          (updated.some, tokenLock.hash.asRight[NonEmptyList[ContextualTokenLockValidationError]])
+        case Validated.Invalid(e) =>
+          (maybeStored, e.toNonEmptyList.asLeft[Hash])
+      }
+    }
+
+  def putBack(tokenLocks: Set[Hashed[TokenLock]]): F[Unit] =
+    tokenLocks
+      .groupBy(_.signed.value.source)
+      .toList
+      .traverse {
+        case (source, txs) =>
+          tokenLocksR(source).update { maybeStored =>
+            val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
+            txs
+              .foldLeft(stored) {
+                case (acc, tx) =>
+                  acc.updatedWith(tx.ordinal) {
+                    case Some(ProcessingTokenLock(existing)) if existing === tx => WaitingTokenLock(tx).some
+                    case None                                                   => none
+                    case existing @ _                                           => existing
+                  }
+              }
+              .some
+          }
+      }
+      .void
+
+  def areWaiting: F[Boolean] =
+    tokenLocksR.toMap.map(_.values.toList.collectFirstSome(_.collectFirst { case (_, w: WaitingTokenLock) => w }).nonEmpty)
+
+  def pull(count: NonNegLong): F[Option[NonEmptyList[Hashed[TokenLock]]]] =
+    for {
+      addresses <- tokenLocksR.keys
+      allPulled <- addresses.traverseCollect { address =>
+        tokenLocksR(address).modify { maybeStored =>
+          maybeStored.flatMap { stored =>
+            NonEmptyList.fromList(stored.values.collect { case w: WaitingTokenLock => w.transaction }.toList).map { waitingTxs =>
+              val updated = stored.map {
+                case (ordinal, WaitingTokenLock(tx)) => (ordinal, ProcessingTokenLock(tx))
+                case existing @ _                    => existing
+              }
+              (updated.some, waitingTxs.some)
+            }
+          } match {
+            case Some(updated) => updated
+            case None          => (maybeStored, none)
+          }
+        }
+      }.map(_.flatten)
+
+      selected = takeFirstNHighestFeeTxs(allPulled, count)
+      toReturn = allPulled.flatMap(_.toList).toSet.diff(selected.toSet)
+      _ <- logger.debug(s"Pulled token lock(s) to return: ${toReturn.size}")
+      _ <- tokenLockLogger.debug(s"Pulled token lock(s) to return: ${toReturn.size}, returned: ${toReturn.map(_.hash).show}")
+      _ <- putBack(toReturn)
+      _ <- logger.debug(s"Pulled ${selected.size} token lock(s) for consensus")
+      _ <- tokenLockLogger.debug(s"Pulled ${selected.size} token lock(s) for consensus, pulled: ${selected.map(_.hash).show}")
+    } yield NonEmptyList.fromList(selected)
+
+  private def takeFirstNHighestFeeTxs(
+    txs: List[NonEmptyList[Hashed[TokenLock]]],
+    count: NonNegLong
+  ): List[Hashed[TokenLock]] = {
+    @tailrec
+    def go(
+      txs: SortedSet[NonEmptyList[Hashed[TokenLock]]],
+      acc: List[Hashed[TokenLock]]
+    ): List[Hashed[TokenLock]] =
+      if (acc.size == count.value)
+        acc.reverse
+      else {
+        txs.headOption match {
+          case Some(txsNel) =>
+            val updatedAcc = txsNel.head :: acc
+
+            NonEmptyList.fromList(txsNel.tail) match {
+              case Some(remainingTxs) => go(txs.tail + remainingTxs, updatedAcc)
+              case None               => go(txs.tail, updatedAcc)
+            }
+
+          case None => acc.reverse
+        }
+      }
+
+    val order: Order[NonEmptyList[Hashed[TokenLock]]] =
+      Order.whenEqual(Order.by(-_.head.ordinal.value.value), Order[NonEmptyList[Hashed[TokenLock]]])
+    val sortedTxs = SortedSet.from(txs)(order.toOrdering)
+
+    go(sortedTxs, List.empty)
+  }
+
+  def findWaiting(hash: Hash): F[Option[WaitingTokenLock]] =
+    tokenLocksR.toMap.map {
+      _.values.toList.collectFirstSome {
+        _.collectFirst { case (_, w: WaitingTokenLock) if w.ref.hash === hash => w }
+      }
+    }
+}
+
+object TokenLockStorage {
+  def make[F[_]: Async](
+    initialTokenLockReference: TokenLockReference,
+    contextualTokenLockValidator: ContextualTokenLockValidator
+  ): F[TokenLockStorage[F]] =
+    for {
+      tokenLocks <- MapRef.ofConcurrentHashMap[F, Address, SortedMap[TokenLockOrdinal, StoredTokenLock]]()
+    } yield
+      new TokenLockStorage[F](
+        tokenLocks,
+        initialTokenLockReference,
+        contextualTokenLockValidator
+      )
+
+  def make[F[_]: Async](
+    tokenLocks: Map[Address, SortedMap[TokenLockOrdinal, StoredTokenLock]],
+    initialTokenLockReference: TokenLockReference,
+    contextualTokenLockValidator: ContextualTokenLockValidator
+  ): F[TokenLockStorage[F]] =
+    MapRef.ofSingleImmutableMap(tokenLocks).map(new TokenLockStorage(_, initialTokenLockReference, contextualTokenLockValidator))
+
+  sealed trait TokenLockAcceptanceError extends NoStackTrace
+
+  private case class ParentNotAccepted(
+    source: Address,
+    lastAccepted: Option[TokenLockReference],
+    attempted: TokenLockReference
+  ) extends TokenLockAcceptanceError {
+    override def getMessage: String =
+      s"TokenLock not accepted in the correct order. source=${source.show} current=${lastAccepted.show} attempted=${attempted.show}"
+  }
+
+  sealed trait MarkingTokenLockReferenceAsMajorityError extends NoStackTrace
+
+  private case class UnexpectedStateWhenMarkingTxRefAsMajority(
+    source: Address,
+    toMark: TokenLockReference,
+    got: Option[StoredTokenLock]
+  ) extends MarkingTokenLockReferenceAsMajorityError {
+    override def getMessage: String =
+      s"Unexpected state encountered when marking token lock reference=$toMark for source address=$source as majority. Got: $got"
+  }
+}
+
+@derive(eqv)
+sealed trait StoredTokenLock {
+  def ref: TokenLockReference
+}
+object StoredTokenLock {
+  implicit val show: Show[StoredTokenLock] = Show.show {
+    case WaitingTokenLock(tx)                    => s"WaitingTokenLock(${tx.hash.show})"
+    case ProcessingTokenLock(tx)                 => s"ProcessingTokenLock(${tx.hash.show}"
+    case AcceptedTokenLock(tx)                   => s"AcceptedTokenLock(${tx.hash.show}"
+    case MajorityTokenLock(ref, snapshotOrdinal) => s"MajorityTokenLock(${ref.hash.show}, ${snapshotOrdinal.show}"
+  }
+
+  implicit val order: Order[StoredTokenLock] = Order[TokenLockOrdinal].contramap(_.ref.ordinal)
+  implicit val ordering: Ordering[StoredTokenLock] = order.toOrdering
+}
+@derive(eqv)
+sealed trait NonMajorityTokenLock extends StoredTokenLock {
+  val transaction: Hashed[TokenLock]
+  def ref: TokenLockReference = TokenLockReference.of(transaction)
+}
+case class WaitingTokenLock(transaction: Hashed[TokenLock]) extends StoredTokenLock with NonMajorityTokenLock
+case class ProcessingTokenLock(transaction: Hashed[TokenLock]) extends StoredTokenLock with NonMajorityTokenLock
+case class AcceptedTokenLock(transaction: Hashed[TokenLock]) extends StoredTokenLock with NonMajorityTokenLock
+
+@derive(eqv)
+case class MajorityTokenLock(ref: TokenLockReference, snapshotOrdinal: SnapshotOrdinal) extends StoredTokenLock

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockValidator.scala
@@ -1,0 +1,54 @@
+package io.constellationnetwork.node.shared.domain.tokenlock
+
+import cats.data.ValidatedNec
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.ext.cats.syntax.validated._
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockValidator.TokenLockValidationErrorOr
+import io.constellationnetwork.schema.tokenLock.TokenLock
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.SignedValidator.SignedValidationError
+import io.constellationnetwork.security.signature.{Signed, SignedValidator}
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+
+trait TokenLockValidator[F[_]] {
+
+  def validate(signedTokenLock: Signed[TokenLock])(implicit hasher: Hasher[F]): F[TokenLockValidationErrorOr[Signed[TokenLock]]]
+
+}
+
+object TokenLockValidator {
+
+  def make[F[_]: Async](signedValidator: SignedValidator[F]): TokenLockValidator[F] =
+    new TokenLockValidator[F] {
+      def validate(
+        signedTokenLock: Signed[TokenLock]
+      )(implicit hasher: Hasher[F]): F[TokenLockValidationErrorOr[Signed[TokenLock]]] =
+        for {
+          signaturesV <- signedValidator
+            .validateSignatures(signedTokenLock)
+            .map(_.errorMap[TokenLockValidationError](InvalidSigned))
+          srcAddressSignatureV <- validateSourceAddressSignature(signedTokenLock)
+        } yield
+          signaturesV
+            .productR(srcAddressSignatureV)
+
+      private def validateSourceAddressSignature(
+        signedTx: Signed[TokenLock]
+      ): F[TokenLockValidationErrorOr[Signed[TokenLock]]] =
+        signedValidator
+          .isSignedExclusivelyBy(signedTx, signedTx.source)
+          .map(_.errorMap[TokenLockValidationError](_ => NotSignedBySourceAddressOwner))
+
+    }
+
+  @derive(eqv, show)
+  sealed trait TokenLockValidationError
+  case class InvalidSigned(error: SignedValidationError) extends TokenLockValidationError
+  case object NotSignedBySourceAddressOwner extends TokenLockValidationError
+
+  type TokenLockValidationErrorOr[A] = ValidatedNec[TokenLockValidationError, A]
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/ConsensusClient.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/ConsensusClient.scala
@@ -1,0 +1,29 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.consensus
+
+import cats.effect.Sync
+import cats.syntax.functor._
+
+import io.constellationnetwork.currency.tokenlock.ConsensusInput
+import io.constellationnetwork.node.shared.http.p2p.PeerResponse
+import io.constellationnetwork.node.shared.http.p2p.PeerResponse.PeerResponse
+import io.constellationnetwork.security.signature.Signed
+
+import io.circe.Encoder
+import org.http4s.Method.POST
+import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
+import org.http4s.client.Client
+
+trait ConsensusClient[F[_]] {
+  def sendConsensusData[A <: ConsensusInput.PeerConsensusInput](data: Signed[A])(implicit e: Encoder[A]): PeerResponse[F, Unit]
+}
+
+object ConsensusClient {
+  def make[F[_]: Sync](client: Client[F]): ConsensusClient[F] =
+    new ConsensusClient[F] {
+
+      def sendConsensusData[A <: ConsensusInput.PeerConsensusInput](data: Signed[A])(implicit e: Encoder[A]): PeerResponse[F, Unit] =
+        PeerResponse("consensus/token-locks", POST)(client) { (req, c) =>
+          c.successful(req.withEntity(data)).void
+        }
+    }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/ConsensusState.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/ConsensusState.scala
@@ -1,0 +1,12 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.consensus
+
+import io.constellationnetwork.schema.round.RoundId
+
+case class ConsensusState(
+  ownConsensus: Option[RoundData],
+  peerConsensuses: Map[RoundId, RoundData]
+)
+
+object ConsensusState {
+  def Empty = ConsensusState(None, Map.empty)
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Engine.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Engine.scala
@@ -1,0 +1,478 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.consensus
+
+import java.security.KeyPair
+
+import cats.Applicative
+import cats.data.{NonEmptyList, OptionT}
+import cats.effect.kernel.{Async, Clock}
+import cats.effect.std.Random
+import cats.syntax.all._
+
+import scala.concurrent.duration.FiniteDuration
+
+import io.constellationnetwork.currency.tokenlock.ConsensusInput._
+import io.constellationnetwork.currency.tokenlock.ConsensusOutput.Noop
+import io.constellationnetwork.currency.tokenlock.{ConsensusInput, ConsensusOutput, TokenLockCancellationReason}
+import io.constellationnetwork.effects.GenUUID
+import io.constellationnetwork.fsm.FSM
+import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.consensus.config.TokenLockConsensusConfig
+import io.constellationnetwork.node.shared.domain.tokenlock.{TokenLockStorage, TokenLockValidator}
+import io.constellationnetwork.schema.node.NodeState
+import io.constellationnetwork.schema.peer.{Peer, PeerId}
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockBlock}
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.SignatureProof
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.types.all.NonNegLong
+import io.circe.Encoder
+import monocle.syntax.all._
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+case class RoundData(
+  roundId: RoundId,
+  startedAt: FiniteDuration,
+  peers: Set[Peer],
+  owner: PeerId,
+  ownProposal: Proposal,
+  ownBlock: Option[Signed[TokenLockBlock]] = None,
+  ownCancellation: Option[TokenLockCancellationReason] = None,
+  peerProposals: Map[PeerId, Proposal] = Map.empty[PeerId, Proposal],
+  peerBlockSignatures: Map[PeerId, SignatureProof] = Map.empty,
+  peerCancellations: Map[PeerId, TokenLockCancellationReason] = Map.empty
+) {
+  def addPeerProposal(proposal: Proposal): RoundData =
+    this.focus(_.peerProposals).modify(_ + (proposal.senderId -> proposal))
+
+  def setOwnBlock(block: Signed[TokenLockBlock]): RoundData = this.focus(_.ownBlock).replace(block.some)
+
+  def addPeerSignature(signatureProposal: SignatureProposal): RoundData = {
+    val proof = SignatureProof(PeerId._Id.get(signatureProposal.senderId), signatureProposal.signature)
+    this.focus(_.peerBlockSignatures).modify(_ + (signatureProposal.senderId -> proof))
+  }
+
+  def setOwnCancellation(reason: TokenLockCancellationReason): RoundData =
+    this.focus(_.ownCancellation).replace(reason.some)
+
+  def addPeerCancellation(cancellation: CancelledCreationRound): RoundData =
+    this.focus(_.peerCancellations).modify(_ + (cancellation.senderId -> cancellation.reason))
+
+  def formBlock[F[_]: Async](
+    validateTokenLocks: Signed[TokenLock] => F[Either[String, Signed[TokenLock]]],
+    constructBlock: RoundId => List[Signed[TokenLock]] => F[Option[TokenLockBlock]]
+  ): F[Option[TokenLockBlock]] =
+    NonEmptyList
+      .fromList((ownProposal.transactions ++ peerProposals.values.flatMap(_.transactions)).toList)
+      .traverse {
+        _.toList
+          .traverse(validateTokenLocks)
+          .flatMap { validatedTokenLocks =>
+            val (_, valid) = validatedTokenLocks.partitionMap(identity)
+
+            valid.pure[F]
+          }
+          .flatMap(constructBlock(roundId))
+      }
+      .map(_.flatten)
+}
+
+object Engine {
+  type In = ConsensusInput
+  type Out = ConsensusOutput
+  type State = ConsensusState
+
+  def fsm[F[_]: Async: Random: SecurityProvider: Hasher](
+    tokenLockConsensusConfig: TokenLockConsensusConfig,
+    clusterStorage: ClusterStorage[F],
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    consensusClient: ConsensusClient[F],
+    tokenLockValidator: TokenLockValidator[F],
+    tokenLockStorage: TokenLockStorage[F],
+    selfId: PeerId,
+    selfKeyPair: KeyPair
+  ): FSM[F, State, In, Out] = {
+
+    def peersCount = tokenLockConsensusConfig.peersCount.value
+    def timeout = tokenLockConsensusConfig.timeout
+    def maxTokenLocksToDequeue = tokenLockConsensusConfig.maxTokenLocksToDequeue
+
+    def logger = Slf4jLogger.getLogger[F]
+    def getTime: F[FiniteDuration] = Clock[F].monotonic
+    def mkRoundId = GenUUID.forSync[F].make.map(RoundId(_))
+
+    def isReadyForConsensus(state: NodeState): Boolean = state === NodeState.Ready
+
+    def pullNewConsensusPeers: F[Option[Set[Peer]]] =
+      clusterStorage.getResponsivePeers
+        .map(_.filter(p => isReadyForConsensus(p.state)))
+        .flatMap(peers => Random[F].shuffleList(peers.toList))
+        .map(_.take(peersCount).toSet match {
+          case peers if peers.size === peersCount => peers.some
+          case _                                  => None
+        })
+
+    def pullTokenLocks: F[Set[Signed[TokenLock]]] =
+      tokenLockStorage
+        .pull(NonNegLong.unsafeFrom(maxTokenLocksToDequeue.value.toLong))
+        .map(_.map(_.map(_.signed).toList.toSet).getOrElse(Set.empty))
+
+    def returnTokenLocks(round: RoundData): F[Unit] =
+      round.ownProposal.transactions.toList
+        .traverse(_.toHashed[F])
+        .map(_.toSet)
+        .flatMap(tokenLockStorage.putBack)
+
+    def removeRound(state: State, round: RoundData): State =
+      if (round.owner === selfId)
+        state.focus(_.ownConsensus).replace(None)
+      else
+        state.focus(_.peerConsensuses).modify(_.removed(round.roundId))
+
+    def cancelRound(state: State, round: RoundData): F[(State, Unit)] =
+      returnTokenLocks(round).tupleLeft(removeRound(state, round))
+
+    def cancelTimeoutedRounds(state: State, rounds: Set[RoundData]): F[(State, Out)] = {
+      val newState = rounds.toList.foldLeft(state)(removeRound(_, _))
+
+      rounds.toList
+        .traverse(returnTokenLocks)
+        .as[Out](ConsensusOutput.CleanedConsensuses(rounds.map(_.roundId)))
+        .tupleLeft(newState)
+    }
+
+    def inspectConsensuses(state: State): F[(State, Out)] = {
+      val own = state.ownConsensus.toSet
+      val peer = state.peerConsensuses.values.toSet
+
+      getTime.flatMap { current =>
+        val toCancel = (peer ++ own)
+          .filter(_.startedAt + timeout < current)
+
+        if (toCancel.nonEmpty) cancelTimeoutedRounds(state, toCancel) else (state, Noop.asInstanceOf[Out]).pure[F]
+      }
+    }
+
+    def deriveConsensusPeerIds(proposal: Proposal): Set[PeerId] =
+      proposal.facilitators + proposal.senderId + proposal.owner - selfId
+
+    def fetchConsensusPeers(proposal: Proposal): F[Option[Set[Peer]]] =
+      clusterStorage.getResponsivePeers.map { knownPeers =>
+        val peerIds = deriveConsensusPeerIds(proposal)
+        val peers = peerIds.map(id => id -> knownPeers.find(_.id === id)).collect { case (id, Some(peer)) => id -> peer }.toMap
+
+        if (peers.keySet === peerIds && peerIds.size == peersCount) peers.values.toSet.some else none[Set[Peer]]
+      }
+
+    def canPersistProposal(proposal: Proposal)(roundData: RoundData): Boolean = {
+      val sameRoundId = roundData.roundId === proposal.roundId
+      lazy val peerExists = roundData.peers.exists(_.id === proposal.senderId)
+      lazy val noProposalYet = !roundData.peerProposals.contains(proposal.senderId)
+
+      sameRoundId && peerExists && noProposalYet
+    }
+
+    def canPersistSignatureProposal(proposal: SignatureProposal)(roundData: RoundData): Boolean = {
+      val sameRoundId = roundData.roundId === proposal.roundId
+      lazy val peerExists = roundData.peers.exists(_.id === proposal.senderId)
+      lazy val noProposalYet = !roundData.peerBlockSignatures.contains(proposal.senderId)
+
+      sameRoundId && peerExists && noProposalYet
+    }
+
+    def canPersistCancellation(cancellation: CancelledCreationRound)(roundData: RoundData): Boolean = {
+      val sameRoundId = roundData.roundId === cancellation.roundId
+      lazy val peerExists = roundData.peers.exists(_.id === cancellation.senderId)
+      lazy val noCancellationYet = !roundData.peerCancellations.contains(cancellation.senderId)
+      lazy val ownCancellation = cancellation.senderId === selfId && roundData.ownCancellation.isEmpty
+
+      sameRoundId && ((peerExists && noCancellationYet) || ownCancellation)
+    }
+
+    def canFinalizeRoundCancellation(roundData: RoundData): Boolean = {
+      val ownCancellation = roundData.ownCancellation.isDefined
+      lazy val peerCancellations = roundData.peers.map(_.id) === roundData.peerCancellations.keySet
+
+      ownCancellation && peerCancellations
+    }
+
+    def gotAllProposals(roundData: RoundData): Boolean =
+      roundData.peers.map(_.id) === roundData.peerProposals.keySet
+
+    def gotAllSignatures(roundData: RoundData): Boolean =
+      roundData.peers.map(_.id) === roundData.peerBlockSignatures.keySet
+
+    def tryPersistProposal(state: State, proposal: Proposal): Option[(State, RoundData)] = {
+      def getRoundData(state: State, proposal: Proposal) =
+        if (proposal.owner === selfId) state.ownConsensus else state.peerConsensuses.get(proposal.roundId)
+
+      getRoundData(state, proposal)
+        .filter(canPersistProposal(proposal))
+        .map { roundData =>
+          if (proposal.owner === selfId) state.focus(_.ownConsensus).modify(_.map(_.addPeerProposal(proposal)))
+          else state.focus(_.peerConsensuses).modify(_.updated(roundData.roundId, roundData.addPeerProposal(proposal)))
+        }
+        .flatMap { newState =>
+          getRoundData(newState, proposal).tupleLeft(newState)
+        }
+    }
+
+    def tryPersistSignatureProposal(state: State, proposal: SignatureProposal): Option[(State, RoundData)] = {
+      def getRoundData(state: State, proposal: SignatureProposal) =
+        if (proposal.owner === selfId) state.ownConsensus else state.peerConsensuses.get(proposal.roundId)
+
+      getRoundData(state, proposal)
+        .filter(canPersistSignatureProposal(proposal))
+        .map { roundData =>
+          if (proposal.owner === selfId) state.focus(_.ownConsensus).modify(_.map(_.addPeerSignature(proposal)))
+          else state.focus(_.peerConsensuses).modify(_.updated(roundData.roundId, roundData.addPeerSignature(proposal)))
+        }
+        .flatMap { newState =>
+          getRoundData(newState, proposal).tupleLeft(newState)
+        }
+    }
+
+    def tryPersistCancellation(
+      state: State,
+      cancellation: CancelledCreationRound
+    ): Option[(State, Set[Peer], Option[CancelledCreationRound])] = {
+      def getRoundData(state: State, cancellation: CancelledCreationRound) =
+        if (cancellation.owner === selfId) state.ownConsensus else state.peerConsensuses.get(cancellation.roundId)
+
+      getRoundData(state, cancellation)
+        .filter(canPersistCancellation(cancellation))
+        .map { roundData =>
+          def ownCancellation =
+            CancelledCreationRound(roundData.roundId, selfId, roundData.owner, TokenLockCancellationReason.PeerCancelled)
+
+          def modified: RoundData = (roundData, cancellation.senderId) match {
+            case (rd, `selfId`) if rd.ownCancellation.isDefined => rd
+            case (rd, `selfId`) if rd.ownCancellation.isEmpty   => rd.setOwnCancellation(cancellation.reason)
+            case (rd, _) if rd.ownCancellation.isDefined        => rd.addPeerCancellation(cancellation)
+            case (rd, _) if rd.ownCancellation.isEmpty => rd.setOwnCancellation(ownCancellation.reason).addPeerCancellation(cancellation)
+            case (_, _)                                => roundData
+          }
+
+          val newState =
+            if (cancellation.owner === selfId)
+              state.focus(_.ownConsensus).modify(_.map(_ => modified))
+            else
+              state.focus(_.peerConsensuses).modify(_.updated(roundData.roundId, modified))
+
+          (newState, roundData.peers, Option.when(cancellation.senderId =!= selfId && roundData.ownCancellation.isEmpty)(ownCancellation))
+        }
+    }
+
+    def broadcast[A <: PeerConsensusInput](data: Signed[A], peers: Set[Peer])(implicit e: Encoder[A]): F[Unit] =
+      peers.toList
+        .traverse(consensusClient.sendConsensusData(data)(e)(_))
+        .void
+
+    def sendBlockProposal(signedBlock: Signed[TokenLockBlock], roundData: RoundData): F[Unit] = {
+      val proposal = SignatureProposal(
+        roundData.roundId,
+        selfId,
+        roundData.owner,
+        signedBlock.proofs.head.signature
+      )
+      val signedProposal = Signed.forAsyncHasher(proposal, selfKeyPair)
+
+      signedProposal.flatMap {
+        broadcast(_, roundData.peers)
+      }
+    }
+
+    def processBlock(state: State, proposal: Proposal, signedBlock: Signed[TokenLockBlock]): F[(State, Unit)] = {
+      val maybeRoundData = if (proposal.owner === selfId) state.ownConsensus else state.peerConsensuses.get(proposal.roundId)
+
+      val newState = maybeRoundData.fproductLeft { roundData =>
+        if (proposal.owner === selfId)
+          state.focus(_.ownConsensus).modify(_.map(_.setOwnBlock(signedBlock)))
+        else
+          state.focus(_.peerConsensuses).modify(_.updated(roundData.roundId, roundData.setOwnBlock(signedBlock)))
+      }
+
+      newState.traverse {
+        case (s, rd) =>
+          sendBlockProposal(signedBlock, rd).tupleLeft(s)
+      }.map(_.getOrElse((state, ())))
+    }
+
+    def processCancellation(state: State, cancellation: CancelledCreationRound): F[(State, Unit)] =
+      tryPersistCancellation(state, cancellation).traverse {
+        case (newState, peers, Some(ownCancellation)) =>
+          Signed.forAsyncHasher[F, CancelledCreationRound](ownCancellation, selfKeyPair).flatMap(broadcast(_, peers)).tupleLeft(newState)
+        case (newState, _, _) =>
+          ().pure[F].tupleLeft(newState)
+      }.flatMap {
+        _.fold {
+          none[(State, Unit)].pure[F]
+        } {
+          case (newState, _) =>
+            (if (cancellation.owner === selfId) newState.ownConsensus else newState.peerConsensuses.get(cancellation.roundId)).traverse {
+              roundData =>
+                if (canFinalizeRoundCancellation(roundData)) cancelRound(newState, roundData)
+                else ().pure[F].tupleLeft(newState)
+            }
+        }
+      }
+        .map(_.getOrElse((state, ())))
+
+    def persistProposal(state: State, proposal: Proposal): F[(State, Unit)] =
+      tryPersistProposal(state, proposal).map {
+        case (newState, roundData) if gotAllProposals(roundData) =>
+          def combine(roundId: RoundId)(transactions: List[Signed[TokenLock]]): F[Option[TokenLockBlock]] =
+            NonEmptyList.fromList(transactions).map(_.toNes).map(TokenLockBlock(roundId, _)).pure[F]
+
+          for {
+            gsOrdinal <- OptionT(lastGlobalSnapshot.getOrdinal)
+              .getOrRaise(new IllegalStateException("Global SnapshotOrdinal unavailable"))
+            validate = (tokenLock: Signed[TokenLock]) => tokenLockValidator.validate(tokenLock)
+
+            maybeBlock <- roundData
+              .formBlock(
+                a => validate(a).map(_.toEither.leftMap(_.toString).as(a)),
+                combine
+              )
+            result <- maybeBlock match {
+              case Some(block) =>
+                Signed.forAsyncHasher(block, selfKeyPair).flatMap { signedBlock =>
+                  signedBlock.transactions.toList
+                    .traverse(validate)
+                    .map(_.forall(_.isValid))
+                    .ifM(
+                      processBlock(newState, proposal, signedBlock), {
+                        val cancellation =
+                          CancelledCreationRound(
+                            roundData.roundId,
+                            senderId = selfId,
+                            owner = roundData.owner,
+                            TokenLockCancellationReason.CreatedInvalidBlock
+                          )
+                        processCancellation(newState, cancellation)
+                      }
+                    )
+                }
+              case None =>
+                val cancellation =
+                  CancelledCreationRound(
+                    roundData.roundId,
+                    senderId = selfId,
+                    owner = roundData.owner,
+                    TokenLockCancellationReason.CreatedEmptyBlock
+                  )
+                processCancellation(newState, cancellation)
+            }
+          } yield result
+        case (newState, _) => ().pure[F].tupleLeft(newState)
+      }.getOrElse(logger.warn(s"Couldn't persist proposal").tupleLeft(state))
+
+    def informAboutInabilityToParticipate(proposal: Proposal, reason: TokenLockCancellationReason): F[Unit] = {
+      def cancellation = CancelledCreationRound(
+        proposal.roundId,
+        senderId = selfId,
+        owner = proposal.owner,
+        reason
+      )
+
+      def cancellationMsg =
+        Signed.forAsyncHasher[F, CancelledCreationRound](cancellation, selfKeyPair)
+
+      def peersToInform = clusterStorage.getResponsivePeers
+        .map(_.filter(peer => deriveConsensusPeerIds(proposal).contains(peer.id)))
+
+      (cancellationMsg, peersToInform).flatMapN(broadcast(_, _))
+    }
+
+    def sendOwnProposal(ownProposal: Proposal, peers: Set[Peer]): F[Unit] =
+      Signed
+        .forAsyncHasher[F, Proposal](ownProposal, selfKeyPair)
+        .flatMap(broadcast(_, peers))
+        .handleErrorWith(e => logger.error(e)(s"Error sending own proposal") >> e.raiseError[F, Unit])
+
+    def processProposal(state: State, proposal: Proposal): F[(State, Unit)] =
+      fetchConsensusPeers(proposal).flatMap { maybePeers =>
+        val maybeRoundData = state.ownConsensus.filter(_.roundId === proposal.roundId).orElse(state.peerConsensuses.get(proposal.roundId))
+
+        (maybeRoundData, maybePeers) match {
+          case (Some(_), _) => persistProposal(state, proposal)
+          case (None, _) if proposal.owner === selfId =>
+            informAboutInabilityToParticipate(proposal, TokenLockCancellationReason.ReceivedProposalForNonExistentOwnRound).tupleLeft(state)
+          case (None, Some(peers)) =>
+            getTime.flatMap { startedAt =>
+              pullTokenLocks.flatMap { transactions =>
+                val ownProposal = Proposal(proposal.roundId, senderId = selfId, owner = proposal.owner, peers.map(_.id), transactions)
+                val roundData =
+                  RoundData(proposal.roundId, startedAt, peers, owner = proposal.owner, ownProposal)
+
+                sendOwnProposal(ownProposal, peers)
+                  .tupleLeft(
+                    state.focus(_.peerConsensuses).modify(_.updated(roundData.roundId, roundData))
+                  )
+                  .map(_._1)
+                  .flatMap(persistProposal(_, proposal))
+              }
+
+            }
+          case (None, None) => informAboutInabilityToParticipate(proposal, TokenLockCancellationReason.MissingRoundPeers).tupleLeft(state)
+        }
+      }
+
+    def processSignatureProposal(state: State, proposal: SignatureProposal): F[(State, Out)] =
+      tryPersistSignatureProposal(state, proposal).traverse {
+        case (newState, roundData) =>
+          roundData match {
+            case roundData @ RoundData(_, _, _, _, _, Some(ownBlock), _, _, _, _) if gotAllSignatures(roundData) =>
+              val block = roundData.peerBlockSignatures.values.foldLeft(ownBlock) {
+                case (agg, proof) => agg.addProof(proof)
+              }
+
+              block.toHashedWithSignatureCheck.flatMap {
+                case Left(_) =>
+                  cancelRound(newState, roundData).map { case (s, _) => (s, Noop.asInstanceOf[Out]) }
+                case Right(hashedBlock) =>
+                  Applicative[F]
+                    .pure[ConsensusOutput](ConsensusOutput.FinalBlock(hashedBlock))
+                    .tupleLeft(removeRound(newState, roundData))
+              }
+            case _ =>
+              Applicative[F].pure[ConsensusOutput](Noop).tupleLeft(newState)
+          }
+      }.map(_.getOrElse((state, Noop)))
+
+    def startOwnRound(state: State): F[(State, Unit)] =
+      state.ownConsensus.fold {
+        pullNewConsensusPeers.flatMap {
+          case Some(peers) =>
+            (mkRoundId, pullTokenLocks, getTime).mapN {
+              case (roundId, transactions, startedAt) =>
+                val proposal = Proposal(roundId, senderId = selfId, owner = selfId, peers.map(_.id), transactions)
+                val roundData = RoundData(roundId, startedAt, peers, selfId, proposal)
+
+                val newState = state.focus(_.ownConsensus).replace(roundData.some)
+
+                sendOwnProposal(proposal, peers).tupleLeft(newState)
+            }.flatten
+          case _ => logger.warn(s"Missing peers").tupleLeft(state)
+        }
+      } { _ =>
+        (state, ()).pure[F]
+      }
+
+    implicit class AsNoopOps(f: F[(State, Unit)]) {
+      def asNoop: F[(State, Out)] = f.map { case (state, _) => (state, Noop) }
+    }
+
+    FSM {
+      case (st, ConsensusInput.OwnRoundTrigger)                      => startOwnRound(st).asNoop
+      case (st, ConsensusInput.InspectionTrigger)                    => inspectConsensuses(st)
+      case (st, proposal: ConsensusInput.Proposal)                   => processProposal(st, proposal).asNoop
+      case (st, signatureProposal: ConsensusInput.SignatureProposal) => processSignatureProposal(st, signatureProposal)
+      case (st, _)                                                   => (st, ()).pure[F].asNoop
+    }
+  }
+
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Validator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Validator.scala
@@ -1,0 +1,76 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.consensus
+
+import cats.Applicative
+import cats.effect.kernel.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.tokenlock.ConsensusInput
+import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
+import io.constellationnetwork.node.shared.domain.node.NodeStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockStorage
+import io.constellationnetwork.schema.node.NodeState
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.types.numeric.PosInt
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object Validator {
+  private def logger[F[_]: Async] = Slf4jLogger.getLogger[F]
+
+  private def isReadyForConsensus(state: NodeState): Boolean = state == NodeState.Ready
+
+  def isLastGlobalSnapshotPresent[F[_]: Async](
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+  ): F[Boolean] =
+    lastGlobalSnapshot.getOrdinal.map(_.isDefined)
+
+  private def enoughPeersForConsensus[F[_]: Async](
+    clusterStorage: ClusterStorage[F],
+    peersCount: PosInt
+  ): F[Boolean] =
+    clusterStorage.getResponsivePeers
+      .map(_.filter(p => isReadyForConsensus(p.state)))
+      .map(_.size >= peersCount.value)
+
+  def isPeerInputValid[F[_]: Async: SecurityProvider: Hasher](
+    input: Signed[ConsensusInput.PeerConsensusInput]
+  ): F[Boolean] =
+    for {
+      validSignature <- input.hasValidSignature
+      signedExclusively = input.isSignedExclusivelyBy(PeerId._Id.get(input.value.senderId))
+    } yield validSignature && signedExclusively
+
+  private def atLeastOneTokenLock[F[_]](
+    tokenLockStorage: TokenLockStorage[F]
+  ): F[Boolean] = tokenLockStorage.areWaiting
+
+  def canStartOwnTokenLockConsensus[F[_]: Async](
+    nodeStorage: NodeStorage[F],
+    clusterStorage: ClusterStorage[F],
+    lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    peersCount: PosInt,
+    tokenLockStorage: TokenLockStorage[F]
+  ): F[Boolean] =
+    for {
+      stateReadyForConsensus <- nodeStorage.getNodeState.map(isReadyForConsensus)
+      enoughPeers <- enoughPeersForConsensus(clusterStorage, peersCount)
+      lastGlobalSnapshotPresent <- isLastGlobalSnapshotPresent(lastGlobalSnapshot)
+      enoughTokenLocks <- atLeastOneTokenLock(tokenLockStorage)
+
+      res = stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent && enoughTokenLocks
+      _ <-
+        Applicative[F].whenA(!res) {
+          val reason = Seq(
+            if (!stateReadyForConsensus) "State not ready for consensus" else "",
+            if (!enoughPeers) "Not enough peers" else "",
+            if (!lastGlobalSnapshotPresent) "No global snapshot" else "",
+            if (!enoughTokenLocks) "No token locks" else ""
+          ).filter(_.nonEmpty).mkString(", ")
+          logger.debug(s"Cannot start token lock own consensus: ${reason}")
+        }
+    } yield res
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/config/TokenLockConsensusConfig.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/config/TokenLockConsensusConfig.scala
@@ -1,0 +1,7 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.consensus.config
+
+import scala.concurrent.duration.FiniteDuration
+
+import eu.timepit.refined.types.numeric.PosInt
+
+case class TokenLockConsensusConfig(peersCount: PosInt, timeout: FiniteDuration, maxTokenLocksToDequeue: PosInt)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/filter/Consecutive.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/filter/Consecutive.scala
@@ -1,0 +1,75 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.filter
+
+import cats.data.NonEmptyList
+import cats.effect.Async
+import cats.syntax.all._
+import cats.{Applicative, Id, Order}
+
+import scala.annotation.tailrec
+
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockReference}
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher}
+
+object Consecutive {
+  def signedTxOrder: Order[Signed[TokenLock]] =
+    Order.whenEqual(Order.by(-_.ordinal.value.value), Order[Signed[TokenLock]])
+
+  def tokenLockTxOrder: Order[Hashed[TokenLock]] = signedTxOrder.contramap(_.signed)
+
+  def take[F[_]: Async](txs: List[Signed[TokenLock]], txHasher: Hasher[F]): F[List[Signed[TokenLock]]] = {
+    val headTx =
+      txs.sorted(Order.whenEqual(Order.by[Signed[TokenLock], Long](_.ordinal.value.value), signedTxOrder).toOrdering).headOption
+
+    headTx match {
+      case None => Applicative[F].pure(List.empty)
+      case Some(headTx) =>
+        implicit val hasher = txHasher
+        TokenLockReference
+          .of(headTx)
+          .flatMap { headTxReference =>
+            takeGeneric[F, TokenLockReference, Signed[TokenLock]](
+              signedTx => TokenLockReference.of(signedTx),
+              _.parent,
+              txs.diff(Seq(headTx)),
+              headTxReference
+            )(Applicative[F], Order[TokenLockReference], signedTxOrder).map(_ :+ headTx)
+          }
+    }
+  }
+
+  def take(
+    txs: List[Hashed[TokenLock]],
+    lastAcceptedTxRef: TokenLockReference
+  ): List[Hashed[TokenLock]] =
+    takeGeneric[Id, TokenLockReference, Hashed[TokenLock]](
+      hashedTx => Id(TokenLockReference.of(hashedTx)),
+      _.parent,
+      txs,
+      lastAcceptedTxRef
+    )(Applicative[Id], Order[TokenLockReference], tokenLockTxOrder)
+
+  private def takeGeneric[F[_]: Applicative, Ref: Order, Item: Order](
+    refOf: Item => F[Ref],
+    prevRefOf: Item => Ref,
+    items: List[Item],
+    initRef: Ref
+  ): F[List[Item]] =
+    items.traverse { item =>
+      refOf(item).map(_ -> item)
+    }.map { refItemPairs =>
+      val grouped = refItemPairs.groupByNel { case (_, item) => prevRefOf(item) }.view.mapValues(_.sortBy(_._2))
+
+      @tailrec
+      def loop(acc: List[Item], prevRef: Ref): List[Item] =
+        grouped.get(prevRef) match {
+          case Some(NonEmptyList((ref, item), _)) =>
+            loop(item :: acc, ref)
+          case None =>
+            acc
+        }
+
+      loop(List.empty, initRef).reverse
+    }
+
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/package.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/package.scala
@@ -1,0 +1,5 @@
+package io.constellationnetwork.node.shared.domain
+
+package object tokenlock {
+  val tokenLockLoggerName = "TokenLockLogger"
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/TokenLockRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/TokenLockRoutes.scala
@@ -1,0 +1,99 @@
+package io.constellationnetwork.node.shared.http.routes
+
+import cats.effect.Async
+import cats.effect.std.{Queue, Supervisor}
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.tokenlock.ConsensusInput
+import io.constellationnetwork.ext.http4s.{AddressVar, HashVar}
+import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
+import io.constellationnetwork.node.shared.domain.tokenlock._
+import io.constellationnetwork.routes.internal._
+import io.constellationnetwork.schema.http.{ErrorCause, ErrorResponse}
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockStatus, TokenLockView}
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.Signed
+
+import eu.timepit.refined.auto._
+import io.circe.shapes._
+import org.http4s.HttpRoutes
+import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder}
+import org.http4s.dsl.Http4sDsl
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import shapeless._
+import shapeless.syntax.singleton._
+
+final case class TokenLockRoutes[F[_]: Async: Hasher](
+  tokenLockConsensusInput: Queue[F, Signed[ConsensusInput.PeerConsensusInput]],
+  l0ClusterStorage: L0ClusterStorage[F],
+  tokenLockService: TokenLockService[F],
+  tokenLockStorage: TokenLockStorage[F]
+)(implicit S: Supervisor[F])
+    extends Http4sDsl[F]
+    with PublicRoutes[F]
+    with P2PRoutes[F] {
+
+  def logger = Slf4jLogger.getLogger[F]
+
+  private val tokenLockLogger = Slf4jLogger.getLoggerFromName[F](tokenLockLoggerName)
+
+  protected val prefixPath: InternalUrlPrefix = "/"
+
+  protected val public: HttpRoutes[F] = HttpRoutes.of[F] {
+    case req @ POST -> Root / "token-locks" =>
+      for {
+        transaction <- req.as[Signed[TokenLock]]
+        hashedTransaction <- transaction.toHashed[F]
+        response <- tokenLockService
+          .offer(hashedTransaction)
+          .flatTap {
+            case Left(errors) =>
+              tokenLockLogger.warn(
+                s"Received tokenLock hash=${hashedTransaction.hash} is invalid: ${transaction.show}, reason: ${errors.show}"
+              )
+            case Right(hash) => tokenLockLogger.info(s"Received valid TokenLock: ${hash.show}")
+          }
+          .flatMap {
+            case Left(errors) => BadRequest(ErrorResponse(errors.map(e => ErrorCause(e.show))))
+            case Right(hash)  => Ok(("hash" ->> hash.value) :: HNil)
+          }
+      } yield response
+
+    case GET -> Root / "token-locks" / HashVar(hash) =>
+      tokenLockStorage.findWaiting(hash).flatMap {
+        case Some(WaitingTokenLock(tx)) => Ok(TokenLockView(tx.signed.value, tx.hash, TokenLockStatus.Waiting))
+        case None                       => NotFound()
+      }
+
+    case GET -> Root / "token-locks" / "last-reference" / AddressVar(address) =>
+      tokenLockStorage
+        .getLastProcessedTokenLock(address)
+        .map(_.ref)
+        .flatMap(Ok(_))
+  }
+
+  protected val p2p: HttpRoutes[F] = HttpRoutes.of[F] {
+    case req @ POST -> Root / "consensus" / "token-locks" =>
+      req
+        .as[Signed[ConsensusInput.Proposal]]
+        .map(_.asInstanceOf[Signed[ConsensusInput.PeerConsensusInput]])
+        .handleErrorWith { _ =>
+          req
+            .as[Signed[ConsensusInput.SignatureProposal]]
+            .map(_.asInstanceOf[Signed[ConsensusInput.PeerConsensusInput]])
+            .handleErrorWith { _ =>
+              req
+                .as[Signed[ConsensusInput.CancelledCreationRound]]
+                .map(_.asInstanceOf[Signed[ConsensusInput.PeerConsensusInput]])
+
+            }
+        }
+        .flatMap { consensusInput =>
+          S.supervise(tokenLockConsensusInput.offer(consensusInput))
+        }
+        .flatMap(_ => Ok())
+        .handleErrorWith { err =>
+          logger.error(err)("An error occured") >> InternalServerError()
+        }
+  }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/tokenlock/ConsensusInput.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/tokenlock/ConsensusInput.scala
@@ -1,0 +1,65 @@
+package io.constellationnetwork.currency.tokenlock
+
+import cats.Show
+
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.tokenLock.TokenLock
+import io.constellationnetwork.security.Encodable
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.Signature
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+
+sealed trait ConsensusInput
+
+object ConsensusInput {
+
+  sealed trait OwnerConsensusInput extends ConsensusInput
+  case object OwnRoundTrigger extends OwnerConsensusInput
+  case object InspectionTrigger extends OwnerConsensusInput
+
+  @derive(encoder, decoder)
+  sealed trait PeerConsensusInput extends ConsensusInput {
+    val senderId: PeerId
+    val owner: PeerId
+  }
+
+  @derive(encoder, decoder)
+  case class Proposal(
+    roundId: RoundId,
+    senderId: PeerId,
+    owner: PeerId,
+    facilitators: Set[PeerId],
+    transactions: Set[Signed[TokenLock]]
+  ) extends PeerConsensusInput
+      with Encodable[(RoundId, PeerId, PeerId, Set[PeerId], Set[Signed[TokenLock]])] {
+    override def toEncode = (roundId, senderId, owner, facilitators, transactions)
+    override def jsonEncoder = implicitly
+  }
+
+  @derive(encoder, decoder)
+  case class SignatureProposal(roundId: RoundId, senderId: PeerId, owner: PeerId, signature: Signature)
+      extends PeerConsensusInput
+      with Encodable[(RoundId, PeerId, PeerId, Signature)] {
+    override def toEncode = (roundId, senderId, owner, signature)
+    override def jsonEncoder = implicitly
+  }
+
+  @derive(encoder, decoder)
+  case class CancelledCreationRound(roundId: RoundId, senderId: PeerId, owner: PeerId, reason: TokenLockCancellationReason)
+      extends PeerConsensusInput
+
+  implicit def showConsensusInput: Show[ConsensusInput] = {
+    case OwnRoundTrigger   => "OwnRoundTrigger"
+    case InspectionTrigger => "InspectionTrigger"
+    case Proposal(roundId, senderId, _, _, transactions) =>
+      s"Proposal(roundId=${roundId.value.toString
+          .take(8)}, senderId=${senderId.value.value.take(8)}, transactionsCount=${transactions.size})"
+    case SignatureProposal(roundId, senderId, _, _) =>
+      s"SignatureProposal(roundId=${roundId.value.toString.take(8)}, senderId=${senderId.value.value.take(8)})"
+    case CancelledCreationRound(roundId, senderId, _, reason) =>
+      s"CancelledCreationRound(roundId=${roundId.value.toString.take(8)}, senderId=${senderId.value.value.take(8)}, reason=$reason)"
+  }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/tokenlock/ConsensusOutput.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/tokenlock/ConsensusOutput.scala
@@ -1,0 +1,14 @@
+package io.constellationnetwork.currency.tokenlock
+
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.Hashed
+
+sealed trait ConsensusOutput
+
+object ConsensusOutput {
+
+  case class FinalBlock(hashedBlock: Hashed[TokenLockBlock]) extends ConsensusOutput
+  case class CleanedConsensuses(ids: Set[RoundId]) extends ConsensusOutput
+  case object Noop extends ConsensusOutput
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/tokenlock/TokenLockCancellationReason.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/tokenlock/TokenLockCancellationReason.scala
@@ -1,0 +1,14 @@
+package io.constellationnetwork.currency.tokenlock
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+
+@derive(encoder, decoder)
+sealed trait TokenLockCancellationReason
+object TokenLockCancellationReason {
+  case object ReceivedProposalForNonExistentOwnRound extends TokenLockCancellationReason
+  case object MissingRoundPeers extends TokenLockCancellationReason
+  case object CreatedInvalidBlock extends TokenLockCancellationReason
+  case object CreatedEmptyBlock extends TokenLockCancellationReason
+  case object PeerCancelled extends TokenLockCancellationReason
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/tokenLock.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/tokenLock.scala
@@ -20,7 +20,7 @@ import io.constellationnetwork.schema.round.RoundId
 import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
-import io.constellationnetwork.security.{Encodable, Hashed, Hasher}
+import io.constellationnetwork.security.{Hashed, Hasher}
 
 import derevo.cats.{eqv, order, show}
 import derevo.circe.magnolia.{decoder, encoder}
@@ -112,10 +112,7 @@ object tokenLock {
   case class TokenLockBlock(
     roundId: RoundId,
     transactions: NonEmptySet[Signed[TokenLock]]
-  ) extends Encodable[(RoundId, NonEmptySet[Signed[TokenLock]])] {
-    override def toEncode = (roundId, transactions)
-    override def jsonEncoder = implicitly
-  }
+  )
 
   object TokenLockBlock {
     implicit val roundIdShow: Show[RoundId] = RoundId.shortShow


### PR DESCRIPTION
## Changes
### Overview
This PR introduces routes for token-lock transactions and integrates consensus handling for this new transaction type. Several critical components are deferred to future PRs.

### Key changes
1. Token-Lock Transaction Routes:
      * Added new API endpoints for handling token-lock transactions.
      * Ensured parity with the existing allow-spends transaction routes.
2. Consensus Integration:
     * Implemented consensus logic specific to token-lock transactions.
     * Reused and adapted patterns from allow-spends for consistency.

### Deferred Work (Future PRs)
1. Block Extraction and Acceptance:
     * Logic for extracting and accepting token-lock transactions in blocks is pending.
     * Will be handled in a separate PR to maintain focus and reviewability.
2. Balance Updates:
     * Mechanisms for updating balances post-token-lock transactions will be introduced in an upcoming PR.
3. State Population:
    * Proper initialization and updates of states related to token-lock transactions will be addressed in future work.