### PR TITLE
fix: fixing last N global snapshot storage

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/StateChannel.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/StateChannel.scala
@@ -133,22 +133,22 @@ object StateChannel {
       spendTransactionIssuedFromThisMetagraph || spendTransactionsReferencesCurrentMetagraph || activeAllowSpendsFromThisMetagraphs || allowSpendsReferencesCurrentMetagraph
     }
 
-    def maybeForceEventTrigger(
-      currentSnapshot: Hashed[GlobalIncrementalSnapshot],
-      currentSnapshotState: GlobalSnapshotInfo
-    ): F[Unit] =
-      for {
+      def maybeForceEventTrigger(
+        currentSnapshot: Hashed[GlobalIncrementalSnapshot],
+        currentSnapshotState: GlobalSnapshotInfo
+      ): F[Unit] =
+        for {
 //        currencyId <- storages.identifier.get
 //        shouldForceEventTrigger = checkIfShouldForceEventTrigger(currentSnapshot, currencyId, currentSnapshotState)
 
-        // Temporarily disabling the force event trigger
+          // Temporarily disabling the force event trigger
 //        _ <-
 //          if (shouldForceEventTrigger) {
 //            Logger[F].info("Should force event trigger detected!")
 //          } else {
 //            ().pure
 //          }
-        _ <- conditionallyTriggerEvent(false)
+          _ <- conditionallyTriggerEvent(false)
 
       } yield ()
 

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -61,16 +61,14 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
             ),
             PriceOracleConfig(None, NonNegLong(0))
           )
-          lastNSnapR <- SignallingRef
-            .of[IO, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
-            .asResource
+          lastNSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None).asResource
           incLastNSnapR <- SignallingRef
             .of[IO, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]](SortedMap.empty)
             .asResource
           lastSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None).asResource
 
           lastGlobalSnapshotsSyncConfig =
-            LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(10), PosInt.unsafeFrom(5))
+            LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(5))
           lastNSnapshotStorage =
             LastNGlobalSnapshotStorage.make[IO](lastGlobalSnapshotsSyncConfig, lastNSnapR, incLastNSnapR)
           lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
@@ -79,7 +77,7 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
             .make(
               FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
               Dev,
-              LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(20), PosInt(50)),
+              LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(50)),
               BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
               TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
               AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -99,14 +99,13 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
           ),
           PriceOracleConfig(None, NonNegLong(0))
         )
-      lastNSnapR <- SignallingRef
-        .of[IO, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
+      lastNSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
       incLastNSnapR <- SignallingRef
         .of[IO, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]](SortedMap.empty)
       lastSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
 
       lastGlobalSnapshotsSyncConfig =
-        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(10), PosInt.unsafeFrom(5))
+        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(5))
       lastNSnapshotStorage =
         LastNGlobalSnapshotStorage.make[IO](lastGlobalSnapshotsSyncConfig, lastNSnapR, incLastNSnapR)
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
@@ -114,7 +113,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
         FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
         Dev,
-        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(20), PosInt(10)),
+        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
         TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
         AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -305,14 +305,13 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
     for {
       validationErrorStorage <- CurrencySnapshotEventValidationErrorStorage.make(TestValidationErrorStorageMaxSize)
-      lastNSnapR <- SignallingRef
-        .of[IO, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
+      lastNSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
       incLastNSnapR <- SignallingRef
         .of[IO, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]](SortedMap.empty)
       lastSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
 
       lastGlobalSnapshotsSyncConfig =
-        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(10), PosInt.unsafeFrom(5))
+        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(5))
       lastNSnapshotStorage =
         LastNGlobalSnapshotStorage.make[IO](lastGlobalSnapshotsSyncConfig, lastNSnapR, incLastNSnapR)
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
@@ -320,7 +319,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
         FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
         Dev,
-        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10), PosInt(10)),
+        LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
         TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
         AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -86,7 +86,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
     Ref[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
     TransactionStorage[IO],
     GlobalSnapshotContextFunctions[IO],
-    Ref[IO, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
+    Ref[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
     Ref[IO, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]]
   )
 
@@ -101,9 +101,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               balancesR <- Ref.of[IO, Map[Address, Balance]](Map.empty).asResource
               blocksR <- MapRef.ofConcurrentHashMap[IO, ProofsHash, StoredBlock]().asResource
               lastSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None).asResource
-              lastNSnapR <- SignallingRef
-                .of[IO, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
-                .asResource
+              lastNSnapR <- SignallingRef.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None).asResource
               incLastNSnapR <- SignallingRef
                 .of[IO, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]](SortedMap.empty)
                 .asResource
@@ -154,7 +152,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
               globalL0AlignmentStorage <- GlobalL0AlignmentStorage.make[IO].asResource
               lastGlobalSnapshotsSyncConfig =
