### PR TITLE
fix: adding parallelism on currency snapshot acceptance

### DIFF
--- a/.github/workflows/check-scala-code.yml
+++ b/.github/workflows/check-scala-code.yml
@@ -17,7 +17,7 @@ jobs:
         java:
           - openjdk@1.11.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java and scala
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check if project version is release version
         run:  test "v$(cut -d \" -f 2 version.sbt)" = "${{ github.ref_name }}"

--- a/.github/workflows/test-currency-transactions.yml
+++ b/.github/workflows/test-currency-transactions.yml
@@ -17,7 +17,7 @@ jobs:
         java:
           - openjdk@1.11.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
@@ -87,92 +87,92 @@ jobs:
           node send_transactions/currency.js
 
       - name: Save Global L0 Genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: rewards-global-l0-genesis-java-${{ matrix.java }}
+          name: rewards-global-l0-genesis-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/global-l0/genesis/global-l0-genesis.log
 
       - name: Save Global L0 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: rewards-global-l0-validator-1-java-${{ matrix.java }}
+          name: rewards-global-l0-validator-1-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/global-l0/validator-1/global-l0-validator-1.log
 
       - name: Save Global L0 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: rewards-global-l0-validator-2-java-${{ matrix.java }}
+          name: rewards-global-l0-validator-2-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/global-l0/validator-2/global-l0-validator-2.log
 
       - name: Save DAG L1 Initial Validator logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-dag-l1-java-${{ matrix.java }}
+          name: send-transactions-dag-l1-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/dag-l1/initial-validator/dag-l1-initial-validator.log
 
       - name: Save DAG L1 Validator - 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-dag-l1-java-${{ matrix.java }}
+          name: send-transactions-dag-l1-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/dag-l1/validator-1/dag-l1-validator-1.log
 
       - name: Save DAG L1 Initial Validator - 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-dag-l1-java-${{ matrix.java }}
+          name: send-transactions-dag-l1-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/dag-l1/validator-2/dag-l1-validator-2.log
 
       - name: Save Metagraph L0 - Create genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-metagraph-l0-create-genesis-java-${{ matrix.java }}
+          name: send-transactions-metagraph-l0-create-genesis-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/genesis/metagraph-l0-create-genesis.log
 
       - name: Save Metagraph L0 - Genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-metagraph-l0-genesis-java-${{ matrix.java }}
+          name: send-transactions-metagraph-l0-genesis-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/genesis/metagraph-l0-genesis.log
 
       - name: Save Metagraph L0 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-metagraph-l0-validator-1-java-${{ matrix.java }}
+          name: send-transactions-metagraph-l0-validator-1-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/validator-1/metagraph-l0-validator-1.log
 
       - name: Save Metagraph L0 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-metagraph-l0-validator-2-java-${{ matrix.java }}
+          name: send-transactions-metagraph-l0-validator-2-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/validator-2/metagraph-l0-validator-2.log
 
       - name: Save Currency L1 - Initial Validator logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-currency-l1-initial-validator-java-${{ matrix.java }}
+          name: send-transactions-currency-l1-initial-validator-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/currency-l1/initial-validator/currency-l1-initial-validator.log
 
       - name: Save Currency L1 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-currency-l1-validator-1-java-${{ matrix.java }}
+          name: send-transactions-currency-l1-validator-1-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/currency-l1/validator-1/currency-l1-1.log
 
       - name: Save Currency L1 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: send-transactions-currency-l1-validator-2-java-${{ matrix.java }}
+          name: send-transactions-currency-l1-validator-2-${{ github.run_id }}-${{ github.job }}-${{ matrix.java }}
           path: .github/config/containers/currency-l1/validator-2/currency-l1-2.log

--- a/.github/workflows/test-data-transactions.yml
+++ b/.github/workflows/test-data-transactions.yml
@@ -17,7 +17,7 @@ jobs:
         java:
           - openjdk@1.11.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
@@ -78,70 +78,70 @@ jobs:
           node send_transactions/data.js
 
       - name: Save Global L0 Genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-global-l0-genesis-java-${{ matrix.java }}
           path: .github/config/containers/global-l0/genesis/global-l0-genesis.log
 
       - name: Save Global L0 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-global-l0-validator-1-java-${{ matrix.java }}
           path: .github/config/containers/global-l0/validator-1/global-l0-validator-1.log
 
       - name: Save Global L0 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-global-l0-validator-2-java-${{ matrix.java }}
           path: .github/config/containers/global-l0/validator-2/global-l0-validator-2.log
 
       - name: Save Metagraph L0 - Create genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-metagraph-l0-create-genesis-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/genesis/metagraph-l0-create-genesis.log
 
       - name: Save Metagraph L0 - Genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-metagraph-l0-genesis-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/genesis/metagraph-l0-genesis.log
 
       - name: Save Metagraph L0 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-metagraph-l0-validator-1-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/validator-1/metagraph-l0-validator-1.log
 
       - name: Save Metagraph L0 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-metagraph-l0-validator-2-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/validator-2/metagraph-l0-validator-2.log
 
       - name: Save Data L1 - Initial Validator logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-data-l1-initial-validator-java-${{ matrix.java }}
           path: .github/config/containers/data-l1/initial-validator/data-l1-initial-validator.log
 
       - name: Save Data L1 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-data-l1-validator-1-java-${{ matrix.java }}
           path: .github/config/containers/data-l1/validator-1/data-l1-1.log
 
       - name: Save Data L1 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: send-transactions-data-l1-validator-2-java-${{ matrix.java }}

