### PR TITLE
feat: adding token lock block acceptance and balance deduction

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/routes/TokenLockBlockRoutes.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/routes/TokenLockBlockRoutes.scala
@@ -1,0 +1,33 @@
+package io.constellationnetwork.currency.l0.http.routes
+
+import cats.effect.Async
+import cats.effect.std.Queue
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.constellationnetwork.node.shared.snapshot.currency.{CurrencySnapshotEvent, TokenLockBlockEvent}
+import io.constellationnetwork.routes.internal._
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.signature.Signed
+
+import eu.timepit.refined.auto._
+import org.http4s.HttpRoutes
+import org.http4s.dsl.Http4sDsl
+
+final case class TokenLockBlockRoutes[F[_]: Async](
+  queue: Queue[F, CurrencySnapshotEvent]
+) extends Http4sDsl[F]
+    with PublicRoutes[F] {
+  import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+
+  protected val prefixPath: InternalUrlPrefix = "/currency"
+
+  protected val public: HttpRoutes[F] = HttpRoutes.of[F] {
+    case req @ POST -> Root / "l1-token-lock-output" =>
+      req
+        .as[Signed[TokenLockBlock]]
+        .map(TokenLockBlockEvent(_))
+        .flatMap(queue.offer)
+        .flatMap(_ => Ok())
+  }
+}

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
@@ -96,6 +96,7 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
   private val gossipRoutes = GossipRoutes[F](storages.rumor, services.gossip)
   private val currencyBlockRoutes = CurrencyBlockRoutes[F](mkCell)
   private val allowSpendBlockRoutes = AllowSpendBlockRoutes[F](queues.l1Output)
+  private val tokenLockBlockRoutes = TokenLockBlockRoutes[F](queues.l1Output)
   private val dataBlockRoutes = maybeDataApplication.map { da =>
     implicit val (d, e) = (da.dataDecoder, da.calculatedStateEncoder)
     DataBlockRoutes[F](mkCell, da)
@@ -150,7 +151,8 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
               metagraphNodeRoutes.map(_.publicRoutes).getOrElse(HttpRoutes.empty) <+>
               currencyMessageRoutes <+>
               DataApplicationCustomRoutes.publicRoutes[F, L0NodeContext[F]](maybeDataApplication) <+>
-              allowSpendBlockRoutes.publicRoutes
+              allowSpendBlockRoutes.publicRoutes <+>
+              tokenLockBlockRoutes.publicRoutes
           }
         }
     }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
@@ -72,7 +72,17 @@ object CurrencySnapshotConsensusFunctions {
       }
 
       currencySnapshotCreator
-        .createProposalArtifact(lastKey, lastArtifact, lastContext, lastArtifactHasher, trigger, blocksForAcceptance, rewards, facilitators)
+        .createProposalArtifact(
+          lastKey,
+          lastArtifact,
+          lastContext,
+          lastArtifactHasher,
+          trigger,
+          blocksForAcceptance,
+          rewards,
+          facilitators,
+          None
+        )
         .map(created => (created.artifact, created.context, created.awaitingEvents))
     }
   }

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
@@ -195,7 +195,10 @@ object CurrencySnapshotProcessor {
         val bs = blockStorage.getState().flatMap(BlockStorage.make[F](_))
         val lcss =
           lastCurrencySnapshotStorage.getCombined.flatMap(LastSnapshotStorage.make[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](_))
-        val as = addressStorage.getState.flatMap(AddressStorage.make(_))
+        val as = addressStorage.getState.flatMap { state =>
+          val (balances) = state
+          AddressStorage.make(balances)
+        }
         val cv = ContextualTransactionValidator.make(transactionLimitConfig, None)
         val ts =
           transactionStorage.getState.flatMap {

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Services.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Services.scala
@@ -9,6 +9,7 @@ import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.dag.l1.config.types.AppConfig
 import io.constellationnetwork.dag.l1.domain.block.BlockService
 import io.constellationnetwork.dag.l1.domain.swap.block.AllowSpendBlockService
+import io.constellationnetwork.dag.l1.domain.tokenlock.block.TokenLockBlockService
 import io.constellationnetwork.dag.l1.domain.transaction.TransactionService
 import io.constellationnetwork.dag.l1.modules.{Services => BaseServices, Validators}
 import io.constellationnetwork.node.shared.cli.CliMethod
@@ -18,6 +19,7 @@ import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotS
 import io.constellationnetwork.node.shared.domain.swap.AllowSpendService
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockAcceptanceManager
 import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockService
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.collateral.Collateral
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
@@ -84,6 +86,13 @@ object Services {
         storages.tokenLock,
         storages.lastSnapshot,
         validators.tokenLock
+      )
+      val tokenLockBlock = TokenLockBlockService.make[F](
+        TokenLockBlockAcceptanceManager.make[F](validators.tokenLockBlock),
+        storages.address,
+        storages.tokenLockBlock,
+        storages.tokenLock,
+        cfg.collateral.amount
       )
       val collateral = Collateral.make[F](cfg.collateral, storages.lastSnapshot)
       val dataApplication = maybeDataApplication

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStora
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockStorage
 import io.constellationnetwork.node.shared.domain.swap.{AllowSpendStorage, ContextualAllowSpendValidator}
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockStorage
 import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockStorage}
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
@@ -60,6 +61,7 @@ object Storages {
         TokenLockStorage.make[F](_, contextualTokenLockValidator)
       }
       addressStorage <- AddressStorage.make[F]
+      tokenLockBlockStorage <- TokenLockBlockStorage.make[F]
       allowSpendBlockStorage <- AllowSpendBlockStorage.make[F]
     } yield
       new Storages[F, P, S, SI] {
@@ -78,6 +80,7 @@ object Storages {
         val allowSpend = allowSpendStorage
         val allowSpendBlock = allowSpendBlockStorage
         val tokenLock = tokenLockStorage
+        val tokenLockBlock = tokenLockBlockStorage
       }
 }
 

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
@@ -115,7 +115,7 @@ object TokenLockRoutesSuite extends HttpSuite {
     new TokenLockStorage[IO](
       emr,
       TokenLockReference.empty,
-      ContextualTokenLockValidator.make(none, TokenLocksConfig(NonNegLong(100L)))
+      ContextualTokenLockValidator.make(none, TokenLocksConfig(NonNegLong(100L)), currencyId.some)
     )
   }
 
@@ -136,7 +136,7 @@ object TokenLockRoutesSuite extends HttpSuite {
       src,
       amount,
       parent,
-      currencyId,
+      currencyId.some,
       lastValidEpochProgress
     )
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/http/routes/TokenLockBlockRoutes.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/http/routes/TokenLockBlockRoutes.scala
@@ -1,0 +1,30 @@
+package io.constellationnetwork.dag.l0.http.routes
+
+import cats.effect.Async
+import cats.effect.std.Queue
+import cats.syntax.flatMap._
+
+import io.constellationnetwork.routes.internal._
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.signature.Signed
+
+import eu.timepit.refined.auto._
+import org.http4s.HttpRoutes
+import org.http4s.dsl.Http4sDsl
+
+final case class TokenLockBlockRoutes[F[_]: Async](
+  queue: Queue[F, Signed[TokenLockBlock]]
+) extends Http4sDsl[F]
+    with PublicRoutes[F] {
+  import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+
+  protected val prefixPath: InternalUrlPrefix = "/dag"
+
+  protected val public: HttpRoutes[F] = HttpRoutes.of[F] {
+    case req @ POST -> Root / "l1-token-lock-output" =>
+      req
+        .as[Signed[TokenLockBlock]]
+        .flatMap(queue.offer)
+        .flatMap(_ => Ok())
+  }
+}

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/HttpApi.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/HttpApi.scala
@@ -95,6 +95,8 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
     )
   private val dagRoutes = DAGBlockRoutes[F](mkDagCell)
   private val allowSpendRoutes = AllowSpendBlockRoutes[F](queues.l1AllowSpendOutput)
+  private val tokenLockRoutes = TokenLockBlockRoutes[F](queues.l1TokenLockOutput)
+
   private val walletRoutes = WalletRoutes[F, GlobalIncrementalSnapshot]("/dag", services.address)
   private val consensusInfoRoutes =
     HasherSelector[F].withCurrent { implicit hasher =>
@@ -132,7 +134,8 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
               nodeRoutes.publicRoutes <+>
               consensusInfoRoutes.publicRoutes <+>
               trustRoutes.publicRoutes <+>
-              allowSpendRoutes.publicRoutes
+              allowSpendRoutes.publicRoutes <+>
+              tokenLockRoutes.publicRoutes
           }
         }
     }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Queues.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Queues.scala
@@ -9,6 +9,7 @@ import io.constellationnetwork.node.shared.modules.SharedQueues
 import io.constellationnetwork.schema.Block
 import io.constellationnetwork.schema.gossip.RumorRaw
 import io.constellationnetwork.schema.swap.AllowSpendBlock
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security.Hashed
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.statechannel.StateChannelOutput
@@ -20,12 +21,14 @@ object Queues {
       stateChannelOutputQueue <- Queue.unbounded[F, StateChannelOutput]
       l1OutputQueue <- Queue.unbounded[F, Signed[Block]]
       l1AllowSpendOutputQueue <- Queue.unbounded[F, Signed[AllowSpendBlock]]
+      l1TokenLockOutputQueue <- Queue.unbounded[F, Signed[TokenLockBlock]]
     } yield
       new Queues[F] {
         val rumor = sharedQueues.rumor
         val stateChannelOutput = stateChannelOutputQueue
         val l1Output = l1OutputQueue
         val l1AllowSpendOutput = l1AllowSpendOutputQueue
+        val l1TokenLockOutput = l1TokenLockOutputQueue
       }
 }
 
