### PR TITLE
feat: adding a security check to not fetch more than 20 snapshots to search spendTxns

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/AllowSpendValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/AllowSpendValidator.scala
@@ -67,8 +67,7 @@ object AllowSpendValidator {
   sealed trait AllowSpendValidationError
   case class InvalidSigned(error: SignedValidationError) extends AllowSpendValidationError
   case object NotSignedBySourceAddressOwner extends AllowSpendValidationError
-  case class InvalidApprover(approvers: List[Address], destination: Address)
-      extends AllowSpendValidationError
+  case class InvalidApprover(approvers: List[Address], destination: Address) extends AllowSpendValidationError
 
   type AllowSpendValidationErrorOr[A] = ValidatedNec[AllowSpendValidationError, A]
 }


### PR DESCRIPTION
### Changes
+ Some metagraphs can be offline for a long period and have the globalView filled.
This PR aims not to allow fetching more than 20 snapshots per metagraph to not slow the network