--- a/.github/workflows/test-metagraph-rewards.yml
+++ b/.github/workflows/test-metagraph-rewards.yml
@@ -18,7 +18,7 @@ jobs:
         java:
           - openjdk@1.11.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
@@ -89,63 +89,63 @@ jobs:
           node metagraph-currency.js
 
       - name: Save Global L0 Genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-global-l0-genesis-java-${{ matrix.java }}
           path: .github/config/containers/global-l0/genesis/global-l0-genesis.log
 
       - name: Save Global L0 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-global-l0-validator-1-java-${{ matrix.java }}
           path: .github/config/containers/global-l0/validator-1/global-l0-validator-1.log
 
       - name: Save Global L0 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-global-l0-validator-2-java-${{ matrix.java }}
           path: .github/config/containers/global-l0/validator-2/global-l0-validator-2.log
 
       - name: Save Metagraph L0 - Genesis logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-metagraph-l0-genesis-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/genesis/metagraph-l0-genesis.log
 
       - name: Save Metagraph L0 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-metagraph-l0-validator-1-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/validator-1/metagraph-l0-validator-1.log
 
       - name: Save Metagraph L0 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-metagraph-l0-validator-2-java-${{ matrix.java }}
           path: .github/config/containers/metagraph-l0/validator-2/metagraph-l0-validator-2.log
 
       - name: Save Currency L1 - Initial Validator logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-currency-l1-initial-validator-java-${{ matrix.java }}
           path: .github/config/containers/currency-l1/initial-validator/currency-l1-initial-validator.log
 
       - name: Save Currency L1 - Validator 1 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-currency-l1-validator-1-java-${{ matrix.java }}
           path: .github/config/containers/currency-l1/validator-1/currency-l1-1.log
 
       - name: Save Currency L1 - Validator 2 logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rewards-currency-l1-validator-2-java-${{ matrix.java }}

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Programs.scala
@@ -2,6 +2,7 @@ package org.tessellation.currency.l0.modules
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.effect.Async
 import cats.effect.std.Random
 
