### PR TITLE
fix: removing stale process on ConsensusStateAdvancer temporarily

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/ConsensusStateAdvancer.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/ConsensusStateAdvancer.scala
@@ -45,15 +45,7 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
       }.map(SortedMap.from(_))
 
     def processStale = {
-      val results = state.facilitators.value.flatMap { peerId =>
-        resources.peerDeclarationsMap
-          .get(peerId)
-          .flatMap(getter)
-          .map((peerId, _))
-      }
-
-      if (results.nonEmpty) Some(SortedMap.from(results))
-      else None
+      processNonStale
     }
 
     for {


### PR DESCRIPTION
I've seen in several metagraphs that when we achieve this step, the nodes are turning offline immediately and not able to maybe pick majority and resume the execution. This can explain the large forking events