### PR TITLE
feat: adding file system merkle trie producer

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/StoragesInitializer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/StoragesInitializer.scala
@@ -78,7 +78,7 @@ object StoragesInitializer {
         _ <- Logger[F].info(s"Successfully initialized lastGlobalSnapshot storage")
 
         kvPairs <- state.allStateEntries[F]
-        _ <- sharedStorages.mptStore.syncFull(kvPairs)
+        _ <- sharedStorages.mptStore.syncFull(kvPairs, snapshot.ordinal)
 
         _ <- Logger[F].info(s"Successfully initialized all global snapshot storages with ordinal=$ordinal")
       } yield ()

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -68,7 +68,8 @@ object method {
       c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
       c.snapshotBinarySenderTimeouts,
       c.snapshot.timeouts,
-      c.combinedRouteRateLimiter
+      c.combinedRouteRateLimiter,
+      c.snapshot.mptSnapshotInfoPath
     )
   }
 

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
@@ -65,7 +65,8 @@ object method {
       c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
       c.snapshotBinarySenderTimeouts,
       c.snapshot.timeouts,
-      c.combinedRouteRateLimiter
+      c.combinedRouteRateLimiter,
+      c.snapshot.mptSnapshotInfoPath
     )
   }
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/StoragesInitializer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/StoragesInitializer.scala
@@ -55,7 +55,7 @@ object StoragesInitializer {
       _ <- Logger[F].info(s"Successfully initialized lastGlobalSnapshot storage")
 
       kvPairs <- globalSnapshotInfo.allStateEntries[F]
-      _ <- mptStore.syncFull(kvPairs)
+      _ <- mptStore.syncFull(kvPairs, ordinal)
 
       _ <- Logger[F].info(s"Storage initialization completed successfully with ordinal=$ordinal")
     } yield ()

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -120,7 +120,7 @@ object Download {
           val ((snapshot, context), observationLimit) = result
           for {
             kvPairs <- hasherSelector.withCurrent(implicit h => context.allStateEntries[F])
-            _ <- mptStore.syncFull(kvPairs)
+            _ <- mptStore.syncFull(kvPairs, snapshot.ordinal)
             _ <- consensus.manager.startFacilitatingAfterDownload(observationLimit, snapshot, context)
           } yield ()
         }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
