### PR TITLE
feat: histogram and metrics middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -336,7 +336,8 @@ lazy val nodeShared = (project in file("modules/node-shared"))
       Libraries.pureconfigHttp4s,
       Libraries.pureconfigIp4s,
       Libraries.refinedPureconfig,
-      Libraries.shapeless
+      Libraries.shapeless,
+      Libraries.jol
     )
   )
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/middlewares/MetricsMiddleware.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/middlewares/MetricsMiddleware.scala
@@ -1,0 +1,104 @@
+package io.constellationnetwork.node.shared.http.p2p.middlewares
+
+import cats.data.Kleisli
+import cats.effect.kernel.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.api.Refined
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+import org.http4s.HttpRoutes
+import org.http4s.headers.`X-Forwarded-For`
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+object MetricsMiddleware {
+
+  def apply[F[_]: Async: Metrics](): HttpRoutes[F] => HttpRoutes[F] = { routes =>
+    Kleisli { req =>
+      val startTime = System.nanoTime()
+      routes(req).semiflatMap { response =>
+        val scriptName = req.scriptName.renderString
+        val endTime = System.nanoTime()
+        val duration = FiniteDuration(endTime - startTime, TimeUnit.NANOSECONDS)
+        // Extract route path and normalize it for metric naming
+        val routePath = normalizeRoutePath(req.pathInfo.renderString)
+        val actualIp = req.remote.map(_.host.toString).getOrElse("unknown")
+        val forwardedIp = req.headers
+          .get[`X-Forwarded-For`]
+          .map(_.values.head.toString.split(",").head.trim)
+          .getOrElse("none")
+
+        // Cannot compile time infer type for Seq
+        val tags: Seq[(Metrics.LabelName, String)] = Seq(
+          Metrics.unsafeLabelName("script_name") -> scriptName,
+          Metrics.unsafeLabelName("method") -> req.method.name,
+          Metrics.unsafeLabelName("status") -> response.status.code.toString,
+          Metrics.unsafeLabelName("route") -> routePath,
+          Metrics.unsafeLabelName("status_class") -> s"${response.status.code / 100}xx",
+          Metrics.unsafeLabelName("actual_ip") -> actualIp,
+          Metrics.unsafeLabelName("forwarded_ip") -> forwardedIp
+        )
+        // Generic HTTP metrics with route as label
+        val durationMetricKey: Metrics.MetricKey = "dag_http_request_time"
+        val requestSizeMetricKey: Metrics.MetricKey = "dag_http_request_size"
+        val responseSizeMetricKey: Metrics.MetricKey = "dag_http_response_size"
+
+        // Record metrics asynchronously without blocking the response
+        val metricsRecording = for {
+
+          _ <- Metrics[F].recordTimeHistogram(durationMetricKey, duration, tags)
+          // 4. Request size histograms (both route-specific and generic)
+
+          _ <- req.contentLength.traverse_ { size =>
+              Metrics[F].recordSizeHistogram(requestSizeMetricKey, size, tags)
+          }
+          // 5. Response size histograms (both route-specific and generic)
+          _ <- response.contentLength.traverse_ { size =>
+            Metrics[F].recordSizeHistogram(responseSizeMetricKey, size, tags)
+          }
+
+
+        } yield ()
+        Async[F].start(metricsRecording) >> response.pure[F]
+      }
+    }
+  }
+  
+  /**
+   * Normalize route path for use in metric names
+   * Examples:
+   * - "/api/v1/users/123" -> "api_v1_users_id"  
+   * - "/health" -> "health"
+   * - "/metrics" -> "metrics"
+   * - "/" -> "root"
+   */
+  private def normalizeRoutePath(path: String): String = {
+    val cleaned = path
+      .stripPrefix("/")
+      .stripSuffix("/")
+      
+    if (cleaned.isEmpty) {
+      "root"
+    } else {
+      cleaned
+        .split("/")
+        .map { segment =>
+          // Replace numeric IDs and UUIDs with generic placeholders
+          if (segment.matches("\\d+")) {
+            "id"
+          } else if (segment.matches("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")) {
+            "uuid"
+          } else if (segment.matches("[0-9a-fA-F]{64}")) {
+            "hash"
+          } else if (segment.matches("(?i).*dag[1-9A-HJ-NP-Za-km-z]{37}.*")) {
+              // DAG address pattern (base58, case insensitive)
+            "address"
+          } else {
+            // Replace non-alphanumeric chars with underscores and lowercase
+            segment.replaceAll("[^a-zA-Z0-9]", "_").toLowerCase
+          }
+        }
+        .mkString("_")
+    }
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/middlewares/MetricsMiddleware.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/middlewares/MetricsMiddleware.scala
@@ -1,23 +1,30 @@
 package io.constellationnetwork.node.shared.http.p2p.middlewares
 
+import java.util.concurrent.TimeUnit
+
 import cats.data.Kleisli
 import cats.effect.kernel.Async
 import cats.syntax.all._
-import eu.timepit.refined.auto._
-import eu.timepit.refined.api.Refined
+
+import scala.concurrent.duration.FiniteDuration
+
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
 import org.http4s.HttpRoutes
 import org.http4s.headers.`X-Forwarded-For`
-import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.TimeUnit
 
 object MetricsMiddleware {
+
+  def isHistogramRoute(path: String): Boolean =
+    path.contains("rumor")
 
   def apply[F[_]: Async: Metrics](): HttpRoutes[F] => HttpRoutes[F] = { routes =>
     Kleisli { req =>
       val startTime = System.nanoTime()
       routes(req).semiflatMap { response =>
-        val scriptName = req.scriptName.renderString
+        // val scriptName = r?eq.scriptName.renderString
         val endTime = System.nanoTime()
         val duration = FiniteDuration(endTime - startTime, TimeUnit.NANOSECONDS)
         // Extract route path and normalize it for metric naming
@@ -29,8 +36,7 @@ object MetricsMiddleware {
           .getOrElse("none")
 
         // Cannot compile time infer type for Seq
-        val tags: Seq[(Metrics.LabelName, String)] = Seq(
-          Metrics.unsafeLabelName("script_name") -> scriptName,
+        var allTags: Seq[(Metrics.LabelName, String)] = Seq(
           Metrics.unsafeLabelName("method") -> req.method.name,
           Metrics.unsafeLabelName("status") -> response.status.code.toString,
           Metrics.unsafeLabelName("route") -> routePath,
@@ -38,45 +44,63 @@ object MetricsMiddleware {
           Metrics.unsafeLabelName("actual_ip") -> actualIp,
           Metrics.unsafeLabelName("forwarded_ip") -> forwardedIp
         )
+
+        // Use discrete label for per event counter metrics; higher granularity than time histogram
+        val bucket = Metrics.unsafeLabelName("time_bucket")
+        val bucketLabel = if (duration.toMillis > 1000) {
+          "gt_1s"
+        } else if (duration.toMillis > 10_000) {
+          "gt_10s"
+        } else {
+          "lt_1s"
+        }
+
+        allTags = allTags :+ (bucket -> bucketLabel)
+
+        val histogramTags: Seq[(Metrics.LabelName, String)] = Seq(
+          Metrics.unsafeLabelName("route") -> routePath
+        )
+
         // Generic HTTP metrics with route as label
         val durationMetricKey: Metrics.MetricKey = "dag_http_request_time"
         val requestSizeMetricKey: Metrics.MetricKey = "dag_http_request_size"
         val responseSizeMetricKey: Metrics.MetricKey = "dag_http_response_size"
+        val requestCounterMetricKey: Metrics.MetricKey = "dag_http_request_count"
 
         // Record metrics asynchronously without blocking the response
         val metricsRecording = for {
-
-          _ <- Metrics[F].recordTimeHistogram(durationMetricKey, duration, tags)
+          _ <- Metrics[F].incrementCounter(requestCounterMetricKey, allTags)
+          _ <-
+            if (isHistogramRoute(req.pathInfo.renderString)) {
+              Metrics[F].recordTimeHistogram(durationMetricKey, duration, histogramTags) >>
+                req.contentLength.traverse_ { size =>
+                  Metrics[F].recordSizeHistogram(requestSizeMetricKey, size, histogramTags)
+                } >>
+                response.contentLength.traverse_ { size =>
+                  Metrics[F].recordSizeHistogram(responseSizeMetricKey, size, histogramTags)
+                }
+            } else {
+              Async[F].unit
+            }
           // 4. Request size histograms (both route-specific and generic)
-
-          _ <- req.contentLength.traverse_ { size =>
-              Metrics[F].recordSizeHistogram(requestSizeMetricKey, size, tags)
-          }
-          // 5. Response size histograms (both route-specific and generic)
-          _ <- response.contentLength.traverse_ { size =>
-            Metrics[F].recordSizeHistogram(responseSizeMetricKey, size, tags)
-          }
-
 
         } yield ()
         Async[F].start(metricsRecording) >> response.pure[F]
       }
     }
   }
-  
-  /**
-   * Normalize route path for use in metric names
-   * Examples:
-   * - "/api/v1/users/123" -> "api_v1_users_id"  
-   * - "/health" -> "health"
-   * - "/metrics" -> "metrics"
-   * - "/" -> "root"
-   */
-  private def normalizeRoutePath(path: String): String = {
+
+  /** Normalize route path for use in metric names Examples:
+    *   - "/api/v1/users/123" -> "api_v1_users_id"
+    *   - "/health" -> "health"
+    *   - "/metrics" -> "metrics"
+    *   - "/" -> "root"
+    */
+  def normalizeRoutePath(path: String): String = {
     val cleaned = path
       .stripPrefix("/")
       .stripSuffix("/")
-      
+
     if (cleaned.isEmpty) {
       "root"
     } else {
@@ -90,9 +114,11 @@ object MetricsMiddleware {
             "uuid"
           } else if (segment.matches("[0-9a-fA-F]{64}")) {
             "hash"
-          } else if (segment.matches("(?i).*dag[1-9A-HJ-NP-Za-km-z]{37}.*")) {
-              // DAG address pattern (base58, case insensitive)
+          } else if (segment.matches("(?i).*dag[1-9A-HJ-NP-Za-km-z].*")) {
+            // DAG address pattern (base58, case insensitive)
             "address"
+          } else if (segment.toLowerCase.startsWith("state_channel_dag")) {
+            "state_channel_dag"
           } else {
             // Replace non-alphanumeric chars with underscores and lowercase
             segment.replaceAll("[^a-zA-Z0-9]", "_").toLowerCase

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,6 +88,7 @@ object Dependencies {
     val catsRetry = "com.github.cb372" %% "cats-retry" % V.catsRetry
 
     val squants = "org.typelevel" %% "squants" % V.squants
+    val jol = "org.openjdk.jol" % "jol-core" % "0.17"
     val comcast = "com.comcast" %% "ip4s-core" % V.comcast
 
     val fs2Core = fs2("core")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,6 +49,7 @@ object Dependencies {
     val organizeImports = "0.5.0"
     val semanticDB = "4.13.1.1"
     val weaver = "0.8.1"
+    val jol = "0.17"
   }
 
   object Libraries {
@@ -88,7 +89,7 @@ object Dependencies {
     val catsRetry = "com.github.cb372" %% "cats-retry" % V.catsRetry
 
     val squants = "org.typelevel" %% "squants" % V.squants
-    val jol = "org.openjdk.jol" % "jol-core" % "0.17"
+    val jol = "org.openjdk.jol" % "jol-core" % V.jol
     val comcast = "com.comcast" %% "ip4s-core" % V.comcast
 
     val fs2Core = fs2("core")


### PR DESCRIPTION
added jol and custom middleware, new histogram method

JOL is a better way to measure in memory object sizes than relying on serialization, if we need more granularity than the external monitoring dashboard. It's not used in this PR just imported and defined. I'll make separate PR with a CL_METRICS_TRACE flag to prevent using it unless explicitly enabled in case we need to investigate in the future in more detail for objects in flight (separate from the state/info).

The current timer using micrometer doesn't integrate properly with prometheus / grafana. We're not capturing default bucket level information in prometheus as is normally intended by micrometer, and we're only capturing max/count/sum with no way to aggregate by buckets as far as I can tell (I don't see them being published in the right format in the /metrics endpoint at least.)

There's another branch ryle/mainnet-debug-mgdocker where I'm actually testing / using these, I've been adjusting the histogram buckets based on the routes I applied them to as part of testing, it appears to at least be returning somewhat correct information.

I tried to use the http4s-prometheus-metrics, that has a serious problem with versions and the way that we're implementing micrometer metrics. There's also metrics4s and others, but all of them would require us manually merging the registry due to the way we've created a custom route to serve the micrometer metrics. I tried a few libraries but they were all more effort to integrate than it was to just recreate directly. This custom middleware also very importantly captures the actual origin IPs. It may need some more headers though, the actual ip is definitely populated though, and I saw request labels being formatted correctly.

I doubt I've perfectly captured the regex for normalizing routes, but its at least mostly correct so far in tests. Also I had to bypass Refined due to compiler error on Seq[] and it doesn't seem right to register every string metric as an individual val since that's almost worse?

No functional changes are made as part of this PR, I am trying to merge code from the debug branch back so please review for correctness and I'll test on a separate branch.