@@ -23,7 +24,7 @@ import org.tessellation.security.{HasherSelector, SecurityProvider}
 
 object Programs {
 
-  def make[F[_]: Async: Random: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector](
+  def make[F[_]: Async: Parallel: Random: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector](
     keyPair: KeyPair,
     nodeId: PeerId,
     globalL0Peer: L0Peer,

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/modules/Services.scala
@@ -2,6 +2,7 @@ package org.tessellation.currency.l0.modules
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.Async
 import cats.effect.std.{Random, Supervisor}
@@ -38,7 +39,7 @@ import org.http4s.client.Client
 
 object Services {
 
-  def make[F[_]: Async: Random: JsonSerializer: KryoSerializer: SecurityProvider: HasherSelector: Metrics: Supervisor](
+  def make[F[_]: Async: Parallel: Random: JsonSerializer: KryoSerializer: SecurityProvider: HasherSelector: Metrics: Supervisor](
     p2PClient: P2PClient[F],
     sharedServices: SharedServices[F],
     storages: Storages[F],

--- a/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/snapshot/programs/Genesis.scala
+++ b/modules/currency-l0/src/main/scala/org/tessellation/currency/l0/snapshot/programs/Genesis.scala
@@ -2,6 +2,7 @@ package org.tessellation.currency.l0.snapshot.programs
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.effect.Async
 import cats.syntax.all._
 
@@ -44,7 +45,7 @@ trait Genesis[F[_]] {
 }
 
 object Genesis {
-  def make[F[_]: Async: SecurityProvider](
+  def make[F[_]: Async: Parallel: SecurityProvider](
     keyPair: KeyPair,
     collateral: Collateral[F],
     stateChannelSnapshotService: StateChannelSnapshotService[F],

--- a/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/modules/Services.scala
+++ b/modules/currency-l1/src/main/scala/org/tessellation/currency/l1/modules/Services.scala
@@ -1,5 +1,6 @@
 package org.tessellation.currency.l1.modules
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.kernel.Async
 
@@ -22,7 +23,7 @@ import org.tessellation.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
 import org.tessellation.security.{Hasher, HasherSelector, SecurityProvider}
 
 object Services {
-  def make[F[_]: Async: HasherSelector: SecurityProvider](
+  def make[F[_]: Async: Parallel: HasherSelector: SecurityProvider](
     storages: Storages[
       F,
       CurrencySnapshotStateProof,

--- a/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/org/tessellation/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -1,0 +1,163 @@
+package org.tessellation.currency.l1.domain.snapshots.programs
+
+import cats.effect._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.util.Random
+
+import org.tessellation.dag.l1.Main
+import org.tessellation.ext.cats.effect.ResourceIO
+import org.tessellation.json.JsonSerializer
+import org.tessellation.kryo.KryoSerializer
+import org.tessellation.node.shared.infrastructure.block.processing.BlockAcceptanceManager
+import org.tessellation.node.shared.infrastructure.snapshot._
+import org.tessellation.node.shared.modules.SharedValidators
+import org.tessellation.node.shared.nodeSharedKryoRegistrar
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.balance.{Amount, Balance}
+import org.tessellation.schema.transaction.{RewardTransaction, TransactionAmount}
+import org.tessellation.security._
+import org.tessellation.transaction.TransactionGenerator
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosLong
+import weaver.SimpleIOSuite
+
+object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
+
+  type TestResources = CurrencySnapshotAcceptanceManager[IO]
+
+  def testResources: Resource[IO, TestResources] =
+    SecurityProvider.forAsync[IO].flatMap { implicit sp =>
+      KryoSerializer.forAsync[IO](Main.kryoRegistrar ++ nodeSharedKryoRegistrar).flatMap { implicit kp =>
+        for {
+          implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+          validators = SharedValidators.make[IO](None, None, Some(Map.empty), SortedMap.empty, Long.MaxValue, Hasher.forKryo[IO])
+          currencySnapshotAcceptanceManager = CurrencySnapshotAcceptanceManager.make(
+            BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
+            Amount(0L),
+            validators.currencyMessageValidator
+          )
+        } yield currencySnapshotAcceptanceManager
+      }
+    }
+
+  val address1: Address = Address("DAG53ho9ssY8KYQdjxsWPYgNbDJ1YqM2RaPDZebU")
+  val address2: Address = Address("DAG53ho9ssY8KYQdjxsWPYgNbDJ1YqM2RaPDZebT")
+  val address3: Address = Address("DAG53ho9ssY8KYQdjxsWPYgNbDJ1YqM2RaPDZebV")
+  val address4: Address = Address("DAG53ho9ssY8KYQdjxsWPYgNbDJ1YqM2RaPDZebX")
+
+  test("should update balances correctly without reward txns") {
+    testResources.use { mgr =>
+      val base = SortedMap(address1 -> Balance(50L), address2 -> Balance(50L))
+      val updates = SortedMap(address1 -> Balance(100L))
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, updates, SortedSet.empty)
+      } yield
+        expect.all(
+          rewardTxs.isEmpty,
+          newBalances(address1).value.value == 100L,
+          newBalances(address2).value.value == 50L
+        )
+    }
+  }
+
+  test("should apply valid reward transactions") {
+    testResources.use { mgr =>
+      val base = SortedMap(address1 -> Balance(50L))
+      val rewards = SortedSet(RewardTransaction(address1, TransactionAmount(30L)))
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, Map.empty, rewards)
+      } yield
+        expect.all(
+          rewardTxs.size == 1,
+          newBalances(address1).value.value == 80L
+        )
+    }
+  }
+
+  test("should skip invalid reward transactions") {
+    testResources.use { mgr =>
+      val base = SortedMap(address1 -> Balance(Long.MaxValue))
+      val rewards = SortedSet(RewardTransaction(address1, TransactionAmount(100L)))
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, Map.empty, rewards)
+      } yield
+        expect.all(
+          rewardTxs.isEmpty,
+          newBalances(address1).value.value == Long.MaxValue
+        )
+    }
+  }
+
+  test("should apply rewards and merge with updated balances") {
+    testResources.use { mgr =>
+      val base = SortedMap(address1 -> Balance(100L))
+      val updates = Map(address2 -> Balance(40L))
+      val rewards = SortedSet(RewardTransaction(address2, TransactionAmount(10L)))
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, updates, rewards)
+      } yield
+        expect.all(
+          rewardTxs.size == 1,
+          newBalances(address1).value.value == 100L,
+          newBalances(address2).value.value == 50L
+        )
+    }
+  }
+
+  test("should include new addresses from updates even with no rewards") {
+    testResources.use { mgr =>
+      val base = SortedMap.empty[Address, Balance]
+      val updates = Map(address3 -> Balance(77L))
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, updates, SortedSet.empty)
+      } yield
+        expect.all(
+          rewardTxs.isEmpty,
+          newBalances(address3).value.value == 77L
+        )
+    }
+  }
+
+  test("should apply multiple randomized reward transactions") {
+    testResources.use { mgr =>
+      val base = SortedMap(address1 -> Balance(200L), address2 -> Balance(100L), address3 -> Balance(0L))
+      val rewards = SortedSet(
+        RewardTransaction(address1, TransactionAmount(PosLong.unsafeFrom(Random.between(10L, 50L)))),
+        RewardTransaction(address2, TransactionAmount(PosLong.unsafeFrom(Random.between(20L, 40L)))),
+        RewardTransaction(address3, TransactionAmount(PosLong.unsafeFrom(Random.between(30L, 60L))))
+      )
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, Map.empty, rewards)
+      } yield
+        expect.all(
+          rewardTxs.nonEmpty,
+          newBalances.keySet == base.keySet,
+          rewardTxs.forall(tx => newBalances(tx.destination).value.value >= base(tx.destination).value.value)
+        )
+    }
+  }
+
+  test("should merge reward and updated balances even with overlapping addresses") {
+    testResources.use { mgr =>
+      val base = SortedMap(address1 -> Balance(100L))
+      val updates = Map(address1 -> Balance(200L))
+      val rewards = SortedSet(RewardTransaction(address1, TransactionAmount(50L)))
+
+      for {
+        (newBalances, rewardTxs) <- mgr.acceptRewardTxs(base, updates, rewards)
+      } yield
+        expect.all(
+          rewardTxs.size == 1,
+          newBalances(address1).value.value == 250L
+        )
+    }
+  }
+}

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/domain/snapshot/programs/Download.scala
@@ -1,9 +1,9 @@
 package org.tessellation.dag.l0.domain.snapshot.programs
 
