### PR TITLE
fix: fixing majority alignment of token locks and allow spends

### DIFF
--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -144,6 +144,8 @@ abstract class CurrencyL1App(
         sharedServices.currencySnapshotContextFns,
         jsonBrotliBinarySerializer,
         cfg.transactionLimit,
+        sharedConfig.allowSpends,
+        sharedConfig.tokenLocks,
         Hasher.forKryo[IO],
         storages.allowSpend,
         storages.tokenLock,

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
@@ -65,6 +65,8 @@ object DAGSnapshotProcessor {
                   _,
                   blockStorage,
                   transactionStorage,
+                  allowSpendStorage,
+                  tokenLockStorage,
                   lastGlobalSnapshotStorage,
                   addressStorage
                 )

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/consensus/Validator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/consensus/Validator.scala
@@ -67,7 +67,8 @@ object Validator {
           val reason = Seq(
             if (!stateReadyForConsensus) "State not ready for consensus" else "",
             if (!enoughPeers) "Not enough peers" else "",
-            if (!lastGlobalSnapshotPresent) "No global snapshot" else ""
+            if (!lastGlobalSnapshotPresent) "No global snapshot" else "",
+            if (!enoughTxs) "No allow spends" else ""
           ).filter(_.nonEmpty).mkString(", ")
           logger.debug(s"Cannot start swap own consensus: ${reason}")
         }


### PR DESCRIPTION
### Changes
+ During testing, I encountered a scenario where an allowSpend expired while holding the user’s full balance. Even after the balance was returned to the user, subsequent allowSpend transactions were blocked due to insufficient balance.
After investigating, I discovered that the function `advanceMajorityRefs` was never being called for allowSpends and token locks
I’ve fixed this issue, ensuring that balances are correctly restored and available for new transactions.