@@ -34,4 +37,5 @@ sealed abstract class Queues[F[_]] private {
   val stateChannelOutput: Queue[F, StateChannelOutput]
   val l1Output: Queue[F, Signed[Block]]
   val l1AllowSpendOutput: Queue[F, Signed[AllowSpendBlock]]
+  val l1TokenLockOutput: Queue[F, Signed[TokenLockBlock]]
 }

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -15,6 +15,7 @@ import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.config.types.{AddressesConfig, SnapshotSizeConfig}
 import io.constellationnetwork.node.shared.domain.statechannel._
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.snapshot._
 import io.constellationnetwork.node.shared.modules.SharedValidators
@@ -69,6 +70,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
         .make[IO](AddressesConfig(Set()), None, None, Some(stateChannelAllowanceLists), SortedMap.empty, Long.MaxValue, Hasher.forKryo[IO])
       currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
+        TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
         Amount(0L),
         validators.currencyMessageValidator,
         validators.globalSnapshotSyncValidator

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -20,6 +20,7 @@ import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.config.types.{AddressesConfig, SnapshotSizeConfig}
 import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.domain.transaction.{TransactionChainValidator, TransactionValidator}
 import io.constellationnetwork.node.shared.infrastructure.block.processing.{BlockAcceptanceLogic, BlockAcceptanceManager, BlockValidator}
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
@@ -239,6 +240,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
     val currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
       BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
+      TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
       Amount(0L),
       validators.currencyMessageValidator,
       validators.globalSnapshotSyncValidator

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.dag.l1.domain.snapshot.programs.DAGSnapshotProces
 import io.constellationnetwork.dag.l1.http.p2p.P2PClient
 import io.constellationnetwork.dag.l1.infrastructure.block.rumor.handler.blockRumorHandler
 import io.constellationnetwork.dag.l1.infrastructure.swap.rumor.handler.allowSpendBlockRumorHandler
+import io.constellationnetwork.dag.l1.infrastructure.tokenlock.rumor.handler.tokenLockBlockRumorHandler
 import io.constellationnetwork.dag.l1.modules._
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.kryo._
@@ -65,7 +66,8 @@ object Main
             seedlist,
             cfg.transactionLimit,
             None,
-            Hasher.forKryo[IO]
+            Hasher.forKryo[IO],
+            None
           )
       }
       storages <- Storages
@@ -112,7 +114,8 @@ object Main
         .make[IO](storages.cluster, services.localHealthcheck, sharedStorages.forkInfo)
         .handlers <+>
         blockRumorHandler[IO](queues.peerBlock) <+>
-        allowSpendBlockRumorHandler[IO](queues.allowSpendBlocks)
+        allowSpendBlockRumorHandler[IO](queues.allowSpendBlocks) <+>
+        tokenLockBlockRumorHandler[IO](queues.tokenLocksBlocks)
 
       _ <- Daemons
         .start(storages, services)
@@ -179,6 +182,7 @@ object Main
           p2pClient.tokenLockConsensusClient,
           services,
           storages.tokenLock,
+          storages.tokenLockBlock,
           queues,
           validators.tokenLock,
           keyPair,

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/tokenlock/block/TokenLockBlockService.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/tokenlock/block/TokenLockBlockService.scala
@@ -1,0 +1,88 @@
+package io.constellationnetwork.dag.l1.domain.tokenlock.block
+
+import cats.data.EitherT
+import cats.effect.Async
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.option._
+import cats.syntax.show._
+
+import scala.util.control.NoStackTrace
+
+import io.constellationnetwork.dag.l1.domain.address.storage.AddressStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockStorage
+import io.constellationnetwork.node.shared.domain.tokenlock.block._
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.schema.tokenLock.{TokenLockBlock, TokenLockReference}
+import io.constellationnetwork.security.hash.ProofsHash
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher}
+
+trait TokenLockBlockService[F[_]] {
+  def accept(signedBlock: Signed[TokenLockBlock], snapshotOrdinal: SnapshotOrdinal)(
+    implicit hasher: Hasher[F]
+  ): F[Unit]
+}
+
+object TokenLockBlockService {
+
+  def make[F[_]: Async](
+    tokenLockBlockAcceptanceManager: TokenLockBlockAcceptanceManager[F],
+    addressStorage: AddressStorage[F],
+    tokenLockBlockStorage: TokenLockBlockStorage[F],
+    tokenLockStorage: TokenLockStorage[F],
+    collateral: Amount
+  ): TokenLockBlockService[F] =
+    new TokenLockBlockService[F] {
+
+      def accept(signedBlock: Signed[TokenLockBlock], snapshotOrdinal: SnapshotOrdinal)(
+        implicit hasher: Hasher[F]
+      ): F[Unit] =
+        signedBlock.toHashed.flatMap { hashedBlock =>
+          EitherT(tokenLockBlockAcceptanceManager.acceptBlock(signedBlock, context, snapshotOrdinal))
+            .leftSemiflatMap(processAcceptanceError(hashedBlock))
+            .semiflatMap(processAcceptanceSuccess(hashedBlock))
+            .rethrowT
+        }
+      private val context: TokenLockBlockAcceptanceContext[F] = new TokenLockBlockAcceptanceContext[F] {
+
+        def getBalance(address: Address): F[Option[Balance]] =
+          addressStorage.getBalance(address).map(_.some)
+
+        def getLastTxRef(address: Address): F[Option[TokenLockReference]] =
+          tokenLockStorage.getLastProcessedTokenLock(address).map(_.ref.some)
+
+        def getInitialTxRef: TokenLockReference =
+          tokenLockStorage.getInitialTx.ref
+
+        def getCollateral: Amount = collateral
+      }
+
+      private def processAcceptanceSuccess(
+        hashedBlock: Hashed[TokenLockBlock]
+      )(contextUpdate: TokenLockBlockAcceptanceContextUpdate)(implicit hasher: Hasher[F]): F[Unit] =
+        for {
+          hashedTransactions <- hashedBlock.signed.tokenLocks.toNonEmptyList
+            .sortBy(_.ordinal)
+            .traverse(_.toHashed)
+
+          _ <- hashedTransactions.traverse(tokenLockStorage.accept)
+          _ <- tokenLockBlockStorage.accept(hashedBlock)
+          _ <- addressStorage.updateBalances(contextUpdate.balances)
+        } yield ()
+
+      private def processAcceptanceError(
+        hashedBlock: Hashed[TokenLockBlock]
+      )(reason: TokenLockBlockNotAcceptedReason): F[TokenLockBlockAcceptanceError] =
+        tokenLockBlockStorage
+          .postpone(hashedBlock)
+          .as(TokenLockBlockAcceptanceError(hashedBlock.proofsHash, reason))
+
+    }
+
+  case class TokenLockBlockAcceptanceError(blockReference: ProofsHash, reason: TokenLockBlockNotAcceptedReason) extends NoStackTrace {
+    override def getMessage: String = s"Block ${blockReference.show} could not be accepted ${reason.show}"
+  }
+}

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/infrastructure/tokenlock/rumor/handler.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/infrastructure/tokenlock/rumor/handler.scala
@@ -1,0 +1,20 @@
+package io.constellationnetwork.dag.l1.infrastructure.tokenlock.rumor
+
+import cats.effect.Async
+import cats.effect.std.Queue
+
+import io.constellationnetwork.node.shared.infrastructure.gossip.RumorHandler
+import io.constellationnetwork.schema.gossip.CommonRumor
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.signature.Signed
+
+object handler {
+
+  def tokenLockBlockRumorHandler[F[_]: Async](
+    peerBlockQueue: Queue[F, Signed[TokenLockBlock]]
+  ): RumorHandler[F] =
+    RumorHandler.fromCommonRumorConsumer[F, Signed[TokenLockBlock]] {
+      case CommonRumor(signedBlock) =>
+        peerBlockQueue.offer(signedBlock)
+    }
+}

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Services.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Services.scala
@@ -6,6 +6,7 @@ import cats.effect.kernel.Async
 import io.constellationnetwork.dag.l1.config.types.AppConfig
 import io.constellationnetwork.dag.l1.domain.block.BlockService
 import io.constellationnetwork.dag.l1.domain.swap.block.AllowSpendBlockService
+import io.constellationnetwork.dag.l1.domain.tokenlock.block.TokenLockBlockService
 import io.constellationnetwork.dag.l1.domain.transaction.TransactionService
 import io.constellationnetwork.dag.l1.http.p2p.P2PClient
 import io.constellationnetwork.node.shared.cli.CliMethod
@@ -19,6 +20,7 @@ import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotS
 import io.constellationnetwork.node.shared.domain.swap.AllowSpendService
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockAcceptanceManager
 import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockService
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.collateral.Collateral
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
@@ -73,6 +75,13 @@ object Services {
         cfg.collateral.amount
       )
       val tokenLock = TokenLockService.make[F, P, S, SI](storages.tokenLock, storages.lastSnapshot, validators.tokenLock)
