### PR TITLE
fix: adding new config fields-added-ordinals on config to read historical snapshots

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -61,7 +61,8 @@ object method {
       c.tokenLocks,
       c.lastGlobalSnapshotsSync,
       c.validationErrorStorage,
-      c.delegatedStaking
+      c.delegatedStaking,
+      c.fieldsAddedOrdinals
     )
   }
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -33,6 +33,7 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot._
 import io.constellationnetwork.node.shared.infrastructure.snapshot.services.AddressService
 import io.constellationnetwork.node.shared.modules.SharedServices
 import io.constellationnetwork.node.shared.snapshot.currency._
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.signature.SignedValidator
 import io.constellationnetwork.security.{Hasher, HasherSelector, SecurityProvider}
@@ -102,7 +103,7 @@ object Services {
       )
 
       validator = CurrencySnapshotValidator.make[F](
-        sharedCfg.environment,
+        SnapshotOrdinal.MinValue,
         creator,
         signedValidator,
         maybeRewards,

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
@@ -58,7 +58,8 @@ object method {
       c.tokenLocks,
       c.lastGlobalSnapshotsSync,
       c.validationErrorStorage,
-      c.delegatedStaking
+      c.delegatedStaking,
+      c.fieldsAddedOrdinals
     )
   }
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -84,6 +84,7 @@ object GlobalSnapshotConsensus {
       jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync
       feeCalculator = FeeCalculator.make(feeConfigs)
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
+        sharedCfg.fieldsAddedOrdinals.globalTokenLocks.getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue),
         BlockAcceptanceManager.make[F](validators.blockValidator, txHasher),
         AllowSpendBlockAcceptanceManager.make[F](validators.allowSpendBlockValidator),
         TokenLockBlockAcceptanceManager.make[F](validators.tokenLockBlockValidator),

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -235,7 +235,16 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
 
     val snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[IO] =
       GlobalSnapshotAcceptanceManager
-        .make[IO](bam, asbam, tlbam, scProcessor, updateNodeParametersAcceptanceManager, spendActionValidator, collateral)
+        .make[IO](
+          SnapshotOrdinal.MinValue,
+          bam,
+          asbam,
+          tlbam,
+          scProcessor,
+          updateNodeParametersAcceptanceManager,
+          spendActionValidator,
+          collateral
+        )
 
     val feeCalculator = new SnapshotBinaryFeeCalculator[IO] {
       override def calculateFee(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -107,7 +107,8 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
           currencyEventsCutter,
           validationErrorStorage
         )
-      currencySnapshotValidator = CurrencySnapshotValidator.make[IO](Dev, creator, validators.signedValidator, None, None)
+      currencySnapshotValidator = CurrencySnapshotValidator
+        .make[IO](SnapshotOrdinal.MinValue, creator, validators.signedValidator, None, None)
       currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
       manager = new GlobalSnapshotStateChannelAcceptanceManager[IO] {
         def accept(ordinal: SnapshotOrdinal, lastGlobalSnapshotInfo: GlobalSnapshotInfo, events: List[StateChannelOutput])(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -303,7 +303,8 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
             currencyEventsCutter,
             validationErrorStorage
           )
-      currencySnapshotValidator = CurrencySnapshotValidator.make[IO](Dev, currencySnapshotCreator, validators.signedValidator, None, None)
+      currencySnapshotValidator = CurrencySnapshotValidator
+        .make[IO](SnapshotOrdinal.MinValue, currencySnapshotCreator, validators.signedValidator, None, None)
 
       currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
       stateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L))
@@ -320,6 +321,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
       updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
+          SnapshotOrdinal.MinValue,
           blockAcceptanceManager,
           allowSpendBlockAcceptanceManager,
           tokenLockBlockAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -153,7 +153,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 validationErrorStorage
               )
             currencySnapshotValidator = CurrencySnapshotValidator
-              .make[IO](Dev, currencySnapshotCreator, validators.signedValidator, None, None)
+              .make[IO](SnapshotOrdinal.MinValue, currencySnapshotCreator, validators.signedValidator, None, None)
 
             currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
             globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L)).asResource
@@ -161,6 +161,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             feeCalculator = FeeCalculator.make(SortedMap.empty)
             updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
             globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
+              SnapshotOrdinal.MinValue,
               BlockAcceptanceManager.make[IO](validators.blockValidator, Hasher.forKryo[IO]),
               AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),
               TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -124,6 +124,21 @@ last-global-snapshots-sync {
   min-global-snapshots-to-participate-consensus: 10
 }
 
