### PR TITLE
fix: adding GlobalIncrementalSnapshot and GlobalSnapshotStateProof to kryo registrar

### DIFF
--- a/modules/shared/src/main/scala/io/constellationnetwork/shared/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/shared/package.scala
@@ -106,7 +106,9 @@ package object shared {
     DataCancellationReason.CreatedEmptyBlock.getClass -> 636,
     DataCancellationReason.PeerCancelled.getClass -> 637,
     classOf[DelegatedStakeRecord] -> 640,
-    classOf[PendingDelegatedStakeWithdrawal] -> 641
+    classOf[PendingDelegatedStakeWithdrawal] -> 641,
+    classOf[GlobalIncrementalSnapshot] -> 642,
+    classOf[GlobalSnapshotStateProof] -> 643
   )
 
 }


### PR DESCRIPTION
### Changes
+ We need to add the classes GlobalIncrementalSnapshot and GlobalSnapshotStateProof to Kryo registrar for backward compatibility, in testnet as one example, if we don't have all snapshots lower or equal `1933590` will fail when decoding and get the hash, because this is the ordinal that we switched to JSON serializer.