+      val tokenLockBlock = TokenLockBlockService.make[F](
+        TokenLockBlockAcceptanceManager.make[F](validators.tokenLockBlock),
+        storages.address,
+        storages.tokenLockBlock,
+        storages.tokenLock,
+        cfg.collateral.amount
+      )
       val collateral = Collateral.make[F](cfg.collateral, storages.lastSnapshot)
       val restart = sharedServices.restart
     }
@@ -89,6 +98,7 @@ trait Services[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P], R <:
   val allowSpend: AllowSpendService[F]
   val allowSpendBlock: AllowSpendBlockService[F]
   val tokenLock: TokenLockService[F]
+  val tokenLockBlock: TokenLockBlockService[F]
   val collateral: Collateral[F]
   val restart: RestartService[F, R]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
@@ -16,6 +16,7 @@ import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockStorage
 import io.constellationnetwork.node.shared.domain.swap.{AllowSpendStorage, ContextualAllowSpendValidator}
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockStorage
 import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockStorage}
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.gossip.RumorStorage
@@ -46,6 +47,7 @@ object Storages {
       allowSpendStorage <- AllowSpendStorage.make[F](AllowSpendReference.empty, contextualAllowSpendValidator)
       allowSpendBlockStorage <- AllowSpendBlockStorage.make[F]
       tokenLockStorage <- TokenLockStorage.make[F](TokenLockReference.empty, contextualTokenLockValidator)
+      tokenLockBlockStorage <- TokenLockBlockStorage.make[F]
     } yield
       new Storages[F, P, S, SI] {
         val address = addressStorage
@@ -61,6 +63,7 @@ object Storages {
         val allowSpend = allowSpendStorage
         val allowSpendBlock = allowSpendBlockStorage
         val tokenLock = tokenLockStorage
+        val tokenLockBlock = tokenLockBlockStorage
       }
 }
 
@@ -78,4 +81,5 @@ trait Storages[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]] {
   val allowSpend: AllowSpendStorage[F]
   val allowSpendBlock: AllowSpendBlockStorage[F]
   val tokenLock: TokenLockStorage[F]
+  val tokenLockBlock: TokenLockBlockStorage[F]
 }

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -22,6 +22,7 @@ import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.config.types.{AddressesConfig, SnapshotSizeConfig}
 import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.snapshot._
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
@@ -94,6 +95,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
             currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
               BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