@@ -116,7 +116,7 @@ abstract class SnapshotProcessor[
 
         val updateMptStorage: F[Unit] = state match {
           case info: GlobalSnapshotInfo =>
-            info.allStateEntries.flatMap(mptStore.sync[Json])
+            info.allStateEntries.flatMap(mptStore.sync[Json](_, snapshot.ordinal))
           case _ => Async[F].unit
         }
 
@@ -163,7 +163,7 @@ abstract class SnapshotProcessor[
 
         val updateMptStorage: F[Unit] = state match {
           case info: GlobalSnapshotInfo =>
-            info.allStateEntries.flatMap(mptStore.sync[Json])
+            info.allStateEntries.flatMap(mptStore.sync[Json](_, snapshot.ordinal))
           case _ => Async[F].unit
         }
 
@@ -203,7 +203,7 @@ abstract class SnapshotProcessor[
 
         val updateMptStorage: F[Unit] = state match {
           case info: GlobalSnapshotInfo =>
-            info.allStateEntries.flatMap(mptStore.sync[Json])
+            info.allStateEntries.flatMap(mptStore.sync[Json](_, snapshot.ordinal))
           case _ => Async[F].unit
         }
 
@@ -256,7 +256,7 @@ abstract class SnapshotProcessor[
 
         val updateMptStorage: F[Unit] = state match {
           case info: GlobalSnapshotInfo =>
-            info.allStateEntries.flatMap(mptStore.sync[Json])
+            info.allStateEntries.flatMap(mptStore.sync[Json](_, snapshot.ordinal))
           case _ => Async[F].unit
         }
 

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -992,7 +992,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             ),
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
-          _ <- mptStore.syncFromGlobalSnapshotInfo(snapshotInfo)
+          _ <- mptStore.syncFromGlobalSnapshotInfo(snapshotInfo, hashedLastSnapshot.ordinal)
           _ <- lastSnapR.set((hashedLastSnapshot, snapshotInfo).some)
           lastN = (hashedLastSnapshot, snapshotInfo).some
           incLastN = SortedMap(hashedLastSnapshot.ordinal -> hashedLastSnapshot)
@@ -1698,7 +1698,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
             ),
             srcKey
           ).flatMap(_.toHashedWithSignatureCheck.map(_.toOption.get))
-          _ <- mptStore.syncFromGlobalSnapshotInfo(snapshotInfo)
+          _ <- mptStore.syncFromGlobalSnapshotInfo(snapshotInfo, hashedLastSnapshot.ordinal)
           _ <- lastSnapR.set((hashedLastSnapshot, snapshotInfo).some)
           lastN = (hashedLastSnapshot, snapshotInfo).some
           _ <- lastNSnapR.set(lastN)

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -42,6 +42,8 @@ snapshot {
     routes = 10 seconds
     client = 5 seconds
   }
+  mpt-snapshot-info-path = "data/mpt_snapshot_info"
+  mpt-snapshot-info-path = ${?CL_MPT_SNAPSHOT_INFO_PATH}
 }
 
 fork-info-storage {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
@@ -77,7 +77,8 @@ trait CliMethod {
     c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
     c.snapshotBinarySenderTimeouts,
     c.snapshot.timeouts,
-    c.combinedRouteRateLimiter
+    c.combinedRouteRateLimiter,
+    c.snapshot.mptSnapshotInfoPath
   )
 
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -91,7 +91,8 @@ object types {
     priceOracle: PriceOracleConfig,
     snapshotBinarySenderTimeouts: SnapshotBinarySenderTimeoutsConfig,
     snapshotTimeoutsConfig: SnapshotTimeoutsConfig,
-    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig]
+    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig],
+    mptSnapshotInfoPath: Path
   )
 
   case class SharedTrustConfig(
@@ -100,7 +101,8 @@ object types {
 
   case class SharedSnapshotConfig(
     size: SnapshotSizeConfig,
-    timeouts: SnapshotTimeoutsConfig
+    timeouts: SnapshotTimeoutsConfig,
+    mptSnapshotInfoPath: Path
   )
 
   case class SnapshotSizeConfig(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -1040,7 +1040,7 @@ object GlobalSnapshotAcceptanceManager {
             metagraphSyncData = metagraphSyncDataDeltas
           )
 
-          _ <- mptStore.syncFromStateChanges(stateChangesAccumulator)
+          _ <- mptStore.syncFromStateChanges(stateChangesAccumulator, ordinal)
           stateProof <- gsi.stateProof(mptStore.underlying)
 
           (expiredAllowSpends, expiredTokenLocks) = (

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedStorages.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedStorages.scala
@@ -5,6 +5,7 @@ import cats.effect.kernel.Async
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
+import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.domain.block.processing.BlockRejectionReason
 import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, SessionStorage}
@@ -22,14 +23,14 @@ import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEve
 import io.constellationnetwork.schema.cluster.ClusterId
 import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
-import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
+import io.constellationnetwork.security.mpt.producer.FileSystemMerklePatriciaProducer
 import io.constellationnetwork.security.{Hasher, HasherSelector}
 
 import io.circe.Json
 
 object SharedStorages {
 
-  def make[F[_]: Parallel: Async: Hasher](
+  def make[F[_]: Parallel: JsonSerializer: Async: Hasher](
     clusterId: ClusterId,
     cfg: SharedConfig
   ): F[SharedStorages[F]] =
@@ -42,7 +43,7 @@ object SharedStorages {
       currencySnapshotEventValidationErrorStorage <- CurrencySnapshotEventValidationErrorStorage.make(cfg.validationErrorStorage.maxSize)
       lastNGlobalSnapshotStorage <- LastNGlobalSnapshotStorage.make[F](cfg.lastGlobalSnapshotsSync)
       lastGlobalSnapshotStorage <- LastSnapshotStorage.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
-      mptProducer <- InMemoryMerklePatriciaProducer.make[F]()
+      mptProducer <- FileSystemMerklePatriciaProducer.make[F](cfg.mptSnapshotInfoPath)
       mptStore = MptStore.make[F, GlobalStateKey](
         mptProducer,
         GlobalStateKey.toHex[F]

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
@@ -246,11 +246,11 @@ object GlobalStateConverter {
     implicit class MptStoreGlobalSnapshotOps[F[_]: Async: Parallel: Hasher](
       val store: MptStore[F, GlobalStateKey]
     ) {
-      def syncFromGlobalSnapshotInfo(info: GlobalSnapshotInfo): F[Unit] =
-        info.allStateEntries[F].flatMap(store.syncFull[Json])
+      def syncFromGlobalSnapshotInfo(info: GlobalSnapshotInfo, snapshotOrdinal: SnapshotOrdinal): F[Unit] =
+        info.allStateEntries[F].flatMap(store.syncFull[Json](_, snapshotOrdinal))
 
-      def syncFromStateChanges(acc: StateChangesAccumulator): F[Unit] =
-        acc.toStateEntries[F].flatMap(store.sync[Json])
+      def syncFromStateChanges(acc: StateChangesAccumulator, snapshotOrdinal: SnapshotOrdinal): F[Unit] =
+        acc.toStateEntries[F].flatMap(store.sync[Json](_, snapshotOrdinal))
 
       def getBalance(address: Address): F[Option[Balance]] =
         store

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
@@ -4,10 +4,11 @@ import cats.Parallel
 import cats.effect.Async
 import cats.syntax.all._
 
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.mpt.MerklePatriciaTrie
-import io.constellationnetwork.security.mpt.producer.{MerklePatriciaError, StatefulMerklePatriciaProducer}
+import io.constellationnetwork.security.mpt.producer._
 
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
@@ -32,9 +33,9 @@ trait MptStore[F[_], K] {
 
   def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]]
 
-  def sync[V: Encoder](newState: Map[K, V]): F[Unit]
+  def sync[V: Encoder](newState: Map[K, V], ordinal: SnapshotOrdinal): F[Unit]
 
-  def syncFull[V: Encoder](newState: Map[K, V]): F[Unit]
+  def syncFull[V: Encoder](newState: Map[K, V], ordinal: SnapshotOrdinal): F[Unit]
 
   def update[V: Encoder](toUpsert: Map[K, V], toRemove: Set[K]): F[Unit]
 
@@ -53,6 +54,17 @@ object MptStore {
     producer: StatefulMerklePatriciaProducer[F],
     toHex: K => F[Hex]
   ) extends MptStore[F, K] {
+
+    private def persistAndCutoff(ordinal: SnapshotOrdinal): F[Unit] =
+      producer match {
+        case p: StatefulWithPersistenceMerklePatriciaProducer[F] =>
+          p.persist(ordinal) >> p.applyCutoff(ordinal)
+        case _ =>
+          Async[F].unit
+      }
+
+    private def toHexEntries[V: Encoder](data: Map[K, V]): F[Map[Hex, Json]] =
+      data.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }.map(_.toMap)
 
     override def get[V: Decoder](key: K): F[Option[V]] =
       for {
@@ -77,9 +89,7 @@ object MptStore {
 
     override def insert[V: Encoder](data: Map[K, V]): F[Unit] =
       if (data.isEmpty) Async[F].unit
-      else
-        data.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }
-          .flatMap(kvs => producer.insert(kvs.toMap).void)
+      else toHexEntries(data).flatMap(kvs => producer.insert(kvs).void)
 
     override def remove(key: K): F[Unit] =
       toHex(key).flatMap(hex => producer.remove(List(hex)).void)
@@ -100,56 +110,34 @@ object MptStore {
     override def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
       producer.build
 
-    override def syncFull[V: Encoder](newState: Map[K, V]): F[Unit] =
+    override def syncFull[V: Encoder](newState: Map[K, V], ordinal: SnapshotOrdinal): F[Unit] =
       if (newState.isEmpty) producer.clear
       else
         for {
-          newEntries <- newState.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }
-            .map(_.toMap)
-
+          newEntries <- toHexEntries(newState)
           currentEntries <- producer.entries
-
           keysToRemove = currentEntries.keySet -- newEntries.keySet
-          keysToUpsert = newEntries.filter {
-            case (k, vJson) =>
-              !currentEntries.get(k).contains(vJson)
-          }
-
+          keysToUpsert = newEntries.filterNot { case (k, v) => currentEntries.get(k).contains(v) }
           _ <- if (keysToRemove.nonEmpty) producer.remove(keysToRemove.toList).void else Async[F].unit
           _ <- if (keysToUpsert.nonEmpty) producer.insert(keysToUpsert).void else Async[F].unit
+          _ <- persistAndCutoff(ordinal)
         } yield ()
 
-    override def sync[V: Encoder](updates: Map[K, V]): F[Unit] =
+    override def sync[V: Encoder](updates: Map[K, V], ordinal: SnapshotOrdinal): F[Unit] =
       if (updates.isEmpty) Async[F].unit
       else
         for {
-          newEntries <- updates.toList.parTraverse {
-            case (k, v) =>
-              toHex(k).map(_ -> v.asJson)
-          }.map(_.toMap)
-
+          newEntries <- toHexEntries(updates)
           currentEntries <- producer.entries
-
-          keysToUpsert = newEntries.filter {
-            case (k, v) =>
-              !currentEntries.get(k).contains(v)
-          }
-
-          _ <- if (keysToUpsert.nonEmpty) producer.insert(keysToUpsert) else Async[F].unit
+          keysToUpsert = newEntries.filterNot { case (k, v) => currentEntries.get(k).contains(v) }
+          _ <- if (keysToUpsert.nonEmpty) producer.insert(keysToUpsert).void else Async[F].unit
+          _ <- persistAndCutoff(ordinal)
         } yield ()
 
     override def update[V: Encoder](toUpsert: Map[K, V], toRemove: Set[K]): F[Unit] =
       for {
-        upsertHex <-
-          if (toUpsert.isEmpty) Async[F].pure(Map.empty[Hex, Json])
-          else
-            toUpsert.toList.parTraverse { case (k, v) => toHex(k).map(_ -> v.asJson) }
-              .map(_.toMap)
-
-        removeHex <-
-          if (toRemove.isEmpty) Async[F].pure(List.empty[Hex])
-          else toRemove.toList.parTraverse(toHex)
-
+        upsertHex <- if (toUpsert.isEmpty) Async[F].pure(Map.empty[Hex, Json]) else toHexEntries(toUpsert)
+        removeHex <- if (toRemove.isEmpty) Async[F].pure(List.empty[Hex]) else toRemove.toList.parTraverse(toHex)
         _ <- if (removeHex.nonEmpty) producer.remove(removeHex).void else Async[F].unit
         _ <- if (upsertHex.nonEmpty) producer.insert(upsertHex).void else Async[F].unit
       } yield ()

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/FileSystemMerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/FileSystemMerklePatriciaProducer.scala
@@ -1,0 +1,113 @@
+package io.constellationnetwork.security.mpt.producer
+
+import cats.Parallel
+import cats.effect.{Async, Ref}
+import cats.syntax.all._
+
+import io.constellationnetwork.cutoff.OrdinalCutoff
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.mpt.GlobalStateKey
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.mpt.MerklePatriciaTrie
+import io.constellationnetwork.security.mpt.prover.MerklePatriciaSingleInclusionProver
+import io.constellationnetwork.security.mpt.storages.MerklePatriciaHexMapLocalFileSystemStorage
+
+import fs2.Stream
+import fs2.io.file.Path
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+class FileSystemMerklePatriciaProducer[F[_]: Async: Hasher](
+  stateRef: Ref[F, Map[Hex, Json]],
+  storage: MerklePatriciaHexMapLocalFileSystemStorage[F]
+) extends StatefulWithPersistenceMerklePatriciaProducer[F] {
+
+  override def getProver: F[MerklePatriciaSingleInclusionProver[F]] =
+    build.flatMap {
+      case Right(trie) => MerklePatriciaSingleInclusionProver.make[F](trie).pure[F]
+      case Left(err)   => Async[F].raiseError(err)
+    }
+
+  override def entries: F[Map[Hex, Json]] =
+    stateRef.get
+
+  override def build: F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    entries.flatMap { currentEntries =>
+      if (currentEntries.isEmpty)
+        OperationError("Cannot build trie with no entries").asLeft[MerklePatriciaTrie].pure[F].widen
+      else
+        MerklePatriciaTrie.make[F, Json](currentEntries).attempt.map {
+          case Right(trie) => trie.asRight[MerklePatriciaError]
+          case Left(e)     => OperationError(e.getMessage).asLeft[MerklePatriciaTrie]
+        }
+    }
+
+  override def insert[A: Encoder](data: Map[Hex, A]): F[Either[MerklePatriciaError, Unit]] =
+    if (data.isEmpty) ().asRight[MerklePatriciaError].pure[F]
+    else {
+      val jsonEntries = data.map { case (k, v) => k -> v.asJson }
+      stateRef.update(_ ++ jsonEntries).as(().asRight[MerklePatriciaError])
+    }
+
+  override def update[A: Encoder](key: Hex, value: A): F[Either[MerklePatriciaError, Unit]] =
+    stateRef.get.flatMap { state =>
+      if (!state.contains(key))
+        OperationError(s"Key not found for update: $key").asLeft[Unit].pure[F].widen
+      else
+        stateRef.update(_ + (key -> value.asJson)).as(().asRight[MerklePatriciaError])
+    }
+
+  override def remove(keys: List[Hex]): F[Either[MerklePatriciaError, Unit]] =
+    if (keys.isEmpty) ().asRight[MerklePatriciaError].pure[F]
+    else stateRef.update(_ -- keys).as(().asRight[MerklePatriciaError])
+
+  override def clear: F[Unit] =
+    stateRef.set(Map.empty)
+
+  override def buildHexMap(data: Map[GlobalStateKey, Json])(implicit parallel: Parallel[F]): F[Map[Hex, Json]] =
+    data.toList.parTraverse {
+      case (key, value) => GlobalStateKey.toHex[F](key).map(_ -> value)
+    }.map(_.toMap)
+
+  override def persist(ordinal: SnapshotOrdinal): F[Unit] =
+    stateRef.get.flatMap(storage.write(ordinal, _))
+
+  override def load(ordinal: SnapshotOrdinal): F[Boolean] =
+    storage.read(ordinal).flatMap {
+      case Some(hexMap) => stateRef.set(hexMap).as(true)
+      case None         => false.pure[F]
+    }
+
+  override def deleteAbove(ordinal: SnapshotOrdinal): F[Unit] =
+    storage.deleteAbove(ordinal)
+
+  override def listStoredOrdinals: F[Stream[F, SnapshotOrdinal]] =
+    storage.listStoredOrdinals
+
+  override def applyCutoff(currentOrdinal: SnapshotOrdinal): F[Unit] =
+    storage.applyCutoff(currentOrdinal)
+}
+
+object FileSystemMerklePatriciaProducer {
+
+  def make[F[_]: Async: Hasher: JsonSerializer](
+    path: Path,
+    initial: Map[Hex, Json] = Map.empty
+  ): F[FileSystemMerklePatriciaProducer[F]] =
+    for {
+      stateRef <- Ref.of[F, Map[Hex, Json]](initial)
+      storage <- MerklePatriciaHexMapLocalFileSystemStorage.make[F](path)
+    } yield new FileSystemMerklePatriciaProducer[F](stateRef, storage)
+
+  def make[F[_]: Async: Hasher: JsonSerializer](
+    path: Path,
+    cutoffLogic: OrdinalCutoff,
+    initial: Map[Hex, Json]
+  ): F[FileSystemMerklePatriciaProducer[F]] =
+    for {
+      stateRef <- Ref.of[F, Map[Hex, Json]](initial)
+      storage <- MerklePatriciaHexMapLocalFileSystemStorage.make[F](path, cutoffLogic)
+    } yield new FileSystemMerklePatriciaProducer[F](stateRef, storage)
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
@@ -4,12 +4,14 @@ import cats.Parallel
 import cats.effect.Async
 import cats.syntax.functor._
 
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.mpt.GlobalStateKey
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.mpt.MerklePatriciaTrie
 import io.constellationnetwork.security.mpt.prover.MerklePatriciaSingleInclusionProver
 
+import fs2.Stream
 import io.circe.{Encoder, Json}
 
 trait MerklePatriciaProducer[F[_]] {
@@ -37,6 +39,14 @@ trait StatefulMerklePatriciaProducer[F[_]] {
   def clear: F[Unit]
   def getProver: F[MerklePatriciaSingleInclusionProver[F]]
   def buildHexMap(data: Map[GlobalStateKey, Json])(implicit parallel: Parallel[F]): F[Map[Hex, Json]]
+}
+
+trait StatefulWithPersistenceMerklePatriciaProducer[F[_]] extends StatefulMerklePatriciaProducer[F] {
+  def persist(ordinal: SnapshotOrdinal): F[Unit]
+  def load(ordinal: SnapshotOrdinal): F[Boolean]
+  def deleteAbove(ordinal: SnapshotOrdinal): F[Unit]
+  def listStoredOrdinals: F[Stream[F, SnapshotOrdinal]]
+  def applyCutoff(ordinal: SnapshotOrdinal): F[Unit]
 }
 
 object MerklePatriciaProducer {

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/storages/MerklePatriciaHexMapLocalFileSystemStorage.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/storages/MerklePatriciaHexMapLocalFileSystemStorage.scala
@@ -1,0 +1,91 @@
+package io.constellationnetwork.security.mpt.storages
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.cutoff.{LogarithmicOrdinalCutoff, OrdinalCutoff}
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.storage.SerializableLocalFileSystemStorage
+
+import fs2.Stream
+import fs2.io.file.Path
+import io.circe.{Decoder, Encoder, Json}
+
+object MerklePatriciaHexMap {
+  type HexMap = Map[Hex, Json]
+
+  implicit val hexKeyEncoder: io.circe.KeyEncoder[Hex] = (key: Hex) => key.value
+  implicit val hexKeyDecoder: io.circe.KeyDecoder[Hex] = (key: String) => Some(Hex(key))
+
+  implicit val hexMapEncoder: Encoder[HexMap] = Encoder.encodeMap[Hex, Json]
+  implicit val hexMapDecoder: Decoder[HexMap] = Decoder.decodeMap[Hex, Json]
+}
+
+class MerklePatriciaHexMapLocalFileSystemStorage[F[_]: Async: JsonSerializer](
+  path: Path,
+  cutoffLogic: OrdinalCutoff = LogarithmicOrdinalCutoff.make
+) extends SerializableLocalFileSystemStorage[F, MerklePatriciaHexMap.HexMap](path) {
+
+  import MerklePatriciaHexMap._
+
+  override def deserializeFallback(bytes: Array[Byte]): Either[Throwable, HexMap] =
+    io.circe.parser.decode[HexMap](new String(bytes, "UTF-8")).leftMap(e => new RuntimeException(e.getMessage))
+
+  private def toOrdinalName(ordinal: SnapshotOrdinal): String = ordinal.value.value.toString
+
+  def write(ordinal: SnapshotOrdinal, hexMap: HexMap): F[Unit] =
+    write(toOrdinalName(ordinal), hexMap)
+
+  def read(ordinal: SnapshotOrdinal): F[Option[HexMap]] =
+    read(toOrdinalName(ordinal))
+
+  def exists(ordinal: SnapshotOrdinal): F[Boolean] =
+    exists(toOrdinalName(ordinal))
+
+  def delete(ordinal: SnapshotOrdinal): F[Unit] =
+    delete(toOrdinalName(ordinal))
+
+  def listStoredOrdinals: F[Stream[F, SnapshotOrdinal]] =
+    listFiles.map {
+      _.map(_.name)
+        .map(_.toLongOption)
+        .map(_.flatMap(SnapshotOrdinal(_)))
+        .collect { case Some(ordinal) => ordinal }
+    }
+
+  def deleteAbove(ordinal: SnapshotOrdinal): F[Unit] =
+    listStoredOrdinals.flatMap {
+      _.filter(_ > ordinal)
+        .evalMap(delete)
+        .compile
+        .drain
+    }
+
+  def applyCutoff(currentOrdinal: SnapshotOrdinal): F[Unit] = {
+    val toKeep = cutoffLogic.cutoff(SnapshotOrdinal.MinValue, currentOrdinal)
+
+    listStoredOrdinals.flatMap {
+      _.compile.toList
+        .map(_.toSet.diff(toKeep).toList)
+        .flatMap(_.traverse_(delete))
+    }
+  }
+}
+
+object MerklePatriciaHexMapLocalFileSystemStorage {
+
+  def make[F[_]: Async: JsonSerializer](path: Path): F[MerklePatriciaHexMapLocalFileSystemStorage[F]] =
+    (new MerklePatriciaHexMapLocalFileSystemStorage[F](path)).pure[F].flatTap { storage =>
+      storage.createDirectoryIfNotExists().rethrowT
+    }
+
+  def make[F[_]: Async: JsonSerializer](
+    path: Path,
+    cutoffLogic: OrdinalCutoff
+  ): F[MerklePatriciaHexMapLocalFileSystemStorage[F]] =
+    (new MerklePatriciaHexMapLocalFileSystemStorage[F](path, cutoffLogic)).pure[F].flatTap { storage =>
+      storage.createDirectoryIfNotExists().rethrowT
+    }
+}


### PR DESCRIPTION
### Merkle Patricia Trie File System Persistence
#### Summary
Adds file system persistence for MPT state, enabling state recovery across node restarts and automatic cleanup of old snapshots.

#### What was added

* **FileSystemMerklePatriciaProducer**: A new producer that combines in-memory Ref for fast operations with file system persistence by SnapshotOrdinal. Implements StatefulWithPersistenceMerklePatriciaProducer.
* **MerklePatriciaHexMapLocalFileSystemStorage**: Storage layer that persists the entire Map[Hex, Json] per ordinal, following the same pattern as SnapshotInfoLocalFileSystemStorage.
* **MptStore** refactored to call persist and applyCutoff after sync/syncFull operations.

#### Why

* Allows MPT state to survive node restarts without rebuilding from scratch
* Provides configurable retention policies (LogarithmicOrdinalCutoff for production, KeepLatestOrdinalCutoff for testing)
* Follows existing codebase patterns for consistency