### PR TITLE
fix: validating state per block and setting last currency snapshot

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -56,7 +56,8 @@ object Programs {
         storages.identifier,
         dataApplication.map { case (da, _) => da },
         storages.lastGlobalSnapshot,
-        services.globalL0.pullGlobalSnapshot
+        services.globalL0.pullGlobalSnapshot,
+        storages.snapshot
       )
 
     val globalL0PeerDiscovery = L0PeerDiscovery.make(


### PR DESCRIPTION
### Changes
+ This PR aims to fix the forking issue with currency L0.
+ After investigation, I've noticed 2 inconsistencies on the  code:
1st -> We were validating the same state to all blocks, and we were validating all blocks/updates at once. So I've fixed this part
2nd -> We were missing the lastCurrencySnapshot to validator nodes joining the network. In some metagraphs, such as DO,R we use this information to combine, and if we don't have this, when we join the consensus, we produce inconsistent artifacts