### PR TITLE
feat: adding cleanup above snapshots function to metagraphs

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/domain/snapshot/storages/CurrencySnapshotCleanupStorage.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/domain/snapshot/storages/CurrencySnapshotCleanupStorage.scala
@@ -1,0 +1,8 @@
+package io.constellationnetwork.currency.l0.domain.snapshot.storages
+
+import io.constellationnetwork.schema._
+import io.constellationnetwork.security.HasherSelector
+
+trait CurrencySnapshotCleanupStorage[F[_]] {
+  def cleanupAbove(ordinal: SnapshotOrdinal)(implicit hs: HasherSelector[F]): F[Unit]
+}

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/infrastructure/snapshot/CurrencySnapshotCleanupStorage.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/infrastructure/snapshot/CurrencySnapshotCleanupStorage.scala
@@ -1,0 +1,77 @@
+package io.constellationnetwork.currency.l0.infrastructure.snapshot
+
+import cats.Parallel
+import cats.effect.Async
+import cats.syntax.all._
+
+import scala.util.control.NoStackTrace
+
+import io.constellationnetwork.currency.l0.domain.snapshot.storages.CurrencySnapshotCleanupStorage
+import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo, CurrencySnapshotStateProof}
+import io.constellationnetwork.kryo.KryoSerializer
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{
+  SnapshotInfoLocalFileSystemStorage,
+  SnapshotLocalFileSystemStorage
+}
+import io.constellationnetwork.schema._
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.hash.Hash
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object CurrencySnapshotCleanupStorage {
+  def make[F[_]: Async: KryoSerializer](
+    persistedStorage: SnapshotLocalFileSystemStorage[F, CurrencyIncrementalSnapshot],
+    snapshotInfoStorage: SnapshotInfoLocalFileSystemStorage[F, CurrencySnapshotStateProof, CurrencySnapshotInfo]
+  ): CurrencySnapshotCleanupStorage[F] =
+    new CurrencySnapshotCleanupStorage[F] {
+      private val logger = Slf4jLogger.getLoggerFromName[F]("CurrencySnapshotCleanupStorage")
+      case object CurrencyCleanupError extends NoStackTrace
+
+      def deletePersisted(hash: Hash, ordinal: SnapshotOrdinal): F[Unit] =
+        persistedStorage.delete(ordinal) >>
+          persistedStorage.delete(hash)
+
+      def cleanupAbove(
+        ordinal: SnapshotOrdinal
+      )(implicit hs: HasherSelector[F]): F[Unit] = {
+        val deleteSnapshotInfo = for {
+          _ <- logger.info(s"Starting cleanup above ordinal ${ordinal.show}")
+          _ <- snapshotInfoStorage
+            .deleteAbove(ordinal)
+            .handleErrorWith(err =>
+              logger.error(err)(s"Error while deleting snapshot_info files above ${ordinal.show}") >>
+                Async[F].raiseError(err)
+            )
+          _ <- logger.info(s"Successfully deleted snapshot_info files above ordinal ${ordinal.show}")
+        } yield ()
+
+        val cleanupAboveOrdinal = persistedStorage
+          .cleanupAboveOrdinal(ordinal, deletePersisted)
+          .handleErrorWith { err =>
+            logger.error(err)("Error during cleanup snapshot of the metagraph") >>
+              CurrencyCleanupError.raiseError[F, Unit]
+          }
+
+        val verify =
+          persistedStorage
+            .findAbove(ordinal)
+            .compile
+            .count
+            .flatMap { remainingFiles =>
+              if (remainingFiles > 0) {
+                logger.error(s"Cleanup incomplete: $remainingFiles files still remain above ordinal ${ordinal.show}") >>
+                  Async[F].raiseError[Unit](
+                    new IllegalStateException(s"Cleanup incomplete: $remainingFiles files still remain above ordinal ${ordinal.show}")
+                  )
+              } else {
+                logger.info(s"Cleanup successful: No files remain above ordinal ${ordinal.show}") >> ().pure
+              }
+            }
+
+        deleteSnapshotInfo >>
+          cleanupAboveOrdinal >>
+          verify
+      }
+    }
+}

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -58,7 +58,8 @@ object Programs {
         dataApplication.map { case (da, _) => da },
         lastNGlobalSnapshotStorage.getLastN,
         services.globalL0.pullGlobalSnapshot,
-        storages.snapshot
+        storages.snapshot,
+        storages.currencySnapshotCleanup
       )
 
     val globalL0PeerDiscovery = L0PeerDiscovery.make(
@@ -90,7 +91,8 @@ object Programs {
       lastNGlobalSnapshotStorage,
       services.collateral,
       services.consensus.manager,
-      dataApplication
+      dataApplication,
+      storages.currencySnapshotCleanup
     )
 
     new Programs[F](sharedPrograms.peerDiscovery, globalL0PeerDiscovery, sharedPrograms.joining, download, genesis, rollback) {}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
@@ -80,6 +80,9 @@ abstract class SnapshotLocalFileSystemStorage[
   def delete(ordinal: SnapshotOrdinal): F[Unit] =
     delete(toOrdinalName(ordinal))
 
+  def delete(hash: Hash): F[Unit] =
+    delete(toHashName(hash))
+
   def getPath(hash: Hash): F[File] =
     getPath(toHashName(hash))
 


### PR DESCRIPTION
### Changes
+ Adding the functionality to cleanup-above ordinals and hashes on metagraphs. We already have this on the global layer, but we don't have this on metagraphs so far, this is important and needed because it can throw invalidChain if we not clean snapshots greater than X starting point

### Tests
+ I've run in a local cluster for rollback and download, both scenarios the cleanup happened successfully:
<img width="2400" alt="Screenshot 2025-06-02 at 10 38 34" src="https://github.com/user-attachments/assets/1cd3a29f-cb91-41f8-8e2a-5886b4b78b67" />
<img width="2295" alt="Screenshot 2025-06-02 at 10 38 24" src="https://github.com/user-attachments/assets/dbaa85bc-d76f-4097-8459-9b65ac47b25c" />