-                LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(10), PosInt.unsafeFrom(5))
+                LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(5))
               lastNSnapshotStorage =
                 LastNGlobalSnapshotStorage.make[IO](lastGlobalSnapshotsSyncConfig, lastNSnapR, incLastNSnapR)
               lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
@@ -163,7 +161,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 .make(
                   FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
                   Dev,
-                  LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(20), PosInt(10)),
+                  LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
                   BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
                   TokenLockBlockAcceptanceManager.make[IO](validators.tokenLockBlockValidator),
                   AllowSpendBlockAcceptanceManager.make[IO](validators.allowSpendBlockValidator),
@@ -248,7 +246,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 val blockStorage = new BlockStorage[IO](blocksR)
                 val lastSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
                 val lastGlobalSnapshotsSyncConfig =
-                  LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(10), PosInt.unsafeFrom(5))
+                  LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt.unsafeFrom(5))
                 val globalL0Service = new GlobalL0Service[IO] {
                   override def pullLatestSnapshot: IO[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)] = ???
 
@@ -921,7 +919,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
           _ <- lastSnapR.set((hashedLastSnapshot, GlobalSnapshotInfo.empty).some)
-          lastN = SortedMap(hashedLastSnapshot.ordinal -> (hashedLastSnapshot, GlobalSnapshotInfo.empty))
+          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
           _ <- lastNSnapsR.set(lastN)
           _ <- incLastNSnapR.set(incLastN)
@@ -1143,7 +1141,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
           }
           _ <- lastSnapR.set((hashedLastSnapshot, lastSnapshotInfo).some)
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
-          lastN = SortedMap(hashedLastSnapshot.ordinal -> (hashedLastSnapshot, GlobalSnapshotInfo.empty))
+          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
           _ <- lastNSnapR.set(lastN)
           _ <- incLastNSnapR.set(incLastN)
           // Inserting tips
@@ -1420,7 +1418,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
           _ <- lastSnapR.set((hashedLastSnapshot, lastSnapshotInfo).some)
-          lastN = SortedMap(hashedLastSnapshot.ordinal -> (hashedLastSnapshot, GlobalSnapshotInfo.empty))
+          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
           _ <- lastNSnapR.set(lastN)
           _ <- incLastNSnapR.set(incLastN)
@@ -1562,7 +1560,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
           _ <- lastSnapR.set((hashedLastSnapshot, GlobalSnapshotInfo.empty).some)
-          lastN = SortedMap(hashedLastSnapshot.ordinal -> (hashedLastSnapshot, GlobalSnapshotInfo.empty))
+          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
           _ <- lastNSnapR.set(lastN)
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
           _ <- incLastNSnapR.set(incLastN)
@@ -1618,7 +1616,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
           _ <- lastSnapR.set((hashedLastSnapshot, GlobalSnapshotInfo.empty).some)
