### PR TITLE
fix: node-params endpoint shows all avaialble nodes

### DIFF
--- a/.github/action_scripts/node_parameters/node_parameters.js
+++ b/.github/action_scripts/node_parameters/node_parameters.js
@@ -121,7 +121,6 @@ const postNodeParamsNodeId = async (urls, nodeId, account, privateKeyString, par
     }
         
     const unsignedNodeParams = await createNodeParams(account, parameterName, rewardFaction, parent);
-    //const proof = await generateProofWithSerializer(unsignedNodeParams, privateKeyString, account);
     const proof = await generateProof(unsignedNodeParams, privateKeyString, account, SerializerType.BROTLI);
     const content = { value: unsignedNodeParams, proofs: [{ ...proof }] };
 
@@ -155,13 +154,15 @@ const checkInitialNodeParamsNode = async (urls, nodeId) => {
 };
 
 const verifyNodeParamsResponse = (nodeParams, nodeId, expectedName, expectedRewardFraction) => {
-    const data = nodeParams.find(item => item.node.id === nodeId);
+    const data = nodeParams.find(item => item.peerId === nodeId);
     if (!data)
-        throw new Error(`Node id is not correct`);
+        throw new Error(`PeerId is not correct`);
     if (data.nodeMetadataParameters.name !== expectedName)
         throw new Error(`Node parameters name expected ${expectedName} but received ${data.nodeMetadataParameters.name}`);
     if (data.delegatedStakeRewardParameters.rewardFraction !== expectedRewardFraction)
         throw new Error(`Node parameters rewardFraction expected ${expectedRewardFraction} but received ${data.delegatedStakeRewardParameters.rewardFraction}`);
+    if (data.node && data.node.id != nodeId)
+        throw new Error(`Node id is not correct`);
 };
 
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/delegatedStake.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/delegatedStake.scala
@@ -2,6 +2,7 @@ package io.constellationnetwork.schema
 
 import cats.Order._
 import cats.effect.kernel.Async
+import cats.kernel.Monoid
 import cats.syntax.functor._
 import cats.syntax.semigroup._
 
@@ -35,7 +36,12 @@ object delegatedStake {
   }
   object DelegatedStakeAmount {
     implicit def toAmount(amount: DelegatedStakeAmount): Amount = Amount(amount.value)
-    val empty = DelegatedStakeAmount(NonNegLong(0L))
+    val emptyAmount: DelegatedStakeAmount = DelegatedStakeAmount(NonNegLong(0L))
+
+    implicit val stakeMonoid: Monoid[DelegatedStakeAmount] = new Monoid[DelegatedStakeAmount] {
+      override def empty: DelegatedStakeAmount = emptyAmount
+      override def combine(x: DelegatedStakeAmount, y: DelegatedStakeAmount): DelegatedStakeAmount = x.plus(y)
+    }
   }
 
   @derive(decoder, encoder, order, show)


### PR DESCRIPTION
/node-params endpoint now shows information about all available nodes, even if the node is not in a cluster (basic information shows then only)