### PR TITLE
feat: adding clickhouse logger support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,9 @@ lazy val shared = (project in file("modules/shared"))
       Libraries.http4sServer,
       Libraries.http4sClient,
       Libraries.http4sCirce,
-      Libraries.circeFs2
+      Libraries.circeFs2,
+      Libraries.clickHouse,
+      Libraries.hikari
     )
   )
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -19,7 +19,7 @@ import io.constellationnetwork.currency.l0.snapshot.schema.{CurrencyConsensusOut
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.kryo._
-import io.constellationnetwork.node.shared.app.{NodeShared, TessellationIOApp, getMajorityPeerIds}
+import io.constellationnetwork.node.shared.app._
 import io.constellationnetwork.node.shared.domain.rewards.Rewards
 import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.node.shared.infrastructure.consensus.state._
@@ -69,6 +69,7 @@ abstract class CurrencyL0App(
       name,
       header,
       clusterId,
+      layer = CurrencyL0,
       version = tessellationVersion,
       metagraphVersion = metagraphVersion
     )

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -68,7 +68,8 @@ object method {
       c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
       c.snapshotBinarySenderTimeouts,
       c.snapshot.timeouts,
-      c.combinedRouteRateLimiter
+      c.combinedRouteRateLimiter,
+      c.clickHouseConfig
     )
   }
 

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -22,7 +22,7 @@ import io.constellationnetwork.dag.l1.modules.{Daemons => DAGL1Daemons, Queues =
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.kryo.{KryoRegistrationId, MapRegistrationId}
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
-import io.constellationnetwork.node.shared.app.{NodeShared, TessellationIOApp, getMajorityPeerIds}
+import io.constellationnetwork.node.shared.app.{CurrencyL1 => CurrencyL1Layer, _}
 import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.node.shared.infrastructure.gossip.{GossipDaemon, RumorHandlers}
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastNGlobalSnapshotStorage
@@ -65,6 +65,7 @@ abstract class CurrencyL1App(
       name,
       header,
       clusterId,
+      layer = CurrencyL1Layer,
       version = tessellationVersion,
       metagraphVersion = metagraphVersion
     )

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
@@ -65,7 +65,8 @@ object method {
       c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
       c.snapshotBinarySenderTimeouts,
       c.snapshot.timeouts,
-      c.combinedRouteRateLimiter
+      c.combinedRouteRateLimiter,
+      c.clickHouseConfig
     )
   }
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
@@ -14,7 +14,7 @@ import io.constellationnetwork.dag.l0.modules._
 import io.constellationnetwork.ext.cats.effect._
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.ext.kryo._
-import io.constellationnetwork.node.shared.app.{NodeShared, TessellationIOApp}
+import io.constellationnetwork.node.shared.app.{DagL0, NodeShared, TessellationIOApp}
 import io.constellationnetwork.node.shared.domain.collateral.OwnCollateralNotSatisfied
 import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.node.shared.infrastructure.consensus.state._
@@ -47,7 +47,8 @@ object Main
       name = "dag-l0",
       header = "Tessellation Node",
       version = TessellationVersion.unsafeFrom(BuildInfo.version),
-      clusterId = ClusterId("6d7f1d6a-213a-4148-9d45-d7200f555ecf")
+      clusterId = ClusterId("6d7f1d6a-213a-4148-9d45-d7200f555ecf"),
+      layer = DagL0
     ) {
 
   val opts: Opts[Run] = cli.method.opts
@@ -96,7 +97,8 @@ object Main
           nodeShared.nodeId,
           keyPair,
           cfg,
-          Hasher.forKryo[IO]
+          Hasher.forKryo[IO],
+          nodeShared.databaseLogger
         )
         .asResource
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -48,6 +48,7 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glob
   GlobalSnapshotStateChannelAcceptanceManager,
   GlobalSnapshotStateChannelEventsProcessor
 }
