### PR TITLE
feat: (dataApp) add optional update hashes to incremental snapshot

### DIFF
--- a/.github/templates/metagraphs/project_template/build.sbt
+++ b/.github/templates/metagraphs/project_template/build.sbt
@@ -19,7 +19,15 @@ ThisBuild / assemblyMergeStrategy := {
 lazy val commonSettings = Seq(
   testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
   scalafmtOnCompile := true,
-  scalafixOnCompile := true
+  scalafixOnCompile := true,
+  scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
+  buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+  resolvers ++= Seq(Resolver.mavenLocal),
+  libraryDependencies ++= Seq(
+    CompilerPlugin.kindProjector,
+    CompilerPlugin.betterMonadicFor,
+    CompilerPlugin.semanticDB
+  )
 )
 
 lazy val root = (project in file(".")).
@@ -28,72 +36,37 @@ lazy val root = (project in file(".")).
   ).aggregate(sharedData, currencyL0, currencyL1, dataL1)
 
 lazy val sharedData = (project in file("modules/shared_data"))
-  .enablePlugins(AshScriptPlugin)
-  .enablePlugins(BuildInfoPlugin)
-  .enablePlugins(JavaAppPackaging)
+  .enablePlugins(AshScriptPlugin, BuildInfoPlugin, JavaAppPackaging)
   .settings(
     name := "project_template-shared_data",
-    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.project_template.shared_data",
-    resolvers ++= Seq(
-      Resolver.mavenLocal,
-      Resolver.githubPackages("abankowski", "http-request-signer")
-    ),
     Defaults.itSettings,
     commonSettings,
     libraryDependencies ++= Seq(
-      CompilerPlugin.kindProjector,
-      CompilerPlugin.betterMonadicFor,
-      CompilerPlugin.semanticDB,
       Libraries.tessellationSdk,
-      Libraries.requests,
+      Libraries.requests
     )
   )
 
 lazy val currencyL1 = (project in file("modules/l1"))
-  .enablePlugins(AshScriptPlugin)
-  .enablePlugins(BuildInfoPlugin)
-  .enablePlugins(JavaAppPackaging)
+  .enablePlugins(AshScriptPlugin, BuildInfoPlugin, JavaAppPackaging)
   .dependsOn(sharedData)
   .settings(
     name := "project_template-currency-l1",
-    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.project_template.l1",
-    resolvers ++= Seq(
-      Resolver.mavenLocal,
-      Resolver.githubPackages("abankowski", "http-request-signer")
-    ),
     Defaults.itSettings,
-    commonSettings,
-    libraryDependencies ++= Seq(
-      CompilerPlugin.kindProjector,
-      CompilerPlugin.betterMonadicFor,
-      CompilerPlugin.semanticDB
-    )
+    commonSettings
   )
 
 lazy val currencyL0 = (project in file("modules/l0"))
-  .enablePlugins(AshScriptPlugin)
-  .enablePlugins(BuildInfoPlugin)
-  .enablePlugins(JavaAppPackaging)
+  .enablePlugins(AshScriptPlugin, BuildInfoPlugin, JavaAppPackaging)
   .dependsOn(sharedData)
   .settings(
     name := "project_template-currency-l0",
-    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.project_template.l0",
-    resolvers ++= Seq(
-      Resolver.mavenLocal,
-      Resolver.githubPackages("abankowski", "http-request-signer")
-    ),
     Defaults.itSettings,
     commonSettings,
     libraryDependencies ++= Seq(
-      CompilerPlugin.kindProjector,
-      CompilerPlugin.betterMonadicFor,
-      CompilerPlugin.semanticDB,
       Libraries.declineRefined,
       Libraries.declineCore,
       Libraries.declineEffect
@@ -101,24 +74,11 @@ lazy val currencyL0 = (project in file("modules/l0"))
   )
 
 lazy val dataL1 = (project in file("modules/data_l1"))
-  .enablePlugins(AshScriptPlugin)
-  .enablePlugins(BuildInfoPlugin)
-  .enablePlugins(JavaAppPackaging)
+  .enablePlugins(AshScriptPlugin, BuildInfoPlugin, JavaAppPackaging)
   .dependsOn(sharedData)
   .settings(
     name := "project_template-data_l1",
-    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.project_template.data_l1",
-    resolvers ++= Seq(
-      Resolver.mavenLocal,
-      Resolver.githubPackages("abankowski", "http-request-signer")
-    ),
     Defaults.itSettings,
-    commonSettings,
-    libraryDependencies ++= Seq(
-      CompilerPlugin.kindProjector,
-      CompilerPlugin.betterMonadicFor,
-      CompilerPlugin.semanticDB
-    )
+    commonSettings
   )

--- a/.github/templates/metagraphs/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
+++ b/.github/templates/metagraphs/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
@@ -67,6 +67,10 @@ object Main
       )(implicit context: L0NodeContext[IO]): IO[DataState[UsageUpdateState, UsageUpdateCalculatedState]] =
         LifecycleSharedFunctions.combine[IO](state, updates)
 