-import cats.Applicative
 import cats.effect.Async
 import cats.effect.std.Random
 import cats.syntax.all._
+import cats.{Applicative, Parallel}
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -34,7 +34,7 @@ import retry.RetryPolicies._
 import retry._
 
 object Download {
-  def make[F[_]: Async: Random: KryoSerializer](
+  def make[F[_]: Async: Parallel: Random: KryoSerializer](
     snapshotStorage: SnapshotDownloadStorage[F],
     p2pClient: P2PClient[F],
     clusterStorage: ClusterStorage[F],

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -2,6 +2,7 @@ package org.tessellation.dag.l0.infrastructure.snapshot
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.kernel.Async
 import cats.effect.std.{Random, Supervisor}
@@ -43,7 +44,7 @@ import org.http4s.client.Client
 
 object GlobalSnapshotConsensus {
 
-  def make[F[_]: Async: Random: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Metrics: Supervisor](
+  def make[F[_]: Async: Parallel: Random: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Metrics: Supervisor](
     gossip: Gossip[F],
     selfId: PeerId,
     keyPair: KeyPair,

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
@@ -1,5 +1,6 @@
 package org.tessellation.dag.l0.infrastructure.snapshot
 
+import cats.Parallel
 import cats.data.NonEmptyChain
 import cats.effect.kernel.Async
 import cats.syntax.all._
@@ -22,7 +23,7 @@ trait GlobalSnapshotTraverse[F[_]] {
 
 object GlobalSnapshotTraverse {
 
-  def make[F[_]: Async: HasherSelector](
+  def make[F[_]: Async: Parallel: HasherSelector](
     loadInc: Hash => F[Option[Signed[GlobalIncrementalSnapshot]]],
     loadFull: Hash => F[Option[Signed[GlobalSnapshot]]],
     loadInfo: SnapshotOrdinal => F[Option[GlobalSnapshotInfo]],

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
@@ -1,5 +1,6 @@
 package org.tessellation.dag.l0.infrastructure.snapshot
 
+import cats.Parallel
 import cats.effect.Async
 import cats.effect.syntax.all._
 import cats.syntax.all._
@@ -17,7 +18,7 @@ import org.tessellation.security.signature.Signed
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object SnapshotDownloadStorage {
-  def make[F[_]: Async: HasherSelector: KryoSerializer](
+  def make[F[_]: Async: Parallel: HasherSelector: KryoSerializer](
     tmpStorage: SnapshotLocalFileSystemStorage[F, GlobalIncrementalSnapshot],
     persistedStorage: SnapshotLocalFileSystemStorage[F, GlobalIncrementalSnapshot],
     fullGlobalSnapshotStorage: SnapshotLocalFileSystemStorage[F, GlobalSnapshot],

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/programs/RollbackLoader.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/infrastructure/snapshot/programs/RollbackLoader.scala
@@ -2,6 +2,7 @@ package org.tessellation.dag.l0.infrastructure.snapshot.programs
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.effect.Async
 import cats.syntax.all._
 
@@ -25,7 +26,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object RollbackLoader {
 
-  def make[F[_]: Async: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector](
+  def make[F[_]: Async: Parallel: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector](
     keyPair: KeyPair,
     snapshotConfig: SnapshotConfig,
     incrementalGlobalSnapshotLocalFileSystemStorage: SnapshotLocalFileSystemStorage[F, GlobalIncrementalSnapshot],
@@ -45,7 +46,7 @@ object RollbackLoader {
     ) {}
 }
 
-sealed abstract class RollbackLoader[F[_]: Async: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider] private (
+sealed abstract class RollbackLoader[F[_]: Async: Parallel: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider] private (
   keyPair: KeyPair,
   snapshotConfig: SnapshotConfig,
   incrementalGlobalSnapshotLocalFileSystemStorage: SnapshotLocalFileSystemStorage[F, GlobalIncrementalSnapshot],

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Programs.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Programs.scala
@@ -2,6 +2,7 @@ package org.tessellation.dag.l0.modules
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.effect.Async
 import cats.effect.std.Random
 
@@ -22,7 +23,7 @@ import org.tessellation.security.{HashSelect, HasherSelector, SecurityProvider}
 
 object Programs {
 
-  def make[F[_]: Async: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Random](
+  def make[F[_]: Async: Parallel: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Random](
     sharedPrograms: SharedPrograms[F],
     storages: Storages[F],
     services: Services[F],

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Services.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Services.scala
@@ -2,6 +2,7 @@ package org.tessellation.dag.l0.modules
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.kernel.Async
 import cats.effect.std.{Random, Supervisor}
@@ -37,7 +38,7 @@ import org.http4s.client.Client
 
 object Services {
 
-  def make[F[_]: Async: Random: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Metrics: Supervisor](
+  def make[F[_]: Async: Parallel: Random: KryoSerializer: JsonSerializer: HasherSelector: SecurityProvider: Metrics: Supervisor](
     sharedServices: SharedServices[F],
     queues: Queues[F],
     storages: Storages[F],

--- a/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Storages.scala
+++ b/modules/dag-l0/src/main/scala/org/tessellation/dag/l0/modules/Storages.scala
@@ -1,5 +1,6 @@
 package org.tessellation.dag.l0.modules
 
+import cats.Parallel
 import cats.effect.Async
 import cats.effect.std.Supervisor
 import cats.syntax.all._
@@ -27,7 +28,7 @@ import org.tessellation.security.{HashSelect, HasherSelector}
 
 object Storages {
 
-  def make[F[+_]: Async: KryoSerializer: JsonSerializer: HasherSelector: Supervisor](
+  def make[F[+_]: Async: Parallel: KryoSerializer: JsonSerializer: HasherSelector: Supervisor](
     sharedStorages: SharedStorages[F],
     sharedConfig: SharedConfig,
     seedlist: Option[Set[SeedlistEntry]],

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -137,7 +137,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
         lastTxRefs = lastTxRefs,
         balances = balances
       )
-      newSnapshotInfoStateProof <- newSnapshotInfo.stateProof(lastSnapshot.ordinal.next)
+      newSnapshotInfoStateProof <- newSnapshotInfo.stateProof[IO](lastSnapshot.ordinal.next)
       snapshot = GlobalIncrementalSnapshot(
         lastSnapshot.ordinal.next,
         Height.MinValue,

--- a/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/StateProofSuite.scala
+++ b/modules/dag-l0/src/test/scala/org/tessellation/dag/l0/infrastructure/snapshot/StateProofSuite.scala
@@ -52,7 +52,7 @@ object StateProofSuite extends MutableIOSuite with Checkers {
 
       snapshotStateProof = snap.stateProof
 
-      infoStateProof <- info.stateProof(snap.ordinal)
+      infoStateProof <- info.stateProof[IO](snap.ordinal)
 
     } yield expect.eql(snapshotStateProof, infoStateProof)
 

--- a/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/Services.scala
+++ b/modules/dag-l1/src/main/scala/org/tessellation/dag/l1/modules/Services.scala
@@ -1,5 +1,6 @@
 package org.tessellation.dag.l1.modules
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.kernel.Async
 
@@ -25,7 +26,7 @@ import org.tessellation.security.{Hasher, HasherSelector, SecurityProvider}
 object Services {
 
   def make[
-    F[_]: Async: SecurityProvider: HasherSelector,
+    F[_]: Async: Parallel: SecurityProvider: HasherSelector,
     P <: StateProof,
     S <: Snapshot,
     SI <: SnapshotInfo[P]

--- a/modules/dag-l1/src/test/scala/org/tessellation/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/org/tessellation/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -825,7 +825,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
           lastSnapshotStateProof <- {
             implicit val hasher = currentHasher
 
-            lastSnapshotInfo.stateProof(snapshotOrdinal10)
+            lastSnapshotInfo.stateProof[IO](snapshotOrdinal10)
           }
           hashedLastSnapshot <- {
             implicit val hasher = currentHasher
@@ -864,7 +864,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
           newSnapshotInfoStateProof <- {
             implicit val hasher = currentHasher
 
-            newSnapshotInfo.stateProof(snapshotOrdinal11)
+            newSnapshotInfo.stateProof[IO](snapshotOrdinal11)
           }
           hashedNextSnapshot <- {
             implicit val hasher = currentHasher
@@ -1083,7 +1083,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
           snapshotBalances = generateSnapshotBalances(Set(srcAddress))
           snapshotTxRefs = generateSnapshotLastAccTxRefs(Map(srcAddress -> correctTxs(5)))
           lastSnapshotInfo = GlobalSnapshotInfo(SortedMap.empty, SortedMap.empty, snapshotBalances, SortedMap.empty, SortedMap.empty)
-          lastSnapshotInfoStateProof <- lastSnapshotInfo.stateProof(snapshotOrdinal10)
+          lastSnapshotInfoStateProof <- lastSnapshotInfo.stateProof[IO](snapshotOrdinal10)
           hashedLastSnapshot <- forAsyncHasher(
             generateSnapshot(peerId).copy(
               tips = SnapshotTips(
@@ -1114,7 +1114,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               balances = balances
             )
           }
-          newSnapshotInfoStateProof <- newSnapshotInfo.stateProof(snapshotOrdinal11)
+          newSnapshotInfoStateProof <- newSnapshotInfo.stateProof[IO](snapshotOrdinal11)
           hashedNextSnapshot <- forAsyncHasher(
             generateSnapshot(peerId).copy(
               ordinal = snapshotOrdinal11,

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/snapshot/services/GlobalL0Service.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/domain/snapshot/services/GlobalL0Service.scala
@@ -6,7 +6,7 @@ import cats.data._
 import cats.effect.Async
 import cats.effect.syntax.concurrent._
 import cats.syntax.all._
-import cats.{Applicative, Show}
+import cats.{Applicative, Parallel, Show}
 
 import scala.collection.immutable.SortedSet
 import scala.util.Random
@@ -46,7 +46,7 @@ object GlobalL0Service {
   case object NoPeerAlignedWithMajority extends Exception("No peer available that is aligned with majority") with NoStackTrace
 
   def make[
-    F[_]: Async: SecurityProvider: HasherSelector
+    F[_]: Async: Parallel: SecurityProvider: HasherSelector
   ](
     l0GlobalSnapshotClient: L0GlobalSnapshotClient[F],
     globalL0ClusterStorage: L0ClusterStorage[F],

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencySnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/CurrencySnapshotContextFunctions.scala
@@ -1,5 +1,6 @@
 package org.tessellation.node.shared.infrastructure.snapshot
 
+import cats.Parallel
 import cats.data.{NonEmptyChain, Validated}
 import cats.effect.Async
 import cats.syntax.applicative._
@@ -24,7 +25,7 @@ abstract class CurrencySnapshotContextFunctions[F[_]]
     extends SnapshotContextFunctions[F, CurrencyIncrementalSnapshot, CurrencySnapshotContext]
 
 object CurrencySnapshotContextFunctions {
-  def make[F[_]: Async](validator: CurrencySnapshotValidator[F]) =
+  def make[F[_]: Async: Parallel](validator: CurrencySnapshotValidator[F]) =
     new CurrencySnapshotContextFunctions[F] {
       def createContext(
         context: CurrencySnapshotContext,

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
@@ -1,5 +1,6 @@
 package org.tessellation.node.shared.infrastructure.snapshot
 
+import cats.Parallel
 import cats.data.Validated
 import cats.effect.Async
 import cats.syntax.applicative._
@@ -27,7 +28,7 @@ import eu.timepit.refined.auto._
 abstract class GlobalSnapshotContextFunctions[F[_]] extends SnapshotContextFunctions[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
 
 object GlobalSnapshotContextFunctions {
-  def make[F[_]: Async: HasherSelector](snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[F]) =
+  def make[F[_]: Async: Parallel: HasherSelector](snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[F]) =
     new GlobalSnapshotContextFunctions[F] {
       def createContext(
         context: GlobalSnapshotInfo,

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessor.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessor.scala
@@ -1,5 +1,6 @@
 package org.tessellation.node.shared.infrastructure.snapshot
 
+import cats.Parallel
 import cats.data._
 import cats.effect.Async
 import cats.syntax.all._
@@ -49,7 +50,7 @@ trait GlobalSnapshotStateChannelEventsProcessor[F[_]] {
 }
 
 object GlobalSnapshotStateChannelEventsProcessor {
-  def make[F[_]: Async](
+  def make[F[_]: Async: Parallel](
     stateChannelValidator: StateChannelValidator[F],
     stateChannelManager: GlobalSnapshotStateChannelAcceptanceManager[F],
     currencySnapshotContextFns: CurrencySnapshotContextFunctions[F],
@@ -164,8 +165,8 @@ object GlobalSnapshotStateChannelEventsProcessor {
       )(implicit hasher: Hasher[F]): F[SortedMap[Address, MetagraphAcceptanceResult]] = {
         val isFeeRequired = feeCalculator.isFeeRequired(snapshotOrdinal)
 
-        events.toList.foldLeftM(SortedMap.empty[Address, MetagraphAcceptanceResult]) {
-          case (agg, (address, binaries)) =>
+        events.toList.parTraverse {
+          case (address, binaries) =>
             type Result = Option[MetagraphAcceptanceResult]
             type Agg = (Result, List[Signed[StateChannelSnapshotBinary]])
 
@@ -268,10 +269,12 @@ object GlobalSnapshotStateChannelEventsProcessor {
                   case None    => maybeProcessed
                 }
               }
-              .map {
-                case Some(updates) => agg + (address -> updates)
-                case None          => agg
-              }
+              .map(result => address -> result)
+        }.map { results =>
+          results.foldLeft(SortedMap.empty[Address, MetagraphAcceptanceResult]) {
+            case (acc, (address, Some(result))) => acc + (address -> result)
+            case (acc, (_, None))               => acc
+          }
         }
       }
 

--- a/modules/node-shared/src/main/scala/org/tessellation/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/org/tessellation/node/shared/modules/SharedServices.scala
@@ -2,6 +2,7 @@ package org.tessellation.node.shared.modules
 
 import java.security.KeyPair
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.Async
 import cats.effect.std.Supervisor
@@ -34,7 +35,7 @@ import fs2.concurrent.SignallingRef
 
 object SharedServices {
 
-  def make[F[_]: Async: HasherSelector: SecurityProvider: Metrics: Supervisor: JsonSerializer: KryoSerializer](
+  def make[F[_]: Async: Parallel: HasherSelector: SecurityProvider: Metrics: Supervisor: JsonSerializer: KryoSerializer](
     cfg: SharedConfig,
     nodeId: PeerId,
     generation: Generation,

--- a/modules/shared/src/main/scala/org/tessellation/merkletree/MerkleTreeValidator.scala
+++ b/modules/shared/src/main/scala/org/tessellation/merkletree/MerkleTreeValidator.scala
@@ -1,11 +1,11 @@
 package org.tessellation.merkletree
 
-import cats.Show
 import cats.data.Validated
 import cats.effect.Async
 import cats.effect.kernel.Sync
 import cats.kernel.Eq
 import cats.syntax.all._
+import cats.{Parallel, Show}
 
 import scala.util.control.NoStackTrace
 
@@ -21,7 +21,7 @@ import io.circe.Encoder
 
 object StateProofValidator {
 
-  def validate[F[_]: Async: Hasher, P <: StateProof: Eq, A <: IncrementalSnapshot[P]: Encoder](
+  def validate[F[_]: Async: Parallel: Hasher, P <: StateProof: Eq, A <: IncrementalSnapshot[P]: Encoder](
     snapshot: Signed[A],
     si: SnapshotInfo[P]
   ): F[Validated[StateBroken, Unit]] = {
@@ -30,7 +30,7 @@ object StateProofValidator {
     (snapshot.toHashed, stateProof).mapN(validate(_, _))
   }
 
-  def validate[F[_]: Sync: Hasher, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
+  def validate[F[_]: Sync: Parallel: Hasher, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
     snapshot: Hashed[A],
     si: SnapshotInfo[P]
   ): F[Validated[StateBroken, Unit]] = {

--- a/modules/shared/src/main/scala/org/tessellation/schema/GlobalSnapshot.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/GlobalSnapshot.scala
@@ -1,5 +1,6 @@
 package org.tessellation.schema
 
+import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect.kernel.Sync
 import cats.syntax.functor._
@@ -45,7 +46,7 @@ case class GlobalIncrementalSnapshot(
 ) extends IncrementalSnapshot[GlobalSnapshotStateProof]
 
 object GlobalIncrementalSnapshot {
-  def fromGlobalSnapshot[F[_]: Sync: Hasher](snapshot: GlobalSnapshot): F[GlobalIncrementalSnapshot] =
+  def fromGlobalSnapshot[F[_]: Sync: Parallel: Hasher](snapshot: GlobalSnapshot): F[GlobalIncrementalSnapshot] =
     snapshot.info.stateProof(snapshot.ordinal).map { stateProof =>
       GlobalIncrementalSnapshot(
         snapshot.ordinal,
@@ -98,7 +99,7 @@ object GlobalSnapshot {
       )
     )
 
-  def mkFirstIncrementalSnapshot[F[_]: Sync: Hasher](
+  def mkFirstIncrementalSnapshot[F[_]: Sync: Parallel: Hasher](
     genesis: Hashed[GlobalSnapshot]
   ): F[GlobalIncrementalSnapshot] =
     genesis.info.stateProof(genesis.ordinal).map { stateProof =>

--- a/modules/shared/src/main/scala/org/tessellation/schema/GlobalSnapshotInfo.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/GlobalSnapshotInfo.scala
@@ -1,5 +1,6 @@
 package org.tessellation.schema
 
+import cats.Parallel
 import cats.effect.kernel.Sync
 import cats.syntax.contravariantSemigroupal._
 import cats.syntax.flatMap._
@@ -29,7 +30,7 @@ case class GlobalSnapshotInfoV1(
   lastTxRefs: SortedMap[Address, TransactionReference],
   balances: SortedMap[Address, Balance]
 ) extends SnapshotInfo[GlobalSnapshotStateProof] {
-  def stateProof[F[_]: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
+  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
     GlobalSnapshotInfoV1.toGlobalSnapshotInfo(this).stateProof[F](ordinal)
 }
 
@@ -79,7 +80,7 @@ case class GlobalSnapshotInfoV2(
       lastCurrencySnapshotsProofs
     )
 
-  def stateProof[F[_]: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
+  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
     lastCurrencySnapshots.merkleTree[F].flatMap(stateProof(_))
 
   def stateProof[F[_]: Sync: Hasher](lastCurrencySnapshots: Option[MerkleTree]): F[GlobalSnapshotStateProof] =
@@ -118,7 +119,7 @@ case class GlobalSnapshotInfo(
   lastCurrencySnapshots: SortedMap[Address, Either[Signed[CurrencySnapshot], (Signed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]],
   lastCurrencySnapshotsProofs: SortedMap[Address, Proof]
 ) extends SnapshotInfo[GlobalSnapshotStateProof] {
-  def stateProof[F[_]: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
+  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
     lastCurrencySnapshots.merkleTree[F].flatMap(stateProof(_))
 
   def stateProof[F[_]: Sync: Hasher](lastCurrencySnapshots: Option[MerkleTree]): F[GlobalSnapshotStateProof] =

--- a/modules/shared/src/main/scala/org/tessellation/schema/snapshot.scala
+++ b/modules/shared/src/main/scala/org/tessellation/schema/snapshot.scala
@@ -1,5 +1,6 @@
 package org.tessellation.schema
 
+import cats.Parallel
 import cats.effect.Async
 import cats.effect.kernel.Sync
 import cats.syntax.functor._
@@ -56,7 +57,7 @@ object snapshot {
     val lastTxRefs: SortedMap[Address, TransactionReference]
     val balances: SortedMap[Address, Balance]
 
-    def stateProof[F[_]: Sync: Hasher](ordinal: SnapshotOrdinal): F[P]
+    def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[P]
   }
 
   @derive(encoder, decoder, show)

--- a/modules/shared/src/test/scala/org/tessellation/json/JsonBinarySerializerSuite.scala
+++ b/modules/shared/src/test/scala/org/tessellation/json/JsonBinarySerializerSuite.scala
@@ -1,5 +1,6 @@
 package org.tessellation.json
 
+import cats.Parallel
 import cats.data.NonEmptySet
 import cats.effect.kernel.Sync
 import cats.effect.{IO, Resource}
@@ -51,7 +52,7 @@ object JsonBinarySerializerSuite extends MutableIOSuite {
     }
   }
 
-  private[json] def currencyIncrementalSnapshot[F[_]: Sync: Hasher](
+  private[json] def currencyIncrementalSnapshot[F[_]: Parallel: Sync: Hasher](
     hash: Hash,
     currencySnapshotInfo: CurrencySnapshotInfo
   ): F[Signed[CurrencyIncrementalSnapshot]] =

--- a/modules/shared/src/test/scala/org/tessellation/merkletree/MerkleTreeValidatorSuite.scala
+++ b/modules/shared/src/test/scala/org/tessellation/merkletree/MerkleTreeValidatorSuite.scala
@@ -1,5 +1,6 @@
 package org.tessellation.merkletree
 
+import cats.Parallel
 import cats.data.{NonEmptyList, NonEmptySet, Validated}
 import cats.effect.{Async, IO, Resource}
 import cats.syntax.flatMap._
@@ -66,7 +67,7 @@ object MerkleTreeValidatorSuite extends MutableIOSuite {
     } yield expect.same(Validated.Invalid(StateProofValidator.StateBroken(SnapshotOrdinal(NonNegLong(1L)), snapshot.hash)), result)
   }
 
-  private def globalIncrementalSnapshot[F[_]: Async: Hasher](
+  private def globalIncrementalSnapshot[F[_]: Async: Parallel: Hasher](
     globalSnapshotInfo: GlobalSnapshotInfo
   ): F[Hashed[GlobalIncrementalSnapshot]] =
     globalSnapshotInfo.stateProof[F](SnapshotOrdinal(NonNegLong(1L))).flatMap { sp =>


### PR DESCRIPTION
### Changes
+ Adding parallelism on the GlobalSnapshotStateChannelEventsProcessor, since we can accept different metagraph snapshots in parallel
+ Updated the acceptRewards function to not merge the 2 balances map directly in memory, and use a optimized structure