### PR TITLE
feat: adding delegated stake min amount and max number validations

### DIFF
--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -185,7 +185,8 @@ abstract class CurrencyL1App(
           tessellationVersion,
           cfg.http,
           metagraphVersion.some,
-          txHasher
+          txHasher,
+          validators
         )
       _ <- MkHttpServer[IO].newEmber(ServerName("public"), cfg.http.publicHttp, api.publicApp)
       _ <- MkHttpServer[IO].newEmber(ServerName("p2p"), cfg.http.p2pHttp, api.p2pApp)

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -52,6 +52,8 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
               RewardFraction(5_000_000),
               RewardFraction(10_000_000),
               PosInt(140),
+              PosInt(10),
+              PosLong((5000 * 1e8).toLong),
               Map(Dev -> EpochProgress(NonNegLong(7338977L)))
             )
           )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributor.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributor.scala
@@ -205,8 +205,8 @@ object GlobalDelegatedRewardsDistributor {
       activeDelegatedStakes: SortedMap[Address, List[DelegatedStakeRecord]],
       nodeParametersMap: SortedMap[Id, (Signed[UpdateNodeParameters], SnapshotOrdinal)],
       totalDelegationRewardPool: BigDecimal
-    ): F[Map[Address, Map[PeerId, Amount]]] =
-      if (activeDelegatedStakes.isEmpty || totalDelegationRewardPool === BigDecimal(0)) Map.empty[Address, Map[PeerId, Amount]].pure[F]
+    ): F[Map[PeerId, Map[Address, Amount]]] =
+      if (activeDelegatedStakes.isEmpty || totalDelegationRewardPool === BigDecimal(0)) Map.empty[PeerId, Map[Address, Amount]].pure[F]
       else {
         val activeStakes = activeDelegatedStakes.flatMap {
           case (address, records) =>
@@ -216,7 +216,7 @@ object GlobalDelegatedRewardsDistributor {
         }
         val totalStakeAmount = BigDecimal(activeStakes.map(_._3.event.value.amount.value.value).sum)
 
-        if (totalStakeAmount <= 0) Map.empty[Address, Map[PeerId, Amount]].pure[F]
+        if (totalStakeAmount <= 0) Map.empty[PeerId, Map[Address, Amount]].pure[F]
         else {
           activeStakes
             .groupBy(_._1)
@@ -255,7 +255,7 @@ object GlobalDelegatedRewardsDistributor {
                           nodePortionOfTotalStake *
                           delegatorPortionOfNodeStake
 
-                      address -> (nodeId.toPeerId -> Amount(NonNegLong.unsafeFrom(math.max(0, delegatorReward.toLong))))
+                      nodeId.toPeerId -> (address -> Amount(NonNegLong.unsafeFrom(math.max(0, delegatorReward.toLong))))
                   }
                 } yield addressRewards
             }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Programs.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Programs.scala
@@ -5,7 +5,6 @@ import java.security.KeyPair
 import cats.Parallel
 import cats.effect.Async
 import cats.effect.std.Random
-import cats.implicits.none
 
 import io.constellationnetwork.dag.l0.config.types.AppConfig
 import io.constellationnetwork.dag.l0.domain.cluster.programs.TrustPush

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributorSuite.scala
@@ -48,8 +48,8 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
 
     DelegationRewardsResult(
       delegatorRewardsMap = SortedMap(
-        address1 -> Map(nodeId1.toPeerId -> Amount(NonNegLong.unsafeFrom(amount.value.value * 10 / 100))),
-        address2 -> Map(nodeId2.toPeerId -> Amount(NonNegLong.unsafeFrom(amount.value.value * 15 / 100)))
+        nodeId1.toPeerId -> Map(address1 -> Amount(NonNegLong.unsafeFrom(amount.value.value * 10 / 100))),
+        nodeId2.toPeerId -> Map(address2 -> Amount(NonNegLong.unsafeFrom(amount.value.value * 15 / 100)))
       ),
       updatedCreateDelegatedStakes = SortedMap(
         address1 -> List(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -41,7 +41,7 @@ import io.constellationnetwork.shared.sharedKryoRegistrar
 import io.constellationnetwork.statechannel.{StateChannelOutput, StateChannelSnapshotBinary, StateChannelValidationType}
 
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
+import eu.timepit.refined.types.numeric.{NonNegLong, PosInt, PosLong}
 import weaver.MutableIOSuite
 object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
   val TestValidationErrorStorageMaxSize: PosInt = PosInt(16)
@@ -90,6 +90,8 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
             RewardFraction(5_000_000),
             RewardFraction(10_000_000),
             PosInt(140),
+            PosInt(10),
+            PosLong((5000 * 1e8).toLong),
             Map(Dev -> EpochProgress(NonNegLong(7338977L)))
           )
         )

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -60,6 +60,7 @@ import io.constellationnetwork.tools.TransactionGenerator._
 import io.constellationnetwork.tools.{DAGBlockGenerator, TransactionGenerator}
 
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.PosLong
 import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
 import org.scalacheck.Gen
 import weaver._
@@ -287,6 +288,8 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
             RewardFraction(5_000_000),
             RewardFraction(10_000_000),
             PosInt(140),
+            PosInt(10),
+            PosLong((5000 * 1e8).toLong),
             Map(Dev -> EpochProgress(NonNegLong(7338977L)))
           )
         )

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -137,7 +137,9 @@ object Main
           nodeShared.nodeId,
           TessellationVersion.unsafeFrom(BuildInfo.version),
           cfg.http,