+      override def hashDataUpdate: Option[UsageUpdate => F[Hash]] = Some(
+        (update: UsageUpdate) => update.computeDigest
+      )
+
       override def dataEncoder: Encoder[UsageUpdate] =
         implicitly[Encoder[UsageUpdate]]
 

--- a/.github/templates/metagraphs/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
+++ b/.github/templates/metagraphs/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
@@ -67,9 +67,8 @@ object Main
       )(implicit context: L0NodeContext[IO]): IO[DataState[UsageUpdateState, UsageUpdateCalculatedState]] =
         LifecycleSharedFunctions.combine[IO](state, updates)
 
-      override def hashDataUpdate: Option[UsageUpdate => F[Hash]] = Some(
-        (update: UsageUpdate) => update.computeDigest
-      )
+      override def hashDataUpdate: Option[UsageUpdate => IO[Hash]] =
+        Some((update: UsageUpdate) => serializeUpdate(update).map(Hash.fromBytes))
 
       override def dataEncoder: Encoder[UsageUpdate] =
         implicitly[Encoder[UsageUpdate]]

--- a/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/serializers/Serializers.scala
+++ b/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/serializers/Serializers.scala
@@ -7,8 +7,8 @@ import io.constellationnetwork.currency.dataApplication.dataApplication.DataAppl
 import io.constellationnetwork.security.signature.Signed
 
 import com.my.project_template.shared_data.types.Types.{UsageUpdate, UsageUpdateCalculatedState, UsageUpdateState}
-import io.circe.{Encoder, Printer}
 import io.circe.syntax.EncoderOps
