### PR TITLE
chore: run publish only on doc/api changes

### DIFF
--- a/.github/workflows/release-apidocs.yml
+++ b/.github/workflows/release-apidocs.yml
@@ -5,7 +5,11 @@ on:
       - release/testnet
       - release/integrationnet
       - develop
+    paths:
+      - 'doc/api/**'
   pull_request:
+    paths:
+      - 'doc/api/**'
 
 name: Publish API docs
 


### PR DESCRIPTION
run release-apidocs only when there's a change in the docs