### PR TITLE
fix: restore trigger on PR

### DIFF
--- a/.github/workflows/release-apidocs.yml
+++ b/.github/workflows/release-apidocs.yml
@@ -7,6 +7,9 @@ on:
       - develop
     paths:
       - 'doc/api/**'
+  pull_request:
+    paths:
+      - 'doc/api/**'
 
 name: Publish API docs
 


### PR DESCRIPTION
restore the trigger on PR so terraform execution can be validated against the doc changes without waiting to the merge