### PR TITLE
feat: allow spends eviction

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -58,7 +58,8 @@ object method {
       c.lastKryoHashOrdinal,
       c.addresses,
       c.allowSpends,
-      c.tokenLocks
+      c.tokenLocks,
+      c.lastGlobalSnapshotsSync
     )
   }
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -13,6 +13,7 @@ import io.constellationnetwork.currency.schema.currency.CurrencySnapshot
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.cli.CliMethod
+import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.cluster.programs.{Joining, L0PeerDiscovery, PeerDiscovery}
 import io.constellationnetwork.node.shared.domain.snapshot.PeerSelect
 import io.constellationnetwork.node.shared.domain.snapshot.programs.Download
@@ -25,6 +26,7 @@ import io.constellationnetwork.security.{HasherSelector, SecurityProvider}
 object Programs {
 
   def make[F[_]: Async: Random: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector, R <: CliMethod](
+    sharedCfg: SharedConfig,
     keyPair: KeyPair,
     nodeId: PeerId,
     globalL0Peer: L0Peer,
@@ -43,6 +45,7 @@ object Programs {
       )
     val download = Download
       .make(
+        sharedCfg.lastGlobalSnapshotsSync,
         p2pClient,
         storages.cluster,
         currencySnapshotContextFns,
@@ -50,7 +53,8 @@ object Programs {
         services.consensus,
         peerSelect,
         storages.identifier,
-        dataApplication.map { case (da, _) => da }
+        dataApplication.map { case (da, _) => da },
+        storages.lastGlobalSnapshot
       )
 
     val globalL0PeerDiscovery = L0PeerDiscovery.make(

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -17,6 +17,7 @@ import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.cli.CliMethod
+import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.cluster.services.{Cluster, Session}
 import io.constellationnetwork.node.shared.domain.collateral.Collateral
 import io.constellationnetwork.node.shared.domain.gossip.Gossip
@@ -41,6 +42,7 @@ import org.http4s.client.Client
 object Services {
 
   def make[F[_]: Async: Random: JsonSerializer: KryoSerializer: SecurityProvider: HasherSelector: Metrics: Supervisor, R <: CliMethod](
+    sharedCfg: SharedConfig,
     p2PClient: P2PClient[F],
     sharedServices: SharedServices[F, R],
     storages: Storages[F],
@@ -107,6 +109,7 @@ object Services {
 
       consensus <- CurrencySnapshotConsensus
         .make[F](
+          sharedCfg,
           sharedServices.gossip,
           selfId,
           keyPair,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/node/L0NodeContext.scala
@@ -5,9 +5,8 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.L0NodeContext
-import io.constellationnetwork.currency.l0.snapshot.storage.LastSynchronizedGlobalSnapshotStorage
 import io.constellationnetwork.currency.schema.currency._
-import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSnapshotStorage, SnapshotStorage}
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSyncGlobalSnapshotStorage, SnapshotStorage}
 import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security._
@@ -16,8 +15,7 @@ object L0NodeContext {
   def make[F[_]: SecurityProvider: Async](
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     hasherSelector: HasherSelector[F],
-    lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
-      with LastSynchronizedGlobalSnapshotStorage[F],
+    lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
     identifierStorage: IdentifierStorage[F]
   ): L0NodeContext[F] = new L0NodeContext[F] {
     def getCurrencyId: F[CurrencyId] =

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -15,8 +15,10 @@ import io.constellationnetwork.currency.l0.snapshot.services.StateChannelSnapsho
 import io.constellationnetwork.currency.schema.currency.CurrencySnapshotContext
 import io.constellationnetwork.ext.collection.FoldableOps.pickMajority
 import io.constellationnetwork.ext.crypto._
+import io.constellationnetwork.node.shared.config.types.LastGlobalSnapshotsSyncConfig
 import io.constellationnetwork.node.shared.domain.gossip.Gossip
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSyncGlobalSnapshotStorage
 import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusStateUpdater._
 import io.constellationnetwork.node.shared.infrastructure.consensus._
 import io.constellationnetwork.node.shared.infrastructure.consensus.declaration._
@@ -29,7 +31,7 @@ import io.constellationnetwork.node.shared.snapshot.currency._
 import io.constellationnetwork.schema.currencyMessage.fetchStakingAddress
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.signature.Signed
-import io.constellationnetwork.security.signature.signature.{Signature, _}
+import io.constellationnetwork.security.signature.signature._
 import io.constellationnetwork.security.{HasherSelector, SecurityProvider}
 import io.constellationnetwork.syntax.sortedCollection._
 
@@ -50,6 +52,7 @@ abstract class CurrencySnapshotConsensusStateAdvancer[F[_]]
 object CurrencySnapshotConsensusStateAdvancer {
 
   def make[F[_]: Async: SecurityProvider: Metrics: HasherSelector](
+    lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
     keyPair: KeyPair,
     consensusStorage: CurrencyConsensusStorage[F],
     consensusFns: CurrencySnapshotConsensusFunctions[F],
@@ -58,7 +61,8 @@ object CurrencySnapshotConsensusStateAdvancer {
     maybeDataApplication: Option[BaseDataApplicationL0Service[F]],
     restartService: RestartService[F, _],
     nodeStorage: NodeStorage[F],
-    leavingDelay: FiniteDuration
+    leavingDelay: FiniteDuration,
+    lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F]
   ): CurrencySnapshotConsensusStateAdvancer[F] =
     new CurrencySnapshotConsensusStateAdvancer[F] {
       val logger = Slf4jLogger.getLogger[F]
@@ -105,6 +109,9 @@ object CurrencySnapshotConsensusStateAdvancer {
                             for {
                               peerEvents <- consensusStorage.pullEvents(bound)
                               events = peerEvents.toList.flatMap(_._2).map(_._2).toSet
+                              lastNGlobalSnapshotsSynchronized <- lastGlobalSnapshotStorage.getLastNSynchronized(
+                                lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
+                              )
                               (artifact, context, returnedEvents) <- consensusFns
                                 .createProposalArtifact(
                                   state.key,
@@ -113,7 +120,8 @@ object CurrencySnapshotConsensusStateAdvancer {
                                   hasher,
                                   majorityTrigger,
                                   events,
-                                  state.facilitators.value.toSet
+                                  state.facilitators.value.toSet,
+                                  lastNGlobalSnapshotsSynchronized
                                 )
                               returnedPeerEvents = peerEvents.map {
                                 case (peerId, events) =>
@@ -150,39 +158,45 @@ object CurrencySnapshotConsensusStateAdvancer {
                     maybeAllProposals
                       .map(allProposals => allProposals.values.toList.map(_.hash))
                       .flatTraverse { allProposalHashes =>
-                        pickValidatedMajorityArtifact(
-                          proposalInfo,
-                          state.lastOutcome.finished.signedMajorityArtifact,
-                          state.lastOutcome.finished.context,
-                          majorityTrigger,
-                          resources,
-                          allProposalHashes,
-                          state.facilitators.value.toSet,
-                          consensusFns
-                        ).flatMap { maybeMajorityArtifactInfo =>
-                          state.facilitators.value.hash.flatMap { facilitatorsHash =>
-                            maybeMajorityArtifactInfo.traverse { majorityArtifactInfo =>
-                              val newState =
-                                state.copy(status =
-                                  identity[CurrencySnapshotStatus](
-                                    CollectingSignatures(
-                                      majorityArtifactInfo,
-                                      majorityTrigger,
-                                      candidates,
-                                      facilitatorsHash
+                        lastGlobalSnapshotStorage
+                          .getLastNSynchronized(lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value)
+                          .flatMap { lastNGlobalSnapshots =>
+                            pickValidatedMajorityArtifact(
+                              proposalInfo,
+                              state.lastOutcome.finished.signedMajorityArtifact,
+                              state.lastOutcome.finished.context,
+                              majorityTrigger,
+                              resources,
+                              allProposalHashes,
+                              state.facilitators.value.toSet,
+                              consensusFns,
+                              lastNGlobalSnapshots
+                            ).flatMap { maybeMajorityArtifactInfo =>
+                              state.facilitators.value.hash.flatMap { facilitatorsHash =>
+                                maybeMajorityArtifactInfo.traverse { majorityArtifactInfo =>
+                                  val newState =
+                                    state.copy(status =
+                                      identity[CurrencySnapshotStatus](
+                                        CollectingSignatures(
+                                          majorityArtifactInfo,
+                                          majorityTrigger,
+                                          candidates,
+                                          facilitatorsHash
+                                        )
+                                      )
                                     )
+                                  val effect = Signature.fromHash(keyPair.getPrivate, majorityArtifactInfo.hash).flatMap { signature =>
+                                    gossip.spread(ConsensusPeerDeclaration(state.key, MajoritySignature(signature, facilitatorsHash)))
+                                  } >> Metrics[F].recordDistribution(
+                                    "dag_consensus_proposal_affinity",
+                                    proposalAffinity(allProposalHashes, proposalInfo.hash)
                                   )
-                                )
-                              val effect = Signature.fromHash(keyPair.getPrivate, majorityArtifactInfo.hash).flatMap { signature =>
-                                gossip.spread(ConsensusPeerDeclaration(state.key, MajoritySignature(signature, facilitatorsHash)))
-                              } >> Metrics[F].recordDistribution(
-                                "dag_consensus_proposal_affinity",
-                                proposalAffinity(allProposalHashes, proposalInfo.hash)
-                              )
-                              (newState, effect).pure[F]
+                                  (newState, effect).pure[F]
+                                }
+                              }
                             }
                           }
-                        }
+
                       }
                 case CollectingSignatures(majorityArtifactInfo, majorityTrigger, candidates, ownFacilitatorsHash) =>
                   val maybeAllSignatures =

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
@@ -9,19 +9,18 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 
-import io.constellationnetwork.currency.l0.snapshot.storage.LastSynchronizedGlobalSnapshotStorage
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer, SizeCalculator}
 import io.constellationnetwork.node.shared.config.types.SnapshotSizeConfig
-import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSnapshotStorage, SnapshotStorage}
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSyncGlobalSnapshotStorage, SnapshotStorage}
 import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
 import io.constellationnetwork.node.shared.infrastructure.snapshot.DataApplicationSnapshotAcceptanceManager
 import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotArtifact
 import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
-import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.signature.Signed
@@ -54,8 +53,7 @@ object StateChannelSnapshotService {
   def make[F[_]: Async: JsonSerializer: SecurityProvider](
     keyPair: KeyPair,
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
-    lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
-      with LastSynchronizedGlobalSnapshotStorage[F],
+    lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
     jsonBrotliBinarySerializer: JsonBrotliBinarySerializer[F],
     dataApplicationSnapshotAcceptanceManager: Option[DataApplicationSnapshotAcceptanceManager[F]],
     stateChannelBinarySender: StateChannelBinarySender[F],

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -132,10 +132,12 @@ abstract class CurrencyL1App(
         )
       jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[IO].asResource
       snapshotProcessor = CurrencySnapshotProcessor.make(
+        sharedConfig.lastGlobalSnapshotsSync,
         method.identifier,
         storages.address,
         storages.block,
         storages.lastGlobalSnapshot,
+        storages.lastNGlobalSnapshot,
         storages.lastSnapshot,
         storages.transaction,
         sharedServices.globalSnapshotContextFns,
@@ -283,10 +285,12 @@ abstract class CurrencyL1App(
         }.getOrElse {
           Swap
             .run[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, Run](
+              sharedConfig,
               cfg.swap,
               storages.cluster,
               storages.l0Cluster,
               storages.lastGlobalSnapshot,
+              storages.lastNGlobalSnapshot,
               storages.node,
               p2pClient.l0BlockOutputClient,
               p2pClient.swapConsensusClient,
@@ -300,10 +304,12 @@ abstract class CurrencyL1App(
             )
             .merge {
               TokenLock.run[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, Run](
+                sharedConfig,
                 cfg.tokenLock,
                 storages.cluster,
                 storages.l0Cluster,
                 storages.lastGlobalSnapshot,
+                storages.lastNGlobalSnapshot,
                 storages.node,
                 p2pClient.l0BlockOutputClient,
                 p2pClient.tokenLockConsensusClient,

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/Swap.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/Swap.scala
@@ -15,10 +15,11 @@ import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnap
 import io.constellationnetwork.currency.swap.ConsensusInput.OwnerConsensusInput
 import io.constellationnetwork.currency.swap.{ConsensusInput, ConsensusOutput}
 import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient
+import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage}
 import io.constellationnetwork.node.shared.domain.consensus.config.SwapConsensusConfig
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
-import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockStorage
 import io.constellationnetwork.node.shared.domain.swap.consensus.Validator._
 import io.constellationnetwork.node.shared.domain.swap.consensus.{ConsensusClient, ConsensusState, Engine}
@@ -32,10 +33,12 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object Swap {
   def run[F[_]: Async: Random: Hasher: SecurityProvider](
+    sharedCfg: SharedConfig,
     swapConsensusCfg: SwapConsensusConfig,
     clusterStorage: ClusterStorage[F],
     l0ClusterStorage: L0ClusterStorage[F],
     lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    lastNGlobalSnapshotStorage: LastNGlobalSnapshotStorage[F],
     nodeStorage: NodeStorage[F],
     blockOutputClient: L0BlockOutputClient[F],
     consensusClient: ConsensusClient[F],
@@ -61,9 +64,11 @@ object Swap {
         .awakeEvery(5.seconds)
         .evalFilter { _ =>
           canStartOwnSwapConsensus(
+            sharedCfg.lastGlobalSnapshotsSync,
             nodeStorage,
             clusterStorage,
             lastGlobalSnapshot,
+            lastNGlobalSnapshotStorage,
             swapConsensusCfg.peersCount,
             allowSpendStorage
           ).handleErrorWith { e =>

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
@@ -55,7 +55,8 @@ object method {
       c.lastKryoHashOrdinal,
       c.addresses,
       c.allowSpends,
-      c.tokenLocks
+      c.tokenLocks,
+      c.lastGlobalSnapshotsSync
     )
   }
 

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
@@ -17,7 +17,7 @@ import io.constellationnetwork.node.shared.domain.swap.{AllowSpendStorage, Conte
 import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockStorage
 import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockStorage}
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
-import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.modules.SharedStorages
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.peer.L0Peer
@@ -51,6 +51,8 @@ object Storages {
       globalL0ClusterStorage <- L0ClusterStorage.make[F](globalL0Peer)
       lastCurrencySnapshotStorage <- LastSnapshotStorage.make[F, S, SI]
       lastGlobalSnapshotStorage <- LastSnapshotStorage.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+      lastNGlobalSnapshotStorage <- LastNGlobalSnapshotStorage.make[F]
+
       transactionStorage <- TransactionReference.emptyCurrency(currencyIdentifier).flatMap {
         TransactionStorage.make[F](_, contextualTransactionValidator)
       }
@@ -81,6 +83,7 @@ object Storages {
         val allowSpendBlock = allowSpendBlockStorage
         val tokenLock = tokenLockStorage
         val tokenLockBlock = tokenLockBlockStorage
+        val lastNGlobalSnapshot = lastNGlobalSnapshotStorage
       }
 }
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
@@ -77,6 +77,7 @@ object Main
         .asResource
       services <- Services
         .make[IO, Run](
+          sharedConfig,
           sharedServices,
           queues,
           storages,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -132,8 +132,10 @@ object Download {
             } >>
             HasherSelector[F]
               .forOrdinal(snapshot.ordinal) { implicit hasher =>
-                globalSnapshotContextFns
-                  .createContext(lastContext, lastSnapshot, snapshot)
+                lastSnapshot.toHashed.flatMap { hashedLastSnapshot =>
+                  globalSnapshotContextFns
+                    .createContext(lastContext, lastSnapshot, snapshot, List(hashedLastSnapshot).some)
+                }
               }
               .handleErrorWith(_ => InvalidChain.raiseError[F, GlobalSnapshotContext])
               .flatTap { _ =>
@@ -240,8 +242,10 @@ object Download {
               case Some(snapshot) =>
                 HasherSelector[F]
                   .forOrdinal(snapshot.ordinal) { implicit hasher =>
-                    globalSnapshotContextFns
-                      .createContext(context, lastSnapshot, snapshot)
+                    lastSnapshot.toHashed.flatMap { hashedLastSnapshot =>
+                      globalSnapshotContextFns
+                        .createContext(context, lastSnapshot, snapshot, List(hashedLastSnapshot).some)
+                    }
                   }
                   .flatTap(newContext =>
                     hasherSelector

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -17,6 +17,7 @@ import io.constellationnetwork.dag.l0.infrastructure.snapshot.schema.{GlobalCons
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.cli.CliMethod
+import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.cluster.services.Session
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.domain.gossip.Gossip
@@ -48,6 +49,7 @@ import org.http4s.client.Client
 object GlobalSnapshotConsensus {
 
   def make[F[_]: Async: Random: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Metrics: Supervisor, R <: CliMethod](
+    sharedCfg: SharedConfig,
     gossip: Gossip[F],
     selfId: PeerId,
     keyPair: KeyPair,
@@ -111,6 +113,7 @@ object GlobalSnapshotConsensus {
       )
       consensusStateAdvancer = GlobalSnapshotConsensusStateAdvancer
         .make[F](
+          sharedCfg.lastGlobalSnapshotsSync,
           keyPair,
           consensusStorage,
           globalSnapshotStorage,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
@@ -110,7 +110,9 @@ object GlobalSnapshotTraverse {
             case ((lastCtx, lastInc), hash) =>
               loadIncOrErr(hash).flatMap { inc =>
                 HasherSelector[F].forOrdinal(inc.ordinal) { implicit hasher =>
-                  contextFns.createContext(lastCtx, lastInc, inc).map(_ -> inc)
+                  lastInc.toHashed.flatMap { lastIncHashed =>
+                    contextFns.createContext(lastCtx, lastInc, inc, List(lastIncHashed).some).map(_ -> inc)
+                  }
                 }
               }
           }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Services.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Services.scala
@@ -19,6 +19,7 @@ import io.constellationnetwork.dag.l0.infrastructure.trust.TrustStorageUpdater
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.cli.CliMethod
+import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.cluster.services.{Cluster, Session}
 import io.constellationnetwork.node.shared.domain.collateral.Collateral
 import io.constellationnetwork.node.shared.domain.gossip.Gossip
@@ -41,6 +42,7 @@ import org.http4s.client.Client
 object Services {
 
   def make[F[_]: Async: Random: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Metrics: Supervisor, R <: CliMethod](
+    sharedCfg: SharedConfig,
     sharedServices: SharedServices[F, R],
     queues: Queues[F],
     storages: Storages[F],
@@ -65,6 +67,7 @@ object Services {
 
       consensus <- GlobalSnapshotConsensus
         .make[F, R](
+          sharedCfg,
           sharedServices.gossip,
           selfId,
           keyPair,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -18,7 +18,7 @@ import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
-import io.constellationnetwork.node.shared.config.types.{AddressesConfig, SnapshotSizeConfig}
+import io.constellationnetwork.node.shared.config.types.{AddressesConfig, LastGlobalSnapshotsSyncConfig, SnapshotSizeConfig}
 import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
 import io.constellationnetwork.node.shared.domain.swap.block.{
   AllowSpendBlockAcceptanceLogic,
@@ -252,6 +252,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
         .make[IO](addressesConfig, None, None, Some(Map.empty[Address, NonEmptySet[PeerId]]), SortedMap.empty, Long.MaxValue, txHasher)
 
     val currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
+      LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
       BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
       TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
       AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
@@ -22,7 +22,9 @@ import fs2.Stream
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-class GlobalSnapshotAlignment[F[_]: Async: HasherSelector: SecurityProvider, P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P], R <: CliMethod](
+class GlobalSnapshotAlignment[F[_]: Async: HasherSelector: SecurityProvider, P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[
+  P
+], R <: CliMethod](
   services: Services[F, P, S, SI, R],
   programs: Programs[F, P, S, SI],
   storages: Storages[F, P, S, SI]

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -102,9 +102,11 @@ object Main
         Hasher.forKryo[IO]
       )
       snapshotProcessor = DAGSnapshotProcessor.make(
+        sharedConfig.lastGlobalSnapshotsSync,
         storages.address,
         storages.block,
         storages.lastSnapshot,
+        storages.lastNGlobalSnapshot,
         storages.transaction,
         storages.allowSpend,
         sharedServices.globalSnapshotContextFns,
@@ -162,10 +164,12 @@ object Main
 
       swapRuntime = hasherSelector.withCurrent { implicit hasher =>
         Swap.run(
+          sharedConfig,
           cfg.swap,
           storages.cluster,
           storages.l0Cluster,
           storages.lastSnapshot,
+          storages.lastNGlobalSnapshot,
           storages.node,
           p2pClient.l0BlockOutputClient,
           p2pClient.swapConsensusClient,
@@ -181,10 +185,12 @@ object Main
 
       tokenLockRuntime = hasherSelector.withCurrent { implicit hasher =>
         TokenLock.run(
+          sharedConfig,
           cfg.tokenLock,
           storages.cluster,
           storages.l0Cluster,
           storages.lastSnapshot,
+          storages.lastNGlobalSnapshot,
           storages.node,
           p2pClient.l0BlockOutputClient,
           p2pClient.tokenLockConsensusClient,

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
@@ -6,8 +6,9 @@ import cats.syntax.all._
 import io.constellationnetwork.dag.l1.domain.address.storage.AddressStorage
 import io.constellationnetwork.dag.l1.domain.block.BlockStorage
 import io.constellationnetwork.dag.l1.domain.transaction.TransactionStorage
+import io.constellationnetwork.node.shared.config.types.LastGlobalSnapshotsSyncConfig
 import io.constellationnetwork.node.shared.domain.snapshot.SnapshotContextFunctions
-import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.domain.swap.AllowSpendStorage
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, GlobalSnapshotStateProof}
 import io.constellationnetwork.security.signature.Signed
@@ -16,9 +17,11 @@ import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 object DAGSnapshotProcessor {
 
   def make[F[_]: Async: SecurityProvider](
+    lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
     addressStorage: AddressStorage[F],
     blockStorage: BlockStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    lastNGlobalSnapshotStorage: LastNGlobalSnapshotStorage[F],
     transactionStorage: TransactionStorage[F],
     allowSpendStorage: AllowSpendStorage[F],
     globalSnapshotContextFns: SnapshotContextFunctions[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
@@ -36,29 +39,40 @@ object DAGSnapshotProcessor {
 
       def process(
         snapshot: Either[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo), Hashed[GlobalIncrementalSnapshot]]
-      )(implicit hasher: Hasher[F]): F[SnapshotProcessingResult] =
-        checkAlignment(snapshot, blockStorage, lastGlobalSnapshotStorage, txHasher)
-          .flatMap(
-            processAlignment(
-              _,
-              blockStorage,
-              transactionStorage,
-              lastGlobalSnapshotStorage,
-              addressStorage
-            )
-          )
+      )(implicit hasher: Hasher[F]): F[SnapshotProcessingResult] = {
+        val snapshotOrdinal = snapshot match {
+          case Left((snapshot, _)) => snapshot.ordinal
+          case Right(value)        => value.ordinal
+        }
+        lastNGlobalSnapshotStorage
+          .getLastN(snapshotOrdinal, lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value)
+          .flatMap { lastGlobalSnapshots =>
+            checkAlignment(snapshot, blockStorage, lastGlobalSnapshotStorage, txHasher, lastGlobalSnapshots)
+              .flatMap(
+                processAlignment(
+                  _,
+                  blockStorage,
+                  transactionStorage,
+                  lastGlobalSnapshotStorage,
+                  addressStorage
+                )
+              )
+          }
+      }
 
       def applySnapshotFn(
         lastState: GlobalSnapshotInfo,
         lastSnapshot: Signed[GlobalIncrementalSnapshot],
-        snapshot: Signed[GlobalIncrementalSnapshot]
-      )(implicit hasher: Hasher[F]): F[GlobalSnapshotInfo] = applyGlobalSnapshotFn(lastState, lastSnapshot, snapshot)
+        snapshot: Signed[GlobalIncrementalSnapshot],
+        lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
+      )(implicit hasher: Hasher[F]): F[GlobalSnapshotInfo] = applyGlobalSnapshotFn(lastState, lastSnapshot, snapshot, lastGlobalSnapshots)
 
       def applyGlobalSnapshotFn(
         lastGlobalState: GlobalSnapshotInfo,
         lastGlobalSnapshot: Signed[GlobalIncrementalSnapshot],
-        globalSnapshot: Signed[GlobalIncrementalSnapshot]
+        globalSnapshot: Signed[GlobalIncrementalSnapshot],
+        lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
       )(implicit hasher: Hasher[F]): F[GlobalSnapshotInfo] =
-        globalSnapshotContextFns.createContext(lastGlobalState, lastGlobalSnapshot, globalSnapshot)
+        globalSnapshotContextFns.createContext(lastGlobalState, lastGlobalSnapshot, globalSnapshot, lastGlobalSnapshots)
     }
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
@@ -13,14 +13,14 @@ import io.constellationnetwork.dag.l1.infrastructure.address.storage.AddressStor
 import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage, SessionStorage}
 import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
-import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockStorage
 import io.constellationnetwork.node.shared.domain.swap.{AllowSpendStorage, ContextualAllowSpendValidator}
 import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockStorage
 import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLockValidator, TokenLockStorage}
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.gossip.RumorStorage
-import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.modules.SharedStorages
 import io.constellationnetwork.schema.peer.L0Peer
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
@@ -42,6 +42,7 @@ object Storages {
       consensusStorage <- ConsensusStorage.make[F]
       l0ClusterStorage <- L0ClusterStorage.make[F](l0Peer)
       lastSnapshotStorage <- LastSnapshotStorage.make[F, S, SI]
+      lastNGlobalSnapshotStorage <- LastNGlobalSnapshotStorage.make[F]
       transactionStorage <- TransactionStorage.make[F](TransactionReference.empty, contextualTransactionValidator)
       addressStorage <- AddressStorage.make[F]
       allowSpendStorage <- AllowSpendStorage.make[F](AllowSpendReference.empty, contextualAllowSpendValidator)
@@ -56,6 +57,7 @@ object Storages {
         val cluster = sharedStorages.cluster
         val l0Cluster = l0ClusterStorage
         val lastSnapshot = lastSnapshotStorage
+        val lastNGlobalSnapshot = lastNGlobalSnapshotStorage
         val node = sharedStorages.node
         val session = sharedStorages.session
         val rumor = sharedStorages.rumor
@@ -74,6 +76,7 @@ trait Storages[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]] {
   val cluster: ClusterStorage[F]
   val l0Cluster: L0ClusterStorage[F]
   val lastSnapshot: LastSnapshotStorage[F, S, SI] with LatestBalances[F]
+  val lastNGlobalSnapshot: LastNGlobalSnapshotStorage[F]
   val node: NodeStorage[F]
   val session: SessionStorage[F]
   val rumor: RumorStorage[F]

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -118,3 +118,8 @@ allow-spends {
 token-locks {
   min-epoch-progresses-to-lock: 1
 }
+
+last-global-snapshots-sync {
+  sync-offset: 2
+  min-global-snapshots-to-participate-consensus: 10
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
@@ -62,7 +62,8 @@ trait CliMethod {
     c.lastKryoHashOrdinal,
     c.addresses,
     c.allowSpends,
-    c.tokenLocks
+    c.tokenLocks,
+    c.lastGlobalSnapshotsSync
   )
 
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -14,7 +14,7 @@ import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.PeerId
 
 import com.comcast.ip4s.{Host, Port}
-import eu.timepit.refined.types.numeric.{NonNegLong, _}
+import eu.timepit.refined.types.numeric._
 import fs2.io.file.Path
 
 object types {
@@ -32,7 +32,8 @@ object types {
     lastKryoHashOrdinal: Map[AppEnvironment, SnapshotOrdinal],
     addresses: AddressesConfig,
     allowSpends: AllowSpendsConfig,
-    tokenLocks: TokenLocksConfig
+    tokenLocks: TokenLocksConfig,
+    lastGlobalSnapshotsSync: LastGlobalSnapshotsSyncConfig
   )
 
   case class SharedConfig(
@@ -50,7 +51,8 @@ object types {
     lastKryoHashOrdinal: Map[AppEnvironment, SnapshotOrdinal],
     addresses: AddressesConfig,
     allowSpends: AllowSpendsConfig,
-    tokenLocks: TokenLocksConfig
+    tokenLocks: TokenLocksConfig,
+    lastGlobalSnapshotsSync: LastGlobalSnapshotsSyncConfig
   )
 
   case class SharedTrustConfig(
@@ -155,4 +157,6 @@ object types {
   case class AllowSpendsConfig(lastValidEpochProgress: MinMax)
 
   case class TokenLocksConfig(minEpochProgressesToLock: NonNegLong)
+
+  case class LastGlobalSnapshotsSyncConfig(syncOffset: NonNegLong, minGlobalSnapshotsToParticipateConsensus: PosInt)
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/consensus/ConsensusFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/consensus/ConsensusFunctions.scala
@@ -4,9 +4,10 @@ import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.node.shared.domain.consensus.ConsensusFunctions.InvalidArtifact
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
+import io.constellationnetwork.schema.GlobalIncrementalSnapshot
 import io.constellationnetwork.schema.peer.PeerId
-import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher}
 
 trait ConsensusFunctions[F[_], Event, Key, Artifact, Context] {
 
@@ -19,7 +20,8 @@ trait ConsensusFunctions[F[_], Event, Key, Artifact, Context] {
     lastContext: Context,
     trigger: ConsensusTrigger,
     artifact: Artifact,
-    facilitators: Set[PeerId]
+    facilitators: Set[PeerId],
+    lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit hasher: Hasher[F]): F[Either[InvalidArtifact, (Artifact, Context)]]
 
   def createProposalArtifact(
@@ -29,7 +31,8 @@ trait ConsensusFunctions[F[_], Event, Key, Artifact, Context] {
     lastArtifactHasher: Hasher[F],
     trigger: ConsensusTrigger,
     events: Set[Event],
-    facilitators: Set[PeerId]
+    facilitators: Set[PeerId],
+    lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit hasher: Hasher[F]): F[(Artifact, Context, Set[Event])]
 }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/SnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/SnapshotContextFunctions.scala
@@ -1,12 +1,14 @@
 package io.constellationnetwork.node.shared.domain.snapshot
 
-import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.schema.GlobalIncrementalSnapshot
 import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher}
 
 trait SnapshotContextFunctions[F[_], Artifact, Context] {
   def createContext(
     context: Context,
     lastArtifact: Signed[Artifact],
-    signedArtifact: Signed[Artifact]
+    signedArtifact: Signed[Artifact],
+    lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit hasher: Hasher[F]): F[Context]
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/LastNGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/LastNGlobalSnapshotStorage.scala
@@ -1,0 +1,8 @@
+package io.constellationnetwork.node.shared.domain.snapshot.storage
+
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
+import io.constellationnetwork.security.Hashed
+
+trait LastNGlobalSnapshotStorage[F[_]] extends LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
+  def getLastN(ordinal: SnapshotOrdinal, n: Int): F[Option[List[Hashed[GlobalIncrementalSnapshot]]]]
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/LastSyncGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/LastSyncGlobalSnapshotStorage.scala
@@ -1,0 +1,10 @@
+package io.constellationnetwork.node.shared.domain.snapshot.storage
+
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.security.Hashed
+
+trait LastSyncGlobalSnapshotStorage[F[_]] extends LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
+  def getLastSynchronizedCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
+  def getLastNSynchronized(n: Int): F[Option[List[Hashed[GlobalIncrementalSnapshot]]]]
+  def deleteOlderThanSynchronized(): F[Unit]
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/SnapshotStorage.scala
@@ -14,6 +14,7 @@ trait SnapshotStorage[F[_], S <: Snapshot, State] {
   def headSnapshot: F[Option[Signed[S]]]
 
   def get(ordinal: SnapshotOrdinal): F[Option[Signed[S]]]
+  def getLastN(ordinal: SnapshotOrdinal, n: Int): F[Option[List[Signed[S]]]]
 
   def get(hash: Hash): F[Option[Signed[S]]]
   def getHash(ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[Option[Hash]]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/consensus/Validator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/consensus/Validator.scala
@@ -5,13 +5,14 @@ import cats.effect.kernel.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.swap.ConsensusInput
+import io.constellationnetwork.node.shared.config.types.LastGlobalSnapshotsSyncConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
-import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.domain.swap.AllowSpendStorage
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.PeerId
-import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, SecurityProvider}
 
@@ -27,6 +28,20 @@ object Validator {
     lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
   ): F[Boolean] =
     lastGlobalSnapshot.getOrdinal.map(_.isDefined)
+
+  def currentNLastGlobalSnapshotsPresent[F[_]: Async](
+    lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
+    lastGlobalSnapshotOrdinal: SnapshotOrdinal,
+    lastNGlobalSnapshot: LastNGlobalSnapshotStorage[F]
+  ): F[Long] = {
+    val minGlobalSnapshotsToParticipateConsensus = lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
+    lastNGlobalSnapshot
+      .getLastN(lastGlobalSnapshotOrdinal, minGlobalSnapshotsToParticipateConsensus)
+      .flatMap {
+        case Some(snapshots) => snapshots.length.toLong.pure
+        case None            => 0L.pure
+      }
+  }
 
   private def enoughPeersForConsensus[F[_]: Async](
     clusterStorage: ClusterStorage[F],
@@ -49,9 +64,11 @@ object Validator {
   ): F[Boolean] = allowSpendStorage.areWaiting
 
   def canStartOwnSwapConsensus[F[_]: Async](
+    lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
     nodeStorage: NodeStorage[F],
     clusterStorage: ClusterStorage[F],
     lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    lastNGlobalSnapshot: LastNGlobalSnapshotStorage[F],
     peersCount: PosInt,
     allowSpendStorage: AllowSpendStorage[F]
   ): F[Boolean] =
@@ -59,15 +76,27 @@ object Validator {
       stateReadyForConsensus <- nodeStorage.getNodeState.map(isReadyForConsensus)
       enoughPeers <- enoughPeersForConsensus(clusterStorage, peersCount)
       lastGlobalSnapshotPresent <- isLastGlobalSnapshotPresent(lastGlobalSnapshot)
+      lastNGlobalSnapshotPresent <-
+        if (lastGlobalSnapshotPresent) {
+          lastGlobalSnapshot.get.flatMap(lastSnapshot =>
+            currentNLastGlobalSnapshotsPresent(lastGlobalSnapshotsSyncConfig, lastSnapshot.get.ordinal, lastNGlobalSnapshot)
+          )
+        } else {
+          0L.pure
+        }
       enoughTxs <- atLeastOneAllowSpend(allowSpendStorage)
-
-      res = stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent && enoughTxs
+      minGlobalSnapshotsToParticipateConsensus = lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
+      res =
+        stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent && enoughTxs && lastNGlobalSnapshotPresent >= lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
       _ <-
         Applicative[F].whenA(!res) {
           val reason = Seq(
             if (!stateReadyForConsensus) "State not ready for consensus" else "",
             if (!enoughPeers) "Not enough peers" else "",
             if (!lastGlobalSnapshotPresent) "No global snapshot" else "",
+            if (lastNGlobalSnapshotPresent < lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value)
+              s"No enough last N global snapshots present ($lastNGlobalSnapshotPresent/$minGlobalSnapshotsToParticipateConsensus)"
+            else "",
             if (!enoughTxs) "No allow spends" else ""
           ).filter(_.nonEmpty).mkString(", ")
           logger.debug(s"Cannot start swap own consensus: ${reason}")

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Validator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/consensus/Validator.scala
@@ -5,13 +5,14 @@ import cats.effect.kernel.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.tokenlock.ConsensusInput
+import io.constellationnetwork.node.shared.config.types.LastGlobalSnapshotsSyncConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
-import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockStorage
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.PeerId
-import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, SecurityProvider}
 
@@ -28,6 +29,19 @@ object Validator {
   ): F[Boolean] =
     lastGlobalSnapshot.getOrdinal.map(_.isDefined)
 
+  def currentNLastGlobalSnapshotsPresent[F[_]: Async](
+    lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
+    lastGlobalSnapshotOrdinal: SnapshotOrdinal,
+    lastNGlobalSnapshot: LastNGlobalSnapshotStorage[F]
+  ): F[Long] = {
+    val minGlobalSnapshotsToParticipateConsensus = lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
+    lastNGlobalSnapshot
+      .getLastN(lastGlobalSnapshotOrdinal, minGlobalSnapshotsToParticipateConsensus.toInt)
+      .flatMap {
+        case Some(snapshots) => snapshots.length.toLong.pure
+        case None            => 0L.pure
+      }
+  }
   private def enoughPeersForConsensus[F[_]: Async](
     clusterStorage: ClusterStorage[F],
     peersCount: PosInt
@@ -49,9 +63,11 @@ object Validator {
   ): F[Boolean] = tokenLockStorage.areWaiting
 
   def canStartOwnTokenLockConsensus[F[_]: Async](
+    lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
     nodeStorage: NodeStorage[F],
     clusterStorage: ClusterStorage[F],
     lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    lastNGlobalSnapshot: LastNGlobalSnapshotStorage[F],
     peersCount: PosInt,
     tokenLockStorage: TokenLockStorage[F]
   ): F[Boolean] =
@@ -59,15 +75,28 @@ object Validator {
       stateReadyForConsensus <- nodeStorage.getNodeState.map(isReadyForConsensus)
       enoughPeers <- enoughPeersForConsensus(clusterStorage, peersCount)
       lastGlobalSnapshotPresent <- isLastGlobalSnapshotPresent(lastGlobalSnapshot)
+      lastNGlobalSnapshotPresent <-
+        if (lastGlobalSnapshotPresent) {
+          lastGlobalSnapshot.get.flatMap(lastSnapshot =>
+            currentNLastGlobalSnapshotsPresent(lastGlobalSnapshotsSyncConfig, lastSnapshot.get.ordinal, lastNGlobalSnapshot)
+          )
+        } else {
+          0L.pure
+        }
       enoughTokenLocks <- atLeastOneTokenLock(tokenLockStorage)
+      minGlobalSnapshotsToParticipateConsensus = lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
 
-      res = stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent && enoughTokenLocks
+      res =
+        stateReadyForConsensus && enoughPeers && lastGlobalSnapshotPresent && enoughTokenLocks && lastNGlobalSnapshotPresent >= lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value
       _ <-
         Applicative[F].whenA(!res) {
           val reason = Seq(
             if (!stateReadyForConsensus) "State not ready for consensus" else "",
             if (!enoughPeers) "Not enough peers" else "",
             if (!lastGlobalSnapshotPresent) "No global snapshot" else "",
+            if (lastNGlobalSnapshotPresent < lastGlobalSnapshotsSyncConfig.minGlobalSnapshotsToParticipateConsensus.value)
+              s"No enough last N global snapshots present ($lastNGlobalSnapshotPresent/$minGlobalSnapshotsToParticipateConsensus)"
+            else "",
             if (!enoughTokenLocks) "No token locks" else ""
           ).filter(_.nonEmpty).mkString(", ")
           logger.debug(s"Cannot start token lock own consensus: ${reason}")

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotContextFunctions.scala
@@ -13,8 +13,9 @@ import scala.util.control.NoStackTrace
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotContext}
 import io.constellationnetwork.merkletree.StateProofValidator
 import io.constellationnetwork.node.shared.domain.snapshot.SnapshotContextFunctions
-import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.schema.GlobalIncrementalSnapshot
 import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher}
 
 import derevo.cats.{eqv, show}
 import derevo.derive
@@ -29,9 +30,10 @@ object CurrencySnapshotContextFunctions {
       def createContext(
         context: CurrencySnapshotContext,
         lastArtifact: Signed[CurrencyIncrementalSnapshot],
-        signedArtifact: Signed[CurrencyIncrementalSnapshot]
+        signedArtifact: Signed[CurrencyIncrementalSnapshot],
+        lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
       )(implicit hasher: Hasher[F]): F[CurrencySnapshotContext] = for {
-        validatedS <- validator.validateSignedSnapshot(lastArtifact, context, signedArtifact)
+        validatedS <- validator.validateSignedSnapshot(lastArtifact, context, signedArtifact, lastGlobalSnapshots)
         validatedContext <- validatedS match {
           case Validated.Valid((_, validatedContext)) => validatedContext.pure[F]
           case Validated.Invalid(e)                   => CannotCreateContext(e).raiseError[F, CurrencySnapshotContext]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/SnapshotConsensusFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/SnapshotConsensusFunctions.scala
@@ -28,7 +28,7 @@ import io.constellationnetwork.schema.height.{Height, SubHeight}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.snapshot.Snapshot
 import io.constellationnetwork.security.signature.Signed
-import io.constellationnetwork.security.{Hasher, SecurityProvider}
+import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 import io.constellationnetwork.syntax.sortedCollection._
 
 import eu.timepit.refined.auto._
@@ -64,7 +64,8 @@ abstract class SnapshotConsensusFunctions[
     lastContext: Context,
     trigger: ConsensusTrigger,
     artifact: Artifact,
-    facilitators: Set[PeerId]
+    facilitators: Set[PeerId],
+    lastGlobalSnapshots: Option[List[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit hasher: Hasher[F]): F[Either[InvalidArtifact, (Artifact, Context)]]
 
   protected def getUpdatedTips(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
@@ -1,0 +1,92 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot.storage
+
+import cats.effect.kernel.Async
+import cats.implicits.{catsSyntaxFlatten, toTraverseOps}
+import cats.syntax.functor._
+import cats.{Applicative, MonadThrow}
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
+import io.constellationnetwork.node.shared.domain.snapshot.Validator.isNextSnapshot
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastNGlobalSnapshotStorage
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.height.Height
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
+import io.constellationnetwork.security.Hashed
+
+import fs2.Stream
+import fs2.concurrent.SignallingRef
+
+object LastNGlobalSnapshotStorage {
+
+  def make[F[_]: Async]: F[LastNGlobalSnapshotStorage[F] with LatestBalances[F]] =
+    SignallingRef.of[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty).map(make(_))
+
+  def make[F[_]: Async](
+    snapshotsR: SignallingRef[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
+  ): LastNGlobalSnapshotStorage[F] with LatestBalances[F] =
+    new LastNGlobalSnapshotStorage[F] with LatestBalances[F] {
+
+      def set(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+        snapshotsR.modify { snapshots =>
+          snapshots.lastOption match {
+            case Some((_, (latest, _))) if isNextSnapshot(latest, snapshot.signed.value) =>
+              (snapshots.updated(snapshot.ordinal, (snapshot, state)), Applicative[F].unit)
+            case _ => (snapshots, MonadThrow[F].raiseError[Unit](new Throwable("Failure during putting new global snapshot!")))
+          }
+        }.flatten
+
+      def setInitial(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+        snapshotsR.modify { snapshots =>
+          if (snapshots.nonEmpty) {
+            (snapshots, MonadThrow[F].raiseError[Unit](new Throwable(s"Failure putting initial snapshot! Storage non empty.")))
+          } else {
+            (snapshots.updated(snapshot.ordinal, (snapshot, state)), Applicative[F].unit)
+          }
+        }.flatten
+
+      def get: F[Option[Hashed[GlobalIncrementalSnapshot]]] = getCombined.map(_.map { case (snapshot, _) => snapshot })
+
+      def get(ordinal: SnapshotOrdinal): F[Option[Hashed[GlobalIncrementalSnapshot]]] =
+        snapshotsR.get.map(_.get(ordinal).map { case (snapshot, _) => snapshot })
+
+      def getCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = snapshotsR.get.map {
+        _.lastOption.map { case (_, combined) => combined }
+      }
+
+      def getCombinedStream: fs2.Stream[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
+        Stream
+          .eval[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](getCombined)
+          .merge(snapshotsR.discrete.map(_.lastOption.map { case (_, combined) => combined }))
+
+      def getOrdinal: F[Option[SnapshotOrdinal]] =
+        get.map(_.map(_.ordinal))
+
+      def getHeight: F[Option[Height]] =
+        get.map(_.map(_.height))
+
+      def getLatestBalances: F[Option[Map[Address, Balance]]] =
+        snapshotsR.get.map(_.headOption.map(_._2._2.balances.toMap))
+
+      def getLatestBalancesStream: Stream[F, Map[Address, Balance]] =
+        snapshotsR.discrete
+          .evalMap(snapshotMap => Async[F].pure(snapshotMap.headOption.map(_._2)))
+          .collect { case Some(snapshot) => snapshot }
+          .map(_._2.balances)
+
+      def getLastN(ordinal: SnapshotOrdinal, n: Int): F[Option[List[Hashed[GlobalIncrementalSnapshot]]]] = {
+        val ordinalsToFetch = (0 until n)
+          .flatMap(i => SnapshotOrdinal(ordinal.value.value - i))
+          .toList
+
+        ordinalsToFetch.traverse(get).map { results =>
+          val snapshots = results.flatten
+
+          if (snapshots.isEmpty) None
+          else Some(snapshots)
+        }
+      }
+    }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastSentGlobalSnapshotSyncStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastSentGlobalSnapshotSyncStorage.scala
@@ -1,4 +1,4 @@
-package io.constellationnetwork.currency.l0.snapshot.storage
+package io.constellationnetwork.node.shared.infrastructure.snapshot.storage
 
 import cats.effect.Ref
 import cats.effect.kernel.Async

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
@@ -210,6 +210,19 @@ object SnapshotStorage {
             case None       => snapshotLocalFileSystemStorage.read(ordinal)
           }
 
+        def getLastN(ordinal: SnapshotOrdinal, n: Int): F[Option[List[Signed[S]]]] = {
+          val ordinalsToFetch = (0 until n)
+            .flatMap(i => SnapshotOrdinal(ordinal.value.value - i))
+            .toList
+
+          ordinalsToFetch.traverse(get).map { results =>
+            val snapshots = results.flatten
+
+            if (snapshots.isEmpty) None
+            else Some(snapshots)
+          }
+        }
+
         def get(hash: Hash): F[Option[Signed[S]]] =
           hashCache(hash).get.flatMap {
             case Some(s) => s.some.pure[F]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -79,6 +79,7 @@ object SharedServices {
       localHealthcheck <- LocalHealthcheck.make[F](nodeClient, storages.cluster)
       gossip <- HasherSelector[F].withCurrent(implicit hasher => Gossip.make[F](queues.rumor, nodeId, generation, keyPair))
       currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
+        cfg.lastGlobalSnapshotsSync,
         BlockAcceptanceManager.make[F](validators.currencyBlockValidator, txHasher),
         TokenLockBlockAcceptanceManager.make[F](validators.tokenLockBlockValidator),
         AllowSpendBlockAcceptanceManager.make[F](validators.allowSpendBlockValidator),

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -32,4 +32,9 @@ object artifact {
     currencyId: Option[CurrencyId],
     address: Address
   ) extends SharedArtifact
+
+  @derive(decoder, encoder, order, ordering, show)
+  case class AllowSpendExpiration(
+    allowSpendRef: Hash
+  ) extends SharedArtifact
 }


### PR DESCRIPTION
### Changes
* Added allow-spend eviction logic.
* An allow-spend should be evicted when its epoch progress expires or when a spend transaction is associated with it.
* If evicted due to expiration, a SharedArtifact expiration event should be emitted, and the full balance should be returned to the user.
* If evicted due to a spend transaction, only the remaining unspent balance (the difference between the allow-spend amount and the spend transaction amount) should be returned to the user.