### PR TITLE
chore: add missing ordering instances and filter empty collections 

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
@@ -266,12 +266,12 @@ object CurrencySnapshotCreator {
             Option.when(currencySnapshotAcceptanceResult.info.lastMessages.nonEmpty)(
               currencySnapshotAcceptanceResult.messages.accepted.toSortedSet
             ),
-            currencySnapshotAcceptanceResult.globalSnapshotSync.accepted.toSortedSet.some,
+            currencySnapshotAcceptanceResult.globalSnapshotSync.accepted.toSortedSet.some.filter(_.nonEmpty),
             currencySnapshotAcceptanceResult.feeTransactions,
             currencySnapshotAcceptanceResult.sharedArtifacts.some,
-            currencySnapshotAcceptanceResult.allowSpendBlock.accepted.toSortedSet.some,
-            currencySnapshotAcceptanceResult.tokenLockBlock.accepted.toSortedSet.some,
-            currencySnapshotAcceptanceResult.globalSyncView.some
+            currencySnapshotAcceptanceResult.allowSpendBlock.accepted.toSortedSet.some.filter(_.nonEmpty),
+            currencySnapshotAcceptanceResult.tokenLockBlock.accepted.toSortedSet.some.filter(_.nonEmpty),
+            currencySnapshotAcceptanceResult.globalSyncView.some.filter(_.ordinal > SnapshotOrdinal.MinValue)
           )
 
           artifactSize: Int <- JsonSerializer[F].serialize(artifact).map(_.length)

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
@@ -99,10 +99,10 @@ object currency {
         balances.hash,
         lastMessages.traverse(_.hash),
         lastFeeTxRefs.traverse(_.hash),
-        lastAllowSpendRefs.traverse(_.hash),
-        activeAllowSpends.traverse(_.hash),
-        globalSnapshotSyncView.traverse(_.hash),
-        lastTokenLockRefs.traverse(_.hash),
+        lastAllowSpendRefs.filter(_.nonEmpty).traverse(_.hash),
+        activeAllowSpends.filter(_.nonEmpty).traverse(_.hash),
+        globalSnapshotSyncView.filter(_.nonEmpty).traverse(_.hash),
+        lastTokenLockRefs.filter(_.nonEmpty).traverse(_.hash),
         activeTokenLocks.traverse(_.hash)
       ).tupled
         .map(CurrencySnapshotStateProof.apply)

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/globalSnapshotSync.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/globalSnapshotSync.scala
@@ -4,6 +4,7 @@ import cats.Order._
 import cats.effect.Async
 import cats.syntax.all._
 
+import io.constellationnetwork.ext.cats.data.OrderBasedOrdering
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.ext.derevo.ordering
 import io.constellationnetwork.schema.SnapshotOrdinal
@@ -32,6 +33,10 @@ object globalSnapshotSync {
     session: SessionToken
   ) {
     def ordinal: GlobalSnapshotSyncOrdinal = parentOrdinal.next
+  }
+
+  object GlobalSnapshotSync {
+    implicit object OrderingInstance extends OrderBasedOrdering[GlobalSnapshotSync]
   }
 
   @derive(decoder, encoder, order, ordering, show)

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/currencyMessage.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/currencyMessage.scala
@@ -5,6 +5,7 @@ import cats.kernel.{Next, PartialOrder, PartialPrevious}
 import cats.syntax.semigroup._
 
 import io.constellationnetwork.currency.schema.currency.CurrencySnapshotInfo
+import io.constellationnetwork.ext.cats.data.OrderBasedOrdering
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.ext.derevo.ordering
 import io.constellationnetwork.schema.address.Address
@@ -29,6 +30,8 @@ object currencyMessage {
 
     case object Owner extends MessageType("Owner")
     case object Staking extends MessageType("Staking")
+
+    implicit object OrderingInstance extends OrderBasedOrdering[MessageType]
   }
 
   @derive(order, ordering, show)
@@ -60,6 +63,10 @@ object currencyMessage {
   @derive(eqv, show, encoder, decoder, order, ordering)
   case class CurrencyMessage(messageType: MessageType, address: Address, metagraphId: Address, parentOrdinal: MessageOrdinal) {
     def ordinal: MessageOrdinal = parentOrdinal.next
+  }
+
+  object CurrencyMessage {
+    implicit object OrderingInstance extends OrderBasedOrdering[CurrencyMessage]
   }
 
   def fetchStakingAddress(state: CurrencySnapshotInfo): Option[Address] =

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/peer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/peer.scala
@@ -11,6 +11,7 @@ import cats.syntax.eq._
 import cats.syntax.functor._
 
 import io.constellationnetwork.env.AppEnvironment
+import io.constellationnetwork.ext.cats.data.OrderBasedOrdering
 import io.constellationnetwork.ext.derevo.ordering
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.Address
@@ -67,6 +68,8 @@ object peer {
       fromId(publicKey.toId)
 
     val shortShow: Show[PeerId] = Show.show[PeerId](p => s"PeerId(${p.value.value.take(5)})")
+
+    implicit object OrderingInstance extends OrderBasedOrdering[PeerId]
   }
 
   implicit class PeerIdOps(peerId: PeerId) {

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/swap.scala
@@ -80,6 +80,8 @@ object swap {
     def emptyCurrency(currencyIdentifier: Hash): AllowSpendReference =
       AllowSpendReference(AllowSpendOrdinal(0L), currencyIdentifier)
 
+    implicit object OrderingInstance extends OrderBasedOrdering[AllowSpendReference]
+
   }
 
   @derive(decoder, encoder, order, show)

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/tokenLock.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/tokenLock.scala
@@ -69,6 +69,8 @@ object tokenLock {
     def emptyCurrency(currencyIdentifier: Hash): TokenLockReference =
       TokenLockReference(TokenLockOrdinal(0L), currencyIdentifier)
 
+    implicit object OrderingInstance extends OrderBasedOrdering[TokenLockReference]
+
   }
 
   @derive(decoder, encoder, order, show)


### PR DESCRIPTION
Changes needed to validate kryo-serialzed currency snapshots