### PR TITLE
feat: adding brotli serialization for fee transactions

### DIFF
--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/DataApplication.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/DataApplication.scala
@@ -18,6 +18,7 @@ import io.constellationnetwork.currency.l1.modules.{Queues, Services}
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.dag.l1.domain.consensus.block.config.DataConsensusConfig
 import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage}
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
@@ -30,7 +31,7 @@ import io.circe.Encoder
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object DataApplication {
-  def run[F[_]: Async: Random: Hasher: SecurityProvider: L1NodeContext](
+  def run[F[_]: Async: Random: Hasher: JsonSerializer: SecurityProvider: L1NodeContext](
     dataConsensusCfg: DataConsensusConfig,
     clusterStorage: ClusterStorage[F],
     l0ClusterStorage: L0ClusterStorage[F],

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -19,6 +19,7 @@ import io.constellationnetwork.currency.validations.DataTransactionsValidator.va
 import io.constellationnetwork.dag.l1.domain.consensus.block.config.DataConsensusConfig
 import io.constellationnetwork.effects.GenUUID
 import io.constellationnetwork.fsm.FSM
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.domain.queue.ViewableQueue
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
@@ -86,7 +87,7 @@ object Engine {
   type Out = ConsensusOutput
   type State = ConsensusState
 
-  def fsm[F[_]: Async: Random: SecurityProvider: Hasher](
+  def fsm[F[_]: Async: Random: SecurityProvider: Hasher: JsonSerializer](
     dataConsensusCfg: DataConsensusConfig,
     dataApplication: BaseDataApplicationL1Service[F],
     clusterStorage: ClusterStorage[F],

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutes.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutes.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.currency.schema.EstimatedFee
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import io.constellationnetwork.currency.validations.DataTransactionsValidator.validateDataTransactionsL1
 import io.constellationnetwork.ext.http4s.error._
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.node.shared.domain.queue.ViewableQueue
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
@@ -31,7 +32,7 @@ import org.http4s.{HttpRoutes, Response}
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-final case class DataApplicationRoutes[F[_]: Async: Hasher: SecurityProvider](
+final case class DataApplicationRoutes[F[_]: Async: Hasher: JsonSerializer: SecurityProvider](
   dataApplicationPeerConsensusInput: Queue[F, Signed[ConsensusInput.PeerConsensusInput]],
   l0ClusterStorage: L0ClusterStorage[F],
   dataApplication: BaseDataApplicationL1Service[F],

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/HttpApi.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/HttpApi.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL1Se
 import io.constellationnetwork.currency.l1.http.{DataApplicationRoutes, TransactionRoutes}
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.dag.l1.http.{Routes => DAGRoutes}
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.cli.CliMethod
 import io.constellationnetwork.node.shared.config.types.HttpConfig
 import io.constellationnetwork.node.shared.http.p2p.middlewares.{PeerAuthMiddleware, `X-Id-Middleware`}
@@ -28,7 +29,7 @@ import org.http4s.{HttpApp, HttpRoutes}
 object HttpApi {
 
   def make[
-    F[_]: Async: HasherSelector: SecurityProvider: Metrics: Supervisor: L1NodeContext,
+    F[_]: Async: HasherSelector: JsonSerializer: SecurityProvider: Metrics: Supervisor: L1NodeContext,
     P <: StateProof,
     S <: Snapshot,
     SI <: SnapshotInfo[P],
@@ -79,7 +80,7 @@ object HttpApi {
 }
 
 sealed abstract class HttpApi[
-  F[_]: Async: HasherSelector: SecurityProvider: Metrics: Supervisor: L1NodeContext,
+  F[_]: Async: HasherSelector: JsonSerializer: SecurityProvider: Metrics: Supervisor: L1NodeContext,
   R <: CliMethod
 ] private (
   maybeDataApplication: Option[BaseDataApplicationL1Service[F]],

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
@@ -22,7 +22,9 @@ import fs2.Stream
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-class GlobalSnapshotAlignment[F[_]: Async: HasherSelector: SecurityProvider, P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P], R <: CliMethod](
+class GlobalSnapshotAlignment[F[_]: Async: HasherSelector: SecurityProvider, P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[
+  P
+], R <: CliMethod](
   services: Services[F, P, S, SI, R],
   programs: Programs[F, P, S, SI],
   storages: Storages[F, P, S, SI]

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -18,7 +18,7 @@ import io.constellationnetwork.currency.http.Codecs.{feeTransactionRequestDecode
 import io.constellationnetwork.currency.schema.EstimatedFee
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import io.constellationnetwork.ext.derevo.ordering
-import io.constellationnetwork.json.JsonBinarySerializer
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.routes.internal.ExternalUrlPrefix
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.{SharedArtifact, TokenUnlock}
@@ -71,7 +71,7 @@ object DataTransaction {
   def getHashes[F[_]: Async: Hasher](
     data: List[DataTransactions],
     serializeDataUpdate: DataUpdate => F[Array[Byte]]
-  ): F[List[NonEmptyList[hash.Hash]]] =
+  )(implicit jsonSerializer: JsonSerializer[F]): F[List[NonEmptyList[hash.Hash]]] =
     data.traverse { dataTransactions =>
       dataTransactions.toList.traverse { signedTransaction =>
         signedTransaction.value match {
@@ -104,8 +104,8 @@ case class FeeTransaction(
 ) extends DataTransaction
 
 object FeeTransaction {
-  def serialize[F[_]: Async](feeTransaction: FeeTransaction): F[Array[Byte]] =
-    Async[F].delay(JsonBinarySerializer.serialize(feeTransaction))
+  def serialize[F[_]: Async](feeTransaction: FeeTransaction)(implicit jsonSerializer: JsonSerializer[F]): F[Array[Byte]] =
+    jsonSerializer.serialize(feeTransaction)
 
   def getFeeTransactions(dataTransactions: List[DataTransactions]): List[Signed[FeeTransaction]] =
     collectTransactions(dataTransactions) {


### PR DESCRIPTION
### Changes
+ Changing the serializer of feeTxn to use the same as AllowSpends, TokenLocks, and CurrencyTxn. All these transactions use brotli, so I've added brotli to feeTxn as well, so we can have all in the same pattern