### PR TITLE
feat: changing from ++ to |+| when combining active delegated stakes

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DelegatedRewardsDistributor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DelegatedRewardsDistributor.scala
@@ -122,11 +122,11 @@ object DelegatedRewardsDistributor {
                 matchingExistingRecord.map(_.rewards).getOrElse(Balance.empty)
               ).pure[F]
           }.map(addr -> _)
-      }.map(_.toMap)
+      }.map(_.toSortedMap)
 
       filteredExistingRecords = filterOutModifiedStakes(existingRecords, modifiedStakes)
 
-      mergedRecords = filteredExistingRecords ++ newRecordsWithRewards
+      mergedRecords = filteredExistingRecords |+| newRecordsWithRewards
 
       activeStakes <- {
         val withdrawnStakes = delegatedStakeDiffs.acceptedWithdrawals.flatMap(_._2.map(_._1.stakeRef)).toSet


### PR DESCRIPTION
### Changes
+ Changing the wrong merging maps that were overriding the active delegated stakes

### Tests
+ I've tested locally, and on the images below, we can confirm:
Same rewards accruing rewards in both delegations
<img width="2143" alt="Screenshot 2025-05-08 at 10 06 20" src="https://github.com/user-attachments/assets/e62dac31-903e-462b-a6da-15aaa0f6fd1f" />

Same address with 2 delegations
<img width="2110" alt="Screenshot 2025-05-08 at 10 06 30" src="https://github.com/user-attachments/assets/e0dabf88-45f0-4c9c-a6fd-fd6093c35d2f" />

After changing the delegation to another nodeId the rewards are kept
<img width="2108" alt="Screenshot 2025-05-08 at 10 10 24" src="https://github.com/user-attachments/assets/ea949b73-5cf1-4447-adbc-c3220e119e28" />

