### PR TITLE
feat: adding mpt store to work as an interface to the trie

### DIFF
--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -146,7 +146,8 @@ abstract class CurrencyL1App(
           dataApplicationService,
           transactionFeeEstimator,
           maybeMajorityPeerIds,
-          Hasher.forKryo[IO]
+          Hasher.forKryo[IO],
+          sharedStorages
         )
       snapshotProcessor = CurrencySnapshotProcessor.make(
         method.identifier,
@@ -166,7 +167,8 @@ abstract class CurrencyL1App(
         storages.tokenLock,
         services.globalL0.pullGlobalSnapshot,
         services.globalL0,
-        storages.globalL0Alignment
+        storages.globalL0Alignment,
+        sharedStorages.mptStore
       )
       programs = Programs
         .make[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, Run](

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
@@ -1,10 +1,10 @@
 package io.constellationnetwork.currency.l1.domain.snapshot.programs
 
-import cats.Applicative
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.effect.Async
 import cats.effect.std.Random
 import cats.syntax.all._
+import cats.{Applicative, Parallel}
 
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.dag.l1.domain.address.storage.AddressStorage
@@ -24,6 +24,7 @@ import io.constellationnetwork.node.shared.domain.tokenlock.{ContextualTokenLock
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.swap.{AllowSpendReference, CurrencyId}
 import io.constellationnetwork.schema.tokenLock.TokenLockReference
 import io.constellationnetwork.schema.transaction.TransactionReference
@@ -31,9 +32,10 @@ import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.signature.Signed.InvalidSignatureForHash
 import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
+import io.circe.Json
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-sealed abstract class CurrencySnapshotProcessor[F[_]: Async: SecurityProvider]
+sealed abstract class CurrencySnapshotProcessor[F[_]: Async: Parallel: SecurityProvider]
     extends SnapshotProcessor[
       F,
       CurrencySnapshotStateProof,
@@ -43,7 +45,7 @@ sealed abstract class CurrencySnapshotProcessor[F[_]: Async: SecurityProvider]
 
 object CurrencySnapshotProcessor {
 
-  def make[F[_]: Async: Random: JsonSerializer: SecurityProvider](
+  def make[F[_]: Async: Parallel: Random: JsonSerializer: SecurityProvider](
     identifier: Address,
     addressStorage: AddressStorage[F],
     blockStorage: BlockStorage[F],
@@ -61,7 +63,8 @@ object CurrencySnapshotProcessor {
     tokenLockStorage: TokenLockStorage[F],
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     l0Service: GlobalL0Service[F],
-    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F]
+    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
+    mptStore: MptStore[F, GlobalStateKey]
   ): CurrencySnapshotProcessor[F] =
     new CurrencySnapshotProcessor[F] {
       def process(
@@ -223,7 +226,7 @@ object CurrencySnapshotProcessor {
                           case _: Ignore =>
                             Applicative[F].pure(none[Success].asRight[Agg])
                           case alignment =>
-                            processAlignment(alignment, bs, ts, als, tls, lcss, as).as {
+                            processAlignment(alignment, bs, ts, als, tls, lcss, as, mptStore).as {
                               val updatedAgg = agg :+ alignment
 
                               NonEmptyList.fromList(nextSnapshots) match {
@@ -249,7 +252,8 @@ object CurrencySnapshotProcessor {
                     allowSpendStorage,
                     tokenLockStorage,
                     lastCurrencySnapshotStorage,
-                    addressStorage
+                    addressStorage,
+                    mptStore
                   )
                 }.flatMap { results =>
                   setGlobalSnapshot >>

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Services.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Services.scala
@@ -47,7 +47,8 @@ object Services {
     maybeDataApplication: Option[BaseDataApplicationL1Service[F]],
     maybeTransactionFeeEstimator: Option[TransactionFeeEstimator[F]],
     maybeMajorityPeerIds: Option[NonEmptySet[PeerId]],
-    txHasher: Hasher[F]
+    txHasher: Hasher[F],
+    sharedStorages: SharedStorages[F]
   ): Services[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, R] =
     new Services[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, R] {
 
@@ -70,7 +71,8 @@ object Services {
       val transaction = TransactionService.make[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](
         storages.transaction,
         storages.lastSnapshot,
-        validators.transaction
+        validators.transaction,
+        sharedStorages.mptStore
       )
       val allowSpend = AllowSpendService.make[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](
         storages.allowSpend,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
@@ -24,14 +24,17 @@ import io.constellationnetwork.node.shared.infrastructure.gossip.{GossipDaemon, 
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.GlobalSnapshotLocalFileSystemStorage
 import io.constellationnetwork.node.shared.resources.MkHttpServer
 import io.constellationnetwork.node.shared.resources.MkHttpServer.ServerName
+import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.cluster.ClusterId
 import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.GlobalStateKey
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.semver.TessellationVersion
-import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshot, SnapshotOrdinal}
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed
 
 import com.monovore.decline.Opts
@@ -111,7 +114,8 @@ object Main
         sharedServices.globalSnapshotContextFns,
         storages.globalSnapshot,
         sharedStorages.lastNGlobalSnapshot,
-        sharedStorages.lastGlobalSnapshot
+        sharedStorages.lastGlobalSnapshot,
+        sharedStorages.mptStore
       )
 
       rumorHandler = RumorHandlers
@@ -225,6 +229,9 @@ object Main
               case (snapshotInfo, snapshot) =>
                 for {
                   hashedSnapshot <- hasherSelector.withCurrent(implicit hasher => snapshot.toHashed[IO])
+                  kvPairs <- snapshotInfo.allStateEntries[IO]
+                  _ <- sharedStorages.mptStore.sync(kvPairs)
+
                   result <- services.consensus.manager.startFacilitatingAfterRollback(
                     snapshot.ordinal,
                     GlobalConsensusOutcome(
@@ -314,6 +321,8 @@ object Main
                                   hashedSnapshot,
                                   hashedGenesis.info
                                 )
+                                kvPairs <- GlobalSnapshotInfoV1.toGlobalSnapshotInfo(hashedGenesis.info).allStateEntries[IO]
+                                _ <- sharedStorages.mptStore.sync(kvPairs)
                                 _ <- services.consensus.manager
                                   .startFacilitatingAfterRollback(
                                     signedFirstIncrementalSnapshot.ordinal,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -24,6 +24,8 @@ import io.constellationnetwork.node.shared.infrastructure.fork.ExitOnFork
 import io.constellationnetwork.node.shared.infrastructure.snapshot.GlobalSnapshotContextFunctions
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.CombinedSnapshotCheckpointFileSystemStorage
 import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.Peer
 import io.constellationnetwork.schema.snapshot.SnapshotMetadata
@@ -33,6 +35,7 @@ import io.constellationnetwork.security.signature.Signed
 
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.Json
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import retry.RetryPolicies._
 import retry._
@@ -54,7 +57,8 @@ object Download {
       F,
       GlobalIncrementalSnapshot,
       GlobalSnapshotInfo
-    ]
+    ],
+    mptStore: MptStore[F, GlobalStateKey]
   ): Download[F, GlobalIncrementalSnapshot] = new Download[F, GlobalIncrementalSnapshot] {
 
     val logger = Slf4jLogger.getLogger[F]
@@ -115,6 +119,8 @@ object Download {
         .flatMap { result =>
           val ((snapshot, context), observationLimit) = result
           for {
+            kvPairs <- context.allStateEntries[F]
+            _ <- mptStore.sync(kvPairs)
             _ <- consensus.manager.startFacilitatingAfterDownload(observationLimit, snapshot, context)
           } yield ()
         }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -53,10 +53,12 @@ import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security._
 
 import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.Json
 import org.http4s.client.Client
 
 /** Factory for creating the Global L0 consensus engine.
@@ -93,7 +95,8 @@ object GlobalSnapshotConsensus {
     restartService: RestartService[F, R],
     lastNGlobalSnapshotStorage: LastNGlobalSnapshotStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
-    getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
+    getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
+    mptStore: MptStore[F, GlobalStateKey]
   )(implicit supervisor: Supervisor[F]): F[GlobalSnapshotConsensus[F]] =
     for {
       globalStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager
@@ -123,7 +126,8 @@ object GlobalSnapshotConsensus {
           sharedServices.priceStateUpdater,
           collateral,
           sharedCfg.delegatedStaking.withdrawalTimeLimit
-            .getOrElse(sharedCfg.environment, EpochProgress.MinValue)
+            .getOrElse(sharedCfg.environment, EpochProgress.MinValue),
+          mptStore
         )
 
       consensusStorage <- ConsensusStorage.make[

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Programs.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Programs.scala
@@ -22,8 +22,11 @@ import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Serv
 import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage, SnapshotStorage}
 import io.constellationnetwork.node.shared.infrastructure.snapshot.{GlobalSnapshotContextFunctions, PeerSelect}
 import io.constellationnetwork.node.shared.modules.{SharedPrograms, SharedStorages}
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security.{HashSelect, HasherSelector, SecurityProvider}
+
+import io.circe.Json
 
 object Programs {
 
@@ -38,7 +41,8 @@ object Programs {
     globalSnapshotContextFns: GlobalSnapshotContextFunctions[F],
     globalSnapshotStorage: SnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
     lastNGlobalSnapshotStorage: LastNGlobalSnapshotStorage[F],
-    lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
+    lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    mptStore: MptStore[F, GlobalStateKey]
   ): Programs[F] =
     HasherSelector[F].withCurrent { implicit hasher =>
       val trustPush = TrustPush.make(storages.trust, services.gossip)
@@ -59,7 +63,8 @@ object Programs {
           peerSelect,
           lastNGlobalSnapshotStorage,
           lastGlobalSnapshotStorage,
-          storages.combinedGlobalSnapshotCheckpointStorage
+          storages.combinedGlobalSnapshotCheckpointStorage,
+          mptStore
         )
       val rollbackLoader = RollbackLoader.make(
         keyPair,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Services.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Services.scala
@@ -117,7 +117,8 @@ object Services {
             sharedServices.restart,
             sharedStorages.lastNGlobalSnapshot,
             sharedStorages.lastGlobalSnapshot,
-            storages.globalSnapshot.getHashed
+            storages.globalSnapshot.getHashed,
+            sharedStorages.mptStore
           )
       }
       addressService = AddressService.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo](cfg.shared.addresses, storages.globalSnapshot)

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -57,12 +57,14 @@ import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.RewardFraction
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed.forAsyncHasher
 import io.constellationnetwork.security.signature.SignedValidator.SignedValidationErrorOr
 import io.constellationnetwork.security.signature.{Signed, SignedValidator}
@@ -71,7 +73,7 @@ import io.constellationnetwork.syntax.sortedCollection._
 
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
-import io.circe.Encoder
+import io.circe.{Encoder, Json}
 import org.scalacheck.Gen
 import weaver.MutableIOSuite
 import weaver.scalacheck.Checkers
@@ -322,26 +324,6 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     val pricingUpdateValidator = PricingUpdateValidator.make[IO](None, NonNegLong(0))
     val priceStateUpdater = PriceStateUpdater.make(Dev, delegatedRewardsConfigProvider)
 
-    val snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[IO] =
-      GlobalSnapshotAcceptanceManager
-        .make[IO](
-          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
-          MetagraphsSyncConfig(PosInt(100)),
-          Dev,
-          bam,
-          asbam,
-          tlbam,
-          scProcessor,
-          updateNodeParametersAcceptanceManager,
-          updateDelegatedStakeAcceptanceManager,
-          updateNodeCollateralAcceptanceManager,
-          spendActionValidator,
-          pricingUpdateValidator,
-          priceStateUpdater,
-          collateral,
-          EpochProgress(NonNegLong(136080L))
-        )
-
     val feeCalculator = new SnapshotBinaryFeeCalculator[IO] {
       override def calculateFee(
         event: StateChannelEvent,
@@ -350,12 +332,47 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       ): IO[NonNegLong] =
         event.value.snapshotBinary.value.fee.value.pure[IO]
     }
-
-    RewardsInfoStorage.make.map { rewardsInfoStorage =>
-      val rewardsInfoCalculator = RewardsInfoCalculator.make(delegatorRewards)
-      val rewardsService = RewardsService[IO](classicRewards, delegatorRewards, rewardsInfoCalculator, rewardsInfoStorage)
-
-      GlobalSnapshotConsensusFunctions
+    for {
+      mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
+      mptStore = MptStore.make[IO, GlobalStateKey](
+        mptProducer,
+        GlobalStateKey.toHex[IO]
+      )
+      rewardsInfoStorage <- RewardsInfoStorage.make
+      rewardsInfoCalculator = RewardsInfoCalculator.make(delegatorRewards)
+      rewardsService = RewardsService[IO](classicRewards, delegatorRewards, rewardsInfoCalculator, rewardsInfoStorage)
+      snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[IO] =
+        GlobalSnapshotAcceptanceManager
+          .make[IO](
+            FieldsAddedOrdinals(
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty
+            ),
+            MetagraphsSyncConfig(PosInt(100)),
+            Dev,
+            bam,
+            asbam,
+            tlbam,
+            scProcessor,
+            updateNodeParametersAcceptanceManager,
+            updateDelegatedStakeAcceptanceManager,
+            updateNodeCollateralAcceptanceManager,
+            spendActionValidator,
+            pricingUpdateValidator,
+            priceStateUpdater,
+            collateral,
+            EpochProgress(NonNegLong(136080L)),
+            mptStore
+          )
+      result = GlobalSnapshotConsensusFunctions
         .make[IO](
           snapshotAcceptanceManager,
           collateral,
@@ -367,7 +384,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
           SnapshotOrdinal.MinValue,
           SnapshotOrdinal.MinValue
         )
-    }
+    } yield result
   }
 
   def getTestData(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -54,6 +54,7 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.RewardFraction
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.transaction.{Transaction, TransactionReference}
@@ -61,6 +62,7 @@ import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.{Hash, ProofsHash}
 import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
 import io.constellationnetwork.security.signature.{Signed, SignedValidator}
 import io.constellationnetwork.shared.sharedKryoRegistrar
 import io.constellationnetwork.syntax.sortedCollection._
@@ -71,6 +73,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
 import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
 import fs2.concurrent.SignallingRef
+import io.circe.Json
 import org.scalacheck.Gen
 import weaver._
 import weaver.scalacheck.Checkers
@@ -372,7 +375,11 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
         validators.updateNodeCollateralValidator
       )
       priceStateUpdater = PriceStateUpdater.make(Dev, DefaultDelegatedRewardsConfigProvider)
-
+      mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
+      mptStore = MptStore.make[IO, GlobalStateKey](
+        mptProducer,
+        GlobalStateKey.toHex[IO]
+      )
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
           FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
@@ -389,7 +396,8 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
           validators.pricingUpdateValidator,
           priceStateUpdater,
           Amount.empty,
-          EpochProgress(NonNegLong(136080L))
+          EpochProgress(NonNegLong(136080L)),
+          mptStore
         )
       snapshotContextFunctions = GlobalSnapshotContextFunctions.make[IO](
         snapshotAcceptanceManager,

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -105,7 +105,8 @@ object Main
         p2pClient,
         cfg,
         maybeMajorityPeerIds,
-        Hasher.forKryo[IO]
+        Hasher.forKryo[IO],
+        sharedStorages
       )
 
       snapshotProcessor = DAGSnapshotProcessor.make(
@@ -120,7 +121,8 @@ object Main
         Hasher.forKryo[IO],
         services.globalL0.pullGlobalSnapshot,
         services.globalL0,
-        storages.globalL0Alignment
+        storages.globalL0Alignment,
+        sharedStorages.mptStore
       )
       programs = Programs.make(sharedPrograms, p2pClient, storages, snapshotProcessor)
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.dag.l1.domain.snapshot.programs
 
+import cats.Parallel
 import cats.effect.Async
 import cats.syntax.all._
 
@@ -15,12 +16,15 @@ import io.constellationnetwork.node.shared.domain.swap.AllowSpendStorage
 import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockStorage
 import io.constellationnetwork.node.shared.modules.SharedStorages
 import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
+import io.circe.Json
+
 object DAGSnapshotProcessor {
 
-  def make[F[_]: Async: SecurityProvider](
+  def make[F[_]: Async: Parallel: SecurityProvider](
     addressStorage: AddressStorage[F],
     blockStorage: BlockStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
@@ -32,7 +36,8 @@ object DAGSnapshotProcessor {
     txHasher: Hasher[F],
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     l0Service: GlobalL0Service[F],
-    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F]
+    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
+    mptStore: MptStore[F, GlobalStateKey]
   ): SnapshotProcessor[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo] =
     new SnapshotProcessor[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
 
@@ -76,7 +81,8 @@ object DAGSnapshotProcessor {
               allowSpendStorage,
               tokenLockStorage,
               lastGlobalSnapshotStorage,
-              addressStorage
+              addressStorage,
+              mptStore
             )
           )
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
@@ -3,7 +3,7 @@ package io.constellationnetwork.dag.l1.domain.snapshot.programs
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.syntax.all._
-import cats.{Applicative, MonadThrow}
+import cats.{Applicative, MonadThrow, Parallel}
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 import scala.util.control.NoStackTrace
@@ -21,6 +21,8 @@ import io.constellationnetwork.node.shared.domain.tokenlock.TokenLockStorage
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.swap.AllowSpendReference
 import io.constellationnetwork.schema.tokenLock.{TokenLockBlock, TokenLockReference}
@@ -32,11 +34,12 @@ import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 import derevo.cats.show
 import derevo.derive
 import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.Json
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 abstract class SnapshotProcessor[
-  F[_]: Async: SecurityProvider,
+  F[_]: Async: Parallel: SecurityProvider,
   P <: StateProof,
   S <: Snapshot,
   SI <: SnapshotInfo[P]
@@ -79,7 +82,8 @@ abstract class SnapshotProcessor[
     allowSpendStorage: AllowSpendStorage[F],
     tokenLockStorage: TokenLockStorage[F],
     lastSnapshotStorage: LastSnapshotStorage[F, S, SI],
-    addressStorage: AddressStorage[F]
+    addressStorage: AddressStorage[F],
+    mptStore: MptStore[F, GlobalStateKey]
   ): F[SnapshotProcessingResult] =
     alignment match {
       case AlignedAtNewOrdinal(
@@ -110,9 +114,16 @@ abstract class SnapshotProcessor[
         val setSnapshot: F[Unit] =
           lastSnapshotStorage.set(snapshot, state)
 
+        val updateMptStorage: F[Unit] = state match {
+          case info: GlobalSnapshotInfo =>
+            info.allStateEntries.flatMap(mptStore.sync[Json])
+          case _ => Async[F].unit
+        }
+
         adjustToMajority >>
           markTxRefsAsMajority >>
           setSnapshot >>
+          updateMptStorage >>
           setLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             Aligned(
               SnapshotReference.fromHashedSnapshot(snapshot),
@@ -150,9 +161,16 @@ abstract class SnapshotProcessor[
         val setSnapshot: F[Unit] =
           lastSnapshotStorage.set(snapshot, state)
 
+        val updateMptStorage: F[Unit] = state match {
+          case info: GlobalSnapshotInfo =>
+            info.allStateEntries.flatMap(mptStore.sync[Json])
+          case _ => Async[F].unit
+        }
+
         adjustToMajority >>
           markTxRefsAsMajority >>
           setSnapshot >>
+          updateMptStorage >>
           setLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             Aligned(
               SnapshotReference.fromHashedSnapshot(snapshot),
@@ -183,10 +201,17 @@ abstract class SnapshotProcessor[
             .info(s"Setting initial snapshot: ${snapshot.ordinal.show}") >>
             lastSnapshotStorage.setInitial(snapshot, state)
 
+        val updateMptStorage: F[Unit] = state match {
+          case info: GlobalSnapshotInfo =>
+            info.allStateEntries.flatMap(mptStore.sync[Json])
+          case _ => Async[F].unit
+        }
+
         adjustToMajority >>
           setBalances >>
           setTransactionRefs >>
           setInitialSnapshot >>
+          updateMptStorage >>
           setInitialLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             DownloadPerformed(
               SnapshotReference.fromHashedSnapshot(snapshot),
@@ -229,10 +254,17 @@ abstract class SnapshotProcessor[
         val setSnapshot: F[Unit] =
           lastSnapshotStorage.set(snapshot, state)
 
+        val updateMptStorage: F[Unit] = state match {
+          case info: GlobalSnapshotInfo =>
+            info.allStateEntries.flatMap(mptStore.sync[Json])
+          case _ => Async[F].unit
+        }
+
         adjustToMajority >>
           setBalances >>
           setTransactionRefs >>
           setSnapshot >>
+          updateMptStorage >>
           setLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             RedownloadPerformed(
               SnapshotReference.fromHashedSnapshot(snapshot),

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionService.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionService.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.dag.l1.domain.transaction
 
+import cats.Parallel
 import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
 import cats.effect.Async
@@ -7,17 +8,18 @@ import cats.syntax.all._
 
 import io.constellationnetwork.dag.l1.domain.transaction.ContextualTransactionValidator.NonContextualValidationError
 import io.constellationnetwork.ext.cats.syntax.validated.validatedSyntax
-import io.constellationnetwork.node.shared.domain.collateral.LatestBalances
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.transaction.TransactionValidator
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.transaction.Transaction
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.{Hashed, Hasher}
 
-import fs2.Stream
+import io.circe.Json
 
 import ContextualTransactionValidator.ContextualTransactionValidationError
 
@@ -30,14 +32,15 @@ trait TransactionService[F[_]] {
 object TransactionService {
 
   def make[
-    F[_]: Async,
+    F[_]: Async: Parallel,
     P <: StateProof,
     S <: Snapshot,
     SI <: SnapshotInfo[P]
   ](
     transactionStorage: TransactionStorage[F],
-    lastSnapshotStorage: LastSnapshotStorage[F, S, SI] with LatestBalances[F],
-    transactionValidator: TransactionValidator[F]
+    lastSnapshotStorage: LastSnapshotStorage[F, S, SI],
+    transactionValidator: TransactionValidator[F],
+    mptStore: MptStore[F, GlobalStateKey]
   ): TransactionService[F] = new TransactionService[F] {
 
     def offer(
@@ -48,17 +51,13 @@ object TransactionService {
         .map(_.errorMap(NonContextualValidationError))
         .flatMap {
           case Valid(_) =>
-            lastSnapshotStorage.getCombinedStream.map {
-              case Some((s, si)) => (s.ordinal, si.balances.getOrElse(transaction.source, Balance.empty))
-              case None          => (SnapshotOrdinal.MinValue, Balance.empty)
-            }.changes.switchMap {
-              case (latestOrdinal, balance) => Stream.eval(transactionStorage.tryPut(transaction, latestOrdinal, balance))
-            }.head.compile.last.flatMap {
-              case Some(value) => value.pure[F]
-              case None =>
-                new Exception(s"Unexpected state, stream should always emit the first snapshot")
-                  .raiseError[F, Either[NonEmptyList[ContextualTransactionValidationError], Hash]]
-            }
+            for {
+              maybeSnapshot <- lastSnapshotStorage.get
+              ordinal = maybeSnapshot.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue)
+              balance <- mptStore.getBalance(transaction.source).map(_.getOrElse(Balance.empty))
+              result <- transactionStorage.tryPut(transaction, ordinal, balance)
+            } yield result
+
           case Invalid(e) =>
             e.toNonEmptyList.asLeft[Hash].leftWiden[NonEmptyList[ContextualTransactionValidationError]].pure[F]
         }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Services.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Services.scala
@@ -25,7 +25,7 @@ import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlock
 import io.constellationnetwork.node.shared.infrastructure.block.processing.BlockAcceptanceManager
 import io.constellationnetwork.node.shared.infrastructure.collateral.Collateral
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
-import io.constellationnetwork.node.shared.modules.SharedServices
+import io.constellationnetwork.node.shared.modules.{SharedServices, SharedStorages}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
@@ -48,7 +48,8 @@ object Services {
     p2PClient: P2PClient[F],
     cfg: AppConfig,
     maybeMajorityPeerIds: Option[NonEmptySet[PeerId]],
-    txHasher: Hasher[F]
+    txHasher: Hasher[F],
+    sharedStorages: SharedStorages[F]
   ): Services[F, P, S, SI, R] =
     new Services[F, P, S, SI, R] {
       val localHealthcheck = sharedServices.localHealthcheck
@@ -66,7 +67,8 @@ object Services {
       val globalL0 = GlobalL0Service
         .make[F](p2PClient.l0GlobalSnapshot, globalL0Cluster, lastGlobalSnapshotStorage, None, maybeMajorityPeerIds)
       val session = sharedServices.session
-      val transaction = TransactionService.make[F, P, S, SI](storages.transaction, storages.lastSnapshot, validators.transaction)
+      val transaction =
+        TransactionService.make[F, P, S, SI](storages.transaction, storages.lastSnapshot, validators.transaction, sharedStorages.mptStore)
       val allowSpend =
         AllowSpendService.make[F, P, S, SI](storages.allowSpend, storages.lastSnapshot, validators.allowSpend)
       val allowSpendBlock = AllowSpendBlockService.make[F, P, S, SI](

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -53,6 +53,8 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.RewardFraction
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.swap.AllowSpendReference
@@ -61,6 +63,7 @@ import io.constellationnetwork.schema.transaction._
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.{Hash, ProofsHash}
 import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.signature.Signed.{ProofsHasher, SignedHasher, forAsyncHasher}
 import io.constellationnetwork.transaction.TransactionGenerator
@@ -69,6 +72,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.{NonNegLong, PosInt, PosLong}
 import fs2.concurrent.SignallingRef
 import io.chrisdavenport.mapref.MapRef
+import io.circe.Json
 import org.scalacheck.Gen.Parameters
 import org.scalacheck.rng.Seed
 import weaver.SimpleIOSuite
@@ -94,7 +98,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
     GlobalSnapshotContextFunctions[IO],
     Ref[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
     Ref[IO, SortedMap[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]],
-    Hasher[IO]
+    Hasher[IO],
+    MptStore[IO, GlobalStateKey]
   )
 
   def testResources: Resource[IO, TestResources] =
@@ -215,7 +220,11 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               updateNodeCollateralAcceptanceManager = UpdateNodeCollateralAcceptanceManager
                 .make(validators.updateNodeCollateralValidator)
               priceStateUpdater = PriceStateUpdater.make(Dev, DefaultDelegatedRewardsConfigProvider)
-
+              mptProducer <- InMemoryMerklePatriciaProducer.make[IO]().asResource
+              mptStore = MptStore.make[IO, GlobalStateKey](
+                mptProducer,
+                GlobalStateKey.toHex[IO]
+              )
               globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
                 FieldsAddedOrdinals(
                   Map.empty,
@@ -248,7 +257,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 validators.pricingUpdateValidator,
                 priceStateUpdater,
                 Amount(0L),
-                EpochProgress(NonNegLong(136080L))
+                EpochProgress(NonNegLong(136080L)),
+                mptStore
               )
               globalSnapshotContextFns = GlobalSnapshotContextFunctions.make(
                 globalSnapshotAcceptanceManager,
@@ -305,7 +315,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                     Hasher.forKryo[IO],
                     globalL0Service.pullGlobalSnapshot,
                     globalL0Service,
-                    globalL0AlignmentStorage
+                    globalL0AlignmentStorage,
+                    mptStore
                   )
               }
               keys <- (
@@ -338,7 +349,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 globalSnapshotContextFns,
                 lastNSnapR,
                 incLastNSnapR,
-                k
+                k,
+                mptStore
               )
           }
         }
@@ -402,6 +414,26 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
   def generateGlobalSnapshotInfo: GlobalSnapshotInfo = GlobalSnapshotInfo.empty
 
+  def mkGlobalSnapshotInfo(lastStateChannelSnapshotHashes: SortedMap[Address, Hash]) =
+    GlobalSnapshotInfo(
+      lastStateChannelSnapshotHashes,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty)
+    )
   test("download should happen for the base no blocks case") {
     testResources.use {
       case (
@@ -422,7 +454,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             _,
             lastNSnapR,
             incLastNSnapR,
-            k
+            k,
+            _
           ) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
@@ -551,7 +584,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             _,
             lastNSnapR,
             incLastNSnapR,
-            k
+            k,
+            _
           ) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
@@ -735,7 +769,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             _,
             lastNSnapR,
             incLastNSnapR,
-            k
+            k,
+            _
           ) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
@@ -918,10 +953,31 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
   test("alignment at same height should happen when snapshot with new ordinal but known height is processed") {
     testResources.use {
-      case (snapshotProcessor, sp, h, _, _, srcKey, _, _, _, peerId, balancesR, blocksR, lastSnapR, ts, _, lastNSnapsR, incLastNSnapR, k) =>
+      case (
+            snapshotProcessor,
+            sp,
+            h,
+            _,
+            _,
+            srcKey,
+            _,
+            _,
+            _,
+            peerId,
+            balancesR,
+            blocksR,
+            lastSnapR,
+            ts,
+            _,
+            lastNSnapsR,
+            incLastNSnapR,
+            k,
+            mptStore
+          ) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
-
+        val address = Address("DAG0y4eLqhhXUafeE3mgBstezPTnr8L3tZjAtMWB")
+        val snapshotInfo = mkGlobalSnapshotInfo(SortedMap(address -> Hash("someHash")))
         for {
           hashedLastSnapshot <- forAsyncHasher(
             generateSnapshot(peerId),
@@ -936,8 +992,10 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             ),
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
-          _ <- lastSnapR.set((hashedLastSnapshot, GlobalSnapshotInfo.empty).some)
-          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
+          kv <- snapshotInfo.allStateEntries[IO]
+          _ <- mptStore.sync(kv)
+          _ <- lastSnapR.set((hashedLastSnapshot, snapshotInfo).some)
+          lastN = (hashedLastSnapshot, snapshotInfo).some
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
           _ <- lastNSnapsR.set(lastN)
           _ <- incLastNSnapR.set(incLastN)
@@ -969,7 +1027,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               ),
               Map.empty,
               Map.empty,
-              Some((hashedNextSnapshot, GlobalSnapshotInfo.empty)),
+              Some((hashedNextSnapshot, snapshotInfo)),
               Map.empty
             )
           )
@@ -996,7 +1054,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             _,
             lastNSnapR,
             incLastNSnapR,
-            k
+            k,
+            _
           ) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val kryo = ks
@@ -1279,7 +1338,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             _,
             lastNSnapR,
             incLastNSnapR,
-            k
+            k,
+            _
           ) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
@@ -1568,7 +1628,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
   test("snapshot should be ignored when a snapshot pushed for processing is not a next one") {
     testResources.use {
-      case (snapshotProcessor, sp, h, _, _, srcKey, _, _, _, peerId, _, _, lastSnapR, _, _, lastNSnapR, incLastNSnapR, k) =>
+      case (snapshotProcessor, sp, h, _, _, srcKey, _, _, _, peerId, _, _, lastSnapR, _, _, lastNSnapR, incLastNSnapR, k, _) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
 
@@ -1608,12 +1668,14 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
   test("error should be thrown when the tips get misaligned") {
     testResources.use {
-      case (snapshotProcessor, sp, h, _, _, srcKey, _, _, _, peerId, _, blocksR, lastSnapR, _, _, lastNSnapR, incLastNSnapR, k) =>
+      case (snapshotProcessor, sp, h, _, _, srcKey, _, _, _, peerId, _, blocksR, lastSnapR, _, _, lastNSnapR, incLastNSnapR, k, mptStore) =>
         implicit val securityProvider: SecurityProvider[IO] = sp
         implicit val hasher = h
 
         val parent1 = BlockReference(Height(8L), ProofsHash("parent1"))
         val parent2 = BlockReference(Height(9L), ProofsHash("parent2"))
+        val address = Address("DAG0y4eLqhhXUafeE3mgBstezPTnr8L3tZjAtMWB")
+        val snapshotInfo = mkGlobalSnapshotInfo(SortedMap(address -> Hash("someHash")))
 
         for {
           hashedLastSnapshot <- forAsyncHasher(
@@ -1637,8 +1699,10 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             ),
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
-          _ <- lastSnapR.set((hashedLastSnapshot, GlobalSnapshotInfo.empty).some)
-          lastN = (hashedLastSnapshot, GlobalSnapshotInfo.empty).some
+          kv <- snapshotInfo.allStateEntries[IO]
+          _ <- mptStore.sync(kv)
+          _ <- lastSnapR.set((hashedLastSnapshot, snapshotInfo).some)
+          lastN = (hashedLastSnapshot, snapshotInfo).some
           _ <- lastNSnapR.set(lastN)
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
           _ <- incLastNSnapR.set(incLastN)
@@ -1655,7 +1719,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             (processingResult, lastSnapshotAfter),
             (
               Left(TipsGotMisaligned(Set(parent1.hash), Set.empty)),
-              (hashedLastSnapshot, GlobalSnapshotInfo.empty)
+              (hashedLastSnapshot, snapshotInfo)
             )
           )
     }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -42,6 +42,8 @@ import io.constellationnetwork.schema.artifact._
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.delegatedStake._
 import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.UpdateNodeParameters
 import io.constellationnetwork.schema.nodeCollateral.{NodeCollateralRecord, PendingNodeCollateralWithdrawal, UpdateNodeCollateral}
 import io.constellationnetwork.schema.peer.PeerId
@@ -52,11 +54,13 @@ import io.constellationnetwork.schema.tokenLock._
 import io.constellationnetwork.schema.transaction._
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.mpt.producer.StatefulMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.statechannel.{StateChannelOutput, StateChannelSnapshotBinary, StateChannelValidationType}
 import io.constellationnetwork.syntax.sortedCollection.{sortedMapSyntax, sortedSetSyntax}
 
 import fs2.Stream
+import io.circe.Json
 import io.circe.disjunctionCodecs._
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -137,7 +141,8 @@ object GlobalSnapshotAcceptanceManager {
     pricingUpdateValidator: PricingUpdateValidator[F],
     priceStateUpdater: PriceStateUpdater[F],
     collateral: Amount,
-    withdrawalTimeLimit: EpochProgress
+    withdrawalTimeLimit: EpochProgress,
+    mptStore: MptStore[F, GlobalStateKey]
   ): GlobalSnapshotAcceptanceManager[F] = {
     val artifactEmissionManager = ArtifactEmissionManager.make[F]()
     val tipUsageManager = TipUsageManager.make[F]()
@@ -1006,7 +1011,8 @@ object GlobalSnapshotAcceptanceManager {
             updatedAcceptedMetagraphSyncData
           )
 
-          stateProof <- gsi.stateProof[F](ordinal)
+          _ <- mptStore.syncFromGlobalSnapshotInfo(gsi)
+          stateProof <- gsi.stateProof(mptStore.underlying)
 
           (expiredAllowSpends, expiredTokenLocks) = (
             allowSpendStateManager.filterExpiredAllowSpends(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -11,7 +11,7 @@ import cats.syntax.all._
 import io.constellationnetwork.domain.allowance_list.AllowanceListEntry
 import io.constellationnetwork.domain.seedlist.SeedlistEntry
 import io.constellationnetwork.env.AppEnvironment
-import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.cli.CliMethod
 import io.constellationnetwork.node.shared.config.DefaultDelegatedRewardsConfigProvider
@@ -163,7 +163,8 @@ object SharedServices {
         validators.pricingUpdateValidator,
         priceStateUpdater,
         collateral.amount,
-        cfg.delegatedStaking.withdrawalTimeLimit.getOrElse(cfg.environment, EpochProgress.MinValue)
+        cfg.delegatedStaking.withdrawalTimeLimit.getOrElse(cfg.environment, EpochProgress.MinValue),
+        storages.mptStore
       )
       globalSnapshotContextFns = GlobalSnapshotContextFunctions.make(
         globalSnapshotAcceptanceManager,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedStorages.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedStorages.scala
@@ -20,8 +20,12 @@ import io.constellationnetwork.node.shared.infrastructure.node.NodeStorage
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
 import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEvent
 import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
-import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
+import io.constellationnetwork.security.{Hasher, HasherSelector}
+
+import io.circe.Json
 
 object SharedStorages {
 
@@ -38,7 +42,11 @@ object SharedStorages {
       currencySnapshotEventValidationErrorStorage <- CurrencySnapshotEventValidationErrorStorage.make(cfg.validationErrorStorage.maxSize)
       lastNGlobalSnapshotStorage <- LastNGlobalSnapshotStorage.make[F](cfg.lastGlobalSnapshotsSync)
       lastGlobalSnapshotStorage <- LastSnapshotStorage.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
-
+      mptProducer <- InMemoryMerklePatriciaProducer.make[F]()
+      mptStore = MptStore.make[F, GlobalStateKey](
+        mptProducer,
+        GlobalStateKey.toHex[F]
+      )
     } yield
       new SharedStorages[F](
         cluster = clusterStorage,
@@ -48,7 +56,8 @@ object SharedStorages {
         forkInfo = forkInfoStorage,
         currencySnapshotEventValidationError = currencySnapshotEventValidationErrorStorage,
         lastNGlobalSnapshot = lastNGlobalSnapshotStorage,
-        lastGlobalSnapshot = lastGlobalSnapshotStorage
+        lastGlobalSnapshot = lastGlobalSnapshotStorage,
+        mptStore = mptStore
       ) {}
 }
 
@@ -60,5 +69,6 @@ sealed abstract class SharedStorages[F[_]] private (
   val forkInfo: ForkInfoStorage[F],
   val currencySnapshotEventValidationError: ValidationErrorStorage[F, CurrencySnapshotEvent, BlockRejectionReason],
   val lastNGlobalSnapshot: LastNGlobalSnapshotStorage[F],
-  val lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LatestBalances[F]
+  val lastGlobalSnapshot: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LatestBalances[F],
+  val mptStore: MptStore[F, GlobalStateKey]
 )

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
@@ -45,6 +45,7 @@ import io.constellationnetwork.schema.artifact.{PricingUpdate, SpendAction, Toke
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.delegatedStake._
 import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node._
 import io.constellationnetwork.schema.nodeCollateral.UpdateNodeCollateral
 import io.constellationnetwork.schema.peer.PeerId
@@ -55,12 +56,14 @@ import io.constellationnetwork.schema.tokenLock._
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
 import io.constellationnetwork.security.signature.{Signed, SignedValidator}
 import io.constellationnetwork.statechannel.{StateChannelOutput, StateChannelSnapshotBinary, StateChannelValidationType}
 import io.constellationnetwork.syntax.sortedCollection.{sortedMapSyntax, sortedSetSyntax}
 
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.{NonNegLong, PosInt, PosLong}
+import io.circe.Json
 
 object Mocks {
 
@@ -249,25 +252,33 @@ object Mocks {
     // Create the manager with mock dependencies
     implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(h)
 
-    GlobalSnapshotAcceptanceManager
-      .make[IO](
-        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
-        MetagraphsSyncConfig(PosInt(100)),
-        AppEnvironment.Dev,
-        blockAcceptanceManager = mockBlockAcceptanceManager,
-        allowSpendBlockAcceptanceManager = mockAllowSpendBlockAcceptanceManager,
-        tokenLockBlockAcceptanceManager = mockTokenLockBlockAcceptanceManager,
-        stateChannelEventsProcessor = mockStateChannelEventsProcessor,
-        updateNodeParametersAcceptanceManager = mockUpdateNodeParametersAcceptanceManager,
-        updateDelegatedStakeAcceptanceManager = updateDelegatedStakeAcceptanceManager,
-        updateNodeCollateralAcceptanceManager = mockUpdateNodeCollateralAcceptanceManager,
-        spendActionValidator = mockSpendActionValidator,
-        pricingUpdateValidator = mockPricingUpdateValidator,
-        priceStateUpdater = mockPriceStateUpdater,
-        collateral = Amount.empty,
-        withdrawalTimeLimit = EpochProgress(4L)
+    InMemoryMerklePatriciaProducer.make[IO]().flatMap { mptProducer =>
+      val mptStore = MptStore.make[IO, GlobalStateKey](
+        mptProducer,
+        GlobalStateKey.toHex[IO]
       )
-      .pure[IO]
+
+      GlobalSnapshotAcceptanceManager
+        .make[IO](
+          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+          MetagraphsSyncConfig(PosInt(100)),
+          AppEnvironment.Dev,
+          blockAcceptanceManager = mockBlockAcceptanceManager,
+          allowSpendBlockAcceptanceManager = mockAllowSpendBlockAcceptanceManager,
+          tokenLockBlockAcceptanceManager = mockTokenLockBlockAcceptanceManager,
+          stateChannelEventsProcessor = mockStateChannelEventsProcessor,
+          updateNodeParametersAcceptanceManager = mockUpdateNodeParametersAcceptanceManager,
+          updateDelegatedStakeAcceptanceManager = updateDelegatedStakeAcceptanceManager,
+          updateNodeCollateralAcceptanceManager = mockUpdateNodeCollateralAcceptanceManager,
+          spendActionValidator = mockSpendActionValidator,
+          pricingUpdateValidator = mockPricingUpdateValidator,
+          priceStateUpdater = mockPriceStateUpdater,
+          collateral = Amount.empty,
+          withdrawalTimeLimit = EpochProgress(4L),
+          mptStore = mptStore
+        )
+        .pure[IO]
+    }
   }
 
   private[snapshot] def mkGlobalSnapshotInfo(

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
@@ -25,6 +25,7 @@ import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockReference}
 import io.constellationnetwork.schema.transaction.TransactionReference
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.mpt.producer.StatefulMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed
 
 import derevo.cats.{eqv, show}
@@ -247,6 +248,12 @@ case class GlobalSnapshotInfo(
         .flatMap(mt => GlobalSnapshotInfo.legacyStateProof(this, mt))
         .map(GlobalSnapshotStateProof.fromLegacyProof)
   }
+
+  def stateProof[F[_]: Parallel: Sync: Hasher](statefulMPTProducer: StatefulMerklePatriciaProducer[F]): F[GlobalSnapshotStateProof] =
+    statefulMPTProducer.build.flatMap {
+      case Left(value)  => (new Throwable(s"Error when building MPT. Message: ${value.getMessage}")).raiseError[F, GlobalSnapshotStateProof]
+      case Right(value) => GlobalSnapshotStateProof(value.rootHash.value).pure
+    }
 
   override def getActiveTokenLocks: SortedMap[Address, SortedSet[Signed[TokenLock]]] = activeTokenLocks.getOrElse(SortedMap.empty)
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
@@ -7,10 +7,17 @@ import cats.syntax.all._
 import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshot, CurrencySnapshotInfo}
+import io.constellationnetwork.merkletree.Proof
 import io.constellationnetwork.schema.GlobalSnapshotInfo
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
-import io.constellationnetwork.schema.swap.AllowSpend
+import io.constellationnetwork.schema.delegatedStake.{DelegatedStakeRecord, PendingDelegatedStakeWithdrawal}
+import io.constellationnetwork.schema.mpt.PartitionNamespace.AddressNamespace
+import io.constellationnetwork.schema.nodeCollateral.{NodeCollateralRecord, PendingNodeCollateralWithdrawal}
+import io.constellationnetwork.schema.snapshot.MetagraphSyncDataInfo
+import io.constellationnetwork.schema.swap.{AllowSpend, AllowSpendReference}
+import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockReference}
+import io.constellationnetwork.schema.transaction.TransactionReference
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.mpt.{MerklePatriciaTrie, MptRoot}
@@ -152,6 +159,98 @@ object GlobalStateConverter {
             )
           _ <- Async[F].cede
         } yield mptRoot
+    }
+
+    implicit class MptStoreGlobalSnapshotOps[F[_]: Async: Parallel: Hasher](
+      val store: MptStore[F, GlobalStateKey]
+    ) {
+      def syncFromGlobalSnapshotInfo(info: GlobalSnapshotInfo): F[Unit] =
+        info.allStateEntries[F].flatMap(store.sync[Json])
+
+      def getBalance(address: Address): F[Option[Balance]] =
+        store
+          .get[Balance](GlobalStateKey.hypergraph(GlobalStateFieldId.Balances, address))
+
+      def getBalances(addresses: List[Address]): F[Map[Address, Balance]] = {
+        val keys = addresses.map(addr => GlobalStateKey.hypergraph(GlobalStateFieldId.Balances, addr))
+        store.getMany[Balance](keys).map { results =>
+          results.flatMap {
+            case (key, balance) =>
+              key.userNamespace match {
+                case AddressNamespace(addr) => Some(addr -> balance)
+                case _                      => None
+              }
+          }
+        }
+      }
+
+      def getTxRef(address: Address): F[Option[TransactionReference]] =
+        store
+          .get[TransactionReference](GlobalStateKey.hypergraph(GlobalStateFieldId.LastTxRefs, address))
+
+      def getStateChannelHash(metagraphAddress: Address): F[Option[Hash]] =
+        store
+          .get[Hash](GlobalStateKey.metagraph(metagraphAddress, GlobalStateFieldId.LastStateChannelSnapshotHashes))
+
+      def getAllowSpendRef(address: Address): F[Option[AllowSpendReference]] =
+        store
+          .get[AllowSpendReference](GlobalStateKey.hypergraph(GlobalStateFieldId.LastAllowSpendRefs, address))
+
+      def getActiveAllowSpends(metagraphId: Option[Address], address: Address): F[Option[SortedSet[Signed[AllowSpend]]]] =
+        store
+          .get[SortedSet[Signed[AllowSpend]]](GlobalStateKey.hypergraph(GlobalStateFieldId.ActiveAllowSpends, metagraphId, address))
+
+      def getTokenLockRef(address: Address): F[Option[TokenLockReference]] =
+        store
+          .get[TokenLockReference](GlobalStateKey.hypergraph(GlobalStateFieldId.LastTokenLockRefs, address))
+
+      def getActiveTokenLocks(address: Address): F[Option[SortedSet[Signed[TokenLock]]]] =
+        store
+          .get[SortedSet[Signed[TokenLock]]](GlobalStateKey.hypergraph(GlobalStateFieldId.ActiveTokenLocks, address))
+
+      def getTokenLockBalance(tokenAddress: Address, holderAddress: Address): F[Option[Balance]] =
+        store
+          .get[Balance](GlobalStateKey.hypergraph(GlobalStateFieldId.TokenLockBalances, tokenAddress, holderAddress))
+
+      def getDelegatedStakes(address: Address): F[Option[SortedSet[DelegatedStakeRecord]]] =
+        store
+          .get[SortedSet[DelegatedStakeRecord]](GlobalStateKey.hypergraph(GlobalStateFieldId.ActiveDelegatedStakes, address))
+
+      def getDelegatedStakeWithdrawals(address: Address): F[Option[SortedSet[PendingDelegatedStakeWithdrawal]]] =
+        store
+          .get[SortedSet[PendingDelegatedStakeWithdrawal]](
+            GlobalStateKey.hypergraph(GlobalStateFieldId.DelegatedStakesWithdrawals, address)
+          )
+
+      def getNodeCollaterals(address: Address): F[Option[SortedSet[NodeCollateralRecord]]] =
+        store
+          .get[SortedSet[NodeCollateralRecord]](GlobalStateKey.hypergraph(GlobalStateFieldId.ActiveNodeCollaterals, address))
+
+      def getNodeCollateralWithdrawals(address: Address): F[Option[SortedSet[PendingNodeCollateralWithdrawal]]] =
+        store
+          .get[SortedSet[PendingNodeCollateralWithdrawal]](GlobalStateKey.hypergraph(GlobalStateFieldId.NodeCollateralWithdrawals, address))
+
+      def getCurrencySnapshot(metagraphAddress: Address): F[Option[Signed[CurrencySnapshot]]] =
+        store
+          .get[Signed[CurrencySnapshot]](GlobalStateKey.metagraph(metagraphAddress, GlobalStateFieldId.LastCurrencySnapshots))
+
+      def getIncrementalCurrencySnapshot(metagraphAddress: Address): F[Option[Signed[CurrencyIncrementalSnapshot]]] =
+        store
+          .get[Signed[CurrencyIncrementalSnapshot]](
+            GlobalStateKey.metagraph(metagraphAddress, GlobalStateFieldId.LastIncrementalCurrencySnapshots)
+          )
+
+      def getCurrencySnapshotInfo(metagraphAddress: Address): F[Option[CurrencySnapshotInfo]] =
+        store
+          .get[CurrencySnapshotInfo](GlobalStateKey.metagraph(metagraphAddress, GlobalStateFieldId.LastCurrencySnapshotInfo))
+
+      def getCurrencySnapshotProof(metagraphAddress: Address): F[Option[Proof]] =
+        store
+          .get[Proof](GlobalStateKey.metagraph(metagraphAddress, GlobalStateFieldId.LastCurrencySnapshotsProofs))
+
+      def getMetagraphSyncData(metagraphAddress: Address): F[Option[MetagraphSyncDataInfo]] =
+        store
+          .get[MetagraphSyncDataInfo](GlobalStateKey.hypergraph(GlobalStateFieldId.MetagraphSyncData, metagraphAddress))
     }
   }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
@@ -1,0 +1,138 @@
+package io.constellationnetwork.schema.mpt
+
+import cats.Parallel
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.mpt.MerklePatriciaTrie
+import io.constellationnetwork.security.mpt.producer.{MerklePatriciaError, StatefulMerklePatriciaProducer}
+
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json}
+
+trait MptStore[F[_], K] {
+
+  def get[V: Decoder](key: K): F[Option[V]]
+
+  def getMany[V: Decoder](keys: List[K]): F[Map[K, V]]
+
+  def insert[V: Encoder](key: K, value: V): F[Unit]
+
+  def insert[V: Encoder](entries: Map[K, V]): F[Unit]
+
+  def remove(key: K): F[Unit]
+
+  def remove(keys: List[K]): F[Unit]
+
+  def contains(key: K): F[Boolean]
+
+  def clear: F[Unit]
+
+  def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]]
+
+  def sync[V: Encoder](newState: Map[K, V]): F[Unit]
+
+  def update[V: Encoder](toUpsert: Map[K, V], toRemove: Set[K]): F[Unit]
+
+  def underlying: StatefulMerklePatriciaProducer[F]
+}
+
+object MptStore {
+
+  def make[F[_]: Async: Parallel: Hasher, K](
+    producer: StatefulMerklePatriciaProducer[F],
+    toHex: K => F[Hex]
+  ): MptStore[F, K] =
+    new Impl[F, K](producer, toHex)
+
+  private final class Impl[F[_]: Async: Parallel: Hasher, K](
+    producer: StatefulMerklePatriciaProducer[F],
+    toHex: K => F[Hex]
+  ) extends MptStore[F, K] {
+
+    override def get[V: Decoder](key: K): F[Option[V]] =
+      for {
+        hex <- toHex(key)
+        entries <- producer.entries
+      } yield entries.get(hex).flatMap(_.as[V].toOption)
+
+    override def getMany[V: Decoder](keys: List[K]): F[Map[K, V]] =
+      if (keys.isEmpty) Async[F].pure(Map.empty)
+      else
+        for {
+          hexKeys <- keys.parTraverse(k => toHex(k).map(k -> _))
+          entries <- producer.entries
+          results = hexKeys.flatMap {
+            case (k, hex) =>
+              entries.get(hex).flatMap(_.as[V].toOption).map(k -> _)
+          }.toMap
+        } yield results
+
+    override def insert[V: Encoder](key: K, value: V): F[Unit] =
+      toHex(key).flatMap(hex => producer.insert(Map(hex -> value.asJson)).void)
+
+    override def insert[V: Encoder](data: Map[K, V]): F[Unit] =
+      if (data.isEmpty) Async[F].unit
+      else
+        data.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }
+          .flatMap(kvs => producer.insert(kvs.toMap).void)
+
+    override def remove(key: K): F[Unit] =
+      toHex(key).flatMap(hex => producer.remove(List(hex)).void)
+
+    override def remove(keys: List[K]): F[Unit] =
+      if (keys.isEmpty) Async[F].unit
+      else keys.parTraverse(toHex).flatMap(hexKeys => producer.remove(hexKeys).void)
+
+    override def contains(key: K): F[Boolean] =
+      for {
+        hex <- toHex(key)
+        entries <- producer.entries
+      } yield entries.contains(hex)
+
+    override def clear: F[Unit] =
+      producer.clear
+
+    override def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+      producer.build
+
+    override def sync[V: Encoder](newState: Map[K, V]): F[Unit] =
+      if (newState.isEmpty) producer.clear
+      else
+        for {
+          newEntries <- newState.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }
+            .map(_.toMap)
+
+          currentEntries <- producer.entries
+
+          keysToRemove = currentEntries.keySet -- newEntries.keySet
+          keysToUpsert = newEntries.filter {
+            case (k, vJson) =>
+              !currentEntries.get(k).contains(vJson)
+          }
+
+          _ <- if (keysToRemove.nonEmpty) producer.remove(keysToRemove.toList).void else Async[F].unit
+          _ <- if (keysToUpsert.nonEmpty) producer.insert(keysToUpsert).void else Async[F].unit
+        } yield ()
+
+    override def update[V: Encoder](toUpsert: Map[K, V], toRemove: Set[K]): F[Unit] =
+      for {
+        upsertHex <-
+          if (toUpsert.isEmpty) Async[F].pure(Map.empty[Hex, Json])
+          else
+            toUpsert.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }
+              .map(_.toMap)
+
+        removeHex <-
+          if (toRemove.isEmpty) Async[F].pure(List.empty[Hex])
+          else toRemove.toList.parTraverse(toHex)
+
+        _ <- if (removeHex.nonEmpty) producer.remove(removeHex).void else Async[F].unit
+        _ <- if (upsertHex.nonEmpty) producer.insert(upsertHex).void else Async[F].unit
+      } yield ()
+
+    override def underlying: StatefulMerklePatriciaProducer[F] = producer
+  }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/InMemoryMerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/InMemoryMerklePatriciaProducer.scala
@@ -1,23 +1,24 @@
 package io.constellationnetwork.security.mpt.producer
 
+import cats.Parallel
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
 
+import io.constellationnetwork.schema.mpt.GlobalStateKey
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.mpt.MerklePatriciaTrie
-import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer.TrieCache
+import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer.{ProducerState, TrieCache}
 import io.constellationnetwork.security.mpt.prover.MerklePatriciaSingleInclusionProver
-import io.constellationnetwork.security.mpt.verifier._
 
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
 class InMemoryMerklePatriciaProducer[F[_]: Async: Hasher](
-  stateRef: Ref[F, InMemoryMerklePatriciaProducer.ProducerState]
+  stateRef: Ref[F, ProducerState]
 ) extends StatefulMerklePatriciaProducer[F] {
 
-  def getProver: F[MerklePatriciaSingleInclusionProver[F]] =
+  override def getProver: F[MerklePatriciaSingleInclusionProver[F]] =
     stateRef.get.flatMap { state =>
       state.currentTrie match {
         case Some(trie) =>
@@ -30,10 +31,10 @@ class InMemoryMerklePatriciaProducer[F[_]: Async: Hasher](
       }
     }
 
-  def entries: F[Map[Hex, Json]] =
+  override def entries: F[Map[Hex, Json]] =
     stateRef.get.map(_.entries)
 
-  def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+  override def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
     stateRef.get.flatMap { state =>
       if (state.entries.isEmpty) {
         OperationError("Cannot build trie with no entries").asLeft[MerklePatriciaTrie].pure[F].widen
@@ -62,22 +63,21 @@ class InMemoryMerklePatriciaProducer[F[_]: Async: Hasher](
       }
     }
 
-  def insert[A: Encoder](data: Map[Hex, A]): F[Either[MerklePatriciaError, Unit]] =
+  override def insert[A: Encoder](data: Map[Hex, A]): F[Either[MerklePatriciaError, Unit]] =
     if (data.isEmpty) ().asRight[MerklePatriciaError].pure[F]
     else {
       stateRef.update { state =>
         val jsonEntries = data.map { case (k, v) => k -> v.asJson }
-        val newKeys = data.keySet
         state.copy(
           entries = state.entries ++ jsonEntries,
-          dirtyKeys = state.dirtyKeys ++ newKeys,
+          dirtyKeys = state.dirtyKeys ++ data.keySet,
           currentTrie = None
         )
       }
         .as(().asRight[MerklePatriciaError])
     }
 
-  def update[A: Encoder](key: Hex, value: A): F[Either[MerklePatriciaError, Unit]] =
+  override def update[A: Encoder](key: Hex, value: A): F[Either[MerklePatriciaError, Unit]] =
     stateRef.get.flatMap { state =>
       if (!state.entries.contains(key)) {
         OperationError(s"Key not found for update: $key").asLeft[Unit].pure[F].widen
@@ -93,28 +93,23 @@ class InMemoryMerklePatriciaProducer[F[_]: Async: Hasher](
       }
     }
 
-  def remove(keys: List[Hex]): F[Either[MerklePatriciaError, Unit]] =
-    if (keys.isEmpty) {
-      ().asRight[MerklePatriciaError].pure[F]
-    } else {
-      stateRef.get.flatMap { state =>
+  override def remove(keys: List[Hex]): F[Either[MerklePatriciaError, Unit]] =
+    if (keys.isEmpty) ().asRight[MerklePatriciaError].pure[F]
+    else {
+      stateRef.update { state =>
         val existing = keys.filter(state.entries.contains)
-        if (existing.isEmpty) {
-          ().asRight[MerklePatriciaError].pure[F]
-        } else {
-          stateRef.update { s =>
-            s.copy(
-              entries = s.entries -- existing,
-              dirtyKeys = s.dirtyKeys ++ existing.toSet,
-              currentTrie = None
-            )
-          }
-            .as(().asRight[MerklePatriciaError])
-        }
+        if (existing.isEmpty) state
+        else
+          state.copy(
+            entries = state.entries -- existing,
+            dirtyKeys = state.dirtyKeys ++ existing.toSet,
+            currentTrie = None
+          )
       }
+        .as(().asRight[MerklePatriciaError])
     }
 
-  def clear: F[Unit] =
+  override def clear: F[Unit] =
     stateRef.update(
       _.copy(
         entries = Map.empty,
@@ -124,6 +119,13 @@ class InMemoryMerklePatriciaProducer[F[_]: Async: Hasher](
         trieCache = None
       )
     )
+
+  override def buildHexMap(data: Map[GlobalStateKey, Json])(implicit parallel: Parallel[F]): F[Map[Hex, Json]] =
+    data.toList.parTraverse {
+      case (key, value) =>
+        GlobalStateKey.toHex[F](key).map(_ -> value)
+    }
+      .map(_.toMap)
 }
 
 object InMemoryMerklePatriciaProducer {
@@ -145,8 +147,8 @@ object InMemoryMerklePatriciaProducer {
   def make[F[_]: Async: Hasher](
     initial: Map[Hex, Json] = Map.empty
   ): F[InMemoryMerklePatriciaProducer[F]] =
-    for {
-      stateRef <- Ref.of[F, ProducerState](
+    Ref
+      .of[F, ProducerState](
         ProducerState(
           entries = initial,
           currentTrie = None,
@@ -155,5 +157,5 @@ object InMemoryMerklePatriciaProducer {
           trieCache = None
         )
       )
-    } yield new InMemoryMerklePatriciaProducer[F](stateRef)
+      .map(new InMemoryMerklePatriciaProducer[F](_))
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
@@ -1,8 +1,10 @@
 package io.constellationnetwork.security.mpt.producer
 
+import cats.Parallel
 import cats.effect.Async
 import cats.syntax.functor._
 
+import io.constellationnetwork.schema.mpt.GlobalStateKey
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.mpt.MerklePatriciaTrie
@@ -34,6 +36,7 @@ trait StatefulMerklePatriciaProducer[F[_]] {
   def remove(keys: List[Hex]): F[Either[MerklePatriciaError, Unit]]
   def clear: F[Unit]
   def getProver: F[MerklePatriciaSingleInclusionProver[F]]
+  def buildHexMap(data: Map[GlobalStateKey, Json])(implicit parallel: Parallel[F]): F[Map[Hex, Json]]
 }
 
 object MerklePatriciaProducer {


### PR DESCRIPTION
✨ Feature: Add MPT Store as an Interface to the Trie

This PR introduces a new Merkle Patricia Trie (MPT) store abstraction to the tessellation codebase. The goal is to provide a clean interface for interacting with the trie-based state storage layer, improving modularity and maintainability.

✅ What’s Included
	•	A new MPT store implementation that acts as a first-class interface to the underlying trie.
	•	Abstractions that decouple direct trie operations from higher-level logic, making the code easier to extend and test.
	•	Aligns with ongoing efforts to migrate to a trie-based state model (feature/migrate-to-mpt-state branch).

🧪 Testing
	•	Manually tested using TransactionService, and all expected behaviors worked correctly.

🔍 Motivation
	•	We need a dedicated store layer that cleanly encapsulates trie state access.
	•	Simplifies future work around persistence, caching, and state transitions using MPT.
	•	Sets up groundwork for improved state management and efficient lookups.

📌 Notes
	•	This PR targets the feature/migrate-to-mpt-state branch.
	•	No behavioral changes are introduced for consensus or protocol logic yet — this is primarily an internal API improvement and architectural step.