+import io.circe.{Encoder, Printer}
 
 object Serializers {
   private def serialize[A: Encoder](

--- a/.github/templates/metagraphs/project_template/project/plugins.sbt
+++ b/.github/templates/metagraphs/project_template/project/plugins.sbt
@@ -6,6 +6,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 addDependencyTreePlugin

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Genesis.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Genesis.scala
@@ -133,7 +133,7 @@ object Genesis {
           .map(_.map(a => (a.address, a.balance)).toMap)
 
       def mkDataApplicationPart =
-        dataApplication.traverse(da => da.serializedOnChainGenesis.map(DataApplicationPart(_, List.empty, Hash.empty)))
+        dataApplication.traverse(da => da.serializedOnChainGenesis.map(DataApplicationPartV1(_, List.empty, Hash.empty)))
 
       for {
         balances <- mkBalances

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
@@ -24,6 +24,7 @@ import io.constellationnetwork.schema.artifact.{SharedArtifact, TokenUnlock}
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, SecurityProvider}
+import io.constellationnetwork.syntax.sortedCollection.sortedSetSyntax
 
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -248,9 +249,22 @@ object DataApplicationSnapshotAcceptanceManager {
         )
 
         sharedArtifacts = newDataState.sharedArtifacts ++ tokenUnlocks
+
+        updateHashes <- OptionT.liftF(
+          service.hashDataUpdate match {
+            case Some(hashFn) if validatedBlocks.nonEmpty =>
+              validatedBlocks.flatMap { block =>
+                getDataUpdates(block.value.dataTransactions.toList)
+              }.traverse { signedUpdate =>
+                hashFn(signedUpdate.value)
+              }.map(hashes => Some(hashes.toSortedSet))
+            case _ =>
+              Async[F].pure(None: Option[SortedSet[Hash]])
+          }
+        )
       } yield
         DataApplicationAcceptanceResult(
-          DataApplicationPart(serializedOnChainState, serializedBlocks, calculatedStateProof),
+          DataApplicationPart(serializedOnChainState, serializedBlocks, calculatedStateProof, updateHashes),
           newDataState.calculated,
           validatedFeeTransactions,
           sharedArtifacts,
@@ -260,9 +274,9 @@ object DataApplicationSnapshotAcceptanceManager {
       newDataState.value.handleErrorWith { err =>
         logger.error(err)("Unhandled exception during calculating new data application state, fallback to last data application") >>
           service.getCalculatedState.map { lastCalculatedState =>
-            maybeLastDataApplication.map(
+            maybeLastDataApplication.map(part =>
               DataApplicationAcceptanceResult(
-                _,
+                part,
                 lastCalculatedState._2,
                 notAccepted = dataBlocks.map(signedBlock => (signedBlock, DataBlockNotAccepted(err.getMessage)))
               )

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -240,6 +240,8 @@ trait BaseDataApplicationL0ContextualOps[F[_]] extends BaseDataApplicationShared
 
   def hashCalculatedState(state: DataCalculatedState)(implicit context: L0NodeContext[F]): F[Hash]
 
+  def hashDataUpdate: Option[DataUpdate => F[Hash]] = None
+
   def extractFees(ds: Seq[Signed[DataUpdate]])(implicit context: L0NodeContext[F], A: Applicative[F]): F[Seq[Signed[FeeTransaction]]] =
     A.pure(Seq.empty)
 }
@@ -332,6 +334,8 @@ trait DataApplicationL0ContextualOps[F[_], D <: DataUpdate, DON <: DataOnChainSt
   def setCalculatedState(ordinal: SnapshotOrdinal, state: DOF)(implicit context: L0NodeContext[F]): F[Boolean]
 
   def hashCalculatedState(state: DOF)(implicit context: L0NodeContext[F]): F[Hash]
+
+  def hashDataUpdate: Option[D => F[Hash]] = None
 
   def extractFees(ds: Seq[Signed[D]])(implicit context: L0NodeContext[F], A: Applicative[F]): F[Seq[Signed[FeeTransaction]]] =
     A.pure(Seq.empty)
@@ -484,6 +488,14 @@ object BaseDataApplicationL0ContextualOps {
         state match {
           case s: DOF => service.hashCalculatedState(s)
           case _      => UnexpectedInput.raiseError[F, Hash]
+        }
+
+      override def hashDataUpdate: Option[DataUpdate => F[Hash]] =
+        service.hashDataUpdate.map { hashFn =>
+          {
+            case d: D => hashFn(d)
+            case _    => UnexpectedInput.raiseError[F, Hash]
+          }
         }
 
       override def validateFee(
@@ -679,6 +691,9 @@ object BaseDataApplicationL0Service {
       def hashCalculatedState(state: DataCalculatedState)(implicit context: L0NodeContext[F]): F[Hash] =
         ctx.hashCalculatedState(state)
 
+      override def hashDataUpdate: Option[DataUpdate => F[Hash]] =
+        ctx.hashDataUpdate
+
       def calculatedStateDecoder: Decoder[DataCalculatedState] = base.calculatedStateDecoder
 
       def calculatedStateEncoder: Encoder[DataCalculatedState] = base.calculatedStateEncoder
@@ -785,7 +800,8 @@ object dataApplication {
   case class DataApplicationBlock(
     roundId: RoundId,
     dataTransactions: NonEmptyList[DataTransactions],
-    dataTransactionsHashes: NonEmptyList[NonEmptyList[Hash]]
+    dataTransactionsHashes: NonEmptyList[NonEmptyList[Hash]],
+    updateHashes: Option[SortedSet[Hash]] = None
   ) extends Encodable[NonEmptyList[NonEmptyList[Hash]]] {
     override def toEncode: NonEmptyList[NonEmptyList[Hash]] = dataTransactionsHashes
     override def jsonEncoder: Encoder[NonEmptyList[NonEmptyList[Hash]]] = implicitly
@@ -800,8 +816,11 @@ object dataApplication {
 
     implicit def eqv: Eq[DataApplicationBlock] =
       Eq.and[DataApplicationBlock](
-        Eq[RoundId].contramap(_.roundId),
-        Eq[NonEmptyList[NonEmptyList[Hash]]].contramap(_.dataTransactionsHashes)
+        Eq.and[DataApplicationBlock](
+          Eq[RoundId].contramap(_.roundId),
+          Eq[NonEmptyList[NonEmptyList[Hash]]].contramap(_.dataTransactionsHashes)
+        ),
+        Eq[Option[SortedSet[Hash]]].contramap(_.updateHashes)
       )
   }
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
@@ -142,14 +142,32 @@ object currency {
   }
 
   @derive(eqv, show, encoder, decoder)
-  case class DataApplicationPart(
+  case class DataApplicationPartV1(
     onChainState: Array[Byte],
     blocks: List[Array[Byte]],
     calculatedStateProof: Hash
+  ) {
+    def toDataApplicationPart: DataApplicationPart =
+      DataApplicationPart(onChainState, blocks, calculatedStateProof, None)
+  }
+
+  object DataApplicationPartV1 {
+    def empty: DataApplicationPartV1 = DataApplicationPartV1(Array.empty, List.empty, Hash.empty)
+  }
+
+  @derive(eqv, show, encoder, decoder)
+  case class DataApplicationPart(
+    onChainState: Array[Byte],
+    blocks: List[Array[Byte]],
+    calculatedStateProof: Hash,
+    updateHashes: Option[SortedSet[Hash]] = None
   )
 
   object DataApplicationPart {
-    def empty: DataApplicationPart = DataApplicationPart(Array.empty, List.empty, Hash.empty)
+    def empty: DataApplicationPart = DataApplicationPart(Array.empty, List.empty, Hash.empty, None)
+
+    def fromDataApplicationPartV1(part: DataApplicationPartV1): DataApplicationPart =
+      DataApplicationPart(part.onChainState, part.blocks, part.calculatedStateProof, None)
   }
 
   @derive(eqv, show, encoder, decoder)
@@ -163,7 +181,7 @@ object currency {
     tips: SnapshotTips,
     info: CurrencySnapshotInfoV1,
     epochProgress: EpochProgress,
-    dataApplication: Option[DataApplicationPart] = None,
+    dataApplication: Option[DataApplicationPartV1] = None,
     globalSyncView: Option[GlobalSyncView] = None,
     version: SnapshotVersion = SnapshotVersion("0.0.1")
   ) extends FullSnapshot[CurrencySnapshotStateProofV1, CurrencySnapshotInfoV1]
@@ -203,7 +221,7 @@ object currency {
           snapshot.tips,
           stateProof.toCurrencySnapshotStateProof,
           snapshot.epochProgress,
-          snapshot.dataApplication,
+          snapshot.dataApplication.map(_.toDataApplicationPart),
           None,
           None,
           None,
@@ -227,7 +245,7 @@ object currency {
     tips: SnapshotTips,
     stateProof: CurrencySnapshotStateProofV1,
     epochProgress: EpochProgress,
-    dataApplication: Option[DataApplicationPart] = None,
+    dataApplication: Option[DataApplicationPartV1] = None,
     version: SnapshotVersion = SnapshotVersion("0.0.1")
   ) extends IncrementalSnapshot[CurrencySnapshotStateProofV1] {
     def toCurrencyIncrementalSnapshot: CurrencyIncrementalSnapshot =
@@ -241,7 +259,7 @@ object currency {
         tips,
         stateProof.toCurrencySnapshotStateProof,
         epochProgress,
-        dataApplication,
+        dataApplication.map(_.toDataApplicationPart),
         None,
         None,
         None,
@@ -265,7 +283,7 @@ object currency {
         snapshot.tips,
         CurrencySnapshotStateProofV1.fromCurrencySnapshotStateProof(snapshot.stateProof),
         snapshot.epochProgress,
-        snapshot.dataApplication,
+        snapshot.dataApplication.flatMap(part => Some(DataApplicationPartV1(part.onChainState, part.blocks, part.calculatedStateProof))),
         snapshot.version
       )
   }
@@ -273,7 +291,7 @@ object currency {
   object CurrencySnapshot {
     def mkGenesis(
       balances: Map[Address, Balance],
-      dataApplicationPart: Option[DataApplicationPart],
+      dataApplicationPart: Option[DataApplicationPartV1],
       latestGlobalSnapshot: Option[Hashed[GlobalIncrementalSnapshot]]
     ): CurrencySnapshot =
       CurrencySnapshot(
@@ -307,7 +325,7 @@ object currency {
           genesis.tips,
           stateProof.toCurrencySnapshotStateProof,
           genesis.epochProgress,
-          genesis.dataApplication,
+          genesis.dataApplication.map(_.toDataApplicationPart),
           None,
           None,
           None,

--- a/modules/shared/src/main/scala/io/constellationnetwork/shared/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/shared/package.scala
@@ -98,7 +98,7 @@ package object shared {
     classOf[GlobalSnapshotStateProofV1] -> 628,
     classOf[CurrencySnapshotStateProofV1] -> 629,
     classOf[StateProof] -> 630,
-    classOf[DataApplicationPart] -> 631,
+    classOf[DataApplicationPartV1] -> 631,
     DataCancellationReason.getClass -> 632,
     DataCancellationReason.ReceivedProposalForNonExistentOwnRound.getClass -> 633,
     DataCancellationReason.MissingRoundPeers.getClass -> 634,


### PR DESCRIPTION
## Summary
Added support for tracking data update hashes in currency snapshots by introducing an optional `updateHashes` field to the `DataApplicationPart` schema. This enhancement allows data applications to optionally provide a hash function for their data updates, enabling better traceability and verification of data updates within snapshots.

## Changes
- Added `updateHashes: Option[SortedSet[Hash]]` field to `DataApplicationPart` for tracking update hashes
- Created `DataApplicationPartV1` to maintain backward compatibility with existing serialized data
- Added `hashDataUpdate` method to `BaseDataApplicationL0ContextualOps` and `DataApplicationL0ContextualOps` traits with the signature  `Option[DataUpdate => F[Hash]]` to make update hashing optional with default value of `None`
- Updated `DataApplicationSnapshotAcceptanceManager` to:
  - Check if `hashDataUpdate` is provided by the data application
  - Compute hashes for all data updates when the function is available
  - Include the computed hashes in the `DataApplicationPart` as a `SortedSet[Hash]`
  - Skip hash computation when no hash function is provided (backwards compatible behavior)
- Registered `DataApplicationPartV1` with Kryo serialization at ID 631 for backward compatibility
- Updated `CurrencyIncrementalSnapshot` to use the new `DataApplicationPart` with the optional field
- Ensured `CurrencyIncrementalSnapshotV1` continues using `DataApplicationPartV1` for deserializing legacy data

## Testing
- Local unit and e2e tests passing
- Verified backward compatibility with existing Kryo-serialized test data
- Confirmed state proof calculations remain consistent for historical snapshots
- Tested with data applications both with and without `hashDataUpdate` implementation