### PR TITLE
fix: fixing CurrencySnapshotAcceptanceManager

### DIFF
--- a/.github/workflows/setup-environment.yml
+++ b/.github/workflows/setup-environment.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}-${{ inputs.tessellation_version }}
 
       - name: Upload hypergraph artifacts to run CI tests
         uses: actions/upload-artifact@v4
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}-${{ inputs.tessellation_version }}
 
       - name: Setup project template metagraph
         if: steps.cache-metagraph.outputs.cache-hit != 'true'

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
@@ -204,7 +204,8 @@ object CurrencySnapshotCreator {
                     .getOrElse(SortedSet.empty[RewardTransaction].pure[F]),
                 facilitators,
                 lastGlobalSnapshots,
-                getGlobalSnapshotByOrdinal
+                getGlobalSnapshotByOrdinal,
+                lastArtifact.globalSyncView
               )
 
           rejectedBlockEvents = currencySnapshotAcceptanceResult.block.notAccepted.collect {


### PR DESCRIPTION
### Changes
+ Since spendActions is a field in the snapshot schema, and we do not aggregate, if we skip on ordinal between lastGlobalView and lastSyncGlobalSnapshot, we have a chance to miss the spend actions. 
+ This PR aims to get all spend actions between this interval