### PR TITLE
fix: wrap the `Hash` and `MerkleTree` operations in blocking

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -683,12 +683,14 @@ object CurrencySnapshotAcceptanceManager {
         }
         .flatTap {
           case (_, toAdd, toReject) =>
-            logger.info(
-              s"Message acceptance complete - " +
-                s"Total processed: ${messagesForAcceptance.size}, " +
-                s"Accepted: ${toAdd.size}, " +
-                s"Rejected: ${toReject.size}"
-            ).whenA(messagesForAcceptance.nonEmpty)
+            logger
+              .info(
+                s"Message acceptance complete - " +
+                  s"Total processed: ${messagesForAcceptance.size}, " +
+                  s"Accepted: ${toAdd.size}, " +
+                  s"Rejected: ${toReject.size}"
+              )
+              .whenA(messagesForAcceptance.nonEmpty)
         }
         .map {
           case (contextUpdate, toAdd, toReject) =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
@@ -484,7 +484,7 @@ object GlobalSnapshotAcceptanceManager {
                 updatedLastCurrencySnapshots.toList.traverse {
                   case (address, state) =>
                     (address, state).hash
-                      .map(merkleTree.findPath(_))
+                      .flatMap(merkleTree.findPath[F](_))
                       .flatMap(MonadThrow[F].fromOption(_, InvalidMerkleTree))
                       .map((address, _))
                 }
@@ -516,7 +516,7 @@ object GlobalSnapshotAcceptanceManager {
                   case (address, state) =>
                     hasher
                       .hash((address, state))
-                      .map(merkleTree.findPath(_))
+                      .flatMap(merkleTree.findPath[F](_))
                       .flatMap(MonadThrow[F].fromOption(_, InvalidMerkleTree))
                       .map((address, _))
                 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -127,9 +127,11 @@ object FeeTransaction {
       case Signed(feeTransaction: FeeTransaction, proofs) => Signed(feeTransaction, proofs)
     }
 
-    serializeDataUpdate(dataUpdate).map { serializedDataUpdate =>
-      feeTransactions.find { feeTransaction =>
-        Hash.fromBytes(serializedDataUpdate) === feeTransaction.value.dataUpdateRef
+    serializeDataUpdate(dataUpdate).flatMap { serializedDataUpdate =>
+      Hash.fromBytesForSync(serializedDataUpdate).map { hash =>
+        feeTransactions.find { feeTransaction =>
+          hash === feeTransaction.value.dataUpdateRef
+        }
       }
     }
   }

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/EstimatedFee.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/EstimatedFee.scala
@@ -1,7 +1,7 @@
 package io.constellationnetwork.currency.schema
 
 import cats.effect.Async
-import cats.syntax.functor._
+import cats.syntax.flatMap._
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate
 import io.constellationnetwork.schema.address.Address
@@ -24,5 +24,5 @@ object EstimatedFee {
     Estimated(fee, address)
 
   def getUpdateHash[F[_]: Async](dataUpdate: DataUpdate, toBytes: DataUpdate => F[Array[Byte]]): F[Hash] =
-    toBytes(dataUpdate).map(Hash.fromBytes)
+    toBytes(dataUpdate).flatMap(Hash.fromBytesForSync[F])
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/FeeTransactionValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/FeeTransactionValidator.scala
@@ -22,8 +22,8 @@ object FeeTransactionValidator {
   ): F[ValidatedNec[DataApplicationValidationError, Unit]] =
     dataTransactions.existsM {
       case Signed(dataUpdate: DataUpdate, _) =>
-        dataApplication.serializeUpdate(dataUpdate).map { serializedUpdate =>
-          Hash.fromBytes(serializedUpdate) === feeTransaction.dataUpdateRef
+        dataApplication.serializeUpdate(dataUpdate).flatMap { serializedUpdate =>
+          Hash.fromBytesForSync(serializedUpdate).map(_ === feeTransaction.dataUpdateRef)
         }
       case _ => false.pure
     }.ifM(

--- a/modules/shared/src/main/scala/io/constellationnetwork/merkletree/MerkleTree.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/merkletree/MerkleTree.scala
@@ -1,9 +1,16 @@
 package io.constellationnetwork.merkletree
 
 import cats.data.NonEmptyList
+import cats.effect.Sync
 import cats.kernel.Eq
+import cats.syntax.applicative._
+import cats.syntax.either._
 import cats.syntax.eq._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
 import cats.syntax.option._
+import cats.syntax.traverse._
 
 import io.constellationnetwork.schema.{nonNegIntDecoder, nonNegIntEncoder}
 import io.constellationnetwork.security.hash.Hash
@@ -20,24 +27,28 @@ case class ProofEntry(target: Hash, sibling: Either[Hash, Hash])
 
 @derive(eqv, show, encoder, decoder)
 case class Proof(entries: NonEmptyList[ProofEntry]) {
-  def verify(candidate: Hash): Boolean =
+  def verify[F[_]: Sync](candidate: Hash): F[Boolean] =
     entries.toList match {
       case x :: Nil =>
-        val leaf = MerkleTree.hashLeaf(candidate)
-        x.target === leaf && x.sibling === Right(leaf)
+        MerkleTree.hashLeaf(candidate).map { leaf =>
+          x.target === leaf && x.sibling === Right(leaf)
+        }
       case _ =>
-        entries
-          .foldLeft(candidate.some.map(MerkleTree.hashLeaf)) {
-            case (Some(curr), pe) =>
-              val (lsib, rsib) = pe.sibling match {
-                case Left(sib)  => (sib, curr)
-                case Right(sib) => (curr, sib)
-              }
-              val hash = MerkleTree.hashIntermediate(lsib, rsib)
-              Option.when(hash == pe.target)(hash)
-            case (None, _) => None
-          }
-          .isDefined
+        candidate.some.traverse(MerkleTree.hashLeaf[F]).flatMap { candidateLeaf =>
+          entries
+            .foldLeftM(candidateLeaf) {
+              case (Some(curr), pe) =>
+                val (lsib, rsib) = pe.sibling match {
+                  case Left(sib)  => (sib, curr)
+                  case Right(sib) => (curr, sib)
+                }
+                MerkleTree.hashIntermediate(lsib, rsib).map { hash =>
+                  Option.when(hash == pe.target)(hash)
+                }
+              case (None, _) => none[Hash].pure[F]
+            }
+            .map(_.isDefined)
+        }
     }
 }
 
@@ -49,10 +60,10 @@ case class MerkleTree(leafCount: NonNegInt, nodes: NonEmptyList[Hash]) {
   def getRoot: MerkleRoot =
     MerkleRoot(leafCount, nodes.last)
 
-  def findPath(leaf: Hash): Option[Proof] =
-    findPath(nodes.toList.indexOf(MerkleTree.hashLeaf(leaf)))
+  def findPath[F[_]: Sync](leaf: Hash): F[Option[Proof]] =
+    MerkleTree.hashLeaf(leaf).flatMap(hash => findPath[F](nodes.toList.indexOf(hash)))
 
-  def findPath(index: Int): Option[Proof] =
+  def findPath[F[_]: Sync](index: Int): F[Option[Proof]] = Sync[F].delay(
     if (index < 0 || index >= leafCount.value)
       None
     else {
@@ -95,6 +106,7 @@ case class MerkleTree(leafCount: NonNegInt, nodes: NonEmptyList[Hash]) {
         case _        => NonEmptyList.fromList(go()).map(Proof(_))
       }
     }
+  )
 }
 
 object MerkleTree {
@@ -104,47 +116,71 @@ object MerkleTree {
   private val leafPrefix: Byte = 0x00
   private val intermediatePrefix: Byte = 0x01
 
-  private[merkletree] def hashLeaf(node: Hash): Hash =
-    Hash.fromBytes(node.value.getBytes.prepended(leafPrefix))
+  private[merkletree] def hashLeaf[F[_]: Sync](node: Hash): F[Hash] =
+    Hash.fromBytesForSync(node.value.getBytes.prepended(leafPrefix))
 
-  private[merkletree] def hashIntermediate(left: Hash, right: Hash): Hash =
-    Hash.fromBytes((left.value + right.value).getBytes.prepended(intermediatePrefix))
+  private[merkletree] def hashIntermediate[F[_]: Sync](left: Hash, right: Hash): F[Hash] =
+    Hash.fromBytesForSync((left.value + right.value).getBytes.prepended(intermediatePrefix))
 
   private def nextLevelLen(levelLen: Int): Int =
     if (levelLen == 1) 0 else (levelLen + 1) / 2
 
-  def from(items: NonEmptyList[Hash]): MerkleTree = {
+  def from[F[_]: Sync](items: NonEmptyList[Hash]): F[MerkleTree] = {
     val leafCount = NonNegInt.unsafeFrom(items.size) // Note: size cannot be less than 0
-    val nodes = items.map(hashLeaf)
+    items.traverse(hashLeaf[F]).flatMap { nodes =>
+      case class State(
+        mt: MerkleTree,
+        levelLen: Int,
+        levelStart: Int,
+        prevLevelLen: Int,
+        prevLevelStart: Int
+      )
 
-    def go(
-      mt: MerkleTree = MerkleTree(leafCount, nodes),
-      levelLen: Int = nextLevelLen(leafCount.value),
-      levelStart: Int = leafCount.value,
-      prevLevelLen: Int = leafCount.value,
-      prevLevelStart: Int = 0
-    ): MerkleTree =
-      if (levelLen <= 0)
-        mt
-      else {
-        val newMt = (0 to levelLen - 1).foldLeft(mt) {
-          case (prevMt, i) =>
-            val prevLevelIdx = 2 * i;
-            val pointer = prevLevelStart + prevLevelIdx;
-            val leftSibling = prevMt.nodes.toList(pointer)
-            val rightSibling =
-              if (prevLevelIdx + 1 < prevLevelLen)
-                prevMt.nodes.toList(pointer + 1)
-              else
-                prevMt.nodes.toList(pointer)
+      def go(state: State): F[State] =
+        if (state.levelLen <= 0) {
+          state.pure[F]
+        } else {
+          val newMt = (0 to state.levelLen - 1).toList.foldLeftM(state.mt) {
+            case (prevMt, i) =>
+              val prevLevelIdx = 2 * i;
+              val pointer = state.prevLevelStart + prevLevelIdx;
+              val leftSibling = prevMt.nodes.toList(pointer)
+              val rightSibling =
+                if (prevLevelIdx + 1 < state.prevLevelLen)
+                  prevMt.nodes.toList(pointer + 1)
+                else
+                  prevMt.nodes.toList(pointer)
 
-            MerkleTree(prevMt.leafCount, prevMt.nodes.append(hashIntermediate(leftSibling, rightSibling)))
+              hashIntermediate[F](leftSibling, rightSibling).map(hash => MerkleTree(prevMt.leafCount, prevMt.nodes.append(hash)))
+          }
+
+          newMt.map { updatedMt =>
+            State(
+              mt = updatedMt,
+              levelLen = nextLevelLen(state.levelLen),
+              levelStart = state.levelStart + state.levelLen,
+              prevLevelLen = state.levelLen,
+              prevLevelStart = state.levelStart
+            )
+          }
         }
 
-        go(newMt, nextLevelLen(levelLen), levelStart + levelLen, levelLen, levelStart)
+      // Use tailRecM for stack-safe recursion
+      Sync[F].tailRecM(
+        State(
+          mt = MerkleTree(leafCount, nodes),
+          levelLen = nextLevelLen(leafCount.value),
+          levelStart = leafCount.value,
+          prevLevelLen = leafCount.value,
+          prevLevelStart = 0
+        )
+      ) { state =>
+        if (state.levelLen <= 0) {
+          state.mt.asRight[State].pure[F]
+        } else {
+          go(state).map(_.asLeft[MerkleTree])
+        }
       }
-
-    go()
+    }
   }
-
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/merkletree/syntax.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/merkletree/syntax.scala
@@ -2,6 +2,7 @@ package io.constellationnetwork.merkletree
 
 import cats.data.NonEmptyList
 import cats.effect.kernel.Sync
+import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 
@@ -20,6 +21,6 @@ trait SortedMapOps {
       a.toList
         .traverse(_.hash)
         .map(NonEmptyList.fromList)
-        .map(_.map(MerkleTree.from))
+        .flatMap(_.traverse(MerkleTree.from[F]))
   }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Hash.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Hash.scala
@@ -3,6 +3,8 @@ package io.constellationnetwork.security
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
+import cats.effect.Sync
+import cats.syntax.functor._
 import cats.{Eq, Show}
 
 import io.constellationnetwork.ext.derevo.ordering
@@ -55,8 +57,13 @@ object hash {
       Sha256Digest(md.digest())
     }
 
+    def sha256DigestFromBytesForSync[F[_]: Sync](bytes: Array[Byte]): F[Sha256Digest] = Sync[F].blocking(sha256DigestFromBytes(bytes))
+
     def fromBytes(bytes: Array[Byte]): Hash =
       Hash(sha256DigestFromBytes(bytes).toHexString)
+
+    def fromBytesForSync[F[_]: Sync](bytes: Array[Byte]): F[Hash] =
+      sha256DigestFromBytesForSync[F](bytes).map(digest => Hash(digest.toHexString))
 
     def empty: Hash = Hash(s"%064d".format(0))
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
@@ -80,8 +80,8 @@ object Hasher {
           case d: Encodable[_] => map(d.toEncode)
           case _               => map(data)
         })
-        .map(Hash.fromBytes)
         .liftTo[F]
+        .flatMap(Hash.fromBytesForSync[F])
     }
 
     def hash[A: Encoder](data: A): F[Hash] =
@@ -100,7 +100,7 @@ object Hasher {
           JsonSerializer[F].serialize(d.toEncode)(d.jsonEncoder)
         case _ =>
           JsonSerializer[F].serialize[A](data)
-      }).map(Hash.fromBytes)
+      }).flatMap(Hash.fromBytesForSync[F])
 
     def hash[A: Encoder](data: A): F[Hash] =
       hashJson(data)

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/signature/Signed.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/signature/Signed.scala
@@ -82,7 +82,7 @@ object Signed {
     data: A,
     keyPair: KeyPair
   )(implicit toBytes: A => F[Array[Byte]]): F[Signed[A]] =
-    toBytes(data).map(Hash.fromBytes).flatMap { hash =>
+    toBytes(data).flatMap(Hash.fromBytesForSync[F]).flatMap { hash =>
       SignatureProof.fromHash(keyPair, hash).map { sp =>
         Signed[A](data, NonEmptySet.fromSetUnsafe(SortedSet(sp)))
       }
@@ -161,7 +161,7 @@ object Signed {
       }
 
     def toHashed[F[_]: Async: Hasher](toBytes: A => F[Array[Byte]]): F[Hashed[A]] =
-      toBytes(signed.value).map(Hash.fromBytes).flatMap { hash =>
+      toBytes(signed.value).flatMap(Hash.fromBytesForSync[F]).flatMap { hash =>
         proofsHash.map(Hashed(signed, hash, _))
       }
 

--- a/modules/shared/src/test/scala/io/constellationnetwork/merkletree/MerkleTreeSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/merkletree/MerkleTreeSuite.scala
@@ -1,7 +1,11 @@
 package io.constellationnetwork.merkletree
 
 import cats.data.NonEmptyList
+import cats.effect.IO
 import cats.syntax.eq._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
 
 import io.constellationnetwork.security.hash.Hash
 
@@ -16,103 +20,106 @@ object MerkleTreeSuite extends SimpleIOSuite with Checkers {
 
   implicit val fixedHashesGen: Gen[NonEmptyList[Hash]] = Gen.listOfN(10, Hash.arbitrary.arbitrary).map(NonEmptyList.fromListUnsafe)
 
-  pureTest("tree created from one hash is possible") {
+  test("tree created from one hash is possible") {
     val hash = Hash("a")
-    val mt = MerkleTree.from(NonEmptyList.one(hash))
-
-    val expected = MerkleRoot(mt.leafCount, MerkleTree.hashLeaf(hash))
-
-    expect(mt.getRoot === expected)
+    for {
+      mt <- MerkleTree.from[IO](NonEmptyList.one(hash))
+      expectedHash <- MerkleTree.hashLeaf[IO](hash)
+      expected = MerkleRoot(mt.leafCount, expectedHash)
+    } yield expect(mt.getRoot === expected)
   }
 
-  pureTest("path for one leaf is the leaf itself") {
-    val mt = MerkleTree.from(NonEmptyList.one(Hash("a")))
-    val leaf = MerkleTree.hashLeaf(Hash("a"))
-
-    expect.eql(Some(Proof(NonEmptyList.one(ProofEntry(leaf, Right(leaf))))), mt.findPath(0))
+  test("path for one leaf is the leaf itself") {
+    for {
+      mt <- MerkleTree.from[IO](NonEmptyList.one(Hash("a")))
+      leaf <- MerkleTree.hashLeaf[IO](Hash("a"))
+      path <- mt.findPath[IO](Hash("a"))
+    } yield expect.eql(Some(Proof(NonEmptyList.one(ProofEntry(leaf, Right(leaf))))), path)
   }
 
   test("can find path when tree has many leaves") {
     forall(fixedHashesGen) {
       case hashes =>
-        val mt = MerkleTree.from(hashes)
-
-        expect.eql(true, mt.findPath(0).isDefined)
+        for {
+          mt <- MerkleTree.from[IO](hashes)
+          path <- mt.findPath(0)
+        } yield expect.eql(true, path.isDefined)
     }
   }
 
   test("cannot find path for index out of range") {
     forall(fixedHashesGen) {
       case hashes =>
-        val mt = MerkleTree.from(hashes)
-
-        expect.eql(true, mt.findPath(11).isEmpty)
-        expect.eql(true, mt.findPath(-1).isEmpty)
+        for {
+          mt <- MerkleTree.from[IO](hashes)
+          path11 <- mt.findPath(11)
+          path_1 <- mt.findPath(-1)
+        } yield expect.eql(true, path11.isEmpty).and(expect.eql(true, path_1.isEmpty))
     }
   }
 
-  pureTest("can verify path for one leaf") {
-    val mt = MerkleTree.from(NonEmptyList.one(Hash("a")))
-    val path = mt.findPath(0)
-
-    expect.eql(true, path.get.verify(Hash("a")))
+  test("can verify path for one leaf") {
+    for {
+      mt <- MerkleTree.from[IO](NonEmptyList.one(Hash("a")))
+      path <- mt.findPath[IO](Hash("a"))
+      verified <- path.get.verify[IO](Hash("a"))
+    } yield expect.eql(true, verified)
   }
 
   test("can verify good path") {
     forall(fixedHashesGen) {
       case hashes =>
-        val mt = MerkleTree.from(hashes)
-
-        expect.eql(Some(true), mt.findPath(0).map(_.verify(hashes.head)))
+        for {
+          mt <- MerkleTree.from[IO](hashes)
+          path <- mt.findPath[IO](hashes.head)
+          verified <- path.traverse(_.verify[IO](hashes.head))
+        } yield expect.eql(Some(true), verified)
     }
   }
 
   test("veryfing bad path fails") {
     forall(fixedHashesGen) {
       case hashes =>
-        val mt = MerkleTree.from(hashes)
-
-        expect.eql(Some(false), mt.findPath(0).map(_.verify(Hash("dummy"))))
+        for {
+          mt <- MerkleTree.from[IO](hashes)
+          path <- mt.findPath[IO](hashes.head)
+          verified <- path.traverse(_.verify[IO](Hash("dummy")))
+        } yield expect.eql(Some(false), verified)
     }
   }
 
-  pureTest("forgery attack with duplicated hashes") {
+  test("forgery attack with duplicated hashes") {
     val hashes = NonEmptyList.fromListUnsafe(('a' to 'd').map(_.toString).map(Hash(_)).toList)
     val doubled = hashes ++ List(Hash("c"), Hash("d"))
 
-    val mt1 = MerkleTree.from(hashes)
-    val mt2 = MerkleTree.from(doubled)
-
-    expect(mt1 =!= mt2)
-    expect(mt1.getRoot =!= mt2.getRoot)
+    for {
+      mt1 <- MerkleTree.from[IO](hashes)
+      mt2 <- MerkleTree.from[IO](doubled)
+    } yield expect(mt1 =!= mt2).and(expect(mt1.getRoot =!= mt2.getRoot))
   }
 
-  pureTest("forgery attack with duplicated last hash to make balanced tree") {
+  test("forgery attack with duplicated last hash to make balanced tree") {
     val hashes = NonEmptyList.fromListUnsafe(('a' to 'c').map(_.toString).map(Hash(_)).toList)
     val doubled = hashes ++ List(Hash("c"))
 
-    val mt1 = MerkleTree.from(hashes)
-    val mt2 = MerkleTree.from(doubled)
-
-    expect(mt1 =!= mt2)
-    expect(mt1.getRoot =!= mt2.getRoot)
+    for {
+      mt1 <- MerkleTree.from[IO](hashes)
+      mt2 <- MerkleTree.from[IO](doubled)
+    } yield expect(mt1 =!= mt2).and(expect(mt1.getRoot =!= mt2.getRoot))
   }
 
-  pureTest("second preimage attack") {
+  test("second preimage attack") {
     val hashes = NonEmptyList.of(Hash("a"), Hash("b"), Hash("c"), Hash("d"))
 
-    val mt1 = MerkleTree.from(hashes)
-
-    val n1 = mt1.nodes.toList(4)
-    val n2 = mt1.nodes.toList(5)
-
-    val mt2 = MerkleTree.from(NonEmptyList.of(n1, n2))
-
-    expect(mt1 =!= mt2)
-    expect(mt1.getRoot =!= mt2.getRoot)
+    for {
+      mt1 <- MerkleTree.from[IO](hashes)
+      n1 = mt1.nodes.toList(4)
+      n2 = mt1.nodes.toList(5)
+      mt2 <- MerkleTree.from[IO](NonEmptyList.of(n1, n2))
+    } yield expect(mt1 =!= mt2).and(expect(mt1.getRoot =!= mt2.getRoot))
   }
 
-  pureTest("ensure that calculation is stable") {
+  test("ensure that calculation is stable") {
     val hashes = NonEmptyList.of(Hash("a"), Hash("b"), Hash("c"), Hash("d"))
     val expected = MerkleTree(
       4,
@@ -127,8 +134,82 @@ object MerkleTreeSuite extends SimpleIOSuite with Checkers {
       )
     )
 
-    val result = MerkleTree.from(hashes)
-
-    expect(result === expected)
+    MerkleTree.from[IO](hashes).map { result =>
+      expect(result === expected)
+    }
   }
+
+  test("stack safety with large input (10,000 leaves)") {
+    val largeHashes = NonEmptyList.fromListUnsafe(
+      (1 to 10000).map(i => Hash(s"hash_$i")).toList
+    )
+
+    for {
+      startTime <- IO(System.currentTimeMillis())
+      mt <- MerkleTree.from[IO](largeHashes)
+      endTime <- IO(System.currentTimeMillis())
+      duration = endTime - startTime
+    } yield
+      expect(mt.leafCount.value === 10000)
+        .and(expect(mt.nodes.length > 10000)) // Should have more nodes than leaves
+        .and(expect(duration < 30000)) // Should complete within 30 seconds
+  }
+
+  /*
+  test("stack safety with very large input (100,000 leaves)") {
+    val veryLargeHashes = NonEmptyList.fromListUnsafe(
+      (1 to 100000).map(i => Hash(s"hash_$i")).toList
+    )
+
+    for {
+      startTime <- IO(System.currentTimeMillis())
+      mt <- MerkleTree.from[IO](veryLargeHashes)
+      endTime <- IO(System.currentTimeMillis())
+      duration = endTime - startTime
+    } yield
+      expect(mt.leafCount.value === 100000)
+        .and(expect(mt.nodes.length > 100000)) // Should have more nodes than leaves
+        .and(expect(duration < 300000)) // Should complete within 5 minutes
+  }
+
+  test("stack safety with extremely large input (1,000,000 leaves)") {
+    val extremelyLargeHashes = NonEmptyList.fromListUnsafe(
+      (1 to 1000000).map(i => Hash(s"hash_$i")).toList
+    )
+
+    for {
+      startTime <- IO(System.currentTimeMillis())
+      mt <- MerkleTree.from[IO](extremelyLargeHashes)
+      endTime <- IO(System.currentTimeMillis())
+      duration = endTime - startTime
+    } yield
+      expect(mt.leafCount.value === 1000000)
+        .and(expect(mt.nodes.length > 1000000)) // Should have more nodes than leaves
+        .and(expect(duration < 1800000)) // Should complete within 30 minutes
+  }
+
+  test("performance comparison with different tree sizes") {
+    val sizes = List(100, 1000, 10000, 100000)
+
+    def testSize(size: Int): IO[(Int, Long)] = {
+      val hashes = NonEmptyList.fromListUnsafe(
+        (1 to size).map(i => Hash(s"hash_$i")).toList
+      )
+
+      for {
+        startTime <- IO(System.currentTimeMillis())
+        _ <- MerkleTree.from[IO](hashes)
+        endTime <- IO(System.currentTimeMillis())
+      } yield (size, endTime - startTime)
+    }
+
+    for {
+      results <- sizes.traverse(testSize)
+    } yield
+      // Verify all sizes completed successfully
+      expect(results.length === 4)
+        .and(expect(results.forall(_._2 > 0))) // All took some time
+        .and(expect(results.forall(_._2 < 300000))) // None took more than 5 minutes
+  }
+   */
 }

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/HashSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/HashSuite.scala
@@ -1,5 +1,7 @@
 package io.constellationnetwork.security
 
+import java.nio.charset.StandardCharsets
+
 import cats.Show
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
@@ -74,6 +76,88 @@ object HashSuite extends MutableIOSuite with Checkers {
       val hashCode = Hash.hashCodeFromBytes(data)
       val sha256Digest = Hash.sha256DigestFromBytes(data)
       expect.eql(hashCode.toString, sha256Digest.toHexString)
+    }
+  }
+
+  pureTest("fromBytes produces consistent hashes") {
+    val testData = "Hello, World!".getBytes(StandardCharsets.UTF_8)
+    val hash1 = Hash.fromBytes(testData)
+    val hash2 = Hash.fromBytes(testData)
+
+    expect.eql(hash1, hash2)
+  }
+
+  pureTest("fromBytes produces different hashes for different inputs") {
+    val data1 = "Hello, World!".getBytes(StandardCharsets.UTF_8)
+    val data2 = "Hello, Universe!".getBytes(StandardCharsets.UTF_8)
+
+    val hash1 = Hash.fromBytes(data1)
+    val hash2 = Hash.fromBytes(data2)
+
+    expect(hash1 != hash2)
+  }
+
+  pureTest("fromBytes produces valid SHA-256 hash") {
+    val testData = "test".getBytes(StandardCharsets.UTF_8)
+    val hash = Hash.fromBytes(testData)
+
+    val expectedHash = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+    expect.eql(hash.value, expectedHash)
+  }
+
+  pureTest("fromBytes handles empty arrays") {
+    val emptyData = Array.empty[Byte]
+    val hash = Hash.fromBytes(emptyData)
+
+    val expectedHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    expect.eql(hash.value, expectedHash)
+  }
+
+  test("fromBytesForSync produces consistent hashes") { implicit res =>
+    val testData = "Hello, World!".getBytes(StandardCharsets.UTF_8)
+
+    for {
+      hash1 <- Hash.fromBytesForSync[IO](testData)
+      hash2 <- Hash.fromBytesForSync[IO](testData)
+    } yield expect.eql(hash1, hash2)
+  }
+
+  test("fromBytesForSync produces different hashes for different inputs") { implicit res =>
+    val data1 = "Hello, World!".getBytes(StandardCharsets.UTF_8)
+    val data2 = "Hello, Universe!".getBytes(StandardCharsets.UTF_8)
+
+    for {
+      hash1 <- Hash.fromBytesForSync[IO](data1)
+      hash2 <- Hash.fromBytesForSync[IO](data2)
+    } yield expect(hash1 != hash2)
+  }
+
+  test("fromBytesForSync produces valid SHA-256 hash") { implicit res =>
+    val testData = "test".getBytes(StandardCharsets.UTF_8)
+
+    Hash.fromBytesForSync[IO](testData).map { hash =>
+      val expectedHash = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+      expect.eql(hash.value, expectedHash)
+    }
+  }
+
+  test("fromBytesForSync handles empty arrays") { implicit res =>
+    val emptyData = Array.empty[Byte]
+
+    Hash.fromBytesForSync[IO](emptyData).map { hash =>
+      val expectedHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      expect.eql(hash.value, expectedHash)
+    }
+  }
+
+  test("fromBytes and fromBytesForSync produce identical results") { implicit res =>
+    val testData = "Hello, World!".getBytes(StandardCharsets.UTF_8)
+
+    Hash.fromBytesForSync[IO](testData).map { asyncHash =>
+      val syncHash = Hash.fromBytes(testData)
+      expect.eql(asyncHash, syncHash)
     }
   }
 


### PR DESCRIPTION
SHA-256 hashing is CPU-intensive and can block the main computation thread pool. Using blocking operations ensures these operations run on dedicated blocking thread pools, preventing thread starvation in the main async execution context.