+fields-added-ordinals {
+  global-sync-view {
+    mainnet: 0,
+    testnet: 2538307,
+    integrationnet: 0,
+    dev: 0
+  }
+  global-token-locks {
+    mainnet: 0,
+    testnet: 2538307,
+    integrationnet: 0,
+    dev: 0
+  }
+}
+
 validation-error-storage {
   max-size = 10000
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
@@ -65,7 +65,8 @@ trait CliMethod {
     c.tokenLocks,
     c.lastGlobalSnapshotsSync,
     c.validationErrorStorage,
-    c.delegatedStaking
+    c.delegatedStaking,
+    c.fieldsAddedOrdinals
   )
 
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -19,6 +19,11 @@ import fs2.io.file.Path
 
 object types {
 
+  case class FieldsAddedOrdinals(
+    globalSyncView: Map[AppEnvironment, SnapshotOrdinal],
+    globalTokenLocks: Map[AppEnvironment, SnapshotOrdinal]
+  )
+
   case class SharedConfigReader(
     gossip: GossipConfig,
     leavingDelay: FiniteDuration,
@@ -35,7 +40,8 @@ object types {
     tokenLocks: TokenLocksConfig,
     lastGlobalSnapshotsSync: LastGlobalSnapshotsSyncConfig,
     validationErrorStorage: ValidationErrorStorageConfig,
-    delegatedStaking: DelegatedStakingConfig
+    delegatedStaking: DelegatedStakingConfig,
+    fieldsAddedOrdinals: FieldsAddedOrdinals
   )
 
   case class SharedConfig(
@@ -56,7 +62,8 @@ object types {
     tokenLocks: TokenLocksConfig,
     lastGlobalSnapshotsSync: LastGlobalSnapshotsSyncConfig,
     validationErrorStorage: ValidationErrorStorageConfig,
-    delegatedStaking: DelegatedStakingConfig
+    delegatedStaking: DelegatedStakingConfig,
+    fieldsAddedOrdinals: FieldsAddedOrdinals
   )
 
   case class SharedTrustConfig(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -318,7 +318,7 @@ object CurrencySnapshotAcceptanceManager {
         updatedAllowSpends.some,
         globalSnapshotSyncAcceptanceResult.contextUpdate.some,
         tokenLockRefs.some,
-        updatedActiveTokenLocks.some
+        if (updatedActiveTokenLocks.nonEmpty) Some(updatedActiveTokenLocks) else None
       )
 
       stateProof <- csi.stateProof(snapshotOrdinal)
@@ -332,15 +332,10 @@ object CurrencySnapshotAcceptanceManager {
         expiredTokenLocks
       )
 
-      globalSyncView = maybeLastGlobalSnapshot
-        .map(gs =>
-          GlobalSyncView(
-            gs.ordinal,
-            gs.hash,
-            gs.epochProgress
-          )
-        )
-        .getOrElse(GlobalSyncView.empty)
+      globalSyncView = maybeLastGlobalSnapshot match {
+        case Some(value) => GlobalSyncView(value.ordinal, value.hash, value.epochProgress)
+        case _           => GlobalSyncView.empty
+      }
     } yield
       CurrencySnapshotAcceptanceResult(
         acceptanceBlocksResult,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -28,6 +28,7 @@ import io.constellationnetwork.node.shared.infrastructure.healthcheck.LocalHealt
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
 import io.constellationnetwork.node.shared.infrastructure.snapshot._
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.generation.Generation
 import io.constellationnetwork.schema.peer.PeerId
@@ -92,7 +93,7 @@ object SharedServices {
       currencyEventsCutter = CurrencyEventsCutter.make[F](None)
 
       currencySnapshotValidator = CurrencySnapshotValidator.make[F](
-        environment,
+        cfg.fieldsAddedOrdinals.globalSyncView.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
         CurrencySnapshotCreator.make[F](
           currencySnapshotAcceptanceManager,
           None,
@@ -112,6 +113,7 @@ object SharedServices {
       jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync
       updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
       globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
+        cfg.fieldsAddedOrdinals.globalTokenLocks.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
         BlockAcceptanceManager.make[F](validators.blockValidator, txHasher),
         AllowSpendBlockAcceptanceManager.make[F](validators.allowSpendBlockValidator),
         TokenLockBlockAcceptanceManager.make[F](validators.tokenLockBlockValidator),


### PR DESCRIPTION
### Changes
+ The new globalSyncView will break for traversing historical snapshots when rolling back since we fetch the missing global snapshots directly from the peers. So, I'm disabling the validation of this field, such as we did with dataAppplication (I think?)