-          lastN = SortedMap(hashedLastSnapshot.ordinal -> (hashedLastSnapshot, GlobalSnapshotInfo.empty))
+          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
           _ <- lastNSnapR.set(lastN)
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
           _ <- incLastNSnapR.set(incLastN)

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -127,8 +127,7 @@ token-locks {
 
 last-global-snapshots-sync {
   sync-offset: 2
-  max-allowed-gap: 80
-  max-last-global-snapshots-in-memory: 100
+  max-last-global-snapshots-in-memory: 50
 }
 
 fields-added-ordinals {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -246,7 +246,7 @@ object types {
 
   case class TokenLocksConfig(minEpochProgressesToLock: NonNegLong)
 
-  case class LastGlobalSnapshotsSyncConfig(syncOffset: NonNegLong, maxAllowedGap: PosInt, maxLastGlobalSnapshotsInMemory: PosInt)
+  case class LastGlobalSnapshotsSyncConfig(syncOffset: NonNegLong, maxLastGlobalSnapshotsInMemory: PosInt)
 
   case class ValidationErrorStorageConfig(maxSize: PosInt)
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
 import io.constellationnetwork.node.shared.domain.snapshot.Validator.isNextSnapshot
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
 import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, SnapshotStorage}
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage.make
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.schema.height.Height
@@ -29,14 +30,13 @@ object LastNGlobalSnapshotStorage {
   def make[F[_]: Async: Hasher: Parallel](
     lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig
   ): F[LastNGlobalSnapshotStorage[F] with LatestBalances[F]] = for {
-    combinedSignalingRef <- SignallingRef
-      .of[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
+    combinedSignalingRef <- SignallingRef.of[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
     incrementalSignalingRef <- SignallingRef.of[F, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]](SortedMap.empty)
   } yield make(lastGlobalSnapshotsSyncConfig, combinedSignalingRef, incrementalSignalingRef)
 
   def make[F[_]: Async: Hasher: Parallel](
     lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
-    combinedSnapshotsR: SignallingRef[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
+    combinedSnapshotsR: SignallingRef[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
     incrementalSnapshotsR: SignallingRef[F, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]]
   ): LastNGlobalSnapshotStorage[F] with LatestBalances[F] =
     new LastNGlobalSnapshotStorage[F] with LatestBalances[F] {
@@ -56,11 +56,13 @@ object LastNGlobalSnapshotStorage {
         snapshot: Hashed[GlobalIncrementalSnapshot],
         state: GlobalSnapshotInfo
       ): F[Unit] =
-        combinedSnapshotsR.modify { snapshots =>
-          if (snapshots.nonEmpty)
-            (snapshots, MonadThrow[F].raiseError[Unit](new Throwable("Failure putting initial snapshot! Storage non empty.")))
-          else
-            (snapshots.updated(snapshot.ordinal, (snapshot, state)), Applicative[F].unit)
+        combinedSnapshotsR.modify {
+          case None => ((snapshot, state).some, Applicative[F].unit)
+          case other =>
+            (
+              other,
+              MonadThrow[F].raiseError[Unit](new Throwable(s"Failure setting initial snapshot! Encountered non empty storage"))
+            )
         }.flatten
 
       private def fetchAndStoreGlobalSnapshots(
@@ -144,15 +146,13 @@ object LastNGlobalSnapshotStorage {
           setInitialInternal(snapshot, state, globalSnapshotFetcher, fetchGL0Function)
 
       def set(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] = for {
-        _ <- combinedSnapshotsR.modify { combinedSnapshots =>
-          combinedSnapshots.lastOption match {
-            case Some((_, (latest, _))) if isNextSnapshot(latest, snapshot.signed.value) =>
-              (combinedSnapshots.updated(snapshot.ordinal, (snapshot, state)), Applicative[F].unit)
-            case Some((_, (latest, _))) if latest.hash === snapshot.hash =>
-              (combinedSnapshots, Applicative[F].unit)
-            case _ => (combinedSnapshots, MonadThrow[F].raiseError[Unit](new Throwable("Failure during putting new global snapshot!")))
-          }
+        _ <- combinedSnapshotsR.modify {
+          case Some((current, _)) if isNextSnapshot(current, snapshot.signed.value) => ((snapshot, state).some, Applicative[F].unit)
+          case s @ Some((current, _)) if current.hash === snapshot.hash             => (s, Applicative[F].unit)
+          case other =>
+            (other, MonadThrow[F].raiseError[Unit](new Throwable("Failure during setting new global snapshot!")))
         }.flatten
+
         _ <- incrementalSnapshotsR.modify { incrementalSnapshots =>
           incrementalSnapshots.lastOption match {
             case Some((_, latest)) if isNextSnapshot(latest, snapshot.signed.value) =>
@@ -174,14 +174,12 @@ object LastNGlobalSnapshotStorage {
 
       def get: F[Option[Hashed[GlobalIncrementalSnapshot]]] = getCombined.map(_.map { case (snapshot, _) => snapshot })
 
-      def getCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = combinedSnapshotsR.get.map {
-        _.lastOption.map { case (_, combined) => combined }
-      }
+      def getCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = combinedSnapshotsR.get
 
       def getCombinedStream: fs2.Stream[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
         Stream
           .eval[F, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](getCombined)
-          .merge(combinedSnapshotsR.discrete.map(_.lastOption.map { case (_, combined) => combined }))
+          .merge(combinedSnapshotsR.discrete)
 
       def getOrdinal: F[Option[SnapshotOrdinal]] =
         get.map(_.map(_.ordinal))
@@ -190,13 +188,13 @@ object LastNGlobalSnapshotStorage {
         get.map(_.map(_.height))
 
       def getLatestBalances: F[Option[Map[Address, Balance]]] =
-        combinedSnapshotsR.get.map(_.headOption.map(_._2._2.balances.toMap))
+        combinedSnapshotsR.get.map(_.map(_._2.balances.toMap))
 
       def getLatestBalancesStream: Stream[F, Map[Address, Balance]] =
         combinedSnapshotsR.discrete
-          .evalMap(snapshotMap => Async[F].pure(snapshotMap.headOption.map(_._2)))
+          .evalMap(snapshotMap => Async[F].pure(snapshotMap.map(_._2)))
           .collect { case Some(snapshot) => snapshot }
-          .map(_._2.balances)
+          .map(_.balances)
 
       def getLastN: F[List[Hashed[GlobalIncrementalSnapshot]]] =
         incrementalSnapshotsR.get.map(_.values.toList)


### PR DESCRIPTION
I've inspected the memory dump and then I've figured out the following behavior:
<img width="2560" height="1070" alt="Screenshot 2025-09-16 at 12 45 04" src="https://github.com/user-attachments/assets/1481ead1-1a84-40af-ae45-ff64d87a08b6" />

The storage was consuming the entire memory, and then I found a bug where we're storing all states for all snapshots without limiting. We definitely don't need this. I also reduced the lastN