### PR TITLE
fix: address main culprits of cpu starvation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -295,7 +295,6 @@ lazy val testShared = (project in file("modules/test-shared"))
       Libraries.http4sServer,
       Libraries.http4sClient,
       Libraries.http4sCirce,
-      Libraries.http4sJwtAuth,
       Libraries.weaverCats,
       Libraries.weaverDiscipline,
       Libraries.weaverScalaCheck
@@ -335,7 +334,6 @@ lazy val nodeShared = (project in file("modules/node-shared"))
       Libraries.http4sServer,
       Libraries.http4sClient,
       Libraries.http4sCirce,
-      Libraries.http4sJwtAuth,
       Libraries.httpSignerCore,
       Libraries.httpSignerHttp4s,
       Libraries.jawnParser,
@@ -520,7 +518,6 @@ lazy val dagL0 = (project in file("modules/dag-l0"))
       Libraries.http4sServer,
       Libraries.http4sClient,
       Libraries.http4sCirce,
-      Libraries.http4sJwtAuth,
       Libraries.httpSignerCore,
       Libraries.httpSignerHttp4s,
       Libraries.log4cats,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -80,8 +80,7 @@ object Services {
     maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]]
   ): F[Services[F, R]] =
     for {
-      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[F]
-      implicit0(hasher: Hasher[F]) = hasherSelector.getCurrent
+      implicit0(hasher: Hasher[F]) <- hasherSelector.getCurrent.pure[F]
 
       stateChannelBinarySender <- StateChannelBinarySender.make(
         storages.identifier,
@@ -109,7 +108,6 @@ object Services {
           keyPair,
           storages.snapshot,
           storages.lastSyncGlobalSnapshot,
-          jsonBrotliBinarySerializer,
           dataApplicationAcceptanceManager,
           stateChannelBinarySender,
           feeCalculator,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala
@@ -126,7 +126,7 @@ object Rollback {
                   logger.error(err)(s"Error when trying to fetch incremental global snapshot {attempt=${retryDetails.retriesSoFar}}")
               )
 
-          DataApplicationTraverse
+          val dat = DataApplicationTraverse
             .make[F](
               globalSnapshotStartingPoint,
               fetchSnapshot,
@@ -138,12 +138,11 @@ object Rollback {
               globalSnapshotContextFunctions,
               globalL0Service
             )
-            .flatMap { dat =>
-              dat.loadChain().flatMap {
-                case Some(_) => Applicative[F].unit
-                case _       => new Exception(s"Metagraph traversing failed").raiseError[F, Unit]
-              }
-            }
+
+          dat.loadChain().flatMap {
+            case Some(_) => Applicative[F].unit
+            case _       => new Exception(s"Metagraph traversing failed").raiseError[F, Unit]
+          }
 
       }.getOrElse(Applicative[F].unit)
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
@@ -55,7 +55,6 @@ object StateChannelSnapshotService {
     keyPair: KeyPair,
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
-    jsonBrotliBinarySerializer: JsonBrotliBinarySerializer[F],
     dataApplicationSnapshotAcceptanceManager: Option[DataApplicationSnapshotAcceptanceManager[F]],
     stateChannelBinarySender: StateChannelBinarySender[F],
     feeCalculator: FeeCalculator[F],
@@ -94,7 +93,7 @@ object StateChannelSnapshotService {
 
       def createGenesisBinary(snapshot: Signed[CurrencySnapshot])(implicit hasher: Hasher[F]): F[Signed[StateChannelSnapshotBinary]] =
         for {
-          bytes <- jsonBrotliBinarySerializer.serialize(snapshot)
+          bytes <- JsonSerializer[F].serialize(snapshot)
           fee <- calculateFee(Hash.empty, bytes, snapshot.proofs.length, None, None)
           binary <- StateChannelSnapshotBinary(Hash.empty, bytes, fee).sign(keyPair)
         } yield binary
@@ -108,7 +107,7 @@ object StateChannelSnapshotService {
         implicit hasher: Hasher[F]
       ): F[Signed[StateChannelSnapshotBinary]] =
         for {
-          bytes <- jsonBrotliBinarySerializer.serialize(snapshot)
+          bytes <- JsonSerializer[F].serialize(snapshot)
           fee <- calculateFee(lastSnapshotBinaryHash, bytes, snapshot.proofs.length, stakingAddress, maybeGlobalSnapshotOrdinal)
           binary <- StateChannelSnapshotBinary(lastSnapshotBinaryHash, bytes, fee).sign(keyPair)
         } yield binary

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/SnapshotEventsPublisherDaemonSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/SnapshotEventsPublisherDaemonSuite.scala
@@ -39,7 +39,7 @@ object SnapshotEventsPublisherDaemonSuite extends MutableIOSuite with Checkers {
   override def sharedResource: Resource[IO, Res] =
     for {
       s <- Supervisor[IO](await = true)
-      implicit0(js: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].toResource
+      implicit0(js: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].toResource
       implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
       h = Hasher.forJson[IO]
       kp <- KeyPairGenerator.makeKeyPair[IO].toResource

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
@@ -271,7 +271,7 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
     for {
       implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
       sp <- SecurityProvider.forAsync[IO]
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
       metrics <- Metrics.forAsync[IO](Seq.empty)
     } yield (ks, h, sp, metrics)

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -148,7 +148,6 @@ abstract class CurrencyL1App(
           maybeMajorityPeerIds,
           Hasher.forKryo[IO]
         )
-      jsonBrotliBinarySerializer <- JsonSerializer.forAsync[IO].asResource
       snapshotProcessor = CurrencySnapshotProcessor.make(
         method.identifier,
         storages.address,
@@ -159,7 +158,6 @@ abstract class CurrencyL1App(
         storages.transaction,
         sharedServices.globalSnapshotContextFns,
         sharedServices.currencySnapshotContextFns,
-        jsonBrotliBinarySerializer,
         cfg.transactionLimit,
         sharedConfig.allowSpends,
         sharedConfig.tokenLocks,

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -21,7 +21,7 @@ import io.constellationnetwork.dag.l1.infrastructure.tokenlock.rumor.handler.tok
 import io.constellationnetwork.dag.l1.modules.{Daemons => DAGL1Daemons, Queues => DAGL1Queues, Validators => DAGL1Validators}
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.kryo.{KryoRegistrationId, MapRegistrationId}
-import io.constellationnetwork.json.JsonBrotliBinarySerializer
+import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.node.shared.app.{NodeShared, TessellationIOApp, getMajorityPeerIds}
 import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.node.shared.infrastructure.gossip.{GossipDaemon, RumorHandlers}
@@ -148,7 +148,7 @@ abstract class CurrencyL1App(
           maybeMajorityPeerIds,
           Hasher.forKryo[IO]
         )
-      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[IO].asResource
+      jsonBrotliBinarySerializer <- JsonSerializer.forAsync[IO].asResource
       snapshotProcessor = CurrencySnapshotProcessor.make(
         method.identifier,
         storages.address,

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
@@ -43,7 +43,7 @@ sealed abstract class CurrencySnapshotProcessor[F[_]: Async: SecurityProvider]
 
 object CurrencySnapshotProcessor {
 
-  def make[F[_]: Async: Random: SecurityProvider](
+  def make[F[_]: Async: Random: JsonSerializer: SecurityProvider](
     identifier: Address,
     addressStorage: AddressStorage[F],
     blockStorage: BlockStorage[F],
@@ -53,7 +53,6 @@ object CurrencySnapshotProcessor {
     transactionStorage: TransactionStorage[F],
     globalSnapshotContextFns: SnapshotContextFunctions[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
     currencySnapshotContextFns: SnapshotContextFunctions[F, CurrencyIncrementalSnapshot, CurrencySnapshotContext],
-    jsonBrotliBinarySerializer: JsonSerializer[F],
     transactionLimitConfig: TransactionLimitConfig,
     allowSpendsConfig: AllowSpendsConfig,
     tokenLocksConfig: TokenLocksConfig,
@@ -335,7 +334,7 @@ object CurrencySnapshotProcessor {
           .get(identifier) match {
           case Some(snapshots) =>
             snapshots.toList.traverse { binary =>
-              jsonBrotliBinarySerializer.deserialize[Signed[CurrencyIncrementalSnapshot]](binary.content)
+              JsonSerializer[F].deserialize[Signed[CurrencyIncrementalSnapshot]](binary.content)
             }
               .map(_.flatMap(_.toOption))
               .map(NonEmptyList.fromList)

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
@@ -13,7 +13,7 @@ import io.constellationnetwork.dag.l1.domain.snapshot.programs.SnapshotProcessor
 import io.constellationnetwork.dag.l1.domain.snapshot.programs.SnapshotProcessor._
 import io.constellationnetwork.dag.l1.domain.transaction.{ContextualTransactionValidator, TransactionLimitConfig, TransactionStorage}
 import io.constellationnetwork.dag.l1.infrastructure.address.storage.AddressStorage
-import io.constellationnetwork.json.JsonBrotliBinarySerializer
+import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.node.shared.config.types.{AllowSpendsConfig, LastGlobalSnapshotsSyncConfig, TokenLocksConfig}
 import io.constellationnetwork.node.shared.domain.globalAlignment.GlobalL0AlignmentStorage
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
@@ -53,7 +53,7 @@ object CurrencySnapshotProcessor {
     transactionStorage: TransactionStorage[F],
     globalSnapshotContextFns: SnapshotContextFunctions[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
     currencySnapshotContextFns: SnapshotContextFunctions[F, CurrencyIncrementalSnapshot, CurrencySnapshotContext],
-    jsonBrotliBinarySerializer: JsonBrotliBinarySerializer[F],
+    jsonBrotliBinarySerializer: JsonSerializer[F],
     transactionLimitConfig: TransactionLimitConfig,
     allowSpendsConfig: AllowSpendsConfig,
     tokenLocksConfig: TokenLocksConfig,

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -41,7 +41,7 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
     SecurityProvider.forAsync[IO].flatMap { implicit sp =>
       KryoSerializer.forAsync[IO](Main.kryoRegistrar ++ nodeSharedKryoRegistrar).flatMap { implicit kp =>
         for {
-          implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+          implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
           implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
           validators = SharedValidators.make[IO](
             Dev,

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutesSuite.scala
@@ -109,7 +109,7 @@ object DataApplicationRoutesSuite extends HttpSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(json2bin: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(json2bin: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h: Hasher[IO] = Hasher.forJson[IO]
     sv <- Supervisor[IO]
     r <- Random.scalaUtilRandom.asResource

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
@@ -80,7 +80,7 @@ object TokenLockRoutesSuite extends HttpSuite {
 
   def sharedResource: Resource[IO, Res] = for {
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(json2bin: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(json2bin: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h: Hasher[IO] = Hasher.forJson[IO]
     sv <- Supervisor[IO]
     r <- Random.scalaUtilRandom.asResource

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -96,14 +96,9 @@ object GlobalSnapshotConsensus {
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit supervisor: Supervisor[F]): F[GlobalSnapshotConsensus[F]] =
     for {
-      globalStateChannelManager <-
-        GlobalSnapshotStateChannelAcceptanceManager.make[F](
-          stateChannelAllowanceLists,
-          pullDelay = stateChannelPullDelay,
-          purgeDelay = stateChannelPurgeDelay
-        )
-
-      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync
+      globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager
+        .make[F](stateChannelAllowanceLists, pullDelay = stateChannelPullDelay, purgeDelay = stateChannelPurgeDelay)
+      jsonBrotliBinarySerializer <- JsonSerializer.forAsync
       feeCalculator = FeeCalculator.make(feeConfigs)
 
       snapshotAcceptanceManager =

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -96,9 +96,9 @@ object GlobalSnapshotConsensus {
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit supervisor: Supervisor[F]): F[GlobalSnapshotConsensus[F]] =
     for {
-      globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager
+      globalStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager
         .make[F](stateChannelAllowanceLists, pullDelay = stateChannelPullDelay, purgeDelay = stateChannelPurgeDelay)
-      jsonBrotliBinarySerializer <- JsonSerializer.forAsync
+
       feeCalculator = FeeCalculator.make(feeConfigs)
 
       snapshotAcceptanceManager =
@@ -113,7 +113,6 @@ object GlobalSnapshotConsensus {
             validators.stateChannelValidator,
             globalStateChannelManager,
             sharedServices.currencySnapshotContextFns,
-            jsonBrotliBinarySerializer,
             feeCalculator
           ),
           sharedServices.updateNodeParametersAcceptanceManager,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/GlobalSnapshotEventCutterSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/GlobalSnapshotEventCutterSuite.scala
@@ -39,7 +39,7 @@ object GlobalSnapshotEventCutterSuite extends MutableIOSuite with Checkers {
     for {
       implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar ++ dagL0KryoRegistrar)
       sp <- SecurityProvider.forAsync[IO]
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
     } yield (j, h, sp)
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/UpdateNodeParametersCutterSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/UpdateNodeParametersCutterSuite.scala
@@ -34,7 +34,7 @@ object UpdateNodeParametersCutterSuite extends MutableIOSuite with Checkers {
     for {
       implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar ++ dagL0KryoRegistrar)
       sp <- SecurityProvider.forAsync[IO]
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
     } yield (j, h, sp)
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/statechannel/StateChannelServiceSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/statechannel/StateChannelServiceSuite.scala
@@ -42,7 +42,7 @@ object StateChannelServiceSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (h, sp)
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributorSuite.scala
@@ -183,7 +183,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Initial emission at epoch 100
@@ -221,7 +221,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Test with epoch just at transition - should use formula
@@ -369,7 +369,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Create distributor with test config
@@ -518,7 +518,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Create distributor with test config
@@ -602,7 +602,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Create distributor with test config
@@ -715,7 +715,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Create distributor with specific test config
@@ -851,7 +851,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Create distributor with our test config
@@ -914,7 +914,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     val context = GlobalSnapshotInfo.empty
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       distributor = GlobalDelegatedRewardsDistributor.make[IO](AppEnvironment.Dev, customConfig)
@@ -1042,7 +1042,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Create distributor with our test config
@@ -1089,7 +1089,7 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     */
   test("Verify all values from the reference are correctly maintained") {
     // Setup implicit JSON serializer
-    JsonSerializer.forSync[IO].flatMap { implicit j: JsonSerializer[IO] =>
+    JsonSerializer.forAsync[IO].flatMap { implicit j: JsonSerializer[IO] =>
       implicit val hasher: Hasher[IO] = Hasher.forJson[IO]
 
       // 1. Set up addresses for users and nodes

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/RewardsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/RewardsSuite.scala
@@ -50,7 +50,7 @@ object RewardsSuite extends MutableIOSuite with Checkers {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar.union(nodeSharedKryoRegistrar))
     implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
     mkKeyPair = () => KeyPairGenerator.makeKeyPair.map(_.getPublic.toId).unsafeRunSync()
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (h, sp, mkKeyPair)
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -105,7 +105,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
   def sharedResource: Resource[IO, Res] = for {
     supervisor <- Supervisor[IO]
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
     m <- Metrics.forAsync[IO](Seq(("application", name)))
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotSerializationSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotSerializationSuite.scala
@@ -58,7 +58,7 @@ object GlobalSnapshotSerializationSuite extends MutableIOSuite with Checkers {
   type Res = Hasher[IO]
 
   def sharedResource: Resource[IO, Res] = for {
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     // Using JSON-based hasher instead of Kryo-based hasher
     hk = Hasher.forJson[IO]
   } yield hk

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -154,7 +154,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
       }
       feeCalculator = FeeCalculator.make(SortedMap.empty)
       processor = GlobalSnapshotStateChannelEventsProcessor
-        .make[IO](validator, manager, currencySnapshotContextFns, J, feeCalculator)
+        .make[IO](validator, manager, currencySnapshotContextFns, feeCalculator)
     } yield processor
   }
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -53,15 +53,14 @@ import weaver.MutableIOSuite
 object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
   val TestValidationErrorStorageMaxSize: PosInt = PosInt(16)
 
-  type Res = (KryoSerializer[IO], Hasher[IO], JsonSerializer[IO], SecurityProvider[IO], JsonBrotliBinarySerializer[IO])
+  type Res = (KryoSerializer[IO], Hasher[IO], JsonSerializer[IO], SecurityProvider[IO])
 
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
-    serializer <- JsonBrotliBinarySerializer.forSync[IO].asResource
-  } yield (ks, h, j, sp, serializer)
+  } yield (ks, h, j, sp)
 
   def mkProcessor(
     stateChannelAllowanceLists: Map[Address, NonEmptySet[PeerId]],
@@ -153,20 +152,19 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
           )
         ] = IO.pure((events.groupByNel(_.address).map { case (k, v) => k -> v.map(_.snapshotBinary) }, Set.empty))
       }
-      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync
       feeCalculator = FeeCalculator.make(SortedMap.empty)
       processor = GlobalSnapshotStateChannelEventsProcessor
-        .make[IO](validator, manager, currencySnapshotContextFns, jsonBrotliBinarySerializer, feeCalculator)
+        .make[IO](validator, manager, currencySnapshotContextFns, J, feeCalculator)
     } yield processor
   }
 
   test("return new sc event") { res =>
-    implicit val (ks, h, j, sp, serializer) = res
+    implicit val (ks, h, j, sp) = res
 
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       address = keyPair.getPublic().toAddress
-      output <- mkStateChannelOutput(keyPair, serializer = serializer)
+      output <- mkStateChannelOutput(keyPair)
       snapshotInfo = mkGlobalSnapshotInfo()
       snapshot <- mkGlobalIncrementalSnapshot[IO](snapshotInfo)
       service <- mkProcessor(Map(address -> output.snapshotBinary.proofs.map(_.id.toPeerId)))
@@ -189,15 +187,15 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
   }
 
   test("return sc events for different addresses") { res =>
-    implicit val (ks, h, j, sp, serializer) = res
+    implicit val (ks, h, j, sp) = res
 
     for {
       keyPair1 <- KeyPairGenerator.makeKeyPair[IO]
       address1 = keyPair1.getPublic().toAddress
-      output1 <- mkStateChannelOutput(keyPair1, serializer = serializer)
+      output1 <- mkStateChannelOutput(keyPair1)
       keyPair2 <- KeyPairGenerator.makeKeyPair[IO]
       address2 = keyPair2.getPublic().toAddress
-      output2 <- mkStateChannelOutput(keyPair2, serializer = serializer)
+      output2 <- mkStateChannelOutput(keyPair2)
       snapshotInfo = mkGlobalSnapshotInfo()
       snapshot <- mkGlobalIncrementalSnapshot[IO](snapshotInfo)
       service <- mkProcessor(
@@ -222,15 +220,15 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
   }
 
   test("return only valid sc events") { res =>
-    implicit val (ks, h, j, sp, serializer) = res
+    implicit val (ks, h, j, sp) = res
 
     for {
       keyPair1 <- KeyPairGenerator.makeKeyPair[IO]
       address1 = keyPair1.getPublic().toAddress
-      output1 <- mkStateChannelOutput(keyPair1, serializer = serializer)
+      output1 <- mkStateChannelOutput(keyPair1)
       keyPair2 <- KeyPairGenerator.makeKeyPair[IO]
       address2 = keyPair2.getPublic().toAddress
-      output2 <- mkStateChannelOutput(keyPair2, serializer = serializer)
+      output2 <- mkStateChannelOutput(keyPair2)
       snapshotInfo = mkGlobalSnapshotInfo()
       snapshot <- mkGlobalIncrementalSnapshot[IO](snapshotInfo)
       service <- mkProcessor(
@@ -255,12 +253,13 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
 
   }
 
-  def mkStateChannelOutput(keyPair: KeyPair, hash: Option[Hash] = None, serializer: JsonBrotliBinarySerializer[IO])(
+  def mkStateChannelOutput(keyPair: KeyPair, hash: Option[Hash] = None)(
     implicit S: SecurityProvider[IO],
-    H: Hasher[IO]
+    H: Hasher[IO],
+    J: JsonSerializer[IO]
   ) = for {
     content <- Random.scalaUtilRandom[IO].flatMap(_.nextString(10))
-    compressedBytes <- serializer.serialize(content)
+    compressedBytes <- J.serialize(content)
     binary <- StateChannelSnapshotBinary(hash.getOrElse(Hash.empty), compressedBytes, SnapshotFee.MinValue).pure[IO]
     signedSC <- forAsyncHasher(binary, keyPair)
   } yield StateChannelOutput(keyPair.getPublic.toAddress, signedSC)

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -85,7 +85,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
   override def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
     metrics <- Metrics.forAsync[IO](Seq.empty)
     random <- Random.scalaUtilRandom[IO].asResource
@@ -356,7 +356,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
       currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
       stateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L))
-      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync
+      jsonBrotliBinarySerializer <- JsonSerializer.forAsync[IO]
       feeCalculator = FeeCalculator.make(SortedMap.empty)
       stateChannelProcessor = GlobalSnapshotStateChannelEventsProcessor
         .make[IO](

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -356,14 +356,12 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
       currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
       stateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L))
-      jsonBrotliBinarySerializer <- JsonSerializer.forAsync[IO]
       feeCalculator = FeeCalculator.make(SortedMap.empty)
       stateChannelProcessor = GlobalSnapshotStateChannelEventsProcessor
         .make[IO](
           validators.stateChannelValidator,
           stateChannelManager,
           currencySnapshotContextFns,
-          jsonBrotliBinarySerializer,
           feeCalculator
         )
       updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
@@ -29,7 +29,7 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
     supervisor <- Supervisor[IO]
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](nodeSharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (supervisor, ks, j, h, sp)
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/StateProofSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/StateProofSuite.scala
@@ -37,7 +37,7 @@ object StateProofSuite extends MutableIOSuite with Checkers {
 
   def sharedResource: Resource[IO, Res] = for {
     // Migrated to JSON serialization for Java 21 compatibility
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (j, h)
 

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockRelationsSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockRelationsSuite.scala
@@ -22,7 +22,7 @@ object BlockRelationsSuite extends MutableIOSuite with Checkers {
 
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](Main.kryoRegistrar ++ nodeSharedKryoRegistrar)
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     hj = Hasher.forJson[IO]
     hk = Hasher.forKryo[IO]
   } yield (hj, hk)

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockServiceSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockServiceSuite.scala
@@ -42,7 +42,7 @@ object BlockServiceSuite extends MutableIOSuite with Checkers {
 
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](Main.kryoRegistrar ++ nodeSharedKryoRegistrar)
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     hj = Hasher.forJson[IO]
     hk = Hasher.forKryo[IO]
   } yield (hj, hk)

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/consensus/block/RoundDataSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/consensus/block/RoundDataSuite.scala
@@ -60,7 +60,7 @@ object RoundDataSuite extends ResourceSuite with Checkers with TransactionGenera
     for {
       implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](Main.kryoRegistrar ++ nodeSharedKryoRegistrar)
       implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       implicit0(h: Hasher[IO]) = Hasher.forKryo[IO]
       srcKey <- KeyPairGenerator.makeKeyPair[IO].asResource
       dstKey <- KeyPairGenerator.makeKeyPair[IO].asResource

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -208,7 +208,6 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
               currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
               globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L)).asResource
-              jsonBrotliBinarySerializer <- JsonSerializer.forAsync[IO].asResource
               feeCalculator = FeeCalculator.make(SortedMap.empty)
               updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
               updateDelegatedStakeAcceptanceManager = UpdateDelegatedStakeAcceptanceManager
@@ -240,7 +239,6 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                     validators.stateChannelValidator,
                     globalSnapshotStateChannelManager,
                     currencySnapshotContextFns,
-                    jsonBrotliBinarySerializer,
                     feeCalculator
                   ),
                 updateNodeParametersAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -103,7 +103,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
         Random.scalaUtilRandom[IO].asResource.flatMap { implicit random =>
           Metrics.forAsync[IO](Seq(("application", name))).flatMap { implicit _metrics =>
             for {
-              implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+              implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
               implicit0(h: Hasher[IO]) = Hasher.forJson[IO]
               balancesR <- Ref.of[IO, Map[Address, Balance]](Map.empty).asResource
               blocksR <- MapRef.ofConcurrentHashMap[IO, ProofsHash, StoredBlock]().asResource
@@ -208,7 +208,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
               currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
               globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make[IO](None, NonNegLong(10L)).asResource
-              jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync[IO].asResource
+              jsonBrotliBinarySerializer <- JsonSerializer.forAsync[IO].asResource
               feeCalculator = FeeCalculator.make(SortedMap.empty)
               updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
               updateDelegatedStakeAcceptanceManager = UpdateDelegatedStakeAcceptanceManager

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/ContextualTransactionValidatorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/ContextualTransactionValidatorSuite.scala
@@ -44,7 +44,7 @@ object ContextualTransactionValidatorSuite extends MutableIOSuite with Checkers 
   def sharedResource: Resource[IO, Res] = for {
     sp <- SecurityProvider.forAsync[IO]
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
-    implicit0(js: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(js: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forKryo[IO]
   } yield (h, sp, ks, js)
 

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorageSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorageSuite.scala
@@ -47,7 +47,7 @@ object TransactionStorageSuite extends SimpleIOSuite with TransactionGenerator {
     SecurityProvider.forAsync[IO].flatMap { implicit sp =>
       KryoSerializer.forAsync[IO](Main.kryoRegistrar ++ nodeSharedKryoRegistrar).flatMap { implicit kp =>
         for {
-          implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+          implicit0(jhs: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
           implicit0(h: Hasher[IO]) = Hasher.forJson[IO]
           transactions <- MapRef.ofConcurrentHashMap[IO, Address, SortedMap[TransactionOrdinal, StoredTransaction]]().asResource
           contextualTransactionValidator = ContextualTransactionValidator

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
@@ -132,7 +132,7 @@ abstract class TessellationIOApp[A <: CliMethod](
                 jarHash(cfg.environment).flatMap { jarHash =>
                   logger.info(s"Jar hash: ${jarHash.value}") >>
                     KryoSerializer.forAsync[IO](registrar).use { implicit _kryoPool =>
-                      JsonSerializer.forSync[IO].asResource.use { implicit _jsonSerializer =>
+                      JsonSerializer.forAsync[IO].asResource.use { implicit _jsonSerializer =>
                         implicit val _hasherSelector = HasherSelector.forSync[IO](Hasher.forJson, Hasher.forKryo, _hashSelect)
                         Metrics.forAsync[IO](Seq(("application", name))).use { implicit _metrics =>
                           SignallingRef.of[IO, Boolean](false).flatMap { _stopSignal =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/middlewares/PeerAuthMiddleware.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/middlewares/PeerAuthMiddleware.scala
@@ -46,19 +46,22 @@ object PeerAuthMiddleware {
     privateKey: PrivateKey,
     sessionStorage: SessionStorage[F],
     selfId: PeerId
-  )(http: HttpRoutes[F]): HttpRoutes[F] =
+  )(http: HttpRoutes[F]): HttpRoutes[F] = {
+    val signer = new Http4sResponseSigner[F](getGenerator(privateKey), new TessellationHttpCryptoConfig {})
+
     Kleisli { req: Request[F] =>
       for {
         res <- http(req)
         headerToken <- getOwnTokenHeader(sessionStorage).attemptT.toOption
         newHeaders = headerToken.fold(res.headers)(h => res.headers.put(h)).put(`X-Id`(selfId))
         resWithHeader = res.copy(headers = newHeaders)
-        signedResponse <- new Http4sResponseSigner[F](getGenerator(privateKey), new TessellationHttpCryptoConfig {})
+        signedResponse <- signer
           .sign(resWithHeader)
           .attemptT
           .toOption
       } yield signedResponse
     }
+  }
 
   def responseTokenVerifierMiddleware[F[_]: Async](
     client: Client[F],
@@ -117,30 +120,32 @@ object PeerAuthMiddleware {
     privateKey: PrivateKey,
     sessionStorage: SessionStorage[F],
     selfId: PeerId
-  ): Client[F] = Client { req: Request[F] =>
+  ): Client[F] = {
     val signer = new Http4sRequestSigner(getGenerator(privateKey), new TessellationHttpCryptoConfig {})
 
-    Resource.suspend {
-      Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
-        Resource.liftK[F] {
+    Client { req: Request[F] =>
+      Resource.suspend {
+        Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
+          Resource.liftK[F] {
 
-          val copiedBody = Stream
-            .eval(vec.get)
-            .flatMap(v => Stream.emits(v).covary[F])
-            .flatMap(c => Stream.chunk(c).covary[F])
+            val copiedBody = Stream
+              .eval(vec.get)
+              .flatMap(v => Stream.emits(v).covary[F])
+              .flatMap(c => Stream.chunk(c).covary[F])
 
-          for {
-            tokenHeader <- getOwnTokenHeader(sessionStorage)
-            newHeaders = tokenHeader.fold(req.headers)(h => req.headers.put(h)).put(`X-Id`(selfId))
-            newReq = req
-              .withBodyStream(req.body.observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s)))))
-              .withHeaders(newHeaders)
-            signedRequest <- signer.sign(newReq).map(r => req.withBodyStream(copiedBody).withHeaders(r.headers))
-          } yield signedRequest
+            for {
+              tokenHeader <- getOwnTokenHeader(sessionStorage)
+              newHeaders = tokenHeader.fold(req.headers)(h => req.headers.put(h)).put(`X-Id`(selfId))
+              newReq = req
+                .withBodyStream(req.body.observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s)))))
+                .withHeaders(newHeaders)
+              signedRequest <- signer.sign(newReq).map(r => req.withBodyStream(copiedBody).withHeaders(r.headers))
+            } yield signedRequest
 
+          }
         }
-      }
-    } >>= client.run
+      } >>= client.run
+    }
   }
 
   def requestCollateralVerifierMiddleware[F[_]: Async](collateral: Collateral[F])(http: HttpRoutes[F]): HttpRoutes[F] =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
@@ -5,8 +5,8 @@ import cats.syntax.all._
 
 import scala.concurrent.duration._
 
-import io.constellationnetwork.ext.http4s.HashVar
 import io.constellationnetwork.ext.http4s.headers.negotiation.resolveEncoder
+import io.constellationnetwork.ext.http4s.{BlockingEntityEncoder, HashVar}
 import io.constellationnetwork.node.shared.config.types.{RouteRateLimiterConfig, SnapshotTimeoutsConfig}
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.snapshot.storage.SnapshotStorage
@@ -26,7 +26,6 @@ import io.circe.Encoder
 import io.circe.shapes._
 import org.http4s._
 import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
-import org.http4s.circe.CirceEntityEncoder
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.middleware.Timeout
 import shapeless.HNil
@@ -48,7 +47,9 @@ final case class SnapshotRoutes[F[_]: Async, S <: Snapshot: Encoder, SI <: Snaps
 
   object FullSnapshotQueryParam extends FlagQueryParamMatcher("full")
 
-  implicit def jsonEncoders[A <: AnyRef: Encoder]: List[EntityEncoder[F, A]] = List(CirceEntityEncoder.circeEntityEncoder[F, A])
+  // Use blocking encoder to prevent CPU starvation when serializing large snapshots
+  implicit def jsonEncoders[A <: AnyRef: Encoder]: List[EntityEncoder[F, A]] =
+    List(BlockingEntityEncoder.blockingJsonEncoder[F, A])
 
   private val serviceUnavailableNodeNotReady: F[Response[F]] =
     ServiceUnavailable(("message" ->> "Node is not ready yet") :: HNil)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/dataApplication/DataApplicationTraverse.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/dataApplication/DataApplicationTraverse.scala
@@ -32,31 +32,6 @@ trait DataApplicationTraverse[F[_]] {
 }
 
 object DataApplicationTraverse {
-  def make[F[_]: Async: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector](
-    lastGlobalSnapshot: Hashed[GlobalIncrementalSnapshot],
-    fetchSnapshot: Hash => F[Option[Hashed[GlobalIncrementalSnapshot]]],
-    dataApplication: BaseDataApplicationL0Service[F],
-    calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F],
-    globalSnapshotsWithStateLocalFileSystemStorage: GlobalSnapshotsWithStateLocalFileSystemStorage[F],
-    globalSnapshotsWithStateDeltasLocalFileSystemStorage: GlobalSnapshotsWithStateDeltasLocalFileSystemStorage[F],
-    identifier: Address,
-    globalSnapshotContextFunctions: GlobalSnapshotContextFunctions[F],
-    globalL0Service: GlobalL0Service[F]
-  )(implicit context: L0NodeContext[F]): F[DataApplicationTraverse[F]] =
-    JsonBrotliBinarySerializer.forSync[F].map { jsonSerializer =>
-      make[F](
-        lastGlobalSnapshot,
-        fetchSnapshot,
-        dataApplication,
-        calculatedStateStorage,
-        globalSnapshotsWithStateLocalFileSystemStorage,
-        globalSnapshotsWithStateDeltasLocalFileSystemStorage,
-        jsonSerializer,
-        identifier,
-        globalSnapshotContextFunctions,
-        globalL0Service
-      )
-    }
 
   def make[F[_]: Async: KryoSerializer: JsonSerializer: SecurityProvider: HasherSelector](
     lastGlobalSnapshot: Hashed[GlobalIncrementalSnapshot],
@@ -65,7 +40,6 @@ object DataApplicationTraverse {
     calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F],
     globalSnapshotsWithStateLocalFileSystemStorage: GlobalSnapshotsWithStateLocalFileSystemStorage[F],
     globalSnapshotsWithStateDeltasLocalFileSystemStorage: GlobalSnapshotsWithStateDeltasLocalFileSystemStorage[F],
-    jsonSerializer: JsonBrotliBinarySerializer[F],
     identifier: Address,
     globalSnapshotContextFunctions: GlobalSnapshotContextFunctions[F],
     globalL0Service: GlobalL0Service[F]
@@ -280,7 +254,7 @@ object DataApplicationTraverse {
           }
 
           lastGlobalSnapshot.tailRecM { globalSnapshot =>
-            fetchCurrencySnapshots(globalSnapshot, jsonSerializer)
+            fetchCurrencySnapshots(globalSnapshot)
               .flatMap(_.traverse {
                 case Validated.Invalid(_) =>
                   (new Exception(
@@ -334,8 +308,7 @@ object DataApplicationTraverse {
       }
 
       private def fetchCurrencySnapshots(
-        globalSnapshot: GlobalIncrementalSnapshot,
-        jsonBrotliBinarySerializer: JsonBrotliBinarySerializer[F]
+        globalSnapshot: GlobalIncrementalSnapshot
       ): F[
         Option[ValidatedNel[Signed.InvalidSignatureForHash[CurrencyIncrementalSnapshot], NonEmptyList[Hashed[CurrencyIncrementalSnapshot]]]]
       ] =
@@ -344,7 +317,7 @@ object DataApplicationTraverse {
           case Some(snapshots) =>
             HasherSelector[F].withCurrent { implicit hasher =>
               snapshots.toList.traverse { binary =>
-                jsonBrotliBinarySerializer.deserialize[Signed[CurrencyIncrementalSnapshot]](binary.content)
+                JsonSerializer[F].deserialize[Signed[CurrencyIncrementalSnapshot]](binary.content)
               }
                 .map(_.flatMap(_.toOption))
                 .map(NonEmptyList.fromList)
@@ -352,7 +325,7 @@ object DataApplicationTraverse {
                 .flatMap(_.map(_.traverse(_.toHashedWithSignatureCheck)).sequence)
                 .map(_.map(_.traverse(_.toValidatedNel)))
             }
-          case None => none.pure[F]
+          case None => Async[F].pure(none)
         }
     }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -402,7 +402,7 @@ object GlobalSnapshotAcceptanceManager {
                     .grouped(batchSize)
                     .toList
                     .traverse { batch =>
-                      batch.traverse {
+                      Async[F].cede *> batch.traverse {
                         case (address, state) =>
                           (address, state).hash
                             .flatMap(tree.findPath[F])
@@ -410,8 +410,7 @@ object GlobalSnapshotAcceptanceManager {
                             .map(address -> _)
                       }
                     }
-                    .map(_.flatten)
-                    .map(SortedMap.from(_))
+                    .flatMap(results => Async[F].cede.as(SortedMap.from(results.flatten)))
 
                 case None =>
                   Async[F].pure(SortedMap.empty[Address, Proof])
@@ -444,7 +443,7 @@ object GlobalSnapshotAcceptanceManager {
                     .grouped(batchSize)
                     .toList
                     .traverse { batch =>
-                      batch.traverse {
+                      Async[F].cede *> batch.traverse {
                         case (address, state) =>
                           (address, state).hash
                             .flatMap(tree.findPath[F])
@@ -452,8 +451,7 @@ object GlobalSnapshotAcceptanceManager {
                             .map(address -> _)
                       }
                     }
-                    .map(_.flatten)
-                    .map(SortedMap.from(_))
+                    .flatMap(results => Async[F].cede.as(SortedMap.from(results.flatten)))
 
                 case None =>
                   Async[F].pure(SortedMap.empty[Address, Proof])
@@ -791,13 +789,13 @@ object GlobalSnapshotAcceptanceManager {
                 .covary[F]
                 .chunkN(100)
                 .parEvalMap(10) { chunk =>
-                  chunk.toList.traverse { tokenLock =>
+                  Async[F].cede *> chunk.toList.traverse { tokenLock =>
                     tokenLock.toHashed.map(hashed => hashed.hash -> tokenLock)
-                  }
+                  } <* Async[F].cede
                 }
                 .compile
                 .toList
-                .map(_.flatten.toMap)
+                .flatMap(results => Async[F].cede.as(results.flatten.toMap))
             }
 
           globalLastAllowSpendRefs = lastSnapshotContext.lastAllowSpendRefs.getOrElse(
@@ -898,7 +896,7 @@ object GlobalSnapshotAcceptanceManager {
                 .covary[F]
                 .chunkN(50)
                 .parEvalMap(10) { chunk =>
-                  chunk.toList.traverse {
+                  Async[F].cede *> chunk.toList.traverse {
                     case (address, allowSpends) =>
                       val allowSpendsList = allowSpends.toList
                       if (allowSpendsList.isEmpty) {
@@ -909,9 +907,9 @@ object GlobalSnapshotAcceptanceManager {
                           .covary[F]
                           .chunkN(20)
                           .parEvalMap(5) { innerChunk =>
-                            innerChunk.toList.traverse { (allowSpend: Signed[AllowSpend]) =>
+                            Async[F].cede *> innerChunk.toList.traverse { (allowSpend: Signed[AllowSpend]) =>
                               allowSpend.toHashed: F[Hashed[AllowSpend]]
-                            }
+                            } <* Async[F].cede
                           }
                           .compile
                           .toList
@@ -923,8 +921,8 @@ object GlobalSnapshotAcceptanceManager {
                 }
                 .compile
                 .toList
-                .map { (lists: List[List[(Address, List[Hashed[AllowSpend]])]]) =>
-                  lists.flatten.toSortedMap
+                .flatMap { (lists: List[List[(Address, List[Hashed[AllowSpend]])]]) =>
+                  Async[F].cede.as(lists.flatten.toSortedMap)
                 }
             }
 
@@ -1008,7 +1006,7 @@ object GlobalSnapshotAcceptanceManager {
             updatedAcceptedMetagraphSyncData
           )
 
-          stateProof <- Async[F].blocking(gsi.stateProof[F](ordinal)).flatten
+          stateProof <- gsi.stateProof[F](ordinal)
 
           (expiredAllowSpends, expiredTokenLocks) = (
             allowSpendStateManager.filterExpiredAllowSpends(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
@@ -9,7 +9,7 @@ import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.ext.cats.syntax.validated.validatedSyntax
-import io.constellationnetwork.json.JsonBrotliBinarySerializer
+import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelAcceptanceResult.CurrencySnapshotWithState
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelValidator.{StateChannelValidationError, getFeeAddresses}
 import io.constellationnetwork.node.shared.domain.statechannel._
@@ -57,7 +57,7 @@ object GlobalSnapshotStateChannelEventsProcessor {
     stateChannelValidator: StateChannelValidator[F],
     stateChannelManager: GlobalSnapshotStateChannelAcceptanceManager[F],
     currencySnapshotContextFns: CurrencySnapshotContextFunctions[F],
-    jsonBrotliBinarySerializer: JsonBrotliBinarySerializer[F],
+    jsonBrotliBinarySerializer: JsonSerializer[F],
     feeCalculator: FeeCalculator[F]
   ) =
     new GlobalSnapshotStateChannelEventsProcessor[F] {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
@@ -53,18 +53,17 @@ trait GlobalSnapshotStateChannelEventsProcessor[F[_]] {
 }
 
 object GlobalSnapshotStateChannelEventsProcessor {
-  def make[F[_]: Async: Parallel](
+  def make[F[_]: Async: JsonSerializer: Parallel](
     stateChannelValidator: StateChannelValidator[F],
     stateChannelManager: GlobalSnapshotStateChannelAcceptanceManager[F],
     currencySnapshotContextFns: CurrencySnapshotContextFunctions[F],
-    jsonBrotliBinarySerializer: JsonSerializer[F],
     feeCalculator: FeeCalculator[F]
   ) =
     new GlobalSnapshotStateChannelEventsProcessor[F] {
       private val logger = Slf4jLogger.getLoggerFromClass[F](GlobalSnapshotStateChannelEventsProcessor.getClass)
 
       def deserialize[A: Decoder](binary: Signed[StateChannelSnapshotBinary]): F[Option[A]] =
-        jsonBrotliBinarySerializer.deserialize[A](binary.value.content).map(_.toOption)
+        JsonSerializer[F].deserialize[A](binary.value.content).map(_.toOption)
 
       def buildSnapshotFeesInfo(
         lastGlobalSnapshotInfo: GlobalSnapshotInfo,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
@@ -193,8 +193,9 @@ abstract class SnapshotLocalFileSystemStorage[
     _ <- baseDirectory.tailRecM { currentBase =>
       for {
         baseDir <- dir.map(_ / "ordinal" / currentBase.toString)
+        baseDirExists <- Async[F].blocking(baseDir.exists)
         result <-
-          if (!baseDir.exists) {
+          if (!baseDirExists) {
             ().asRight[Long].pure
           } else {
             for {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -134,7 +134,7 @@ object SharedServices {
       )
       feeCalculator = FeeCalculator.make(cfg.feeConfigs)
       globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make(stateChannelAllowanceLists)
-      jsonBrotliBinarySerializer <- JsonBrotliBinarySerializer.forSync
+      jsonBrotliBinarySerializer <- JsonSerializer.forAsync
       updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
       updateDelegatedStakeAcceptanceManager = UpdateDelegatedStakeAcceptanceManager.make(
         validators.updateDelegatedStakeValidator

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -134,7 +134,6 @@ object SharedServices {
       )
       feeCalculator = FeeCalculator.make(cfg.feeConfigs)
       globalSnapshotStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager.make(stateChannelAllowanceLists)
-      jsonBrotliBinarySerializer <- JsonSerializer.forAsync
       updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
       updateDelegatedStakeAcceptanceManager = UpdateDelegatedStakeAcceptanceManager.make(
         validators.updateDelegatedStakeValidator
@@ -155,7 +154,6 @@ object SharedServices {
             validators.stateChannelValidator,
             globalSnapshotStateChannelManager,
             currencySnapshotContextFns,
-            jsonBrotliBinarySerializer,
             feeCalculator
           ),
         updateNodeParametersAcceptanceManager,

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/delegatedStake/UpdateDelegatedStakeAcceptanceManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/delegatedStake/UpdateDelegatedStakeAcceptanceManagerSuite.scala
@@ -42,7 +42,7 @@ object UpdateDelegatedStakeAcceptanceManagerSuite extends MutableIOSuite {
 
   def sharedResource: Resource[IO, Res] = for {
     implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
     kp <- KeyPairGenerator.makeKeyPair[IO].asResource
     sourceAddress <- kp.getPublic.toId.toAddress.asResource

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/delegatedStake/UpdateDelegatedStakeValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/delegatedStake/UpdateDelegatedStakeValidatorSuite.scala
@@ -46,7 +46,7 @@ object UpdateDelegatedStakeValidatorSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
     kp <- KeyPairGenerator.makeKeyPair[IO].asResource
     sourceAddress <- kp.getPublic.toId.toAddress.asResource

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/node/UpdateNodeParametersAcceptanceManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/node/UpdateNodeParametersAcceptanceManagerSuite.scala
@@ -31,7 +31,7 @@ object UpdateNodeParametersAcceptanceManagerSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (j, h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/node/UpdateNodeParametersValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/node/UpdateNodeParametersValidatorSuite.scala
@@ -35,7 +35,7 @@ object UpdateNodeParametersValidatorSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (j, h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/nodeCollateral/UpdateNodeCollateralValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/nodeCollateral/UpdateNodeCollateralValidatorSuite.scala
@@ -41,7 +41,7 @@ object UpdateNodeCollateralValidatorSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
     kp <- KeyPairGenerator.makeKeyPair[IO].asResource
     sourceAddress <- kp.getPublic.toId.toAddress.asResource

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/statechannel/StateChannelValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/statechannel/StateChannelValidatorSuite.scala
@@ -40,7 +40,7 @@ object StateChannelValidatorSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (j, h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/swap/SpendActionValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/swap/SpendActionValidatorSuite.scala
@@ -35,7 +35,7 @@ object SpendActionValidatorSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (j, h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidatorSuite.scala
@@ -33,7 +33,7 @@ object ContextualTokenLockValidatorSuite extends MutableIOSuite {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/block/processing/BlockAcceptanceManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/block/processing/BlockAcceptanceManagerSuite.scala
@@ -40,7 +40,7 @@ object BlockAcceptanceManagerSuite extends MutableIOSuite with Checkers {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         (Hasher.forJson[IO], Hasher.forKryo[IO])
       }
     }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/genesis/GenesisFSSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/genesis/GenesisFSSuite.scala
@@ -25,7 +25,7 @@ object GenesisFSSuite extends MutableIOSuite with Checkers {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](nodeSharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(js: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(js: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (ks, js, h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyEventsCutterSuite.scala
@@ -76,7 +76,7 @@ object CurrencyEventsCutterSuite extends MutableIOSuite with Checkers {
   }
 
   def sharedResource: Resource[IO, JsonSerializer[IO]] =
-    JsonSerializer.forSync[F].asResource
+    JsonSerializer.forAsync[F].asResource
 
   test("does not cut messages") { implicit j =>
     val cutter = CurrencyEventsCutter.make[IO](testDataApplication.some)

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreatorSuite.scala
@@ -24,7 +24,7 @@ object CurrencySnapshotCreatorSuite extends MutableIOSuite with Checkers {
   def sharedResource: Resource[IO, Res] =
     for {
       implicit0(k: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](nodeSharedKryoRegistrar)
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
       sp <- SecurityProvider.forAsync[IO]
     } yield (j, h, sp)

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DelegatedRewardsDistributorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DelegatedRewardsDistributorSuite.scala
@@ -90,7 +90,7 @@ object DelegatedRewardsDistributorSuite extends SimpleIOSuite with Checkers {
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       updatedStakes <- DelegatedRewardsDistributor.getUpdatedCreateDelegatedStakes[IO](
@@ -149,7 +149,7 @@ object DelegatedRewardsDistributorSuite extends SimpleIOSuite with Checkers {
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       updatedStakes <- DelegatedRewardsDistributor.getUpdatedCreateDelegatedStakes[IO](
@@ -208,7 +208,7 @@ object DelegatedRewardsDistributorSuite extends SimpleIOSuite with Checkers {
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       stakeRef <- DelegatedStakeReference.of[IO](stake1)
@@ -275,7 +275,7 @@ object DelegatedRewardsDistributorSuite extends SimpleIOSuite with Checkers {
     )
 
     for {
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
       // Process first round - stake is modified, should preserve existing rewards but not add new ones
@@ -402,7 +402,7 @@ object DelegatedRewardsDistributorSuite extends SimpleIOSuite with Checkers {
         case DelegateRewardsInput(delegatedStakeAcceptanceResult, partitionedRecords, _) =>
           // Simple calculation: add 100L to each existing balance for unmodified stakes
           for {
-            implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO]
+            implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
             implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
 
             modifiedStakes = DelegatedRewardsDistributor.identifyModifiedStakes(

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotStateChannelAcceptanceManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotStateChannelAcceptanceManagerSuite.scala
@@ -39,7 +39,7 @@ object GlobalSnapshotStateChannelAcceptanceManagerSuite extends MutableIOSuite w
   override def sharedResource: Resource[IO, GlobalSnapshotStateChannelAcceptanceManagerSuite.Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/TokenLockOpsManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/TokenLockOpsManagerSuite.scala
@@ -33,7 +33,7 @@ object TokenLockOpsManagerSuite extends MutableIOSuite {
   override def sharedResource: Resource[IO, Res] =
     for {
       sp <- SecurityProvider.forAsync[IO]
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
     } yield (h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManagerSuite.scala
@@ -31,7 +31,7 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, GlobalSnapshotAcceptanceManagerSuite.Res] = for {
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TokenLockStateManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TokenLockStateManagerSuite.scala
@@ -40,7 +40,7 @@ object TokenLockStateManagerSuite extends MutableIOSuite with Checkers {
   override def sharedResource: Resource[IO, Res] =
     for {
       sp <- SecurityProvider.forAsync[IO]
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
     } yield (h, sp)
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorageSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorageSuite.scala
@@ -35,7 +35,7 @@ object SnapshotLocalFileSystemStorageSuite extends MutableIOSuite with Checkers 
     for {
       s <- Supervisor[IO]
       implicit0(k: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar.union(nodeSharedKryoRegistrar))
-      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
       h = Hasher.forJson[IO]
       sp <- SecurityProvider.forAsync[IO]
     } yield (s, k, j, h, sp)

--- a/modules/rosetta/src/test/scala/io/constellationnetwork/rosetta/domain/construction/ConstructionServiceSuite.scala
+++ b/modules/rosetta/src/test/scala/io/constellationnetwork/rosetta/domain/construction/ConstructionServiceSuite.scala
@@ -49,7 +49,7 @@ object ConstructionServiceSuite extends MutableIOSuite with Checkers with Transa
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     hk = Hasher.forKryo[IO]
     hj = Hasher.forJson[IO]
   } yield (sp, hk, ks, hj)

--- a/modules/rosetta/src/test/scala/io/constellationnetwork/rosetta/domain/networkapi/NetworkApiServiceSuite.scala
+++ b/modules/rosetta/src/test/scala/io/constellationnetwork/rosetta/domain/networkapi/NetworkApiServiceSuite.scala
@@ -38,7 +38,7 @@ object NetworkApiServiceSuite extends MutableIOSuite with Checkers {
   def sharedResource: Resource[IO, Res] = for {
     implicit0(ks: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
     sp <- SecurityProvider.forAsync[IO]
-    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
     h = Hasher.forJson[IO]
   } yield (sp, h)
 

--- a/modules/shared/src/main/resources/logback-included.xml
+++ b/modules/shared/src/main/resources/logback-included.xml
@@ -20,8 +20,8 @@
     <property name="TRANSACTIONS_JSON_LOG" value="logs/json_logs/transactions.json.log"/>
     <property name="TRANSACTIONS_JSON_ROLLING_LOG" value="logs/json_logs/archived/transactions.%i.json.log"/>
 
-
-    <appender name="APP" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!-- Synchronous file appenders (wrapped by async appenders below) -->
+    <appender name="APP_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${APP_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${APP_ROLLING_LOG}</fileNamePattern>
@@ -33,7 +33,7 @@
             <pattern>%date [%thread] [%property{self_id}] %highlight(%-5level) %cyan(%logger{15}) - %msg%n</pattern>
         </encoder>
     </appender>
-    <appender name="HTTP" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="HTTP_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${HTTP_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${HTTP_ROLLING_LOG}</fileNamePattern>
@@ -45,7 +45,7 @@
             <pattern>%date [%thread] [%property{self_id}] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
         </encoder>
     </appender>
-    <appender name="GOSSIP" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="GOSSIP_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${GOSSIP_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${GOSSIP_ROLLING_LOG}</fileNamePattern>
@@ -57,7 +57,7 @@
             <pattern>%date [%thread] [%property{self_id}] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
         </encoder>
     </appender>
-    <appender name="PEER_SELECT" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="PEER_SELECT_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${PEER_SELECT_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${PEER_SELECT_ROLLING_LOG}</fileNamePattern>
@@ -69,7 +69,7 @@
             <pattern>%date [%thread] [%property{self_id}] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
         </encoder>
     </appender>
-    <appender name="TRANSACTIONS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="TRANSACTIONS_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${TRANSACTIONS_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${TRANSACTIONS_ROLLING_LOG}</fileNamePattern>
@@ -82,7 +82,7 @@
         </encoder>
     </appender>
 
-    <appender name="APP_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="APP_JSON_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${APP_JSON_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${APP_JSON_ROLLING_LOG}</fileNamePattern>
@@ -96,7 +96,7 @@
             <customFields>{"application":"${application_name}", "peer_id_short": "${self_id}", "ip": "${external_ip}"}</customFields>
         </encoder>
     </appender>
-    <appender name="HTTP_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="HTTP_JSON_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${HTTP_JSON_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${HTTP_JSON_ROLLING_LOG}</fileNamePattern>
@@ -110,7 +110,7 @@
             <customFields>{"application":"${application_name}", "peer_id_short": "${self_id}", "ip": "${external_ip}"}</customFields>
         </encoder>
     </appender>
-    <appender name="GOSSIP_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="GOSSIP_JSON_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${GOSSIP_JSON_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${GOSSIP_JSON_ROLLING_LOG}</fileNamePattern>
@@ -124,7 +124,7 @@
             <customFields>{"application":"${application_name}", "peer_id_short": "${self_id}", "ip": "${external_ip}"}</customFields>
         </encoder>
     </appender>
-    <appender name="TRANSACTIONS_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="TRANSACTIONS_JSON_SYNC" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${TRANSACTIONS_JSON_LOG}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${TRANSACTIONS_JSON_ROLLING_LOG}</fileNamePattern>
@@ -137,6 +137,62 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>{"application":"${application_name}", "peer_id_short": "${self_id}", "ip": "${external_ip}"}</customFields>
         </encoder>
+    </appender>
+
+    <!-- Async wrappers to prevent log calls from blocking compute threads -->
+    <appender name="APP" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="APP_SYNC" />
+    </appender>
+    <appender name="HTTP" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="HTTP_SYNC" />
+    </appender>
+    <appender name="GOSSIP" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="GOSSIP_SYNC" />
+    </appender>
+    <appender name="PEER_SELECT" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="PEER_SELECT_SYNC" />
+    </appender>
+    <appender name="TRANSACTIONS" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="TRANSACTIONS_SYNC" />
+    </appender>
+    <appender name="APP_JSON" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="APP_JSON_SYNC" />
+    </appender>
+    <appender name="HTTP_JSON" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="HTTP_JSON_SYNC" />
+    </appender>
+    <appender name="GOSSIP_JSON" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="GOSSIP_JSON_SYNC" />
+    </appender>
+    <appender name="TRANSACTIONS_JSON" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="TRANSACTIONS_JSON_SYNC" />
     </appender>
 
     <root level="INFO">

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
@@ -1,7 +1,7 @@
 package io.constellationnetwork.currency.schema
 
 import cats.Parallel
-import cats.effect.kernel.Sync
+import cats.effect.Async
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -94,7 +94,7 @@ object currency {
     lastTokenLockRefs: Option[SortedMap[Address, TokenLockReference]],
     activeTokenLocks: Option[SortedMap[Address, SortedSet[Signed[TokenLock]]]]
   ) extends SnapshotInfo[CurrencySnapshotStateProof] {
-    def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[CurrencySnapshotStateProof] =
+    def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[CurrencySnapshotStateProof] =
       (
         lastTxRefs.hash,
         balances.hash,
@@ -116,7 +116,7 @@ object currency {
     lastTxRefs: SortedMap[Address, TransactionReference],
     balances: SortedMap[Address, Balance]
   ) extends SnapshotInfo[CurrencySnapshotStateProofV1] {
-    def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[CurrencySnapshotStateProofV1] =
+    def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[CurrencySnapshotStateProofV1] =
       (lastTxRefs.hash, balances.hash).tupled.map(CurrencySnapshotStateProofV1.apply)
 
     def toCurrencySnapshotInfo: CurrencySnapshotInfo =
@@ -209,7 +209,7 @@ object currency {
   ) extends IncrementalSnapshot[CurrencySnapshotStateProof]
 
   object CurrencyIncrementalSnapshot {
-    def fromCurrencySnapshot[F[_]: Parallel: Sync: Hasher](snapshot: CurrencySnapshot): F[CurrencyIncrementalSnapshot] =
+    def fromCurrencySnapshot[F[_]: Parallel: Async: Hasher](snapshot: CurrencySnapshot): F[CurrencyIncrementalSnapshot] =
       snapshot.info.stateProof[F](snapshot.ordinal).map { stateProof =>
         CurrencyIncrementalSnapshot(
           snapshot.ordinal,
@@ -311,7 +311,7 @@ object currency {
         }
       )
 
-    def mkFirstIncrementalSnapshot[F[_]: Parallel: Sync: Hasher](
+    def mkFirstIncrementalSnapshot[F[_]: Parallel: Async: Hasher](
       genesis: Hashed[CurrencySnapshot]
     ): F[CurrencyIncrementalSnapshot] =
       genesis.info.stateProof[F](genesis.ordinal).map { stateProof =>

--- a/modules/shared/src/main/scala/io/constellationnetwork/ext/http4s/BlockingEntityEncoder.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/ext/http4s/BlockingEntityEncoder.scala
@@ -1,0 +1,73 @@
+package io.constellationnetwork.ext.http4s
+
+import cats.effect.Async
+
+import io.circe.{Encoder, Printer}
+import org.http4s.headers.`Content-Type`
+import org.http4s.{Entity, EntityEncoder, MediaType}
+
+/** Entity encoders that perform JSON serialization on the blocking thread pool to prevent CPU starvation on compute threads when encoding
+  * large payloads.
+  *
+  * The standard http4s circe encoder runs JSON serialization on the calling thread. For large payloads (70MB+ GlobalSnapshotInfo), this can
+  * block compute threads for hundreds of milliseconds, causing fiber starvation.
+  *
+  * These encoders wrap serialization in `Async[F].blocking` to move the work to the blocking thread pool.
+  */
+object BlockingEntityEncoder {
+
+  private val defaultPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
+
+  /** Creates an EntityEncoder that streams JSON serialization from the blocking thread pool.
+    *
+    * Use this for large payloads (e.g., snapshots, state) to prevent compute thread starvation.
+    *
+    * Example usage in routes:
+    * {{{
+    * import io.constellationnetwork.ext.http4s.BlockingEntityEncoder.blockingJsonEncoder
+    *
+    * implicit def jsonEncoders[A <: AnyRef: Encoder]: List[EntityEncoder[F, A]] =
+    *   List(blockingJsonEncoder[F, A])
+    * }}}
+    */
+  def blockingJsonEncoder[F[_]: Async, A: Encoder]: EntityEncoder[F, A] =
+    blockingJsonEncoderWithPrinter[F, A](defaultPrinter)
+
+  /** Creates an EntityEncoder with a custom Printer that serializes JSON on the blocking thread pool.
+    */
+  def blockingJsonEncoderWithPrinter[F[_]: Async, A: Encoder](printer: Printer): EntityEncoder[F, A] =
+    EntityEncoder[F, fs2.Stream[F, Byte]]
+      .contramap[A] { value =>
+        fs2.Stream.evalUnChunk(
+          Async[F].blocking {
+            val bytes = printer.print(Encoder[A].apply(value)).getBytes("UTF-8")
+            fs2.Chunk.array(bytes)
+          }
+        )
+      }
+      .withContentType(`Content-Type`(MediaType.application.json))
+
+  /** Creates an EntityEncoder that produces the full byte array from the blocking thread pool. The bytes are then streamed as a single
+    * chunk.
+    *
+    * This is slightly more efficient than blockingJsonEncoder for responses where you want to set Content-Length header (non-chunked
+    * transfer).
+    */
+  def blockingJsonEncoderStrict[F[_]: Async, A: Encoder]: EntityEncoder[F, A] =
+    new EntityEncoder[F, A] {
+      override def toEntity(a: A): Entity[F] = {
+        val bytes = fs2.Stream
+          .eval(
+            Async[F].blocking {
+              defaultPrinter.print(Encoder[A].apply(a)).getBytes("UTF-8")
+            }
+          )
+          .flatMap(arr => fs2.Stream.chunk(fs2.Chunk.array(arr)))
+
+        Entity(bytes)
+      }
+
+      override def headers: org.http4s.Headers =
+        org.http4s.Headers(`Content-Type`(MediaType.application.json))
+    }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/json/JsonBrotliBinarySerializer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/json/JsonBrotliBinarySerializer.scala
@@ -3,7 +3,7 @@ package io.constellationnetwork.json
 import java.io.{ByteArrayOutputStream, OutputStream}
 import java.nio.charset.StandardCharsets
 
-import cats.effect.kernel.Sync
+import cats.effect.Async
 import cats.syntax.all._
 
 import com.aayushatharva.brotli4j.Brotli4jLoader
@@ -22,10 +22,6 @@ object JsonBrotliBinarySerializer {
   private val compressionLevel = 2
   private val parser = JawnParser(allowDuplicateKeys = false)
   private val UTF8 = StandardCharsets.UTF_8
-  private val deterministicPrinter: Printer = Printer.noSpaces.copy(
-    dropNullValues = true,
-    sortKeys = true
-  )
 
   private class OutputStreamAppendable(os: OutputStream) extends Appendable {
     def append(csq: CharSequence): Appendable = { os.write(csq.toString.getBytes(UTF8)); this }
@@ -58,26 +54,23 @@ object JsonBrotliBinarySerializer {
 
   def apply[F[_]: JsonBrotliBinarySerializer]: JsonBrotliBinarySerializer[F] = implicitly
 
-  def forSync[F[_]: Sync]: F[JsonBrotliBinarySerializer[F]] =
-    forSync[F](deterministicPrinter)
-
-  def forSync[F[_]: Sync](printer: Printer): F[JsonBrotliBinarySerializer[F]] =
-    Sync[F].delay(Brotli4jLoader.ensureAvailability()).map { _ =>
+  def forAsync[F[_]: Async](printer: Printer): F[JsonBrotliBinarySerializer[F]] =
+    Async[F].delay(Brotli4jLoader.ensureAvailability()).map { _ =>
       new JsonBrotliBinarySerializer[F] {
         private val params = new Parameters().setQuality(compressionLevel)
 
         def serialize[A: Encoder](content: A): F[Array[Byte]] =
-          Sync[F].blocking {
+          Async[F].blocking {
             streamPrintAndCompress(content, printer, params)
-          }
+          } <* Async[F].cede
 
         def deserialize[A: Decoder](content: Array[Byte]): F[Either[Throwable, A]] =
-          Sync[F].blocking {
+          Async[F].blocking {
             val decompressed = brotliDecompress(content).getDecompressedData
             parser
               .parseByteBuffer(java.nio.ByteBuffer.wrap(decompressed))
-              .flatMap(_.as[A])
-          }
+              .flatMap[Throwable, A](_.as[A])
+          } <* Async[F].cede
       }
     }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/json/JsonSerializer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/json/JsonSerializer.scala
@@ -1,6 +1,6 @@
 package io.constellationnetwork.json
 
-import cats.effect.Sync
+import cats.effect.Async
 import cats.syntax.all._
 
 import io.circe.{Decoder, Encoder, Printer}
@@ -13,9 +13,9 @@ trait JsonSerializer[F[_]] {
 object JsonSerializer {
   def apply[F[_]](implicit ev: JsonSerializer[F]): JsonSerializer[F] = ev
 
-  def forSync[F[_]: Sync]: F[JsonSerializer[F]] = {
+  def forAsync[F[_]: Async]: F[JsonSerializer[F]] = {
     val printer = Printer(dropNullValues = true, indent = "", sortKeys = true)
-    JsonBrotliBinarySerializer.forSync[F](printer).map { brotli =>
+    JsonBrotliBinarySerializer.forAsync[F](printer).map { brotli =>
       new JsonSerializer[F] {
         override def serialize[A: Encoder](content: A): F[Array[Byte]] =
           brotli.serialize(content)

--- a/modules/shared/src/main/scala/io/constellationnetwork/merkletree/MerkleTreeValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/merkletree/MerkleTreeValidator.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.merkletree
 
 import cats.data.Validated
 import cats.data.Validated.Invalid
-import cats.effect.{Async, Sync}
+import cats.effect.Async
 import cats.kernel.Eq
 import cats.syntax.all._
 import cats.{Parallel, Show}
@@ -32,13 +32,13 @@ object StateProofValidator {
         validate(hashedSnapshot, stateProof)
     }
 
-  def validate[F[_]: Sync: Parallel: Hasher, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
+  def validate[F[_]: Async: Parallel: Hasher, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
     snapshot: Hashed[A],
     snapshotInfo: SnapshotInfo[P]
   ): F[Validated[StateBroken, Unit]] =
     snapshotInfo.stateProof(snapshot.ordinal).flatMap(validate(snapshot, _))
 
-  def validate[F[_]: Sync: Parallel, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
+  def validate[F[_]: Async: Parallel, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
     snapshot: Hashed[A],
     stateProof: P
   ): F[Validated[StateBroken, Unit]] = {

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalIncrementalSnapshot.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalIncrementalSnapshot.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.schema
 
 import cats.Parallel
 import cats.data.NonEmptyList
-import cats.effect.Sync
+import cats.effect.Async
 import cats.syntax.functor._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -150,7 +150,7 @@ case class GlobalIncrementalSnapshotV2(
 }
 
 object GlobalIncrementalSnapshotV2 {
-  def fromGlobalSnapshot[F[_]: Parallel: Sync: Hasher](snapshot: GlobalSnapshot): F[GlobalIncrementalSnapshotV2] = {
+  def fromGlobalSnapshot[F[_]: Parallel: Async: Hasher](snapshot: GlobalSnapshot): F[GlobalIncrementalSnapshotV2] = {
     val gsi = GlobalSnapshotInfoV1.toGlobalSnapshotInfo(snapshot.info)
     val gsiv3 = GlobalSnapshotInfoV3.fromGlobalSnapshotInfo(gsi)
     gsiv3.stateProof[F](snapshot.ordinal).map { stateProof =>
@@ -208,7 +208,7 @@ case class GlobalIncrementalSnapshot(
 ) extends IncrementalSnapshot[GlobalSnapshotStateProof]
 
 object GlobalIncrementalSnapshot {
-  def fromGlobalSnapshot[F[_]: Parallel: Sync: Hasher](snapshot: GlobalSnapshot): F[GlobalIncrementalSnapshot] =
+  def fromGlobalSnapshot[F[_]: Parallel: Async: Hasher](snapshot: GlobalSnapshot): F[GlobalIncrementalSnapshot] =
     GlobalSnapshotInfoV1.toGlobalSnapshotInfo(snapshot.info).stateProof[F](snapshot.ordinal).map { stateProof =>
       GlobalIncrementalSnapshot(
         snapshot.ordinal,

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshot.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshot.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.schema
 
 import cats.Parallel
 import cats.data.NonEmptyList
-import cats.effect.Sync
+import cats.effect.Async
 import cats.syntax.functor._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -76,7 +76,7 @@ object GlobalSnapshot {
       )
     )
 
-  def mkFirstIncrementalSnapshot[F[_]: Parallel: Sync: Hasher](
+  def mkFirstIncrementalSnapshot[F[_]: Parallel: Async: Hasher](
     genesis: Hashed[GlobalSnapshot]
   ): F[GlobalIncrementalSnapshot] =
     GlobalSnapshotInfoV1.toGlobalSnapshotInfo(genesis.info).stateProof[F](genesis.ordinal).map { stateProof =>

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
@@ -1,7 +1,7 @@
 package io.constellationnetwork.schema
 
 import cats.Parallel
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -42,7 +42,7 @@ case class GlobalSnapshotInfoV1(
   lastTxRefs: SortedMap[Address, TransactionReference],
   balances: SortedMap[Address, Balance]
 ) extends SnapshotInfo[GlobalSnapshotStateProofV2] {
-  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProofV2] = {
+  def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProofV2] = {
     val info = GlobalSnapshotInfoV1.toGlobalSnapshotInfo(this)
     info.lastCurrencySnapshots.merkleTree[F].flatMap { mt =>
       GlobalSnapshotInfo.legacyStateProof(info, mt)
@@ -106,10 +106,10 @@ case class GlobalSnapshotInfoV2(
       None
     )
 
-  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProofV2] =
+  def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProofV2] =
     lastCurrencySnapshots.merkleTree[F].flatMap(stateProof(_))
 
-  def stateProof[F[_]: Parallel: Sync: Hasher](lastCurrencySnapshots: Option[MerkleTree]): F[GlobalSnapshotStateProofV2] =
+  def stateProof[F[_]: Parallel: Async: Hasher](lastCurrencySnapshots: Option[MerkleTree]): F[GlobalSnapshotStateProofV2] =
     GlobalSnapshotInfo.legacyStateProof[F](toGlobalSnapshotInfo, lastCurrencySnapshots)
 }
 
@@ -152,12 +152,12 @@ case class GlobalSnapshotInfoV3(
   priceState: Option[SortedMap[TokenPair, PriceRecord]],
   metagraphSyncData: Option[SortedMap[Address, MetagraphSyncDataInfo]]
 ) extends SnapshotInfo[GlobalSnapshotStateProofV2] {
-  def legacyStateProof[F[_]: Parallel: Sync: Hasher](
+  def legacyStateProof[F[_]: Parallel: Async: Hasher](
     lastCurrencySnapshots: Option[MerkleTree]
   ): F[GlobalSnapshotStateProofV2] =
     GlobalSnapshotInfo.legacyStateProof[F](toGlobalSnapshotInfo, lastCurrencySnapshots)
 
-  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProofV2] =
+  def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProofV2] =
     lastCurrencySnapshots.merkleTree[F].flatMap(legacyStateProof(_))
 
   def toGlobalSnapshotInfo: GlobalSnapshotInfo =
@@ -233,10 +233,10 @@ case class GlobalSnapshotInfo(
   metagraphSyncData: Option[SortedMap[Address, MetagraphSyncDataInfo]]
 ) extends SnapshotInfo[GlobalSnapshotStateProof] {
 
-  def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
+  def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[GlobalSnapshotStateProof] =
     this.allStateEntries.buildMpt.map(mptRoot => GlobalSnapshotStateProof(mptRoot.value))
 
-  def stateProofFor[F[_]: Parallel: Sync: Hasher](
+  def stateProofFor[F[_]: Parallel: Async: Hasher](
     hashScheme: HashLogic,
     ordinal: SnapshotOrdinal
   ): F[GlobalSnapshotStateProof] = hashScheme match {

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/address.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/address.scala
@@ -66,10 +66,19 @@ object address {
         {
           case a if a == StardustCollective.address => true
           case a if a.length != 40                  => false
-          case a =>
-            val par = a.substring(4).filter(Character.isDigit).map(_.toString.toInt).sum % 9
+          case a                                    =>
+            // optimized lookup without intermediate allocations
+            val suffix = a.substring(4)
+            var digitSum = 0
+            var i = 0
+            while (i < suffix.length) {
+              val c = suffix.charAt(i)
+              if (Character.isDigit(c)) digitSum += c - '0'
+              i += 1
+            }
+            val par = digitSum % 9
 
-            val isBase58 = Base58.isBase58(a.substring(4))
+            val isBase58 = Base58.isBase58(suffix)
             val hasDAGPrefixAndParity = a.startsWith(s"DAG$par")
 
             isBase58 && hasDAGPrefixAndParity

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
@@ -1,7 +1,7 @@
 package io.constellationnetwork.schema.mpt
 
 import cats.Parallel
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -135,19 +135,22 @@ object GlobalStateConverter {
         toAllStateKeyValuePairs(info)
     }
 
-    implicit class MptBuilderOps[F[_]: Parallel: Sync: Hasher](kvPairsF: F[Map[GlobalStateKey, Json]]) {
+    implicit class MptBuilderOps[F[_]: Parallel: Async: Hasher](kvPairsF: F[Map[GlobalStateKey, Json]]) {
       def buildMpt: F[MptRoot] =
         for {
           kvPairs <- kvPairsF
+          _ <- Async[F].cede
           hexMap <- kvPairs.toList.parTraverse {
             case (key, value) => GlobalStateKey.toHex[F](key).map(_ -> value)
           }.map(_.toMap)
+          _ <- Async[F].cede
           mptRoot <- hexMap.isEmpty
             .pure[F]
             .ifM(
               ifTrue = MptRoot(Hash.empty).pure[F],
               ifFalse = MerklePatriciaTrie.make[F, Json](hexMap).map(_.rootHash)
             )
+          _ <- Async[F].cede
         } yield mptRoot
     }
   }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/snapshot.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/snapshot.scala
@@ -2,7 +2,6 @@ package io.constellationnetwork.schema
 
 import cats.Parallel
 import cats.effect.Async
-import cats.effect.kernel.Sync
 import cats.syntax.functor._
 import cats.syntax.traverse._
 
@@ -59,7 +58,7 @@ object snapshot {
     val lastTxRefs: SortedMap[Address, TransactionReference]
     val balances: SortedMap[Address, Balance]
 
-    def stateProof[F[_]: Parallel: Sync: Hasher](ordinal: SnapshotOrdinal): F[P]
+    def stateProof[F[_]: Parallel: Async: Hasher](ordinal: SnapshotOrdinal): F[P]
     def getActiveTokenLocks: SortedMap[Address, SortedSet[Signed[TokenLock]]] = SortedMap.empty
     def getActiveDelegatedStakes: SortedMap[Address, SortedSet[DelegatedStakeRecord]] = SortedMap.empty
   }

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Base58.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Base58.scala
@@ -9,6 +9,8 @@ object Base58 {
   val alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
   // char -> value
   val map: Map[Char, Int] = alphabet.zipWithIndex.toMap
+  // Pre-computed Set for O(1) lookups without per-call allocation
+  private val alphabetSet: Set[Char] = alphabet.toSet
 
   /** Documentation.
     *
@@ -59,5 +61,5 @@ object Base58 {
     *   true if input contains base58 chars only, false otherwise
     */
   def isBase58(input: String): Boolean =
-    input.forall(alphabet.toSet.contains)
+    input.forall(alphabetSet.contains)
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
@@ -138,7 +138,7 @@ object Hasher {
             JsonSerializer[F].serialize(d.toEncode)(d.jsonEncoder)
           case _ =>
             JsonSerializer[F].serialize[A](data)
-        }).map(Hash.fromBytes)
+        }).flatMap(Hash.fromBytesForSync[F])
 
       def hash[A: Encoder](data: A): F[Hash] =
         hashJson(data)

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
@@ -66,6 +66,19 @@ object Hasher {
 
   def apply[F[_]: Hasher]: Hasher[F] = implicitly
 
+  /** Cache key wrapper using identity semantics (reference equality).
+    *
+    * Using the data object directly as a cache key requires computing hashCode() on every lookup, which for large objects like
+    * GlobalSnapshotInfo means iterating millions of map entries. Identity-based keys use System.identityHashCode() which is O(1).
+    */
+  private class IdentityKey(val value: AnyRef) {
+    override def hashCode(): Int = System.identityHashCode(value)
+    override def equals(obj: Any): Boolean = obj match {
+      case other: IdentityKey => value eq other.value
+      case _                  => false
+    }
+  }
+
   def forKryo[F[_]: Sync: KryoSerializer]: Hasher[F] = new Hasher[F] {
     def getLogic(ordinal: SnapshotOrdinal): HashLogic = KryoHash
 
@@ -110,12 +123,12 @@ object Hasher {
     else forJsonCached[F]
 
   def forJsonCached[F[_]: Sync: JsonSerializer]: Hasher[F] = {
-    val cache: Cache[Any, Hash] = Scaffeine()
+    val cache: Cache[IdentityKey, Hash] = Scaffeine()
       .recordStats()
       .expireAfterAccess(5.minutes)
       .maximumSize(10000)
       .softValues()
-      .build[Any, Hash]()
+      .build[IdentityKey, Hash]()
 
     new Hasher[F] {
       def getLogic(ordinal: SnapshotOrdinal): HashLogic = JsonHash
@@ -123,14 +136,16 @@ object Hasher {
       def compare[A: Encoder](data: A, expectedHash: Hash): F[Boolean] =
         hashJson(data).map(_ === expectedHash)
 
-      def hashJson[A: Encoder](data: A): F[Hash] =
-        Sync[F].delay(cache.getIfPresent(data)).flatMap {
+      def hashJson[A: Encoder](data: A): F[Hash] = {
+        val key = new IdentityKey(data.asInstanceOf[AnyRef])
+        Sync[F].delay(cache.getIfPresent(key)).flatMap {
           case Some(hash) => hash.pure[F]
           case None =>
             computeHash(data).flatTap { hash =>
-              Sync[F].delay(cache.put(data, hash))
+              Sync[F].delay(cache.put(key, hash))
             }
         }
+      }
 
       private def computeHash[A: Encoder](data: A): F[Hash] =
         (data match {

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/MerklePatriciaTrie.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/MerklePatriciaTrie.scala
@@ -1,6 +1,6 @@
 package io.constellationnetwork.security.mpt
 
-import cats.effect.Sync
+import cats.effect.Async
 
 import scala.annotation.tailrec
 
@@ -23,7 +23,7 @@ object MerklePatriciaTrie {
   implicit val merklePatriciaTrieDecoder: Decoder[MerklePatriciaTrie] = (c: HCursor) =>
     c.downField("rootNode").as[MerklePatriciaNode].map(MerklePatriciaTrie(_))
 
-  def make[F[_]: Hasher: Sync, A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
+  def make[F[_]: Hasher: Async, A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
     MerklePatriciaProducer
       .stateless[F]
       .create(data)

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/InMemoryMerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/InMemoryMerklePatriciaProducer.scala
@@ -1,6 +1,6 @@
 package io.constellationnetwork.security.mpt.producer
 
-import cats.effect.{Ref, Sync}
+import cats.effect.{Async, Ref}
 import cats.syntax.all._
 
 import io.constellationnetwork.security.Hasher
@@ -13,7 +13,7 @@ import io.constellationnetwork.security.mpt.verifier._
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
-class InMemoryMerklePatriciaProducer[F[_]: Sync: Hasher](
+class InMemoryMerklePatriciaProducer[F[_]: Async: Hasher](
   stateRef: Ref[F, InMemoryMerklePatriciaProducer.ProducerState]
 ) extends StatefulMerklePatriciaProducer[F] {
 
@@ -25,7 +25,7 @@ class InMemoryMerklePatriciaProducer[F[_]: Sync: Hasher](
         case None =>
           build.flatMap {
             case Right(trie) => MerklePatriciaSingleInclusionProver.make[F](trie).pure[F]
-            case Left(err)   => Sync[F].raiseError(err)
+            case Left(err)   => Async[F].raiseError(err)
           }
       }
     }
@@ -142,7 +142,7 @@ object InMemoryMerklePatriciaProducer {
     maxDirtyKeys: Int = 100
   )
 
-  def make[F[_]: Sync: Hasher](
+  def make[F[_]: Async: Hasher](
     initial: Map[Hex, Json] = Map.empty
   ): F[InMemoryMerklePatriciaProducer[F]] =
     for {

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
@@ -1,6 +1,6 @@
 package io.constellationnetwork.security.mpt.producer
 
-import cats.effect.Sync
+import cats.effect.Async
 import cats.syntax.functor._
 
 import io.constellationnetwork.security.Hasher
@@ -39,12 +39,12 @@ trait StatefulMerklePatriciaProducer[F[_]] {
 object MerklePatriciaProducer {
   def apply[F[_]](implicit producer: MerklePatriciaProducer[F]): MerklePatriciaProducer[F] = producer
 
-  def make[F[_]: Hasher: Sync]: MerklePatriciaProducer[F] = stateless[F]
+  def make[F[_]: Hasher: Async]: MerklePatriciaProducer[F] = stateless[F]
 
-  def stateless[F[_]: Hasher: Sync]: MerklePatriciaProducer[F] =
+  def stateless[F[_]: Hasher: Async]: MerklePatriciaProducer[F] =
     new StatelessMerklePatriciaProducer[F]
 
-  def inMemory[F[_]: Sync: Hasher](
+  def inMemory[F[_]: Async: Hasher](
     initial: Map[Hex, Json] = Map.empty
   ): F[StatefulMerklePatriciaProducer[F]] =
     InMemoryMerklePatriciaProducer.make[F](initial).widen[StatefulMerklePatriciaProducer[F]]

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/StatelessMerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/StatelessMerklePatriciaProducer.scala
@@ -1,7 +1,7 @@
 package io.constellationnetwork.security.mpt.producer
 
 import cats.data.NonEmptyList
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.syntax.all._
 
 import scala.collection.immutable.ArraySeq
@@ -15,10 +15,12 @@ import io.constellationnetwork.security.mpt.verifier._
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
-class StatelessMerklePatriciaProducer[F[_]: Hasher: Sync] extends MerklePatriciaProducer[F] {
+class StatelessMerklePatriciaProducer[F[_]: Hasher: Async] extends MerklePatriciaProducer[F] {
 
   def getProver(trie: MerklePatriciaTrie): F[MerklePatriciaSingleInclusionProver[F]] =
     MerklePatriciaSingleInclusionProver.make[F](trie).pure[F]
+
+  private val yieldEveryN = 100
 
   def create[A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
     NonEmptyList.fromList(data.toList) match {
@@ -29,12 +31,14 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Sync] extends MerklePatricia
           initialNode <- MerklePatriciaNode.Leaf[F](Nibble(hPath), hData.asJson)
           sortedTail = nel.tail.sortBy(_._1.value.length)
 
-          resultNode <- sortedTail.foldM[F, MerklePatriciaNode](initialNode) {
-            case (acc, (path, value)) =>
-              insertEncoded(acc, Nibble(path), value.asJson).flatMap {
+          resultNode <- sortedTail.zipWithIndex.foldM[F, MerklePatriciaNode](initialNode) {
+            case (acc, ((path, value), idx)) =>
+              val work = insertEncoded(acc, Nibble(path), value.asJson).flatMap {
                 case Left(err)    => err.raiseError[F, MerklePatriciaNode]
                 case Right(value) => value.pure[F]
               }
+              if (idx % yieldEveryN == 0) Async[F].cede *> work <* Async[F].cede
+              else work
           }
         } yield MerklePatriciaTrie(resultNode)
 
@@ -66,9 +70,11 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Sync] extends MerklePatricia
     initialNode: MerklePatriciaNode,
     entries: List[(Hex, A)]
   ): F[Either[MerklePatriciaError, MerklePatriciaNode]] =
-    entries.foldM(initialNode.asRight[MerklePatriciaError]) {
-      case (Right(acc), (path, value)) =>
-        insertEncoded(acc, Nibble(path), value.asJson)
+    entries.zipWithIndex.foldM(initialNode.asRight[MerklePatriciaError]) {
+      case (Right(acc), ((path, value), idx)) =>
+        val work = insertEncoded(acc, Nibble(path), value.asJson)
+        if (idx % yieldEveryN == 0) Async[F].cede *> work <* Async[F].cede
+        else work
       case (Left(err), _) =>
         err.asLeft[MerklePatriciaNode].pure[F]
     }
@@ -77,9 +83,11 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Sync] extends MerklePatricia
     initialNode: MerklePatriciaNode,
     paths: List[Hex]
   ): F[Either[MerklePatriciaError, MerklePatriciaNode]] =
-    paths.foldM(initialNode.asRight[MerklePatriciaError]) {
-      case (Right(acc), path) =>
-        removeEncoded(acc, Nibble(path))
+    paths.zipWithIndex.foldM(initialNode.asRight[MerklePatriciaError]) {
+      case (Right(acc), (path, idx)) =>
+        val work = removeEncoded(acc, Nibble(path))
+        if (idx % yieldEveryN == 0) Async[F].cede *> work <* Async[F].cede
+        else work
       case (Left(err), _) =>
         err.asLeft[MerklePatriciaNode].pure[F]
     }
@@ -393,6 +401,6 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Sync] extends MerklePatricia
 
 object StatelessMerklePatriciaProducer {
 
-  def apply[F[_]: Hasher: Sync]: StatelessMerklePatriciaProducer[F] =
+  def apply[F[_]: Hasher: Async]: StatelessMerklePatriciaProducer[F] =
     new StatelessMerklePatriciaProducer[F]
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/signature/Signing.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/signature/Signing.scala
@@ -24,8 +24,10 @@ object Signing {
         .flatMap { secureRandom =>
           Async[F].delay(s.initSign(privateKey, secureRandom))
         }
-      _ <- Async[F].delay(s.update(bytes))
-      signed <- Async[F].delay(s.sign())
+      signed <- Async[F].blocking {
+        s.update(bytes)
+        s.sign()
+      }
     } yield signed
 
   def verifySignature[F[_]: Async: SecurityProvider](
@@ -38,7 +40,9 @@ object Signing {
         Signature.getInstance(signFunc, SecurityProvider[F].provider)
       }
       _ <- Async[F].delay(s.initVerify(publicKey))
-      _ <- Async[F].delay(s.update(originalInput))
-      result <- Async[F].delay(s.verify(signedOutput))
+      result <- Async[F].blocking {
+        s.update(originalInput)
+        s.verify(signedOutput)
+      }
     } yield result
 }

--- a/modules/shared/src/test/scala/io/constellationnetwork/json/JsonBinarySerializerSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/json/JsonBinarySerializerSuite.scala
@@ -2,8 +2,7 @@ package io.constellationnetwork.json
 
 import cats.Parallel
 import cats.data.NonEmptySet
-import cats.effect.kernel.Sync
-import cats.effect.{IO, Resource}
+import cats.effect.{Async, IO, Resource}
 import cats.syntax.functor._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -58,7 +57,7 @@ object JsonBinarySerializerSuite extends MutableIOSuite {
     }
   }
 
-  private[json] def currencyIncrementalSnapshot[F[_]: Parallel: Sync: Hasher](
+  private[json] def currencyIncrementalSnapshot[F[_]: Parallel: Async: Hasher](
     hash: Hash,
     currencySnapshotInfo: CurrencySnapshotInfo
   ): F[Signed[CurrencyIncrementalSnapshot]] =

--- a/modules/shared/src/test/scala/io/constellationnetwork/json/JsonBinarySerializerSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/json/JsonBinarySerializerSuite.scala
@@ -30,7 +30,7 @@ object JsonBinarySerializerSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit res =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         Hasher.forJson[IO]
       }
     }

--- a/modules/shared/src/test/scala/io/constellationnetwork/json/JsonBrotliBinarySerializerSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/json/JsonBrotliBinarySerializerSuite.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.shared.sharedKryoRegistrar
 
 import eu.timepit.refined.auto._
+import io.circe.Printer
 import weaver.MutableIOSuite
 
 object JsonBrotliBinarySerializerSuite extends MutableIOSuite {
@@ -24,12 +25,12 @@ object JsonBrotliBinarySerializerSuite extends MutableIOSuite {
     KryoSerializer
       .forAsync[IO](sharedKryoRegistrar)
       .flatMap { implicit res =>
-        JsonSerializer.forSync[IO].asResource.map { implicit json =>
+        JsonSerializer.forAsync[IO].asResource.map { implicit json =>
           Hasher.forJson[IO]
         }
       }
       .flatMap { kp =>
-        JsonBrotliBinarySerializer.forSync[IO].asResource.map((kp, _))
+        JsonBrotliBinarySerializer.forAsync[IO](Printer(dropNullValues = true, indent = "", sortKeys = true)).asResource.map((kp, _))
       }
 
   test("should deserialize properly serialized object") {

--- a/modules/shared/src/test/scala/io/constellationnetwork/json/JsonHashSerializerSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/json/JsonHashSerializerSuite.scala
@@ -14,7 +14,7 @@ object JsonSerializerSuite extends MutableIOSuite {
   type Res = JsonSerializer[IO]
 
   override def sharedResource: Resource[IO, Res] =
-    JsonSerializer.forSync[IO].asResource
+    JsonSerializer.forAsync[IO].asResource
 
   test("maintains consistent key ordering") { serializer =>
     val foo = Foo("lorem", 1)

--- a/modules/shared/src/test/scala/io/constellationnetwork/merkletree/MerkleTreeValidatorSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/merkletree/MerkleTreeValidatorSuite.scala
@@ -33,7 +33,7 @@ object MerkleTreeValidatorSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit res =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         Hasher.forJson[IO]
       }
     }

--- a/modules/shared/src/test/scala/io/constellationnetwork/schema/CoinbaseSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/schema/CoinbaseSuite.scala
@@ -17,7 +17,7 @@ object CoinbaseSuite extends ResourceSuite with Checkers {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit res =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         Hasher.forJson[IO]
       }
     }

--- a/modules/shared/src/test/scala/io/constellationnetwork/schema/GlobalSnapshotSchemaMigrationSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/schema/GlobalSnapshotSchemaMigrationSuite.scala
@@ -27,7 +27,7 @@ object GlobalSnapshotSchemaMigrationSuite extends MutableIOSuite with Checkers {
   override def sharedResource: Resource[IO, Res] =
     for {
       implicit0(kryo: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
-      implicit0(json: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].toResource
+      implicit0(json: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].toResource
     } yield
       HasherSelector.forSync[IO](
         Hasher.forJson[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/schema/TransactionSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/schema/TransactionSuite.scala
@@ -25,7 +25,7 @@ object TransactionSuite extends ResourceSuite with Checkers {
     KryoSerializer
       .forAsync[IO](sharedKryoRegistrar, List.empty, setReferences = true)
       .flatMap { implicit res =>
-        JsonSerializer.forSync[IO].asResource.map { implicit json =>
+        JsonSerializer.forAsync[IO].asResource.map { implicit json =>
           Hasher.forKryo[IO]
         }
       }

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/HashSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/HashSuite.scala
@@ -36,7 +36,7 @@ object HashSuite extends MutableIOSuite with Checkers {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync(registrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/HasherPerformanceSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/HasherPerformanceSuite.scala
@@ -167,7 +167,9 @@ object HasherPerformanceSuite extends MutableIOSuite {
           uncachedResults.map(_._2).toSet.size == 1 &&
           cachedResults.head._2 == uncachedResults.head._2
 
-        _ <- IO.println(s"Size: ${sizeMB}MB - Cached: ${f"$cachedAvg%.2f"}ms, Uncached: ${f"$uncachedAvg%.2f"}ms, Speedup: ${f"$speedup%.2f"}x, Consistent: $allHashesEqual")
+        _ <- IO.println(
+          s"Size: ${sizeMB}MB - Cached: ${f"$cachedAvg%.2f"}ms, Uncached: ${f"$uncachedAvg%.2f"}ms, Speedup: ${f"$speedup%.2f"}x, Consistent: $allHashesEqual"
+        )
 
       } yield expect(allHashesEqual, s"Hashes should be consistent for ${sizeMB}MB object")
     }.map(_.combineAll)

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/HasherPerformanceSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/HasherPerformanceSuite.scala
@@ -1,0 +1,175 @@
+package io.constellationnetwork.security
+
+import java.util.UUID
+
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import scala.util.Random
+
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import weaver.MutableIOSuite
+
+object HasherPerformanceSuite extends MutableIOSuite {
+
+  type Res = JsonSerializer[IO]
+
+  override def sharedResource: Resource[IO, Res] =
+    JsonSerializer.forAsync[IO].asResource
+
+  @derive(encoder, decoder)
+  case class SubData(
+    field1: String,
+    field2: Int,
+    field3: List[String]
+  )
+
+  @derive(encoder, decoder)
+  case class NestedData(
+    value: String,
+    numbers: List[Double],
+    subData: Option[SubData]
+  )
+
+  @derive(encoder, decoder)
+  case class LargeObject(
+    id: String,
+    data: List[NestedData],
+    metadata: Map[String, String]
+  )
+
+  def generateLargeObject(sizeMB: Double): LargeObject = {
+    val random = new Random(42)
+    val targetBytes = (sizeMB * 1024 * 1024).toInt
+    val estimatedStringSize = 100
+    val numItems = targetBytes / estimatedStringSize
+
+    val dataItems = (1 to numItems).map { _ =>
+      NestedData(
+        value = s"value_${UUID.randomUUID()}",
+        numbers = List.fill(10)(random.nextDouble()),
+        subData = Some(
+          SubData(
+            field1 = s"field_${UUID.randomUUID()}",
+            field2 = random.nextInt(10000),
+            field3 = List.fill(5)(UUID.randomUUID().toString)
+          )
+        )
+      )
+    }.toList
+
+    LargeObject(
+      id = UUID.randomUUID().toString,
+      data = dataItems,
+      metadata = (1 to 100).map(i => s"key_$i" -> s"value_${UUID.randomUUID()}").toMap
+    )
+  }
+
+  test("cached hasher produces consistent hashes for same object") { implicit json =>
+    implicit val hasher: Hasher[IO] = Hasher.forJsonCached[IO]
+    val testObject = generateLargeObject(0.1)
+    val iterations = 10
+
+    (1 to iterations).toList
+      .traverse(_ => hasher.hash(testObject))
+      .map { hashes =>
+        expect(hashes.distinct.size == 1, s"Expected all hashes to be equal, got ${hashes.distinct.size} distinct values")
+      }
+  }
+
+  test("uncached hasher produces consistent hashes for same object") { implicit json =>
+    implicit val hasher: Hasher[IO] = Hasher.forJsonUncached[IO]
+    val testObject = generateLargeObject(0.1)
+    val iterations = 10
+
+    (1 to iterations).toList
+      .traverse(_ => hasher.hash(testObject))
+      .map { hashes =>
+        expect(hashes.distinct.size == 1, s"Expected all hashes to be equal, got ${hashes.distinct.size} distinct values")
+      }
+  }
+
+  test("cached and uncached hashers produce identical hashes") { implicit json =>
+    val cachedHasher = Hasher.forJsonCached[IO]
+    val uncachedHasher = Hasher.forJsonUncached[IO]
+    val testObject = generateLargeObject(0.1)
+
+    for {
+      cachedHash <- cachedHasher.hash(testObject)
+      uncachedHash <- uncachedHasher.hash(testObject)
+    } yield expect.eql(cachedHash, uncachedHash)
+  }
+
+  test("cached hasher is faster than uncached for repeated hashes") { implicit json =>
+    val cachedHasher = Hasher.forJsonCached[IO]
+    val uncachedHasher = Hasher.forJsonUncached[IO]
+    val testObject = generateLargeObject(0.5)
+    val iterations = 20
+
+    for {
+      _ <- cachedHasher.hash(testObject)
+      _ <- uncachedHasher.hash(testObject)
+
+      cachedTimed <- IO.monotonic.flatMap { start =>
+        (1 to iterations).toList.traverse(_ => cachedHasher.hash(testObject)) >>
+          IO.monotonic.map(end => (end - start).toMillis)
+      }
+
+      uncachedTimed <- IO.monotonic.flatMap { start =>
+        (1 to iterations).toList.traverse(_ => uncachedHasher.hash(testObject)) >>
+          IO.monotonic.map(end => (end - start).toMillis)
+      }
+
+      _ <- IO.println(s"Cached: ${cachedTimed}ms total (${cachedTimed.toDouble / iterations}ms avg)")
+      _ <- IO.println(s"Uncached: ${uncachedTimed}ms total (${uncachedTimed.toDouble / iterations}ms avg)")
+      _ <- IO.println(s"Speedup: ${uncachedTimed.toDouble / cachedTimed}x faster with cache")
+    } yield expect(cachedTimed < uncachedTimed, s"Expected cached ($cachedTimed ms) < uncached ($uncachedTimed ms)")
+  }
+
+  test("performance comparison across different object sizes") { implicit json =>
+    val cachedHasher = Hasher.forJsonCached[IO]
+    val uncachedHasher = Hasher.forJsonUncached[IO]
+    val testSizes = List(0.1, 0.5, 1.0)
+    val iterations = 10
+
+    testSizes.traverse { sizeMB =>
+      val testObject = generateLargeObject(sizeMB)
+
+      for {
+        _ <- cachedHasher.hash(testObject)
+        _ <- uncachedHasher.hash(testObject)
+
+        cachedResults <- (1 to iterations).toList.traverse { _ =>
+          IO.monotonic.flatMap { start =>
+            cachedHasher.hash(testObject).flatMap { hash =>
+              IO.monotonic.map(end => ((end - start).toNanos, hash))
+            }
+          }
+        }
+
+        uncachedResults <- (1 to iterations).toList.traverse { _ =>
+          IO.monotonic.flatMap { start =>
+            uncachedHasher.hash(testObject).flatMap { hash =>
+              IO.monotonic.map(end => ((end - start).toNanos, hash))
+            }
+          }
+        }
+
+        cachedAvg = cachedResults.map(_._1).sum.toDouble / iterations / 1_000_000
+        uncachedAvg = uncachedResults.map(_._1).sum.toDouble / iterations / 1_000_000
+        speedup = uncachedAvg / cachedAvg
+
+        allHashesEqual = cachedResults.map(_._2).toSet.size == 1 &&
+          uncachedResults.map(_._2).toSet.size == 1 &&
+          cachedResults.head._2 == uncachedResults.head._2
+
+        _ <- IO.println(s"Size: ${sizeMB}MB - Cached: ${f"$cachedAvg%.2f"}ms, Uncached: ${f"$uncachedAvg%.2f"}ms, Speedup: ${f"$speedup%.2f"}x, Consistent: $allHashesEqual")
+
+      } yield expect(allHashesEqual, s"Hashes should be consistent for ${sizeMB}MB object")
+    }.map(_.combineAll)
+  }
+}

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/GlobalStateKeySerializationSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/GlobalStateKeySerializationSuite.scala
@@ -23,7 +23,7 @@ object GlobalStateKeySerializationSuite extends MutableIOSuite with Checkers {
   override def sharedResource: Resource[IO, Res] =
     for {
       implicit0(kryo: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
-      implicit0(json: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].toResource
+      implicit0(json: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].toResource
     } yield
       HasherSelector.forSync[IO](
         Hasher.forJson[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/GlobalStateProofPatternsSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/GlobalStateProofPatternsSuite.scala
@@ -33,7 +33,7 @@ object GlobalStateProofPatternsSuite extends MutableIOSuite with Checkers {
   override def sharedResource: Resource[IO, Res] =
     for {
       implicit0(kryo: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](sharedKryoRegistrar)
-      implicit0(json: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].toResource
+      implicit0(json: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].toResource
     } yield
       HasherSelector.forSync[IO](
         Hasher.forJson[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/InMemoryMerklePatriciaProducerSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/InMemoryMerklePatriciaProducerSuite.scala
@@ -21,7 +21,7 @@ object InMemoryMerklePatriciaProducerSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaBatchInclusionProverSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaBatchInclusionProverSuite.scala
@@ -23,7 +23,7 @@ object MerklePatriciaBatchInclusionProverSuite extends MutableIOSuite with Check
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaBatchInclusionVerifierSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaBatchInclusionVerifierSuite.scala
@@ -23,7 +23,7 @@ object MerklePatriciaBatchInclusionVerifierSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaInclusionProverSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaInclusionProverSuite.scala
@@ -23,7 +23,7 @@ object MerklePatriciaInclusionProverSuite extends MutableIOSuite with Checkers {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaInclusionVerifierSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaInclusionVerifierSuite.scala
@@ -22,7 +22,7 @@ object MerklePatriciaInclusionVerifierSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaPrefixProverSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaPrefixProverSuite.scala
@@ -25,7 +25,7 @@ object MerklePatriciaPrefixProverSuite extends MutableIOSuite with Checkers {
 
   def sharedResource: Resource[IO, HasherSelector[IO]] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaRangeProverSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaRangeProverSuite.scala
@@ -29,7 +29,7 @@ object MerklePatriciaRangeProverSuite extends MutableIOSuite with Checkers {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaRangeVerifierSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/MerklePatriciaRangeVerifierSuite.scala
@@ -23,7 +23,7 @@ object MerklePatriciaRangeVerifierSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/ProducerProverIntegrationSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/ProducerProverIntegrationSuite.scala
@@ -31,7 +31,7 @@ object ProducerProverIntegrationSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/StatelessMerklePatriciaProducerSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/mpt/StatelessMerklePatriciaProducerSuite.scala
@@ -21,7 +21,7 @@ object StatelessMerklePatriciaProducerSuite extends MutableIOSuite {
 
   override def sharedResource: Resource[IO, Res] =
     KryoSerializer.forAsync[IO](sharedKryoRegistrar).flatMap { implicit kryo =>
-      JsonSerializer.forSync[IO].asResource.map { implicit json =>
+      JsonSerializer.forAsync[IO].asResource.map { implicit json =>
         HasherSelector.forSync[IO](
           Hasher.forJson[IO],
           Hasher.forKryo[IO],

--- a/modules/shared/src/test/scala/io/constellationnetwork/security/signature/SignedValidatorSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/security/signature/SignedValidatorSuite.scala
@@ -36,7 +36,7 @@ object SignedValidatorSuite extends MutableIOSuite with Checkers {
     KryoSerializer
       .forAsync[IO](sharedKryoRegistrar.union(Map[Class[_], KryoRegistrationId[Interval.Closed[5000, 5001]]](classOf[TestObject] -> 5000)))
       .flatMap { implicit res =>
-        JsonSerializer.forSync[IO].asResource.map { implicit json =>
+        JsonSerializer.forAsync[IO].asResource.map { implicit json =>
           Hasher.forJson[IO]
         }
       }

--- a/modules/tools/src/main/scala/io/constellationnetwork/tools/Main.scala
+++ b/modules/tools/src/main/scala/io/constellationnetwork/tools/Main.scala
@@ -70,7 +70,7 @@ object Main
     cli.method.opts.map { method =>
       SecurityProvider.forAsync[IO].use { implicit sp =>
         KryoSerializer.forAsync[IO](sharedKryoRegistrar).use { implicit kryo =>
-          JsonSerializer.forSync[IO].asResource.use { implicit jsonSerializer =>
+          JsonSerializer.forAsync[IO].asResource.use { implicit jsonSerializer =>
             implicit val hasher = Hasher.forJson[IO]
             EmberClientBuilder.default[IO].build.use { client =>
               Random.scalaUtilRandom[IO].flatMap { implicit random =>

--- a/modules/wallet/src/main/scala/io/constellationnetwork/wallet/Main.scala
+++ b/modules/wallet/src/main/scala/io/constellationnetwork/wallet/Main.scala
@@ -57,7 +57,7 @@ object Main
       case (method, envs) =>
         SecurityProvider.forAsync[IO].use { implicit sp =>
           KryoSerializer.forAsync[IO](sharedKryoRegistrar).use { implicit kryo =>
-            JsonSerializer.forSync[IO].asResource.use { implicit jsonSerializer =>
+            JsonSerializer.forAsync[IO].asResource.use { implicit jsonSerializer =>
               loadKeyPair[IO](envs).flatMap { keyPair =>
                 val selfAddress = keyPair.getPublic.toAddress
                 val selfId = keyPair.getPublic.toId

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,8 +25,7 @@ object Dependencies {
     val fs2Data = "1.6.0"
     val guava = "31.1-jre"
     val http4s = "0.23.16"
-    val http4sJwtAuth = "1.0.0"
-    val httpSigner = "0.1.0"
+    val httpSigner = "0.1.1"
     val log4cats = "2.5.0"
     val micrometer = "1.10.2"
     val monocle = "3.1.0"
@@ -142,8 +141,6 @@ object Dependencies {
     val httpSignerHttp4s = "io.constellationnetwork" %% "http4s-request-signer" % V.httpSigner
 
     val guava = "com.google.guava" % "guava" % V.guava
-
-    val http4sJwtAuth = "dev.profunktor" %% "http4s-jwt-auth" % V.http4sJwtAuth
 
     val jawnParser = jawn("jawn-parser")
     val jawnAst = jawn("jawn-ast")

--- a/util-scripts/monitor-blocking.sh
+++ b/util-scripts/monitor-blocking.sh
@@ -1,48 +1,31 @@
 #!/bin/bash
 # monitor-blocking.sh
 
-# Get PID from argument or find via jps
-if [ -n "$1" ]; then
-  PID=$1
-else
-  # Find cl-node.jar processes
-  MATCHES=$(jps | grep "cl-node.jar")
-  COUNT=$(echo "$MATCHES" | grep -c "cl-node.jar")
-  
-  if [ "$COUNT" -eq 0 ]; then
-    echo "Error: No cl-node.jar process found"
-    exit 1
-  elif [ "$COUNT" -gt 1 ]; then
-    echo "Error: Multiple cl-node.jar processes found:"
-    echo "$MATCHES"
-    echo "Please specify PID as argument: $0 <pid>"
-    exit 1
-  fi
-  
-  PID=$(echo "$MATCHES" | awk '{print $1}')
-fi
-
-# Verify PID is valid
-if ! kill -0 "$PID" 2>/dev/null; then
-  echo "Error: PID $PID is not running"
-  exit 1
-fi
-
 DUMP_DIR=/home/admin/tessellation/l0/blocking_dumps
 mkdir -p $DUMP_DIR
 
-echo "Monitoring PID $PID for blocked compute threads..."
+echo "Monitoring for blocked compute threads..."
 echo "Dumps will be saved to $DUMP_DIR"
 echo "Press Ctrl+C to stop"
 
 PREV_BUSY=""
-
 while true; do
-  DUMP=$(jcmd $PID Thread.print 2>/dev/null)
-  
+  # Resolve PID fresh each iteration
+  PID=$(jps | grep "cl-node.jar" | awk '{print $1}')
+
+  if [ -z "$PID" ]; then
+    echo "$(date): cl-node.jar not running, waiting..."
+    sleep 5
+    PREV_BUSY=""
+    continue
+  fi
+
+  DUMP=$(jcmd "$PID" Thread.print 2>/dev/null)
+
   if [ -z "$DUMP" ]; then
     echo "$(date): Failed to get thread dump, process may have exited"
     sleep 5
+    PREV_BUSY=""
     continue
   fi
   

--- a/util-scripts/monitor-blocking.sh
+++ b/util-scripts/monitor-blocking.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# monitor-blocking.sh
+
+# Get PID from argument or find via jps
+if [ -n "$1" ]; then
+  PID=$1
+else
+  # Find cl-node.jar processes
+  MATCHES=$(jps | grep "cl-node.jar")
+  COUNT=$(echo "$MATCHES" | grep -c "cl-node.jar")
+  
+  if [ "$COUNT" -eq 0 ]; then
+    echo "Error: No cl-node.jar process found"
+    exit 1
+  elif [ "$COUNT" -gt 1 ]; then
+    echo "Error: Multiple cl-node.jar processes found:"
+    echo "$MATCHES"
+    echo "Please specify PID as argument: $0 <pid>"
+    exit 1
+  fi
+  
+  PID=$(echo "$MATCHES" | awk '{print $1}')
+fi
+
+# Verify PID is valid
+if ! kill -0 "$PID" 2>/dev/null; then
+  echo "Error: PID $PID is not running"
+  exit 1
+fi
+
+DUMP_DIR=/home/admin/tessellation/l0/blocking_dumps
+mkdir -p $DUMP_DIR
+
+echo "Monitoring PID $PID for blocked compute threads..."
+echo "Dumps will be saved to $DUMP_DIR"
+echo "Press Ctrl+C to stop"
+
+PREV_BUSY=""
+
+while true; do
+  DUMP=$(jcmd $PID Thread.print 2>/dev/null)
+  
+  if [ -z "$DUMP" ]; then
+    echo "$(date): Failed to get thread dump, process may have exited"
+    sleep 5
+    continue
+  fi
+  
+  # Find io-compute threads (not blocker) that are RUNNABLE and not parked
+  BUSY=$(echo "$DUMP" | grep -B1 "State: RUNNABLE" | grep '"io-compute-[0-9]"' | sed 's/.*"\(io-compute-[0-9]\)".*/\1/' | sort | uniq)
+  
+  if [ -n "$BUSY" ]; then
+    for thread in $BUSY; do
+      if echo "$PREV_BUSY" | grep -q "$thread"; then
+        TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+        FILENAME="$DUMP_DIR/blocked_${TIMESTAMP}.txt"
+        echo "$DUMP" > "$FILENAME"
+        echo "$(date): $thread stuck RUNNABLE across samples - saved to $FILENAME"
+        sleep 5  # Cooldown after finding something
+        break
+      fi
+    done
+  fi
+  
+  PREV_BUSY="$BUSY"
+  sleep 2
+done

--- a/util-scripts/monitor-starvation.sh
+++ b/util-scripts/monitor-starvation.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# monitor-starvation.sh
+
+# Get PID from argument or find via jps
+if [ -n "$1" ]; then
+  PID=$1
+else
+  # Find cl-node.jar processes
+  MATCHES=$(jps | grep "cl-node.jar")
+  COUNT=$(echo "$MATCHES" | grep -c "cl-node.jar")
+  
+  if [ "$COUNT" -eq 0 ]; then
+    echo "Error: No cl-node.jar process found"
+    exit 1
+  elif [ "$COUNT" -gt 1 ]; then
+    echo "Error: Multiple cl-node.jar processes found:"
+    echo "$MATCHES"
+    echo "Please specify PID as argument: $0 <pid>"
+    exit 1
+  fi
+  
+  PID=$(echo "$MATCHES" | awk '{print $1}')
+fi
+
+# Verify PID is valid
+if ! kill -0 "$PID" 2>/dev/null; then
+  echo "Error: PID $PID is not running"
+  exit 1
+fi
+
+DUMP_DIR=/home/admin/tessellation/l0/starvation_dumps
+mkdir -p $DUMP_DIR
+
+echo "Monitoring l0.service for CPU starvation warnings..."
+echo "Thread dumps will be saved to $DUMP_DIR"
+echo "Press Ctrl+C to stop"
+
+LAST_DUMP=0
+COOLDOWN=5  # Seconds between dumps to avoid spam
+
+journalctl -u l0.service -f --no-pager | while read -r line; do
+  if echo "$line" | grep -q "responsiveness"; then
+    NOW=$(date +%s)
+    if (( NOW - LAST_DUMP >= COOLDOWN )); then
+      TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+      FILENAME="$DUMP_DIR/starvation_${TIMESTAMP}.txt"
+      
+      echo "$(date): Starvation detected! Capturing thread dump..."
+      echo "Message: $line"
+      
+      jcmd $PID Thread.print > "$FILENAME" 2>&1
+      echo "Saved to $FILENAME"
+      echo "---"
+      
+      LAST_DUMP=$NOW
+    fi
+  fi
+done

--- a/util-scripts/monitor-starvation.sh
+++ b/util-scripts/monitor-starvation.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 # monitor-starvation.sh
 
-# Get PID from argument or find via jps
-if [ -n "$1" ]; then
-  PID=$1
-else
-  # Find cl-node.jar processes
-  MATCHES=$(jps | grep "cl-node.jar")
-  COUNT=$(echo "$MATCHES" | grep -c "cl-node.jar")
-  
-  if [ "$COUNT" -eq 0 ]; then
-    echo "Error: No cl-node.jar process found"
-    exit 1
-  elif [ "$COUNT" -gt 1 ]; then
-    echo "Error: Multiple cl-node.jar processes found:"
-    echo "$MATCHES"
-    echo "Please specify PID as argument: $0 <pid>"
-    exit 1
-  fi
-  
-  PID=$(echo "$MATCHES" | awk '{print $1}')
-fi
-
-# Verify PID is valid
-if ! kill -0 "$PID" 2>/dev/null; then
-  echo "Error: PID $PID is not running"
-  exit 1
-fi
-
 DUMP_DIR=/home/admin/tessellation/l0/starvation_dumps
 mkdir -p $DUMP_DIR
 
@@ -38,17 +11,26 @@ echo "Press Ctrl+C to stop"
 LAST_DUMP=0
 COOLDOWN=5  # Seconds between dumps to avoid spam
 
-journalctl -u l0.service -f --no-pager | while read -r line; do
+journalctl -u l0.service -f --no-pager --since "now" | while read -r line; do
   if echo "$line" | grep -q "responsiveness"; then
     NOW=$(date +%s)
     if (( NOW - LAST_DUMP >= COOLDOWN )); then
       TIMESTAMP=$(date +%Y%m%d_%H%M%S)
       FILENAME="$DUMP_DIR/starvation_${TIMESTAMP}.txt"
-      
+
       echo "$(date): Starvation detected! Capturing thread dump..."
       echo "Message: $line"
-      
-      jcmd $PID Thread.print > "$FILENAME" 2>&1
+
+      # Resolve PID fresh each time
+      PID=$(jps | grep "cl-node.jar" | awk '{print $1}')
+
+      if [ -z "$PID" ]; then
+        echo "Error: cl-node.jar not running, skipping dump"
+        echo "---"
+        continue
+      fi
+
+      jcmd "$PID" Thread.print > "$FILENAME" 2>&1
       echo "Saved to $FILENAME"
       echo "---"
       


### PR DESCRIPTION
## Summary

Addressed CPU starvation issues observed on large-scale (100+ node) public networks with ~70MB GlobalSnapshotInfo state. Primary fixes were async logback appenders, strategic `Async[F].cede` yield points in batch processing, and a blocking entity encoder for snapshot HTTP routes.

## Changes

- Added `AsyncAppender` wrappers for all 9 file appenders in `logback-included.xml`
- Added `BlockingEntityEncoder` for HTTP JSON responses to move serialization to blocking pool
- Added `Async[F].cede` yield points before/after heavy work in `parEvalMap` chunks in `GlobalSnapshotAcceptanceManager`
- Added `Async[F].cede` yield points between batches in `buildMerkleTreeAndProofs`
- Fixed `Hasher.forJsonCached` to use `Hash.fromBytesForSync[F]` (was missing blocking wrapper for SHA-256)
- Fixed `SnapshotLocalFileSystemStorage` to wrap `baseDir.exists` in `Async[F].blocking`
- Removed incorrect `Async[F].blocking(...).flatten` pattern on `stateProof` call (was no-op)
- Updated `SnapshotRoutes` to use `BlockingEntityEncoder` instead of standard circe encoder

## Testing

- Unit tests passing
- Deployed to testnet node and compared thread dumps before and after

**Before**

| Metric | Value |
|--------|-------|
| CpuStarvationCount | 1 |
| MaxClockDriftMs | 262ms |
| BlockedWorkerThreadCount | 3/7 (43%) |
| Starvation warnings | Bursts of 6-12 in <60s |

Thread dumps showed synchronous logback writes and large fs2 stream collections blocking compute threads.

**After**

| Metric | Value |
|--------|-------|
| CpuStarvationCount | 0 |
| MaxClockDriftMs | 12-18ms |
| BlockedWorkerThreadCount | 0 |
| Starvation warnings | None |

Note: Monitoring scripts were developed to help with future diagnosis of similar issues.