+import io.constellationnetwork.node.shared.logger.DatabaseLogger
 import io.constellationnetwork.node.shared.modules.{SharedServices, SharedValidators}
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
@@ -93,7 +94,8 @@ object GlobalSnapshotConsensus {
     restartService: RestartService[F, R],
     lastNGlobalSnapshotStorage: LastNGlobalSnapshotStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
-    getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
+    getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
+    dbLogger: DatabaseLogger[F]
   )(implicit supervisor: Supervisor[F]): F[GlobalSnapshotConsensus[F]] =
     for {
       globalStateChannelManager <- GlobalSnapshotStateChannelAcceptanceManager
@@ -123,7 +125,8 @@ object GlobalSnapshotConsensus {
           sharedServices.priceStateUpdater,
           collateral,
           sharedCfg.delegatedStaking.withdrawalTimeLimit
-            .getOrElse(sharedCfg.environment, EpochProgress.MinValue)
+            .getOrElse(sharedCfg.environment, EpochProgress.MinValue),
+          dbLogger
         )
 
       consensusStorage <- ConsensusStorage.make[

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Services.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/Services.scala
@@ -33,6 +33,7 @@ import io.constellationnetwork.node.shared.infrastructure.delegatedStake.{Reward
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
 import io.constellationnetwork.node.shared.infrastructure.snapshot.services.AddressService
+import io.constellationnetwork.node.shared.logger.DatabaseLogger
 import io.constellationnetwork.node.shared.modules.{SharedServices, SharedStorages, SharedValidators}
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.peer.PeerId
@@ -60,7 +61,8 @@ object Services {
     selfId: PeerId,
     keyPair: KeyPair,
     cfg: AppConfig,
-    txHasher: Hasher[F]
+    txHasher: Hasher[F],
+    dbLogger: DatabaseLogger[F]
   ): F[Services[F, R]] =
     for {
       classicRewards <- Rewards
@@ -117,7 +119,8 @@ object Services {
             sharedServices.restart,
             sharedStorages.lastNGlobalSnapshot,
             sharedStorages.lastGlobalSnapshot,
-            storages.globalSnapshot.getHashed
+            storages.globalSnapshot.getHashed,
+            dbLogger
           )
       }
       addressService = AddressService.make[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo](cfg.shared.addresses, storages.globalSnapshot)

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -53,6 +53,7 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glob
   GlobalSnapshotAcceptanceManager,
   GlobalSnapshotStateChannelEventsProcessor
 }
+import io.constellationnetwork.node.shared.logger.NoDbLogger
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.{Amount, Balance}
@@ -322,25 +323,39 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     val pricingUpdateValidator = PricingUpdateValidator.make[IO](None, NonNegLong(0))
     val priceStateUpdater = PriceStateUpdater.make(Dev, delegatedRewardsConfigProvider)
 
-    val snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[IO] =
-      GlobalSnapshotAcceptanceManager
-        .make[IO](
-          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
-          MetagraphsSyncConfig(PosInt(100)),
-          Dev,
-          bam,
-          asbam,
-          tlbam,
-          scProcessor,
-          updateNodeParametersAcceptanceManager,
-          updateDelegatedStakeAcceptanceManager,
-          updateNodeCollateralAcceptanceManager,
-          spendActionValidator,
-          pricingUpdateValidator,
-          priceStateUpdater,
-          collateral,
-          EpochProgress(NonNegLong(136080L))
-        )
+    val snapshotAcceptanceManagerF: F[GlobalSnapshotAcceptanceManager[IO]] =
+      NoDbLogger.makeUnsafe[IO].map { dbLogger =>
+        GlobalSnapshotAcceptanceManager
+          .make[IO](
+            FieldsAddedOrdinals(
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty,
+              Map.empty
+            ),
+            MetagraphsSyncConfig(PosInt(100)),
+            Dev,
+            bam,
+            asbam,
+            tlbam,
+            scProcessor,
+            updateNodeParametersAcceptanceManager,
+            updateDelegatedStakeAcceptanceManager,
+            updateNodeCollateralAcceptanceManager,
+            spendActionValidator,
+            pricingUpdateValidator,
+            priceStateUpdater,
+            collateral,
+            EpochProgress(NonNegLong(136080L)),
+            dbLogger
+          )
+      }
 
     val feeCalculator = new SnapshotBinaryFeeCalculator[IO] {
       override def calculateFee(
@@ -351,11 +366,12 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
         event.value.snapshotBinary.value.fee.value.pure[IO]
     }
 
-    RewardsInfoStorage.make.map { rewardsInfoStorage =>
-      val rewardsInfoCalculator = RewardsInfoCalculator.make(delegatorRewards)
-      val rewardsService = RewardsService[IO](classicRewards, delegatorRewards, rewardsInfoCalculator, rewardsInfoStorage)
-
-      GlobalSnapshotConsensusFunctions
+    for {
+      rewardsInfoStorage <- RewardsInfoStorage.make
+      rewardsInfoCalculator = RewardsInfoCalculator.make(delegatorRewards)
+      rewardsService = RewardsService[IO](classicRewards, delegatorRewards, rewardsInfoCalculator, rewardsInfoStorage)
+      snapshotAcceptanceManager <- snapshotAcceptanceManagerF
+      globalSnapshotConsensusFunction = GlobalSnapshotConsensusFunctions
         .make[IO](
           snapshotAcceptanceManager,
           collateral,
@@ -367,7 +383,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
           SnapshotOrdinal.MinValue,
           SnapshotOrdinal.MinValue
         )
-    }
+    } yield globalSnapshotConsensusFunction
   }
 
   def getTestData(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -48,6 +48,7 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glob
   GlobalSnapshotStateChannelEventsProcessor
 }
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
+import io.constellationnetwork.node.shared.logger.NoDbLogger
 import io.constellationnetwork.node.shared.modules.SharedValidators
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
@@ -372,6 +373,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
         validators.updateNodeCollateralValidator
       )
       priceStateUpdater = PriceStateUpdater.make(Dev, DefaultDelegatedRewardsConfigProvider)
+      dbLogger <- NoDbLogger.makeUnsafe[IO]
 
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
@@ -389,7 +391,8 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
           validators.pricingUpdateValidator,
           priceStateUpdater,
           Amount.empty,
-          EpochProgress(NonNegLong(136080L))
+          EpochProgress(NonNegLong(136080L)),
+          dbLogger
         )
       snapshotContextFunctions = GlobalSnapshotContextFunctions.make[IO](
         snapshotAcceptanceManager,

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -14,7 +14,8 @@ import io.constellationnetwork.dag.l1.infrastructure.tokenlock.rumor.handler.tok
 import io.constellationnetwork.dag.l1.modules._
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.kryo._
-import io.constellationnetwork.node.shared.app.{NodeShared, TessellationIOApp, getMajorityPeerIds}
+import io.constellationnetwork.node.shared.app._
+import io.constellationnetwork.node.shared.app.{DagL1 => DagL1Layer}
 import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.node.shared.infrastructure.DagL1
 import io.constellationnetwork.node.shared.infrastructure.gossip.{GossipDaemon, RumorHandlers}
@@ -44,7 +45,8 @@ object Main
       "dag-l1",
       "DAG L1 node",
       ClusterId("17e78993-37ea-4539-a4f3-039068ea1e92"),
-      version = TessellationVersion.unsafeFrom(BuildInfo.version)
+      version = TessellationVersion.unsafeFrom(BuildInfo.version),
+      layer = DagL1Layer
     ) {
 
   val opts: Opts[Run] = cli.method.opts(DagL1)

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -46,6 +46,7 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glob
   GlobalSnapshotStateChannelEventsProcessor
 }
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{LastNGlobalSnapshotStorage, LastSnapshotStorage}
+import io.constellationnetwork.node.shared.logger.NoDbLogger
 import io.constellationnetwork.node.shared.modules.SharedValidators
 import io.constellationnetwork.node.shared.nodeSharedKryoRegistrar
 import io.constellationnetwork.schema._