-          Hasher.forKryo[IO]
+          Hasher.forKryo[IO],
+          validators,
+          sharedConfig.delegatedStaking
         )
       _ <- MkHttpServer[IO].newEmber(ServerName("public"), cfg.http.publicHttp, api.publicApp)
       _ <- MkHttpServer[IO].newEmber(ServerName("p2p"), cfg.http.p2pHttp, api.p2pApp)

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -55,7 +55,7 @@ import io.constellationnetwork.security.signature.Signed.forAsyncHasher
 import io.constellationnetwork.transaction.TransactionGenerator
 
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
+import eu.timepit.refined.types.numeric.{NonNegLong, PosInt, PosLong}
 import fs2.concurrent.SignallingRef
 import io.chrisdavenport.mapref.MapRef
 import org.scalacheck.Gen.Parameters
@@ -113,6 +113,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                   RewardFraction(5_000_000),
                   RewardFraction(10_000_000),
                   PosInt(140),
+                  PosInt(10),
+                  PosLong((5000 * 1e8).toLong),
                   Map(Dev -> EpochProgress(NonNegLong(7338977L)))
                 )
               )

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -141,6 +141,8 @@ delegated-staking {
   min-reward-fraction:  5000000
   max-reward-fraction: 10000000
   max-metadata-fields-chars: 140
+  max-token-locks-per-address: 10
+  min-token-lock-amount: 500000000000
   withdrawal-time-limit {
     # 21 days * 24 hours * 60 minutes * 60 seconds / 43 seconds per epoch
     mainnet: 42195,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -154,6 +154,8 @@ object types {
     minRewardFraction: RewardFraction,
     maxRewardFraction: RewardFraction,
     maxMetadataFieldsChars: PosInt,
+    maxTokenLocksPerAddress: PosInt,
+    minTokenLockAmount: PosLong,
     withdrawalTimeLimit: Map[AppEnvironment, EpochProgress]
   )
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/TokenLockRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/TokenLockRoutes.scala
@@ -1,16 +1,25 @@
 package io.constellationnetwork.node.shared.http.routes
 
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
 import cats.effect.Async
 import cats.effect.std.{Queue, Supervisor}
 import cats.syntax.all._
 
+import io.constellationnetwork.currency.schema.currency.CurrencySnapshotInfo
 import io.constellationnetwork.currency.tokenlock.ConsensusInput
 import io.constellationnetwork.ext.http4s.{AddressVar, HashVar}
+import io.constellationnetwork.node.shared.cli.CliMethod
+import io.constellationnetwork.node.shared.config.types.DelegatedStakingConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
+import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.tokenlock._
 import io.constellationnetwork.routes.internal._
 import io.constellationnetwork.schema.http.{ErrorCause, ErrorResponse}
+import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockStatus, TokenLockView}
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.signature.Signed
 
@@ -23,11 +32,19 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import shapeless._
 import shapeless.syntax.singleton._
 
-final case class TokenLockRoutes[F[_]: Async: Hasher](
+final case class TokenLockRoutes[
+  F[_]: Async: Hasher,
+  P <: StateProof,
+  S <: Snapshot,
+  SI <: SnapshotInfo[P]
+](
   tokenLockConsensusInput: Queue[F, Signed[ConsensusInput.PeerConsensusInput]],
   l0ClusterStorage: L0ClusterStorage[F],
   tokenLockService: TokenLockService[F],
-  tokenLockStorage: TokenLockStorage[F]
+  tokenLockStorage: TokenLockStorage[F],
+  lastSnapshotStorage: LastSnapshotStorage[F, S, SI] with LatestBalances[F],
+  validator: TokenLockValidator[F],
+  maybeDelegatedStakingCfg: Option[DelegatedStakingConfig]
 )(implicit S: Supervisor[F])
     extends Http4sDsl[F]
     with PublicRoutes[F]
@@ -44,19 +61,42 @@ final case class TokenLockRoutes[F[_]: Async: Hasher](
       for {
         transaction <- req.as[Signed[TokenLock]]
         hashedTransaction <- transaction.toHashed[F]
-        response <- tokenLockService
-          .offer(hashedTransaction)
-          .flatTap {
-            case Left(errors) =>
-              tokenLockLogger.warn(
-                s"Received tokenLock hash=${hashedTransaction.hash} is invalid: ${transaction.show}, reason: ${errors.show}"
-              )
-            case Right(hash) => tokenLockLogger.info(s"Received valid TokenLock: ${hash.show}")
-          }
-          .flatMap {
-            case Left(errors) => BadRequest(ErrorResponse(errors.map(e => ErrorCause(e.show))))
-            case Right(hash)  => Ok(("hash" ->> hash.value) :: HNil)
-          }
+        result <- maybeDelegatedStakingCfg match {
+          case Some(value) =>
+            lastSnapshotStorage.getCombined.map {
+              case Some((_, state)) =>
+                state match {
+                  case currencyState: CurrencySnapshotInfo => currencyState.activeTokenLocks
+                  case globalState: GlobalSnapshotInfo     => globalState.activeTokenLocks
+                  case _                                   => none
+                }
+              case None =>
+                throw new IllegalStateException("Expected a last snapshot, but none was found.")
+            }.flatMap { activeTokenLocks =>
+              validator.validateWithDelegatedStakeInfo(transaction, value, activeTokenLocks)
+            }
+          case None => transaction.validNec.pure
+        }
+        response <- result match {
+          case Valid(_) =>
+            tokenLockService
+              .offer(hashedTransaction)
+              .flatTap {
+                case Left(errors) =>
+                  tokenLockLogger.warn(
+                    s"Received tokenLock hash=${hashedTransaction.hash} is invalid: ${transaction.show}, reason: ${errors.show}"
+                  )
+                case Right(hash) => tokenLockLogger.info(s"Received valid TokenLock: ${hash.show}")
+              }
+              .flatMap {
+                case Left(errors) => BadRequest(ErrorResponse(errors.map(e => ErrorCause(e.show))))
+                case Right(hash)  => Ok(("hash" ->> hash.value) :: HNil)
+              }
+          case Invalid(errors) =>
+            logger.warn(s"Invalid create token lock: $errors") >>
+              BadRequest(errors.mkString_("\n"))
+          case _ => throw new RuntimeException("Unexpected Validated value")
+        }
       } yield response
 
     case GET -> Root / "token-locks" / HashVar(hash) =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
@@ -98,7 +98,7 @@ trait GlobalSnapshotAcceptanceManager[F[_]] {
       Map[Address, List[SpendAction]],
       SortedMap[Id, Signed[UpdateNodeParameters]],
       SortedSet[SharedArtifact],
-      SortedMap[Address, Map[PeerId, Amount]]
+      SortedMap[PeerId, Map[Address, Amount]]
     )
   ]
 }
@@ -155,7 +155,7 @@ object GlobalSnapshotAcceptanceManager {
         Map[Address, List[SpendAction]],
         SortedMap[Id, Signed[UpdateNodeParameters]],
         SortedSet[SharedArtifact],
-        SortedMap[Address, Map[PeerId, Amount]]
+        SortedMap[PeerId, Map[Address, Amount]]
       )
     ] = {
       implicit val hasher = HasherSelector[F].getForOrdinal(ordinal)

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -94,7 +94,7 @@ object DataUpdate {
       case dataUpdate: DataUpdate => dataUpdate
     }
 }