+              TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
               Amount(0L),
               validators.currencyMessageValidator,
               validators.globalSnapshotSyncValidator

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -116,5 +116,5 @@ allow-spends {
 }
 
 token-locks {
-  min-epoch-progresses-to-lock: 100
+  min-epoch-progresses-to-lock: 1
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
@@ -146,15 +146,17 @@ abstract class TessellationIOApp[A <: CliMethod](
                                       session = Session.make[IO](storages.session, storages.node, storages.cluster)
                                       p2pClient = SharedP2PClient.make[IO](res.client, session)
                                       queues <- SharedQueues.make[IO].asResource
-                                      validators = SharedValidators.make[IO](
-                                        cfg.addresses,
-                                        _l0Seedlist,
-                                        _seedlist,
-                                        method.stateChannelAllowanceLists,
-                                        cfg.feeConfigs,
-                                        cfg.snapshotSize.maxStateChannelSnapshotBinarySizeInBytes,
-                                        Hasher.forKryo[IO]
-                                      )
+                                      validators = _hasherSelector.withCurrent { implicit hasher =>
+                                        SharedValidators.make[IO](
+                                          cfg.addresses,
+                                          _l0Seedlist,
+                                          _seedlist,
+                                          method.stateChannelAllowanceLists,
+                                          cfg.feeConfigs,
+                                          cfg.snapshotSize.maxStateChannelSnapshotBinarySizeInBytes,
+                                          Hasher.forKryo[IO]
+                                        )
+                                      }
                                       services <- SharedServices
                                         .make[IO, A](
                                           cfg,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockChainValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockChainValidator.scala
@@ -1,0 +1,71 @@
+package io.constellationnetwork.node.shared.domain.tokenlock
+
+import cats.data._
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockChainValidator.{TokenLockChainValidationErrorOr, TokenLockNel}
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockReference}
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.Signed
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+
+trait TokenLockChainValidator[F[_]] {
+
+  def validate(
+    transactions: NonEmptySet[Signed[TokenLock]]
+  ): F[TokenLockChainValidationErrorOr[Map[Address, TokenLockNel]]]
+}
+
+object TokenLockChainValidator {
+
+  def make[F[_]: Async: Hasher]: TokenLockChainValidator[F] =
+    new TokenLockChainValidator[F] {
+
+      def validate(
+        transactions: NonEmptySet[Signed[TokenLock]]
+      ): F[TokenLockChainValidationErrorOr[Map[Address, TokenLockNel]]] =
+        transactions.toNonEmptyList
+          .groupBy(_.value.source)
+          .toList
+          .traverse {
+            case (address, txs) =>
+              validateChainForSingleAddress(address, txs)
+                .map(chainedTxs => address -> chainedTxs)
+                .value
+                .map(_.toValidatedNec)
+          }
+          .map(_.foldMap(_.map(Chain(_))))
+          .map(_.map(_.toList.toMap))
+
+      private def validateChainForSingleAddress(
+        address: Address,
+        txs: TokenLockNel
+      ): EitherT[F, TokenLockChainBroken, TokenLockNel] = {
+        val sortedTxs = txs.sortBy(_.ordinal)
+        val initChain = NonEmptyList.of(sortedTxs.head).asRight[TokenLockChainBroken].toEitherT[F]
+        sortedTxs.tail
+          .foldLeft(initChain) { (errorOrParents, tx) =>
+            errorOrParents.flatMap { parents =>
+              EitherT(TokenLockReference.of(parents.head).map { parentRef =>
+                Either.cond(
+                  parentRef === tx.parent,
+                  tx :: parents,
+                  TokenLockChainBroken(address, tx.parent)
+                )
+              })
+            }
+          }
+          .map(_.reverse)
+      }
+    }
+
+  @derive(eqv, show)
+  case class TokenLockChainBroken(address: Address, referenceNotFound: TokenLockReference)
+
+  type TokenLockNel = NonEmptyList[Signed[TokenLock]]
+  type TokenLockChainValidationErrorOr[A] = ValidatedNec[TokenLockChainBroken, A]
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceContext.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceContext.scala
@@ -1,0 +1,44 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import cats.Applicative
+import cats.syntax.applicative._
+
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.schema.tokenLock.TokenLockReference
+
+trait TokenLockBlockAcceptanceContext[F[_]] {
+
+  def getBalance(address: Address): F[Option[Balance]]
+
+  def getLastTxRef(address: Address): F[Option[TokenLockReference]]
+
+  def getInitialTxRef: TokenLockReference
+
+  def getCollateral: Amount
+
+}
+
+object TokenLockBlockAcceptanceContext {
+
+  def fromStaticData[F[_]: Applicative](
+    balances: Map[Address, Balance],
+    lastTxRefs: Map[Address, TokenLockReference],
+    collateral: Amount,
+    initialTxRef: TokenLockReference
+  ): TokenLockBlockAcceptanceContext[F] =
+    new TokenLockBlockAcceptanceContext[F] {
+
+      def getBalance(address: Address): F[Option[Balance]] =
+        balances.get(address).pure[F]
+
+      def getLastTxRef(address: Address): F[Option[TokenLockReference]] =
+        lastTxRefs.get(address).pure[F]
+
+      def getInitialTxRef: TokenLockReference =
+        initialTxRef
+
+      def getCollateral: Amount = collateral
+    }
+
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceContextUpdate.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceContextUpdate.scala
@@ -1,0 +1,22 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.tokenLock.TokenLockReference
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+
+@derive(eqv, show)
+case class TokenLockBlockAcceptanceContextUpdate(
+  balances: Map[Address, Balance],
+  lastTokenLocksRefs: Map[Address, TokenLockReference]
+)
+
+object TokenLockBlockAcceptanceContextUpdate {
+
+  val empty: TokenLockBlockAcceptanceContextUpdate = TokenLockBlockAcceptanceContextUpdate(
+    Map.empty,
+    Map.empty
+  )
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceLogic.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceLogic.scala
@@ -1,0 +1,169 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import cats.data.{EitherT, NonEmptyList}
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockChainValidator.TokenLockNel
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance, BalanceArithmeticError}
+import io.constellationnetwork.schema.tokenLock.{TokenLockBlock, TokenLockReference}
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+trait TokenLockBlockAcceptanceLogic[F[_]] {
+  def acceptBlock(
+    block: Signed[TokenLockBlock],
+    txChains: Map[Address, TokenLockNel],
+    context: TokenLockBlockAcceptanceContext[F],
+    contextUpdate: TokenLockBlockAcceptanceContextUpdate
+  )(implicit hasher: Hasher[F]): EitherT[F, TokenLockBlockNotAcceptedReason, TokenLockBlockAcceptanceContextUpdate]
+
+}
+
+object TokenLockBlockAcceptanceLogic {
+
+  def make[F[_]: Async: SecurityProvider]: TokenLockBlockAcceptanceLogic[F] =
+    new TokenLockBlockAcceptanceLogic[F] {
+
+      def acceptBlock(
+        signedBlock: Signed[TokenLockBlock],
+        txChains: Map[Address, TokenLockNel],
+        context: TokenLockBlockAcceptanceContext[F],
+        contextUpdate: TokenLockBlockAcceptanceContextUpdate
+      )(implicit hasher: Hasher[F]): EitherT[F, TokenLockBlockNotAcceptedReason, TokenLockBlockAcceptanceContextUpdate] =
+        for {
+          _ <- processSignatures(signedBlock, context)
+          contextUpdate1 <- processLastTxRefs(txChains, context, contextUpdate)
+          contextUpdate2 <- processBalances(signedBlock, context, contextUpdate1)
+        } yield contextUpdate2
+
+      def processLastTxRefs(
+        txChains: Map[Address, TokenLockNel],
+        context: TokenLockBlockAcceptanceContext[F],
+        contextUpdate: TokenLockBlockAcceptanceContextUpdate
+      )(implicit hasher: Hasher[F]): EitherT[F, TokenLockBlockNotAcceptedReason, TokenLockBlockAcceptanceContextUpdate] =
+        txChains.toList
+          .foldLeft((contextUpdate.lastTokenLocksRefs, none[TokenLockBlockAwaitReason]).asRight[RejectedTokenLock].toEitherT[F]) {
+            case (acc, (address, txChain)) =>
+              acc.flatMap {
+                case (lastTxRefsUpdate, maybeAwaitingBlock) =>
+                  val rejectionOrUpdate
+                    : F[Either[RejectedTokenLock, (Map[Address, TokenLockReference], Option[TokenLockBlockAwaitReason])]] =
+                    for {
+                      lastTxRef <- contextUpdate.lastTokenLocksRefs
+                        .get(address)
+                        .toOptionT[F]
+                        .orElseF(context.getLastTxRef(address))
+                        .getOrElse(context.getInitialTxRef)
+
+                      headTxChainRef <- TokenLockReference.of(txChain.head)
+                      lastTxChainRef <- TokenLockReference.of(txChain.last)
+
+                      result =
+                        if (txChain.head.parent.ordinal < lastTxRef.ordinal)
+                          RejectedTokenLock(
+                            headTxChainRef,
+                            ParentOrdinalBelowLastTxOrdinal(txChain.head.parent.ordinal, lastTxRef.ordinal)
+                          ).asLeft
+                        else if (txChain.head.parent.ordinal > lastTxRef.ordinal)
+                          (
+                            lastTxRefsUpdate,
+                            maybeAwaitingBlock.orElse(
+                              AwaitingTokenLock(
+                                headTxChainRef,
+                                ParentOrdinalAboveLastTxOrdinal(txChain.head.parent.ordinal, lastTxRef.ordinal)
+                              ).some
+                            )
+                          ).asRight
+                        else if (txChain.head.parent.hash =!= lastTxRef.hash) // ordinals are equal
+                          RejectedTokenLock(
+                            headTxChainRef,
+                            ParentHashNotEqLastTxHash(txChain.head.parent.hash, lastTxRef.hash)
+                          ).asLeft
+                        else // hashes and ordinals are equal
+                          (lastTxRefsUpdate.updated(address, lastTxChainRef), maybeAwaitingBlock).asRight
+
+                    } yield result
+
+                  EitherT(rejectionOrUpdate)
+              }
+          }
+          .leftWiden[TokenLockBlockNotAcceptedReason]
+          .flatMap {
+            case (update, maybeAwaitReason) =>
+              maybeAwaitReason
+                .widen[TokenLockBlockNotAcceptedReason]
+                .toLeft(update)
+                .toEitherT[F]
+          }
+          .map { lastTxRefsUpdate =>
+            contextUpdate.copy(lastTokenLocksRefs = lastTxRefsUpdate)
+          }
+
+      private def processBalances(
+        block: Signed[TokenLockBlock],
+        context: TokenLockBlockAcceptanceContext[F],
+        contextUpdate: TokenLockBlockAcceptanceContextUpdate
+      ): EitherT[F, TokenLockBlockNotAcceptedReason, TokenLockBlockAcceptanceContextUpdate] = {
+        val minusFn: Amount => Balance => Either[BalanceArithmeticError, Balance] = a => _.minus(a)
+
+        val sortedTxs = block.tokenLocks.toNonEmptyList
+        val minusAmountOps = sortedTxs.groupMap(_.source)(tx => minusFn(tx.amount))
+
+        val balancesUpdate = minusAmountOps
+          .foldLeft(contextUpdate.balances.asRight[AddressBalanceOutOfRange].toEitherT[F]) { (acc, addressAndOps) =>
+            acc.flatMap { balancesUpdate =>
+              val (address, ops) = addressAndOps
+
+              EitherT(
+                balancesUpdate
+                  .get(address)
+                  .toOptionT[F]
+                  .orElseF(context.getBalance(address))
+                  .getOrElse(Balance.empty)
+                  .map { balance =>
+                    ops
+                      .foldLeft(balance.asRight[BalanceArithmeticError]) { (acc, op) =>
+                        acc.flatMap(op)
+                      }
+                      .leftMap(AddressBalanceOutOfRange(address, _))
+                      .map(balancesUpdate.updated(address, _))
+                  }
+              )
+            }
+          }
+          .leftWiden[TokenLockBlockNotAcceptedReason]
+
+        balancesUpdate.map { balances =>
+          contextUpdate.copy(
+            balances = balances
+          )
+        }
+      }
+    }
+
+  def processSignatures[F[_]: Async: SecurityProvider](
+    signedBlock: Signed[TokenLockBlock],
+    context: TokenLockBlockAcceptanceContext[F]
+  ): EitherT[F, TokenLockBlockNotAcceptedReason, Unit] =
+    EitherT(
+      signedBlock.proofs
+        .map(_.id.toPeerId)
+        .toList
+        .traverse(_.toAddress)
+        .flatMap(
+          _.filterA(address =>
+            context.getBalance(address).map { balances =>
+              !balances.getOrElse(Balance.empty).satisfiesCollateral(context.getCollateral)
+            }
+          )
+        )
+        .map(list =>
+          NonEmptyList
+            .fromList(list)
+            .map(nel => SigningPeerBelowCollateral(nel).asLeft[Unit])
+            .getOrElse(().asRight[TokenLockBlockNotAcceptedReason])
+        )
+    )
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceManager.scala
@@ -1,0 +1,124 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockChainValidator.TokenLockNel
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import monocle.syntax.all._
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait TokenLockBlockAcceptanceManager[F[_]] {
+
+  def acceptBlocksIteratively(
+    blocks: List[Signed[TokenLockBlock]],
+    context: TokenLockBlockAcceptanceContext[F],
+    snapshotOrdinal: SnapshotOrdinal
+  )(implicit hasher: Hasher[F]): F[TokenLockBlockAcceptanceResult]
+
+  def acceptBlock(
+    block: Signed[TokenLockBlock],
+    context: TokenLockBlockAcceptanceContext[F],
+    snapshotOrdinal: SnapshotOrdinal
+  )(implicit hasher: Hasher[F]): F[Either[TokenLockBlockNotAcceptedReason, TokenLockBlockAcceptanceContextUpdate]]
+
+}
+
+object TokenLockBlockAcceptanceManager {
+
+  def make[F[_]: Async: SecurityProvider](
+    blockValidator: TokenLockBlockValidator[F]
+  ): TokenLockBlockAcceptanceManager[F] = make(TokenLockBlockAcceptanceLogic.make[F], blockValidator)
+
+  def make[F[_]: Async](
+    logic: TokenLockBlockAcceptanceLogic[F],
+    blockValidator: TokenLockBlockValidator[F]
+  ): TokenLockBlockAcceptanceManager[F] =
+    new TokenLockBlockAcceptanceManager[F] {
+      private val logger = Slf4jLogger.getLoggerFromClass[F](TokenLockBlockAcceptanceManager.getClass)
+
+      def acceptBlocksIteratively(
+        blocks: List[Signed[TokenLockBlock]],
+        context: TokenLockBlockAcceptanceContext[F],
+        snapshotOrdinal: SnapshotOrdinal
+      )(implicit hasher: Hasher[F]): F[TokenLockBlockAcceptanceResult] = {
+
+        def go(
+          initState: TokenLockBlockAcceptanceState,
+          toProcess: List[(Signed[TokenLockBlock], Map[Address, TokenLockNel])]
+        ): F[TokenLockBlockAcceptanceState] =
+          for {
+            currState <- toProcess.foldLeftM[F, TokenLockBlockAcceptanceState](initState.copy(awaiting = List.empty)) {
+              (acc, blockAndTxChains) =>
+                blockAndTxChains match {
+                  case (block, txChains) =>
+                    logic
+                      .acceptBlock(block, txChains, context, acc.contextUpdate)
+                      .map {
+                        case contextUpdate =>
+                          acc
+                            .focus(_.contextUpdate)
+                            .replace(contextUpdate)
+                            .focus(_.accepted)
+                            .modify(block :: _)
+                      }
+                      .leftMap {
+                        case reason: TokenLockBlockRejectionReason =>
+                          acc
+                            .focus(_.rejected)
+                            .modify(_ :+ (block, reason))
+                        case reason: TokenLockBlockAwaitReason =>
+                          acc
+                            .focus(_.awaiting)
+                            .modify(_ :+ (blockAndTxChains, reason))
+                      }
+                      .merge
+                }
+            }
+            result <-
+              if (initState === currState) currState.pure[F]
+              else go(currState, currState.awaiting.map(_._1))
+          } yield result
+
+        blocks.sorted
+          .foldLeftM(
+            (List.empty[(Signed[TokenLockBlock], Map[Address, TokenLockNel])], List.empty[(Signed[TokenLockBlock], ValidationFailed)])
+          ) { (acc, block) =>
+            acc match {
+              case (validList, invalidList) =>
+                blockValidator.validate(block, snapshotOrdinal).map {
+                  case Valid(blockAndTxChains) => (blockAndTxChains :: validList, invalidList)
+                  case Invalid(errors)         => (validList, (block, ValidationFailed(errors.toNonEmptyList)) :: invalidList)
+                }
+            }
+          }
+          .flatMap {
+            case (validList, invalidList) =>
+              go(TokenLockBlockAcceptanceState.withRejectedBlocks(invalidList), validList)
+                .map(_.toBlockAcceptanceResult)
+          }
+      }
+
+      def acceptBlock(
+        block: Signed[TokenLockBlock],
+        context: TokenLockBlockAcceptanceContext[F],
+        snapshotOrdinal: SnapshotOrdinal
+      )(implicit hasher: Hasher[F]): F[Either[TokenLockBlockNotAcceptedReason, TokenLockBlockAcceptanceContextUpdate]] =
+        blockValidator.validate(block, snapshotOrdinal).flatMap {
+          _.toEither
+            .leftMap(errors => ValidationFailed(errors.toNonEmptyList))
+            .toEitherT[F]
+            .flatMap {
+              case (block, txChains) => logic.acceptBlock(block, txChains, context, TokenLockBlockAcceptanceContextUpdate.empty)
+            }
+            .value
+        }
+    }
+
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceResult.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceResult.scala
@@ -1,0 +1,15 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.signature.Signed
+
+import derevo.cats.show
+import derevo.derive
+import eu.timepit.refined.cats._
+
+@derive(show)
+case class TokenLockBlockAcceptanceResult(
+  contextUpdate: TokenLockBlockAcceptanceContextUpdate,
+  accepted: List[Signed[TokenLockBlock]],
+  notAccepted: List[(Signed[TokenLockBlock], TokenLockBlockNotAcceptedReason)]
+)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceState.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockAcceptanceState.scala
@@ -1,0 +1,37 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockChainValidator.TokenLockNel
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.signature.Signed
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+import eu.timepit.refined.cats._
+
+@derive(eqv, show)
+case class TokenLockBlockAcceptanceState(
+  contextUpdate: TokenLockBlockAcceptanceContextUpdate,
+  accepted: List[Signed[TokenLockBlock]],
+  rejected: List[(Signed[TokenLockBlock], TokenLockBlockRejectionReason)],
+  awaiting: List[((Signed[TokenLockBlock], Map[Address, TokenLockNel]), TokenLockBlockAwaitReason)]
+) {
+
+  def toBlockAcceptanceResult: TokenLockBlockAcceptanceResult =
+    TokenLockBlockAcceptanceResult(
+      contextUpdate,
+      accepted,
+      awaiting.map { case ((block, _), reason) => (block, reason) } ++ rejected
+    )
+}
+
+object TokenLockBlockAcceptanceState {
+
+  def withRejectedBlocks(rejected: List[(Signed[TokenLockBlock], TokenLockBlockRejectionReason)]): TokenLockBlockAcceptanceState =
+    TokenLockBlockAcceptanceState(
+      contextUpdate = TokenLockBlockAcceptanceContextUpdate.empty,
+      accepted = List.empty,
+      rejected = rejected,
+      awaiting = List.empty
+    )
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockNotAcceptedReason.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockNotAcceptedReason.scala
@@ -1,0 +1,51 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import cats.data.NonEmptyList
+
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.BalanceArithmeticError
+import io.constellationnetwork.schema.tokenLock.{TokenLockOrdinal, TokenLockReference}
+import io.constellationnetwork.security.hash.Hash
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+
+@derive(eqv, show)
+sealed trait TokenLockBlockNotAcceptedReason
+
+@derive(eqv, show)
+sealed trait TokenLockBlockRejectionReason extends TokenLockBlockNotAcceptedReason
+
+@derive(eqv, show)
+case class ValidationFailed(reasons: NonEmptyList[TokenLockBlockValidationError]) extends TokenLockBlockRejectionReason
+
+@derive(eqv, show)
+case class RejectedTokenLock(tx: TokenLockReference, reason: TokenLockRejectionReason) extends TokenLockBlockRejectionReason
+
+@derive(eqv, show)
+sealed trait TokenLockBlockAwaitReason extends TokenLockBlockNotAcceptedReason
+
+@derive(eqv, show)
+case class AwaitingTokenLock(tx: TokenLockReference, reason: TokenLockAwaitReason) extends TokenLockBlockAwaitReason
+
+@derive(eqv, show)
+case class AddressBalanceOutOfRange(address: Address, error: BalanceArithmeticError) extends TokenLockBlockAwaitReason
+
+@derive(eqv, show)
+case class SigningPeerBelowCollateral(peerIds: NonEmptyList[Address]) extends TokenLockBlockAwaitReason
+
+@derive(eqv, show)
+sealed trait TokenLockAwaitReason
+
+@derive(eqv, show)
+case class ParentOrdinalAboveLastTxOrdinal(parentOrdinal: TokenLockOrdinal, lastTxOrdinal: TokenLockOrdinal) extends TokenLockAwaitReason
+
+@derive(eqv, show)
+sealed trait TokenLockRejectionReason
+
+@derive(eqv, show)
+case class ParentHashNotEqLastTxHash(parentHash: Hash, lastTxHash: Hash) extends TokenLockRejectionReason
+
+@derive(eqv, show)
+case class ParentOrdinalBelowLastTxOrdinal(parentOrdinal: TokenLockOrdinal, lastTxOrdinal: TokenLockOrdinal)
+    extends TokenLockRejectionReason

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockStorage.scala
@@ -1,0 +1,219 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import cats.Show
+import cats.effect.Sync
+import cats.effect.std.Random
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.option._
+import cats.syntax.show._
+import cats.syntax.traverse._
+
+import scala.util.control.NoStackTrace
+
+import io.constellationnetwork.ext.collection.MapRefUtils.MapRefOps
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockStorage._
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.security.Hashed
+import io.constellationnetwork.security.hash.ProofsHash
+import io.constellationnetwork.security.signature.Signed
+
+import io.chrisdavenport.mapref.MapRef
+
+class TokenLockBlockStorage[F[_]: Sync: Random](blocks: MapRef[F, ProofsHash, Option[TokenLockStoredBlock]]) {
+
+  def getState(): F[Map[ProofsHash, TokenLockStoredBlock]] =
+    blocks.toMap
+
+  def accept(hashedBlock: Hashed[TokenLockBlock]): F[Unit] =
+    blocks(hashedBlock.proofsHash).modify {
+      case Some(WaitingBlock(_)) => (AcceptedBlock(hashedBlock).some, hashedBlock.asRight)
+      case other                 => (other, BlockAcceptanceError(hashedBlock.proofsHash, other).asLeft)
+    }.flatMap(_.liftTo[F]).void
+
+  def postpone(hashedBlock: Hashed[TokenLockBlock]): F[Unit] =
+    blocks(hashedBlock.proofsHash).modify {
+      case Some(WaitingBlock(_)) => (PostponedBlock(hashedBlock.signed).some, hashedBlock.asRight)
+      case other                 => (other, BlockPostponementError(hashedBlock.proofsHash, other).asLeft)
+    }.flatMap(_.liftTo[F]).void
+
+  def adjustToMajority(
+    toAdd: Set[Hashed[TokenLockBlock]] = Set.empty,
+    toMarkMajority: Set[ProofsHash] = Set.empty,
+    acceptedToRemove: Set[ProofsHash] = Set.empty,
+    obsoleteToRemove: Set[ProofsHash] = Set.empty,
+    toReset: Set[ProofsHash] = Set.empty,
+    postponedToWaiting: Set[ProofsHash] = Set.empty
+  ): F[Unit] = {
+
+    def addMajorityBlocks: F[Unit] =
+      toAdd.toList.traverse {
+        case tokenLockBlock =>
+          val reference = tokenLockBlock.proofsHash
+          blocks(tokenLockBlock.proofsHash).modify {
+            case Some(WaitingBlock(_)) | Some(PostponedBlock(_)) | None =>
+              (MajorityBlock(reference).some, tokenLockBlock.asRight)
+            case other => (other, UnexpectedBlockStateWhenAddingMajorityBlock(tokenLockBlock.proofsHash, other).asLeft)
+          }.flatMap(_.liftTo[F])
+      }.void
+
+    def markMajorityBlocks: F[Unit] =
+      toMarkMajority.toList.traverse {
+        case proofsHash =>
+          blocks(proofsHash).modify {
+            case Some(AcceptedBlock(block)) =>
+              val reference = block.proofsHash
+              (MajorityBlock(reference).some, ().asRight)
+            case other =>
+              (other, UnexpectedBlockStateWhenMarkingAsMajority(proofsHash, other).asLeft)
+          }.flatMap(_.liftTo[F])
+      }.void
+
+    def removeAcceptedNonMajorityBlocks: F[Unit] =
+      acceptedToRemove.toList.traverse { hash =>
+        blocks(hash).modify {
+          case Some(AcceptedBlock(block)) => (None, block.asRight)
+          case other                      => (None, UnexpectedBlockStateWhenRemovingAccepted(hash, other).asLeft)
+        }.flatMap(_.liftTo[F])
+      }.void
+
+    def removeObsoleteBlocks: F[Unit] =
+      obsoleteToRemove.toList.traverse { hash =>
+        blocks(hash).modify {
+          case Some(WaitingBlock(_)) | Some(PostponedBlock(_)) => (None, ().asRight)
+          case other                                           => (other, UnexpectedBlockStateWhenRemoving(hash, other).asLeft)
+        }.flatMap(_.liftTo[F])
+      }.void
+
+    def resetBlocks: F[Unit] =
+      toReset.toList.traverse { hash =>
+        blocks(hash).modify {
+          case Some(AcceptedBlock(block)) => (WaitingBlock(block.signed).some, ().asRight)
+          case other                      => (None, UnexpectedBlockStateWhenResetting(hash, other).asLeft)
+        }.flatMap(_.liftTo[F])
+      }.void
+
+    def resetPostponedBlocks: F[Unit] =
+      postponedToWaiting.toList.traverse { hash =>
+        blocks(hash).modify {
+          case Some(PostponedBlock(block)) => (WaitingBlock(block).some, ().asRight)
+          case other                       => (other, UnexpectedBlockStateWhenResettingPostponed(hash, other).asLeft)
+        }.flatMap(_.liftTo[F])
+      }.void
+
+    addMajorityBlocks >>
+      markMajorityBlocks >>
+      removeAcceptedNonMajorityBlocks >>
+      removeObsoleteBlocks >>
+      resetBlocks >>
+      resetPostponedBlocks
+  }
+
+  def store(hashedBlock: Hashed[TokenLockBlock]): F[Unit] =
+    blocks(hashedBlock.proofsHash).modify {
+      case None  => (WaitingBlock(hashedBlock.signed).some, ().asRight)
+      case other => (other, BlockAlreadyStoredError(hashedBlock.proofsHash, other).asLeft)
+    }.flatMap(_.liftTo[F])
+
+  def getWaiting: F[Map[ProofsHash, Signed[TokenLockBlock]]] =
+    blocks.toMap.map(_.collect { case (hash, WaitingBlock(block)) => hash -> block })
+}
+
+object TokenLockBlockStorage {
+
+  def make[F[_]: Sync: Random]: F[TokenLockBlockStorage[F]] =
+    MapRef.ofConcurrentHashMap[F, ProofsHash, TokenLockStoredBlock]().map(new TokenLockBlockStorage[F](_))
+
+  def make[F[_]: Sync: Random](blocks: Map[ProofsHash, TokenLockStoredBlock]): F[TokenLockBlockStorage[F]] =
+    MapRef.ofSingleImmutableMap(blocks).map(new TokenLockBlockStorage[F](_))
+
+  sealed trait TokenLockStoredBlock
+  case class WaitingBlock(block: Signed[TokenLockBlock]) extends TokenLockStoredBlock
+  case class PostponedBlock(block: Signed[TokenLockBlock]) extends TokenLockStoredBlock
+  case class AcceptedBlock(block: Hashed[TokenLockBlock]) extends TokenLockStoredBlock
+  case class MajorityBlock(blockReference: ProofsHash) extends TokenLockStoredBlock
+
+  implicit val showTokenLockStoredBlock: Show[TokenLockStoredBlock] = {
+    case _: WaitingBlock   => "Waiting"
+    case _: PostponedBlock => "Postponed"
+    case _: AcceptedBlock  => "Accepted"
+    case _: MajorityBlock  => "Majority"
+  }
+
+  case class MajorityReconciliationData(
+    waitingInRange: Set[ProofsHash],
+    postponedInRange: Set[ProofsHash],
+    relatedPostponed: Set[ProofsHash],
+    acceptedInRange: Set[ProofsHash],
+    acceptedAbove: Set[ProofsHash]
+  )
+
+  sealed trait TokenLockBlockStorageError extends NoStackTrace {
+    val errorMessage: String
+    override def getMessage: String = errorMessage
+  }
+
+  case class BlockAcceptanceError(hash: ProofsHash, encountered: Option[TokenLockStoredBlock]) extends TokenLockBlockStorageError {
+
+    val errorMessage: String =
+      s"Block with hash=${hash.show} failed to transition state to Accepted! Encountered state: ${encountered.show}."
+  }
+
+  case class BlockPostponementError(hash: ProofsHash, encountered: Option[TokenLockStoredBlock]) extends TokenLockBlockStorageError {
+
+    val errorMessage: String =
+      s"Block with hash=${hash.show} failed to transition state to Postponed! Encountered state: ${encountered.show}."
+  }
+
+  case class BlockRestorationError(hash: ProofsHash, encountered: Option[TokenLockStoredBlock]) extends TokenLockBlockStorageError {
+
+    val errorMessage: String =
+      s"Block with hash=${hash.show} failed to transition state to Waiting! Encountered state: ${encountered.show}."
+  }
+
+  case class BlockAlreadyStoredError(hash: ProofsHash, encountered: Option[TokenLockStoredBlock]) extends TokenLockBlockStorageError {
+
+    val errorMessage: String =
+      s"Block with hash=${hash.show} is already stored. Encountered state: ${encountered.show}."
+  }
+
+  sealed trait BlockMajorityUpdateError extends TokenLockBlockStorageError
+
+  case class UnexpectedBlockStateWhenMarkingAsMajority(hash: ProofsHash, got: Option[TokenLockStoredBlock])
+      extends BlockMajorityUpdateError {
+    val errorMessage: String = s"Accepted block to be marked as majority with hash: $hash not found! But got: $got"
+  }
+
+  case class UnexpectedBlockStateWhenRemovingAccepted(hash: ProofsHash, got: Option[TokenLockStoredBlock])
+      extends BlockMajorityUpdateError {
+
+    val errorMessage: String =
+      s"Accepted block to be removed during majority update with hash: $hash not found! But got: $got"
+  }
+
+  case class UnexpectedBlockStateWhenRemoving(hash: ProofsHash, got: Option[TokenLockStoredBlock]) extends BlockMajorityUpdateError {
+
+    val errorMessage: String =
+      s"Block to be removed during majority update with hash: $hash not found in expected state! But got: $got"
+  }
+
+  case class UnexpectedBlockStateWhenResetting(hash: ProofsHash, got: Option[TokenLockStoredBlock]) extends BlockMajorityUpdateError {
+
+    val errorMessage: String =
+      s"Block to be reset during majority update with hash: $hash not found in expected state! But got: $got"
+  }
+
+  case class UnexpectedBlockStateWhenAddingMajorityBlock(hash: ProofsHash, got: Option[TokenLockStoredBlock])
+      extends BlockMajorityUpdateError {
+
+    val errorMessage: String =
+      s"Block to be added during majority update with hash: $hash not found in expected state! But got: $got"
+  }
+
+  case class UnexpectedBlockStateWhenResettingPostponed(hash: ProofsHash, got: Option[TokenLockStoredBlock])
+      extends TokenLockBlockStorageError {
+    val errorMessage: String =
+      s"Postponed block to be reset to waiting block with hash: $hash not found in expected state! But got: $got"
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/block/TokenLockBlockValidator.scala
@@ -1,0 +1,151 @@
+package io.constellationnetwork.node.shared.domain.tokenlock.block
+
+import cats.Functor
+import cats.data.ValidatedNec
+import cats.effect.Async
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.partialOrder._
+import cats.syntax.validated._
+
+import io.constellationnetwork.ext.cats.syntax.validated._
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockChainValidator.{TokenLockChainBroken, TokenLockNel}
+import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockValidator.TokenLockValidationError
+import io.constellationnetwork.node.shared.domain.tokenlock.{TokenLockChainValidator, TokenLockValidator}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.tokenLock.{TokenLockBlock, TokenLockReference}
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.SignedValidator.SignedValidationError
+import io.constellationnetwork.security.signature.{Signed, SignedValidator}
+
+import derevo.cats.{eqv, show}
+import derevo.derive
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
+
+trait TokenLockBlockValidator[F[_]] {
+
+  type TokenLockBlockValidationErrorOr[A] = ValidatedNec[TokenLockBlockValidationError, A]
+
+  def validate(
+    signedBlock: Signed[TokenLockBlock],
+    snapshotOrdinal: SnapshotOrdinal,
+    params: TokenLockBlockValidationParams = TokenLockBlockValidationParams.default
+  )(implicit hasher: Hasher[F]): F[TokenLockBlockValidationErrorOr[(Signed[TokenLockBlock], Map[Address, TokenLockNel])]]
+
+  def validateGetBlock(
+    signedBlock: Signed[TokenLockBlock],
+    params: TokenLockBlockValidationParams = TokenLockBlockValidationParams.default,
+    epochProgress: EpochProgress,
+    snapshotOrdinal: SnapshotOrdinal
+  )(implicit ev: Functor[F], hasher: Hasher[F]): F[TokenLockBlockValidationErrorOr[Signed[TokenLockBlock]]] =
+    validate(signedBlock, snapshotOrdinal, params).map(_.map(_._1))
+
+  def validateGetTxChains(
+    signedBlock: Signed[TokenLockBlock],
+    snapshotOrdinal: SnapshotOrdinal,
+    epochProgress: EpochProgress,
+    params: TokenLockBlockValidationParams = TokenLockBlockValidationParams.default
+  )(implicit ev: Functor[F], hasher: Hasher[F]): F[TokenLockBlockValidationErrorOr[Map[Address, TokenLockNel]]] =
+    validate(signedBlock, snapshotOrdinal, params).map(_.map(_._2))
+}
+
+object TokenLockBlockValidator {
+
+  def make[F[_]: Async](
+    signedValidator: SignedValidator[F],
+    TokenLockChainValidator: TokenLockChainValidator[F],
+    TokenLockValidator: TokenLockValidator[F]
+  ): TokenLockBlockValidator[F] =
+    new TokenLockBlockValidator[F] {
+
+      def validate(
+        signedBlock: Signed[TokenLockBlock],
+        snapshotOrdinal: SnapshotOrdinal,
+        params: TokenLockBlockValidationParams
+      )(implicit hasher: Hasher[F]): F[TokenLockBlockValidationErrorOr[(Signed[TokenLockBlock], Map[Address, TokenLockNel])]] =
+        for {
+          signedV <- validateSigned(signedBlock, params)(hasher)
+          lockedV = validateNotLockedAtOrdinal(signedBlock, snapshotOrdinal)
+          transactionsV <- validateTokenLocks(signedBlock)
+          transactionChainV <- validateTokenLockChain(signedBlock)
+        } yield
+          signedV
+            .productR(lockedV)
+            .productR(transactionsV)
+            .product(transactionChainV)
+
+      private def validateSigned(
+        signedBlock: Signed[TokenLockBlock],
+        params: TokenLockBlockValidationParams
+      )(implicit hasher: Hasher[F]): F[TokenLockBlockValidationErrorOr[Signed[TokenLockBlock]]] =
+        signedValidator
+          .validateSignatures(signedBlock)
+          .map { signaturesV =>
+            signaturesV
+              .productR(signedValidator.validateUniqueSigners(signedBlock))
+              .productR(signedValidator.validateMinSignatureCount(signedBlock, params.minSignatureCount))
+          }
+          .map(_.errorMap[TokenLockBlockValidationError](InvalidSigned))
+
+      private def validateTokenLocks(
+        signedBlock: Signed[TokenLockBlock]
+      )(implicit hasher: Hasher[F]): F[TokenLockBlockValidationErrorOr[Signed[TokenLockBlock]]] =
+        signedBlock.value.tokenLocks.toNonEmptyList.traverse { signedTransaction =>
+          for {
+            txRef <- TokenLockReference.of(signedTransaction)
+            txV <- TokenLockValidator.validate(signedTransaction)
+          } yield txV.errorMap(InvalidTokenLock(txRef, _))
+        }.map { vs =>
+          vs.foldLeft(signedBlock.validNec[TokenLockBlockValidationError]) { (acc, v) =>
+            acc.productL(v)
+          }
+        }
+
+      private def validateTokenLockChain(
+        signedBlock: Signed[TokenLockBlock]
+      ): F[TokenLockBlockValidationErrorOr[Map[Address, TokenLockNel]]] =
+        TokenLockChainValidator
+          .validate(signedBlock.tokenLocks)
+          .map(_.errorMap[TokenLockBlockValidationError](InvalidTokenLockChain))
+
+      private val addressesLockedAtOrdinal: Map[Address, SnapshotOrdinal] = Map.empty
+
+      private def validateNotLockedAtOrdinal(
+        signedBlock: Signed[TokenLockBlock],
+        ordinal: SnapshotOrdinal
+      ): TokenLockBlockValidationErrorOr[Signed[TokenLockBlock]] =
+        signedBlock.value.tokenLocks.toNonEmptyList
+          .map(signedTxn =>
+            addressesLockedAtOrdinal
+              .get(signedTxn.value.source)
+              .filter(lockedAt => ordinal >= lockedAt)
+              .fold(signedBlock.validNec[TokenLockBlockValidationError])(
+                AddressLockedAtOrdinal(signedTxn.value.source, ordinal, _).invalidNec[Signed[TokenLockBlock]]
+              )
+          )
+          .reduce[TokenLockBlockValidationErrorOr[Signed[TokenLockBlock]]](_ *> _)
+
+    }
+}
+
+case class TokenLockBlockValidationParams(minSignatureCount: PosInt)
+
+object TokenLockBlockValidationParams {
+  val default: TokenLockBlockValidationParams = TokenLockBlockValidationParams(minSignatureCount = 3)
+}
+
+@derive(eqv, show)
+sealed trait TokenLockBlockValidationError
+
+case class InvalidTokenLockChain(error: TokenLockChainBroken) extends TokenLockBlockValidationError
+
+case class InvalidTokenLock(TokenLockReference: TokenLockReference, error: TokenLockValidationError) extends TokenLockBlockValidationError
+
+case class InvalidSigned(error: SignedValidationError) extends TokenLockBlockValidationError
+
+case class AddressLockedAtOrdinal(address: Address, ordinal: SnapshotOrdinal, lockedAt: SnapshotOrdinal)
+    extends TokenLockBlockValidationError

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Engine.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Engine.scala
@@ -340,7 +340,7 @@ object Engine {
             result <- maybeBlock match {
               case Some(block) =>
                 Signed.forAsyncHasher(block, selfKeyPair).flatMap { signedBlock =>
-                  signedBlock.transactions.toList
+                  signedBlock.tokenLocks.toList
                     .traverse(validate)
                     .map(_.forall(_.isValid))
                     .ifM(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyEventsCutter.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyEventsCutter.scala
@@ -9,6 +9,7 @@ import io.constellationnetwork.currency.dataApplication.dataApplication.DataAppl
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.snapshot.currency._
 import io.constellationnetwork.schema.currencyMessage.CurrencyMessage
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.schema.{Block, SnapshotOrdinal}
 import io.constellationnetwork.security.signature.Signed
 
@@ -18,6 +19,7 @@ trait CurrencyEventsCutter[F[_]] {
   def cut(
     ordinal: SnapshotOrdinal,
     acceptedBlocks: List[Signed[Block]],
+    acceptedTokenLockBlocks: List[Signed[TokenLockBlock]],
     acceptedDataBlocks: List[Signed[DataApplicationBlock]],
     acceptedMessages: List[Signed[CurrencyMessage]]
   ): F[Option[(Set[CurrencySnapshotEvent], CurrencySnapshotEvent)]]
@@ -27,46 +29,61 @@ object CurrencyEventsCutter {
   def make[F[_]: Async: JsonSerializer](maybeDataApplication: Option[BaseDataApplicationL0Service[F]]): CurrencyEventsCutter[F] = (
     ordinal: SnapshotOrdinal,
     acceptedBlocks: List[Signed[Block]],
+    acceptedTokenLockBlocks: List[Signed[TokenLockBlock]],
     acceptedDataBlocks: List[Signed[DataApplicationBlock]],
     acceptedMessages: List[Signed[CurrencyMessage]]
   ) => {
     val blockEvents = acceptedBlocks.map(BlockEvent(_))
+    val tokenLockBlockEvents = acceptedTokenLockBlocks.map(TokenLockBlockEvent(_))
     val dataBlockEvents = acceptedDataBlocks.map(DataApplicationBlockEvent(_))
     val currencyMessageEvents = acceptedMessages.map(CurrencyMessageEvent(_))
     val acceptedDataBlocksLength = acceptedDataBlocks.length
     val acceptedBlocksLength = acceptedBlocks.length
+    val acceptedTokenLockBlocksLength = acceptedTokenLockBlocks.length
 
     val eventsToCutFrom: F[Option[List[CurrencySnapshotEvent]]] =
       maybeDataApplication match {
-        case None => if (acceptedBlocksLength <= 1) none.pure[F] else blockEvents.widen[CurrencySnapshotEvent].some.pure[F]
-        case Some(dataApplication) =>
-          if (acceptedBlocksLength + acceptedDataBlocksLength <= 1) {
+        case None =>
+          if (acceptedBlocksLength <= 1 && acceptedTokenLockBlocksLength <= 1) {
             none.pure[F]
-          } else if (acceptedBlocksLength < acceptedDataBlocksLength) {
+          } else {
+            (blockEvents.widen[CurrencySnapshotEvent] ++ tokenLockBlockEvents.widen[CurrencySnapshotEvent]).some.pure[F]
+          }
+        case Some(dataApplication) =>
+          if (acceptedBlocksLength + acceptedDataBlocksLength + acceptedTokenLockBlocksLength <= 1) {
+            none.pure[F]
+          } else if (acceptedBlocksLength < acceptedDataBlocksLength && acceptedTokenLockBlocksLength < acceptedDataBlocksLength) {
             dataBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
-          } else if (acceptedBlocksLength > acceptedDataBlocksLength) {
+          } else if (acceptedBlocksLength > acceptedDataBlocksLength && acceptedBlocksLength > acceptedTokenLockBlocksLength) {
             blockEvents.widen[CurrencySnapshotEvent].some.pure[F]
+          } else if (acceptedTokenLockBlocksLength > acceptedDataBlocksLength && acceptedTokenLockBlocksLength > acceptedBlocksLength) {
+            tokenLockBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
           } else {
             implicit val dataEncoder = dataApplication.dataEncoder
 
             val lastBlockSize: F[Option[Int]] = acceptedBlocks.lastOption.traverse(a => JsonSerializer[F].serialize(a).map(_.length))
+            val lastTokenLockBlockSize: F[Option[Int]] =
+              acceptedTokenLockBlocks.lastOption.traverse(a => JsonSerializer[F].serialize(a).map(_.length))
             val lastDataBlockSize: F[Option[Int]] =
               acceptedDataBlocks.lastOption.traverse(JsonSerializer[F].serialize(_)).map(_.map(_.length))
 
-            (lastBlockSize, lastDataBlockSize).tupled.flatMap {
-              case (Some(lbs), Some(ldbs)) =>
-                if (lbs > ldbs) {
+            (lastBlockSize, lastTokenLockBlockSize, lastDataBlockSize).tupled.flatMap {
+              case (Some(lbs), Some(ltlbs), Some(ldbs)) =>
+                if (lbs > ldbs && lbs > ltlbs) {
                   blockEvents.widen[CurrencySnapshotEvent].some.pure[F]
-                } else if (lbs < ldbs) {
+                } else if (lbs < ldbs && ltlbs < ldbs) {
                   dataBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
+                } else if (ltlbs > lbs && ltlbs > ldbs) {
+                  tokenLockBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
                 } else {
                   Random
                     .scalaUtilRandomSeedLong(ordinal.value)
-                    .flatMap(_.elementOf(Set(blockEvents.some, dataBlockEvents.some)))
+                    .flatMap(_.elementOf(Set(blockEvents.some, tokenLockBlockEvents.some, dataBlockEvents.some)))
                 }
-              case (Some(_), None) => blockEvents.widen[CurrencySnapshotEvent].some.pure[F]
-              case (None, Some(_)) => dataBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
-              case _               => none.pure[F]
+              case (Some(_), None, None) => blockEvents.widen[CurrencySnapshotEvent].some.pure[F]
+              case (None, Some(_), None) => tokenLockBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
+              case (None, None, Some(_)) => dataBlockEvents.widen[CurrencySnapshotEvent].some.pure[F]
+              case _                     => none.pure[F]
             }
           }
       }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -18,6 +18,7 @@ import io.constellationnetwork.node.shared.domain.gossip.Gossip
 import io.constellationnetwork.node.shared.domain.healthcheck.LocalHealthcheck
 import io.constellationnetwork.node.shared.domain.seedlist.SeedlistEntry
 import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
+import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.http.p2p.clients.NodeClient
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.cluster.services.Cluster
@@ -78,6 +79,7 @@ object SharedServices {
       gossip <- HasherSelector[F].withCurrent(implicit hasher => Gossip.make[F](queues.rumor, nodeId, generation, keyPair))
       currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
         BlockAcceptanceManager.make[F](validators.currencyBlockValidator, txHasher),
+        TokenLockBlockAcceptanceManager.make[F](validators.tokenLockBlockValidator),
         collateral.amount,
         validators.currencyMessageValidator,
         validators.globalSnapshotSyncValidator

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/snapshot/currency.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/snapshot/currency.scala
@@ -7,6 +7,7 @@ import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSnapshot
 import io.constellationnetwork.schema.Block
 import io.constellationnetwork.schema.currencyMessage.CurrencyMessage
 import io.constellationnetwork.schema.swap.AllowSpendBlock
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security.signature.Signed
 
 import derevo.cats.eqv
@@ -31,6 +32,9 @@ object currency {
 
   @derive(encoder, decoder, eqv)
   case class AllowSpendBlockEvent(value: Signed[AllowSpendBlock]) extends CurrencySnapshotEvent
+
+  @derive(encoder, decoder, eqv)
+  case class TokenLockBlockEvent(value: Signed[TokenLockBlock]) extends CurrencySnapshotEvent
 
   @derive(eqv)
   case class DataApplicationBlockEvent(value: Signed[DataApplicationBlock]) extends CurrencySnapshotEvent

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
@@ -116,7 +116,8 @@ object currency {
     def stateProof[F[_]: Sync: Hasher](ordinal: SnapshotOrdinal): F[CurrencySnapshotStateProofV1] =
       (lastTxRefs.hash, balances.hash).tupled.map(CurrencySnapshotStateProofV1.apply)
 
-    def toCurrencySnapshotInfo: CurrencySnapshotInfo = CurrencySnapshotInfo(lastTxRefs, balances, None, None, None, None, None, None, None)
+    def toCurrencySnapshotInfo: CurrencySnapshotInfo =
+      CurrencySnapshotInfo(lastTxRefs, balances, None, None, None, None, None, None, None)
   }
 
   object CurrencySnapshotInfoV1 {
@@ -179,6 +180,7 @@ object currency {
     globalSnapshotSyncs: Option[SortedSet[Signed[GlobalSnapshotSync]]] = SortedSet.empty[Signed[GlobalSnapshotSync]].some,
     feeTransactions: Option[SortedSet[Signed[FeeTransaction]]] = None,
     artifacts: Option[SortedSet[SharedArtifact]] = SortedSet.empty[SharedArtifact].some,
+    tokenLockBlocks: Option[SortedSet[Signed[TokenLockBlock]]] = SortedSet.empty[Signed[TokenLockBlock]].some,
     version: SnapshotVersion = SnapshotVersion("0.0.1")
   ) extends IncrementalSnapshot[CurrencySnapshotStateProof]
 
@@ -196,6 +198,7 @@ object currency {
           stateProof.toCurrencySnapshotStateProof,
           snapshot.epochProgress,
           snapshot.dataApplication,
+          None,
           None,
           None,
           None,
@@ -231,6 +234,7 @@ object currency {
         stateProof.toCurrencySnapshotStateProof,
         epochProgress,
         dataApplication,
+        None,
         None,
         None,
         None,
@@ -286,6 +290,7 @@ object currency {
           stateProof.toCurrencySnapshotStateProof,
           genesis.epochProgress,
           genesis.dataApplication,
+          None,
           None,
           None,
           None,

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -29,7 +29,7 @@ object artifact {
   case class TokenUnlock(
     lockReference: TokenLockReference,
     amount: TokenLockAmount,
-    currencyId: CurrencyId,
+    currencyId: Option[CurrencyId],
     address: Address
   ) extends SharedArtifact
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/tokenLock.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/tokenLock.scala
@@ -76,7 +76,7 @@ object tokenLock {
     source: Address,
     amount: TokenLockAmount,
     parent: TokenLockReference,
-    currencyId: CurrencyId,
+    currencyId: Option[CurrencyId],
     unlockEpoch: EpochProgress
   ) {
     val ordinal: TokenLockOrdinal = parent.ordinal.next
@@ -108,15 +108,16 @@ object tokenLock {
       Decoder.decodeString.emapTry(s => Try(TokenLockStatus.withName(s)))
   }
 
-  @derive(decoder, encoder, show)
+  @derive(decoder, encoder, show, order)
   case class TokenLockBlock(
     roundId: RoundId,
-    transactions: NonEmptySet[Signed[TokenLock]]
+    tokenLocks: NonEmptySet[Signed[TokenLock]]
   )
 
   object TokenLockBlock {
     implicit val roundIdShow: Show[RoundId] = RoundId.shortShow
     implicit val transactionsDecoder: Decoder[NonEmptySet[Signed[TokenLock]]] =
       NonEmptySetCodec.decoder[Signed[TokenLock]]
+    implicit object OrderingInstance extends OrderBasedOrdering[TokenLockBlock]
   }
 }

--- a/modules/shared/src/test/scala/io/constellationnetwork/block/generators.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/block/generators.scala
@@ -1,10 +1,14 @@
 package io.constellationnetwork.block
 
+import java.util.UUID
+
 import cats.data.{NonEmptyList, NonEmptySet}
 
 import scala.collection.immutable.SortedSet
 
-import io.constellationnetwork.schema.generators.{signedOf, signedTransactionGen}
+import io.constellationnetwork.schema.generators.{signedOf, signedTokenLockGen, signedTransactionGen}
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.schema.{Block, BlockReference}
 import io.constellationnetwork.security.signature.Signed
 
@@ -21,7 +25,14 @@ object generators {
       signedTxn <- signedTransactionGen
     } yield Block(blockReferences, NonEmptySet.fromSetUnsafe(SortedSet(signedTxn)))
 
+  val tokenLockBlockGen: Gen[TokenLockBlock] =
+    for {
+      signedTxn <- signedTokenLockGen
+      roundId <- Gen.delay(RoundId(UUID.randomUUID()))
+    } yield TokenLockBlock(roundId, NonEmptySet.fromSetUnsafe(SortedSet(signedTxn)))
+
   val signedBlockGen: Gen[Signed[Block]] = signedOf(blockGen)
+  val signedTokenLockBlockGen: Gen[Signed[TokenLockBlock]] = signedOf(tokenLockBlockGen)
   implicit val signedBlockArbitrary: Arbitrary[Signed[Block]] = Arbitrary(signedBlockGen)
 
 }


### PR DESCRIPTION
### Changes
+ Implemented the flow to handle acceptance of new blocks for token locks.
+ This flow includes the integration of services, validators, acceptance logic, and storages.
+ Introduced the initial deduction of balances when a TokenLock transaction is received.

### Tests
<img width="1671" alt="Screenshot 2024-12-05 at 12 25 28" src="https://github.com/user-attachments/assets/93e79fdd-33f3-4dc6-962e-68cfe98229de">

### Notes
+ Structural and validation checks are still in progress.
+ Specifically, some validations related to epoch progress are pending and will be implemented in upcoming updates.