@@ -216,6 +217,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 .make(validators.updateNodeCollateralValidator)
               priceStateUpdater = PriceStateUpdater.make(Dev, DefaultDelegatedRewardsConfigProvider)
 
+              dbLogger <- NoDbLogger.make[IO]
+
               globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
                 FieldsAddedOrdinals(
                   Map.empty,
@@ -248,7 +251,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                 validators.pricingUpdateValidator,
                 priceStateUpdater,
                 Amount(0L),
-                EpochProgress(NonNegLong(136080L))
+                EpochProgress(NonNegLong(136080L)),
+                dbLogger
               )
               globalSnapshotContextFns = GlobalSnapshotContextFunctions.make(
                 globalSnapshotAcceptanceManager,

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -269,3 +269,22 @@ snapshot-binary-sender-timeouts {
  routes = 10 seconds
  client = 5 seconds
 }
+
+click-house-config {
+ max-retries = 3
+ max-queue-size = 10000
+ retry-base-delay = 1 second
+ batch-size = 100
+ flush-interval = 5 seconds
+ retention-period-in-days = 30
+ error-pause-duration = 30 seconds
+
+ host = ${?CLICKHOUSE_HOST}
+ user = ${?CLICKHOUSE_USER}
+ password = ${?CLICKHOUSE_PASSWORD}
+ table-name = ${?CLICKHOUSE_TABLE_NAME}
+ port = 8443
+ port = ${?CLICKHOUSE_PORT}
+ database = default
+ database = ${?CLICKHOUSE_DATABASE}
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/Layer.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/Layer.scala
@@ -1,0 +1,7 @@
+package io.constellationnetwork.node.shared.app
+
+sealed trait Layer
+case object DagL0 extends Layer
+case object DagL1 extends Layer
+case object CurrencyL0 extends Layer
+case object CurrencyL1 extends Layer

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/NodeShared.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/NodeShared.scala
@@ -12,6 +12,7 @@ import io.constellationnetwork.node.shared.cli.CliMethod
 import io.constellationnetwork.node.shared.config.types.SharedConfig
 import io.constellationnetwork.node.shared.http.p2p.SharedP2PClient
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+import io.constellationnetwork.node.shared.logger.DatabaseLogger
 import io.constellationnetwork.node.shared.modules._
 import io.constellationnetwork.node.shared.resources.SharedResources
 import io.constellationnetwork.schema.generation.Generation
@@ -49,6 +50,8 @@ trait NodeShared[F[_], A <: CliMethod] {
   val customAllowanceList: Option[Set[AllowanceListEntry]]
 
   val hashSelect: HashSelect
+
+  val databaseLogger: DatabaseLogger[F]
 
   def restartSignal: SignallingRef[F, Option[A]]
   def stopSignal: SignallingRef[F, Boolean]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
@@ -29,6 +29,8 @@ import io.constellationnetwork.node.shared.infrastructure.logs.LoggerConfigurato
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.seedlist.{Loader => SeedlistLoader}
 import io.constellationnetwork.node.shared.infrastructure.trust.TrustRatingCsvLoader
+import io.constellationnetwork.node.shared.logger.clickhouse.ClickHouseLogger
+import io.constellationnetwork.node.shared.logger.{DatabaseLogger, NoDbLogger}
 import io.constellationnetwork.node.shared.modules._
 import io.constellationnetwork.node.shared.resources.SharedResources
 import io.constellationnetwork.schema.SnapshotOrdinal
@@ -59,6 +61,7 @@ abstract class TessellationIOApp[A <: CliMethod](
   name: String,
   header: String,
   clusterId: ClusterId,
+  layer: Layer,
   helpFlag: Boolean = true,
   version: TessellationVersion = TessellationVersion.unsafeFrom("0.0.1"),
   metagraphVersion: MetagraphVersion = MetagraphVersion.unsafeFrom("0.0.1")
@@ -190,6 +193,35 @@ abstract class TessellationIOApp[A <: CliMethod](
                                       session = Session.make[IO](storages.session, storages.node, storages.cluster)
                                       p2pClient = SharedP2PClient.make[IO](res.client, session, cfg)
                                       queues <- SharedQueues.make[IO].asResource
+
+                                      _databaseLogger <- {
+                                        val useClickHouse = layer == DagL0 || layer == DagL1
+
+                                        if (useClickHouse) {
+                                          ClickHouseLogger
+                                            .make[IO](selfId, cfg.environment, cfg.clickHouseConfig)
+                                            .recoverWith {
+                                              case ClickHouseLogger.NotConfigured =>
+                                                Resource.eval(logger.info("ClickHouse not configured. Using console logger.")) >>
+                                                  NoDbLogger.make[IO]
+                                              case ClickHouseLogger.ConfigError(e) =>
+                                                Resource.eval(
+                                                  logger.warn(s"ClickHouse config invalid: ${e.getMessage}. Using console logger.")
+                                                ) >>
+                                                  NoDbLogger.make[IO]
+                                              case ClickHouseLogger.ConnectionError(e) =>
+                                                Resource.eval(
+                                                  logger.warn(s"ClickHouse connection failed: ${e.getMessage}. Using console logger.")
+                                                ) >>
+                                                  NoDbLogger.make[IO]
+                                            }
+                                        } else {
+                                          NoDbLogger.make[IO]
+                                        }
+                                      }
+
+                                      _ <- _databaseLogger.createLogsTable().asResource
+
                                       validators = _hasherSelector.withCurrent { implicit hasher =>
                                         SharedValidators.make[IO](
                                           cfg.environment,
@@ -225,7 +257,8 @@ abstract class TessellationIOApp[A <: CliMethod](
                                           cfg.environment,
                                           Hasher.forKryo[IO],
                                           maybeCustomAllowanceList,
-                                          tokenIdentifierOpt
+                                          tokenIdentifierOpt,
+                                          _databaseLogger
                                         )
                                         .asResource
 
@@ -273,6 +306,8 @@ abstract class TessellationIOApp[A <: CliMethod](
                                         val sharedValidators = validators
                                         val prioritySeedlist = _prioritySeedlist
                                         val customAllowanceList = maybeCustomAllowanceList
+
+                                        val databaseLogger = _databaseLogger
 
                                         def restartSignal = _restartSignal
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
@@ -77,7 +77,8 @@ trait CliMethod {
     c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
     c.snapshotBinarySenderTimeouts,
     c.snapshot.timeouts,
-    c.combinedRouteRateLimiter
+    c.combinedRouteRateLimiter,
+    c.clickHouseConfig
   )
 
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -64,7 +64,8 @@ object types {
     metagraphsSync: MetagraphsSyncConfig,
     priceOracle: Map[AppEnvironment, PriceOracleConfig],
     snapshotBinarySenderTimeouts: SnapshotBinarySenderTimeoutsConfig,
-    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig]
+    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig],
+    clickHouseConfig: ClickHouseAppConfig
   )
 
   case class SharedConfig(
@@ -91,7 +92,8 @@ object types {
     priceOracle: PriceOracleConfig,
     snapshotBinarySenderTimeouts: SnapshotBinarySenderTimeoutsConfig,
     snapshotTimeoutsConfig: SnapshotTimeoutsConfig,
-    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig]
+    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig],
+    clickHouseConfig: ClickHouseAppConfig
   )
 
   case class SharedTrustConfig(
@@ -172,6 +174,21 @@ object types {
         0.second
       )
   }
+  case class ClickHouseAppConfig(
+    maxRetries: Int,
+    maxQueueSize: Int,
+    retryBaseDelay: FiniteDuration,
+    batchSize: Int,
+    flushInterval: FiniteDuration,
+    retentionPeriodInDays: Int,
+    errorPauseDuration: FiniteDuration,
+    host: Option[String],
+    user: Option[String],
+    password: Option[String],
+    tableName: Option[String],
+    port: Option[Int],
+    database: Option[String]
+  )
 
   case class SnapshotConfig(
     consensus: ConsensusConfig,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -35,6 +35,7 @@ import io.constellationnetwork.node.shared.domain.swap.SpendActionValidator.Spen
 import io.constellationnetwork.node.shared.domain.swap.block.{AllowSpendBlockAcceptanceManager, AllowSpendBlockAcceptanceResult}
 import io.constellationnetwork.node.shared.domain.tokenlock.block.{TokenLockBlockAcceptanceManager, TokenLockBlockAcceptanceResult}
 import io.constellationnetwork.node.shared.infrastructure.snapshot._
+import io.constellationnetwork.node.shared.logger.DatabaseLogger
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
@@ -137,7 +138,8 @@ object GlobalSnapshotAcceptanceManager {
     pricingUpdateValidator: PricingUpdateValidator[F],
     priceStateUpdater: PriceStateUpdater[F],
     collateral: Amount,
-    withdrawalTimeLimit: EpochProgress
+    withdrawalTimeLimit: EpochProgress,
+    dbLogger: DatabaseLogger[F]
   ): GlobalSnapshotAcceptanceManager[F] = {
     val artifactEmissionManager = ArtifactEmissionManager.make[F]()
     val tipUsageManager = TipUsageManager.make[F]()
@@ -744,11 +746,20 @@ object GlobalSnapshotAcceptanceManager {
             globalBalances,
             lastSnapshotContext
           )
+          acceptedSpendActionsMessage = s"[ORDINAL=$ordinal] Accepted spend actions: ${acceptedSpendActions.show}"
+          rejectedSpendActionMessage = s"[ORDINAL=$ordinal] Rejected spend actions: ${rejectedSpendActions.show}"
+          acceptedPricingUpdatesMessage = s"[ORDINAL=$ordinal] Accepted pricing updates: ${acceptedPricingUpdates.show}"
+          rejectedPricingUpdatesMessage = s"[ORDINAL=$ordinal] Rejected pricing updates: ${rejectedPricingUpdates.show}"
 
-          _ <- logger.debug(s"[ORDINAL=$ordinal] Accepted spend actions: ${acceptedSpendActions.show}")
-          _ <- logger.debug(s"[ORDINAL=$ordinal] Rejected spend actions: ${rejectedSpendActions.show}")
-          _ <- logger.debug(s"[ORDINAL=$ordinal] Accepted pricing updates: ${acceptedPricingUpdates.show}")
-          _ <- logger.debug(s"[ORDINAL=$ordinal] Rejected pricing updates: ${rejectedPricingUpdates.show}")
+          _ <- logger.debug(acceptedSpendActionsMessage)
+          _ <- logger.debug(rejectedSpendActionMessage)
+          _ <- logger.debug(acceptedPricingUpdatesMessage)
+          _ <- logger.debug(rejectedPricingUpdatesMessage)
+
+          _ <- dbLogger.debug(acceptedSpendActionsMessage)
+          _ <- dbLogger.debug(rejectedSpendActionMessage)
+          _ <- dbLogger.debug(acceptedPricingUpdatesMessage)
+          _ <- dbLogger.debug(rejectedPricingUpdatesMessage)
 
           updatedLastStateChannelSnapshotHashes = lastSnapshotContext.lastStateChannelSnapshotHashes ++ sCSnapshotHashes
           updatedLastCurrencySnapshots = lastSnapshotContext.lastCurrencySnapshots ++ currencySnapshots

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/DatabaseLogger.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/DatabaseLogger.scala
@@ -1,0 +1,19 @@
+package io.constellationnetwork.node.shared.logger
+
+import io.circe.Encoder
+
+trait DatabaseLogger[F[_]] {
+  def createLogsTable(): F[Unit]
+
+  def log[T: Encoder](logType: String, data: T): F[Unit]
+
+  def info[T: Encoder](data: T): F[Unit]
+  def error[T: Encoder](data: T): F[Unit]
+  def warn[T: Encoder](data: T): F[Unit]
+  def debug[T: Encoder](data: T): F[Unit]
+
+  def info(message: String): F[Unit]
+  def error(message: String): F[Unit]
+  def warn(message: String): F[Unit]
+  def debug(message: String): F[Unit]
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/NoDbLogger.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/NoDbLogger.scala
@@ -1,0 +1,34 @@
+package io.constellationnetwork.node.shared.logger
+
+import cats.effect.{Async, Resource}
+import cats.syntax.all._
+
+import io.circe.Encoder
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object NoDbLogger {
+  def make[F[_]: Async]: Resource[F, DatabaseLogger[F]] =
+    Resource.eval(Slf4jLogger.create[F]).map(new NoDbLoggerImpl[F](_))
+
+  def makeUnsafe[F[_]: Async]: F[DatabaseLogger[F]] =
+    Slf4jLogger.create[F].map(new NoDbLoggerImpl[F](_))
+
+  private class NoDbLoggerImpl[F[_]: Async](
+    logger: SelfAwareStructuredLogger[F]
+  ) extends DatabaseLogger[F] {
+
+    def createLogsTable(): F[Unit] = Async[F].unit
+
+    def log[T: Encoder](logType: String, data: T): F[Unit] = logger.info(s"[$logType] $data")
+    def info[T: Encoder](data: T): F[Unit] = logger.info(s"$data")
+    def error[T: Encoder](data: T): F[Unit] = logger.error(s"$data")
+    def warn[T: Encoder](data: T): F[Unit] = logger.warn(s"$data")
+    def debug[T: Encoder](data: T): F[Unit] = logger.debug(s"$data")
+
+    def info(message: String): F[Unit] = logger.info(message)
+    def error(message: String): F[Unit] = logger.error(message)
+    def warn(message: String): F[Unit] = logger.warn(message)
+    def debug(message: String): F[Unit] = logger.debug(message)
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/clickhouse/ClickHouseDbConfig.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/clickhouse/ClickHouseDbConfig.scala
@@ -1,0 +1,75 @@
+package io.constellationnetwork.node.shared.logger.clickhouse
+
+import io.constellationnetwork.node.shared.config.types.ClickHouseAppConfig
+
+case class ClickHouseDbConfig(
+  host: String,
+  port: Int,
+  database: String,
+  user: String,
+  password: String,
+  tableName: String
+)
+
+object ClickHouseDbConfig {
+
+  sealed trait ConfigValidationError extends Throwable
+  case class InvalidHost(value: String) extends ConfigValidationError {
+    override def getMessage: String = s"Invalid CLICKHOUSE_HOST: '$value'"
+  }
+  case class InvalidPort(value: Int) extends ConfigValidationError {
+    override def getMessage: String = s"Invalid CLICKHOUSE_PORT: $value. Must be between 1 and 65535."
+  }
+  case class InvalidIdentifier(field: String, value: String) extends ConfigValidationError {
+    override def getMessage: String = s"Invalid $field: '$value'. Must be alphanumeric with underscores only."
+  }
+  case object MissingConfig extends ConfigValidationError {
+    override def getMessage: String = "Missing required ClickHouse configuration"
+  }
+
+  private val hostnamePattern = "^[a-zA-Z0-9]([a-zA-Z0-9\\-\\.]{0,253}[a-zA-Z0-9])?$".r
+  private val ipv4Pattern = "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$".r
+  private val ipv6Pattern = "^\\[?([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\\]?$".r
+  private val identifierPattern = "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$".r
+
+  def fromAppConfig(config: ClickHouseAppConfig): Either[ConfigValidationError, Option[ClickHouseDbConfig]] = {
+    val allMissing = config.host.isEmpty &&
+      config.user.isEmpty &&
+      config.password.isEmpty &&
+      config.tableName.isEmpty
+
+    if (allMissing) Right(None)
+    else {
+      for {
+        host <- config.host.toRight(MissingConfig).flatMap(validateHost)
+        port <- config.port.toRight(MissingConfig).flatMap(validatePort)
+        database <- config.database.toRight(MissingConfig).flatMap(validateIdentifier("database", _))
+        user <- config.user.toRight(MissingConfig)
+        tableName <- config.tableName.toRight(MissingConfig).flatMap(validateIdentifier("tableName", _))
+        password <- config.password.toRight(MissingConfig)
+      } yield
+        Some(
+          ClickHouseDbConfig(
+            host = host,
+            port = port,
+            database = database,
+            user = user,
+            password = password,
+            tableName = tableName
+          )
+        )
+    }
+  }
+
+  private def validateHost(host: String): Either[ConfigValidationError, String] =
+    if (hostnamePattern.matches(host) || ipv4Pattern.matches(host) || ipv6Pattern.matches(host)) Right(host)
+    else Left(InvalidHost(host))
+
+  private def validatePort(port: Int): Either[ConfigValidationError, Int] =
+    if (port >= 1 && port <= 65535) Right(port)
+    else Left(InvalidPort(port))
+
+  private def validateIdentifier(field: String, value: String): Either[ConfigValidationError, String] =
+    if (identifierPattern.matches(value)) Right(value)
+    else Left(InvalidIdentifier(field, value))
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/clickhouse/ClickHouseLogger.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/clickhouse/ClickHouseLogger.scala
@@ -1,0 +1,232 @@
+package io.constellationnetwork.node.shared.logger.clickhouse
+
+import cats.effect._
+import cats.effect.std.Queue
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.env.AppEnvironment
+import io.constellationnetwork.node.shared.config.types.ClickHouseAppConfig
+import io.constellationnetwork.node.shared.logger.DatabaseLogger
+import io.constellationnetwork.schema.peer.PeerId
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object ClickHouseLogger {
+
+  private case class SimpleLog(message: String)
+  private case class LogEntry(logType: String, data: Json, retryCount: Int = 0, retryAfter: Long = 0L)
+
+  case class ConfigError(error: ClickHouseDbConfig.ConfigValidationError) extends Exception(error.getMessage)
+  case class ConnectionError(cause: Throwable) extends Exception(cause.getMessage, cause)
+  case object NotConfigured extends Exception("ClickHouse not configured")
+
+  private val MaxBackoffMillis = 3600000L // 1 hour cap
+
+  def make[F[_]: Async](
+    nodeId: PeerId,
+    networkId: AppEnvironment,
+    appConfig: ClickHouseAppConfig
+  ): Resource[F, DatabaseLogger[F]] =
+    for {
+      maybeConfig <- Resource.eval(
+        Async[F].fromEither(
+          ClickHouseDbConfig.fromAppConfig(appConfig).leftMap(ConfigError)
+        )
+      )
+      config <- maybeConfig match {
+        case Some(c) => Resource.pure[F, ClickHouseDbConfig](c)
+        case None    => Resource.raiseError[F, ClickHouseDbConfig, Throwable](NotConfigured)
+      }
+      logger <- Resource.eval(Slf4jLogger.create[F])
+      dataSource <- makeDataSource[F](config).adaptError { case e => ConnectionError(e) }
+      queue <- Resource.eval(Queue.bounded[F, LogEntry](appConfig.maxQueueSize))
+      pausedUntil <- Resource.eval(Ref.of[F, Long](0L))
+      droppedCount <- Resource.eval(Ref.of[F, Long](0L))
+      _ <- startFlusher(queue, dataSource, config, nodeId, networkId, appConfig, logger, pausedUntil, droppedCount)
+    } yield new Impl[F](queue, dataSource, config, appConfig, logger, droppedCount)
+
+  private def makeDataSource[F[_]: Async](config: ClickHouseDbConfig): Resource[F, HikariDataSource] =
+    Resource.make(
+      Async[F].blocking {
+        val hc = new HikariConfig()
+        hc.setJdbcUrl(s"jdbc:clickhouse:https://${config.host}:${config.port}/${config.database}")
+        hc.setUsername(config.user)
+        hc.setPassword(config.password)
+        hc.setMinimumIdle(2)
+        hc.setMaximumPoolSize(10)
+        hc.setConnectionTimeout(30000)
+        hc.setPoolName("clickhouse-logger-pool")
+        hc.setConnectionTestQuery("SELECT 1")
+        new HikariDataSource(hc)
+      }
+    )(ds => Async[F].blocking(ds.close()).handleError(_ => ()))
+
+  private def startFlusher[F[_]: Async](
+    queue: Queue[F, LogEntry],
+    dataSource: HikariDataSource,
+    config: ClickHouseDbConfig,
+    nodeId: PeerId,
+    networkId: AppEnvironment,
+    appConfig: ClickHouseAppConfig,
+    logger: SelfAwareStructuredLogger[F],
+    pausedUntil: Ref[F, Long],
+    droppedCount: Ref[F, Long]
+  ): Resource[F, Unit] = {
+
+    def requeue(entry: LogEntry): F[Unit] =
+      queue.tryOffer(entry).flatMap {
+        case true => Async[F].unit
+        case false =>
+          droppedCount.update(_ + 1) >>
+            logger.warn(s"Failed to requeue ${entry.logType} entry (retry ${entry.retryCount}), queue full")
+      }
+
+    def flush: F[Unit] =
+      for {
+        now <- Async[F].realTime.map(_.toMillis)
+        paused <- pausedUntil.get
+        _ <-
+          if (now < paused) Async[F].unit
+          else
+            queue.tryTakeN(Some(appConfig.batchSize)).flatMap { entries =>
+              val (ready, notReady) = entries.partition(_.retryAfter <= now)
+              notReady.traverse_(requeue) >>
+                (if (ready.nonEmpty)
+                   writeBatch(ready, dataSource, config, nodeId, networkId, appConfig, logger, queue, pausedUntil, droppedCount)
+                 else Async[F].unit)
+            }
+      } yield ()
+
+    Spawn[F]
+      .background(
+        (Temporal[F].sleep(appConfig.flushInterval) >> flush).foreverM
+      )
+      .void
+  }
+
+  private def calculateBackoff(retryCount: Int, baseDelayMillis: Long): Long = {
+    val exponent = Math.min(retryCount, 20) // Cap exponent to prevent overflow
+    val delay = baseDelayMillis * (1L << exponent)
+    Math.min(delay, MaxBackoffMillis)
+  }
+
+  private def writeBatch[F[_]: Async](
+    entries: List[LogEntry],
+    dataSource: HikariDataSource,
+    config: ClickHouseDbConfig,
+    nodeId: PeerId,
+    networkId: AppEnvironment,
+    appConfig: ClickHouseAppConfig,
+    logger: SelfAwareStructuredLogger[F],
+    queue: Queue[F, LogEntry],
+    pausedUntil: Ref[F, Long],
+    droppedCount: Ref[F, Long]
+  ): F[Unit] =
+    Resource
+      .make(Async[F].blocking(dataSource.getConnection))(c => Async[F].blocking(c.close()).handleError(_ => ()))
+      .flatMap { conn =>
+        // Table name is validated by identifierPattern in ClickHouseDbConfig
+        val sql = s"INSERT INTO ${config.tableName} (timestamp, node_id, network_id, log_type, data) VALUES (now64(3), ?, ?, ?, ?)"
+        Resource.make(Async[F].blocking(conn.prepareStatement(sql)))(s => Async[F].blocking(s.close()).handleError(_ => ()))
+      }
+      .use { stmt =>
+        Async[F].blocking {
+          entries.foreach { entry =>
+            stmt.setString(1, nodeId.toString)
+            stmt.setString(2, networkId.toString)
+            stmt.setString(3, entry.logType)
+            stmt.setString(4, entry.data.noSpaces)
+            stmt.addBatch()
+          }
+          stmt.executeBatch()
+        }
+      }
+      .void
+      .handleErrorWith { e =>
+        for {
+          _ <- logger.warn(s"Failed to write to ClickHouse: ${e.getMessage}")
+          now <- Async[F].realTime.map(_.toMillis)
+          _ <- pausedUntil.set(now + appConfig.errorPauseDuration.toMillis)
+          retryable = entries.filter(_.retryCount < appConfig.maxRetries)
+          dropped = entries.size - retryable.size
+          _ <-
+            if (dropped > 0) {
+              droppedCount.update(_ + dropped) >>
+                logger.warn(s"Dropping $dropped entries after exhausting retries")
+            } else Async[F].unit
+          _ <- retryable.traverse_ { entry =>
+            val newRetryCount = entry.retryCount + 1
+            val delay = calculateBackoff(newRetryCount, appConfig.retryBaseDelay.toMillis)
+            queue.tryOffer(entry.copy(retryCount = newRetryCount, retryAfter = now + delay)).flatMap {
+              case true => Async[F].unit
+              case false =>
+                droppedCount.update(_ + 1) >>
+                  logger.warn(s"Failed to requeue ${entry.logType} for retry, queue full")
+            }
+          }
+        } yield ()
+      }
+
+  private class Impl[F[_]: Async](
+    queue: Queue[F, LogEntry],
+    dataSource: HikariDataSource,
+    config: ClickHouseDbConfig,
+    appConfig: ClickHouseAppConfig,
+    logger: SelfAwareStructuredLogger[F],
+    droppedCount: Ref[F, Long]
+  ) extends DatabaseLogger[F] {
+
+    def createLogsTable(): F[Unit] =
+      Resource
+        .make(Async[F].blocking(dataSource.getConnection))(c => Async[F].blocking(c.close()).handleError(_ => ()))
+        .flatMap { conn =>
+          Resource.make(Async[F].blocking(conn.createStatement()))(s => Async[F].blocking(s.close()).handleError(_ => ()))
+        }
+        .use { stmt =>
+          Async[F].blocking {
+            val retentionDays = Math.max(1, appConfig.retentionPeriodInDays)
+            stmt.execute(
+              s"""
+                 |CREATE TABLE IF NOT EXISTS ${config.tableName} (
+                 |    timestamp DateTime64(3),
+                 |    node_id LowCardinality(String),
+                 |    network_id LowCardinality(String),
+                 |    log_type LowCardinality(String),
+                 |    data JSON
+                 |) ENGINE = MergeTree()
+                 |PARTITION BY (network_id, toYYYYMM(timestamp))
+                 |ORDER BY (node_id, timestamp)
+                 |TTL toDateTime(timestamp) + INTERVAL $retentionDays DAY
+                 |""".stripMargin
+            )
+            ()
+          }
+        }
+
+    private def enqueue[T: Encoder](logType: String, data: T): F[Unit] =
+      queue.tryOffer(LogEntry(logType, data.asJson)).flatMap {
+        case true => Async[F].unit
+        case false =>
+          droppedCount.update(_ + 1) >>
+            logger.warn(s"Log queue full, dropping $logType")
+      }
+
+    def log[T: Encoder](logType: String, data: T): F[Unit] = enqueue(logType, data)
+    def info[T: Encoder](data: T): F[Unit] = enqueue("INFO", data)
+    def error[T: Encoder](data: T): F[Unit] = enqueue("ERROR", data)
+    def warn[T: Encoder](data: T): F[Unit] = enqueue("WARN", data)
+    def debug[T: Encoder](data: T): F[Unit] = enqueue("DEBUG", data)
+
+    def info(message: String): F[Unit] = enqueue("INFO", SimpleLog(message))
+    def error(message: String): F[Unit] = enqueue("ERROR", SimpleLog(message))
+    def warn(message: String): F[Unit] = enqueue("WARN", SimpleLog(message))
+    def debug(message: String): F[Unit] = enqueue("DEBUG", SimpleLog(message))
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -40,6 +40,7 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glob
   GlobalSnapshotStateChannelAcceptanceManager,
   GlobalSnapshotStateChannelEventsProcessor
 }
+import io.constellationnetwork.node.shared.logger.DatabaseLogger
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.epoch.EpochProgress
@@ -72,7 +73,8 @@ object SharedServices {
     environment: AppEnvironment,
     txHasher: Hasher[F],
     allowanceList: Option[Set[AllowanceListEntry]],
-    metagraphId: Option[Address]
+    metagraphId: Option[Address],
+    dbLogger: DatabaseLogger[F]
   ): F[SharedServices[F, A]] =
     for {
       restartService <- RestartService.make(restartSignal, storages.cluster)
@@ -163,7 +165,8 @@ object SharedServices {
         validators.pricingUpdateValidator,
         priceStateUpdater,
         collateral.amount,
-        cfg.delegatedStaking.withdrawalTimeLimit.getOrElse(cfg.environment, EpochProgress.MinValue)
+        cfg.delegatedStaking.withdrawalTimeLimit.getOrElse(cfg.environment, EpochProgress.MinValue),
+        dbLogger
       )
       globalSnapshotContextFns = GlobalSnapshotContextFunctions.make(
         globalSnapshotAcceptanceManager,

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
@@ -38,6 +38,7 @@ import io.constellationnetwork.node.shared.domain.swap.block._
 import io.constellationnetwork.node.shared.domain.tokenlock.block._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.EventTrigger
 import io.constellationnetwork.node.shared.infrastructure.snapshot.{DelegateRewardsInput, DelegatedRewardsResult, RewardsInput}
+import io.constellationnetwork.node.shared.logger.{DatabaseLogger, NoDbLogger}
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
@@ -249,25 +250,28 @@ object Mocks {
     // Create the manager with mock dependencies
     implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(h)
 
-    GlobalSnapshotAcceptanceManager
-      .make[IO](
-        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
-        MetagraphsSyncConfig(PosInt(100)),
-        AppEnvironment.Dev,
-        blockAcceptanceManager = mockBlockAcceptanceManager,
-        allowSpendBlockAcceptanceManager = mockAllowSpendBlockAcceptanceManager,
-        tokenLockBlockAcceptanceManager = mockTokenLockBlockAcceptanceManager,
-        stateChannelEventsProcessor = mockStateChannelEventsProcessor,
-        updateNodeParametersAcceptanceManager = mockUpdateNodeParametersAcceptanceManager,
-        updateDelegatedStakeAcceptanceManager = updateDelegatedStakeAcceptanceManager,
-        updateNodeCollateralAcceptanceManager = mockUpdateNodeCollateralAcceptanceManager,
-        spendActionValidator = mockSpendActionValidator,
-        pricingUpdateValidator = mockPricingUpdateValidator,
-        priceStateUpdater = mockPriceStateUpdater,
-        collateral = Amount.empty,
-        withdrawalTimeLimit = EpochProgress(4L)
-      )
-      .pure[IO]
+    NoDbLogger.makeUnsafe[IO].flatMap { dbLogger =>
+      GlobalSnapshotAcceptanceManager
+        .make[IO](
+          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+          MetagraphsSyncConfig(PosInt(100)),
+          AppEnvironment.Dev,
+          blockAcceptanceManager = mockBlockAcceptanceManager,
+          allowSpendBlockAcceptanceManager = mockAllowSpendBlockAcceptanceManager,
+          tokenLockBlockAcceptanceManager = mockTokenLockBlockAcceptanceManager,
+          stateChannelEventsProcessor = mockStateChannelEventsProcessor,
+          updateNodeParametersAcceptanceManager = mockUpdateNodeParametersAcceptanceManager,
+          updateDelegatedStakeAcceptanceManager = updateDelegatedStakeAcceptanceManager,
+          updateNodeCollateralAcceptanceManager = mockUpdateNodeCollateralAcceptanceManager,
+          spendActionValidator = mockSpendActionValidator,
+          pricingUpdateValidator = mockPricingUpdateValidator,
+          priceStateUpdater = mockPriceStateUpdater,
+          collateral = Amount.empty,
+          withdrawalTimeLimit = EpochProgress(4L),
+          dbLogger = dbLogger
+        )
+        .pure[IO]
+    }
   }
 
   private[snapshot] def mkGlobalSnapshotInfo(

--- a/modules/shared/src/main/resources/logback.xml
+++ b/modules/shared/src/main/resources/logback.xml
@@ -16,4 +16,6 @@
     <logger name="org.http4s.client.middleware.RequestLogger" level="OFF" />
     <logger name="org.http4s.client.middleware.ResponseLogger" level="OFF" />
     <logger name="RumorLogger" level="OFF" />
+    <logger name="org.http4s.ember.client.EmberClientBuilderCompanionPlatform" level="ERROR" />
+    <logger name="com.clickhouse.client.api.ClientConfigProperties" level="ERROR" />
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,6 +40,8 @@ object Dependencies {
     val scaffeine = "5.3.0"
     val semanticDB = "4.14.2"
     val weaver = "0.11.3"
+    val clickHouse = "0.9.5"
+    val hikari = "7.0.2"
   }
 
   object Libraries {
@@ -166,6 +168,12 @@ object Dependencies {
 
     // Scalafix
     val scalafixRules = "io.constellationnetwork" %% "constellation-scalafix-rules" % V.scalafixRules
+
+    // Clickhouse
+    val clickHouse = "com.clickhouse" % "clickhouse-jdbc" % V.clickHouse
+
+    // Hikari
+    val hikari = "com.zaxxer" % "HikariCP" % V.hikari
   }
 
   object CompilerPlugin {


### PR DESCRIPTION
# Add ClickHouse database logging
Adds centralized logging to ClickHouse for blockchain events across nodes.

## Changes:

**ClickHouseLogger**: Logs structured JSON data to ClickHouse with node metadata (node_id, node_ip, network_id)
**NoDbLogger**: Fallback logger that outputs to console when ClickHouse is not configured
**DatabaseLogger**: Common trait for both implementations
**ClickHouseConfig**: Configuration loaded from environment variables

## Configuration:
Required environment variables:

`CLICKHOUSE_HOST`
`CLICKHOUSE_USER`
`CLICKHOUSE_PASSWORD`
`CLICKHOUSE_TABLE_NAME`

Optional:

`CLICKHOUSE_PORT (default: 8443)`
`CLICKHOUSE_DATABASE (default: "default")`

## Behavior:

If credentials are provided, logs to ClickHouse
If credentials are missing, falls back to console logging with a warning
Supports any data type with a Circe Encoder

## Tests
Using a trial version of ClickHouse, the logs were sent to the platform
<img width="1951" height="847" alt="Screenshot 2026-01-08 at 12 19 12" src="https://github.com/user-attachments/assets/36bd41be-e8fa-4aa7-b881-12693f5f00e8" />