-@derive(decoder, encoder, order, ordering, show)
+@derive(decoder, encoder, ordering, show)
 case class FeeTransaction(
   source: Address,
   destination: Address,
@@ -103,6 +103,8 @@ case class FeeTransaction(
 ) extends DataTransaction
 
 object FeeTransaction {
+  implicit val orderFeeTransaction: Order[FeeTransaction] = Order.by(_.amount)
+
   def serialize[F[_]: Async](feeTransaction: FeeTransaction)(implicit jsonSerializer: JsonSerializer[F]): F[Array[Byte]] =
     jsonSerializer.serialize(feeTransaction)
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshot.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshot.scala
@@ -45,7 +45,7 @@ case class GlobalIncrementalSnapshot(
   blocks: SortedSet[BlockAsActiveTip],
   stateChannelSnapshots: SortedMap[Address, NonEmptyList[Signed[StateChannelSnapshotBinary]]],
   rewards: SortedSet[RewardTransaction],
-  delegateRewards: Option[SortedMap[Address, Map[PeerId, Amount]]],
+  delegateRewards: Option[SortedMap[PeerId, Map[Address, Amount]]],
   epochProgress: EpochProgress,
   nextFacilitators: NonEmptyList[PeerId],
   tips: SnapshotTips,


### PR DESCRIPTION
### Changes
* Added `max-token-locks-per-address` and `min-token-lock-amount` parameters to application.config.
* These parameters will initially be used only on the DAG layer. However, since they are defined as `Option` types (with None provided for the currency layer), we can easily enable them for the currency layer in the future if needed.
* Introduced a new validation function in the existing TokenLocks validation file. This new validation checks the number of active token locks, which requires access to the latest state via lastSnapshotStorage. The function is invoked in the POST endpoint and also triggers the existing validations.
* Refactored the delegateRewards field to use `Map[PeerId, Map[Address, Amount]]` instead of `Map[Address, Map[PeerId, Amount]]` for improved structure and clarity.

### Tests
* I've tested all the changes from a fresh cluster and it's working as expected, to both layers:
    * DAG
    * Currency
* I've also confirmed that the Map has changed as expected:
<img width="1960" alt="Screenshot 2025-04-22 at 20 17 52" src="https://github.com/user-attachments/assets/987b1231-c25c-4522-a5b8-1eb9c97dae66" />
