### PR TITLE
fix: adding offset to remove from unapplied ordinals to avoid snapshotDiff error

### DIFF
--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -307,7 +307,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       GlobalSnapshotAcceptanceManager
         .make[IO](
           FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty),
-          MetagraphsSyncConfig(PosInt(100)),
+          MetagraphsSyncConfig(PosInt(100), NonNegLong(10)),
           Dev,
           bam,
           asbam,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -368,7 +368,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
           FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty),
-          MetagraphsSyncConfig(PosInt(100)),
+          MetagraphsSyncConfig(PosInt(100), NonNegLong(10)),
           Dev,
           blockAcceptanceManager,
           allowSpendBlockAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -200,7 +200,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
               globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
                 FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty),
-                MetagraphsSyncConfig(PosInt(100)),
+                MetagraphsSyncConfig(PosInt(100), NonNegLong(10)),
                 Dev,
                 BlockAcceptanceManager.make[IO](validators.blockValidator, Hasher.forKryo[IO]),
                 AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -181,6 +181,7 @@ delegated-staking {
 
 metagraphs-sync {
  max-unapplied-global-change-ordinals: 100
+ offset-to-clean-unapplied-ordinals: 10
 }
 
 price-oracle {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -34,7 +34,8 @@ object types {
   )
 
   case class MetagraphsSyncConfig(
-    maxUnappliedGlobalChangeOrdinals: PosInt
+    maxUnappliedGlobalChangeOrdinals: PosInt,
+    offsetToCleanUnappliedOrdinals: NonNegLong
   )
 
   case class SharedConfigReader(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
@@ -1199,6 +1199,7 @@ object GlobalSnapshotAcceptanceManager {
         case (address, snapshots) =>
           val currentInfo = existingData.getOrElse(address, MetagraphSyncDataInfo.empty)
           val lastSyncOrdinal = extractLastSynchronizedOrdinal(snapshots)
+          val lastSyncOrdinalWithOffset = lastSyncOrdinal.plus(metagraphsSyncConfig.offsetToCleanUnappliedOrdinals)
 
           val updatedInfo = currentInfo
             .focus(_.globalOrdinalLastAcceptedOn)
@@ -1206,7 +1207,7 @@ object GlobalSnapshotAcceptanceManager {
             .focus(_.globalEpochProgressLastAcceptedOn)
             .replace(currentEpochProgress)
             .focus(_.unappliedGlobalChangeOrdinals)
-            .modify(_.filter(_ >= lastSyncOrdinal))
+            .modify(_.filter(_ >= lastSyncOrdinalWithOffset))
 
           address -> updatedInfo
       }.toSortedMap


### PR DESCRIPTION
### Changes
+ Adding a offset to remove from the calculated state the unnaplied ordinal to avoid snapshotDiff error when validating snapshots in GL0