### PR TITLE
refactor: optimize mpt ops for large state objects

### DIFF
--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/GlobalStateConverter.scala
@@ -117,16 +117,13 @@ object GlobalStateConverter {
       convertOptionalHypergraph(info.nodeCollateralWithdrawals, GlobalStateFieldId.NodeCollateralWithdrawals),
       convertOptionalHypergraph(info.metagraphSyncData, GlobalStateFieldId.MetagraphSyncData)
     ).parMapN { (m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) =>
-      List(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15)
-        .flatMap(_.toList)
-        .foldLeft(Right(Map.empty[GlobalStateKey, Json]): Either[Throwable, Map[GlobalStateKey, Json]]) {
-          case (Right(acc), (k, v)) =>
-            if (acc.contains(k))
-              Left(new IllegalStateException(s"Duplicate key found: $k"))
-            else
-              Right(acc.updated(k, v))
-          case (left @ Left(_), _) => left
-        }
+      // Merge all maps - O(n) instead of O(n log n) foldLeft
+      val allMaps = List(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15)
+      val expectedSize = allMaps.map(_.size).sum
+      val merged = allMaps.foldLeft(Map.empty[GlobalStateKey, Json])(_ ++ _)
+
+      if (merged.size == expectedSize) Right(merged)
+      else Left(new IllegalStateException(s"Duplicate keys found: expected $expectedSize entries but got ${merged.size}"))
     }.flatMap(_.liftTo[F])
 
   object syntax {
@@ -140,15 +137,21 @@ object GlobalStateConverter {
         for {
           kvPairs <- kvPairsF
           _ <- Async[F].cede
-          hexMap <- kvPairs.toList.parTraverse {
-            case (key, value) => GlobalStateKey.toHex[F](key).map(_ -> value)
-          }.map(_.toMap)
+          hexMap <- kvPairs.toList
+            .grouped(1000)
+            .toList
+            .flatTraverse { batch =>
+              batch.parTraverse {
+                case (key, value) => GlobalStateKey.toHex[F](key).map(_ -> value)
+              } <* Async[F].cede
+            }
+            .map(_.toMap)
           _ <- Async[F].cede
           mptRoot <- hexMap.isEmpty
             .pure[F]
             .ifM(
               ifTrue = MptRoot(Hash.empty).pure[F],
-              ifFalse = MerklePatriciaTrie.make[F, Json](hexMap).map(_.rootHash)
+              ifFalse = MerklePatriciaTrie.makeParallel[F, Json](hexMap).map(_.rootHash)
             )
           _ <- Async[F].cede
         } yield mptRoot

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/Hasher.scala
@@ -114,8 +114,8 @@ object Hasher {
       KryoSerializer[F]
         .serialize(data)
         .map(bytes => prefix ++ bytes)
-        .map(Hash.fromBytes)
         .liftTo[F]
+        .flatMap(Hash.fromBytesForSync[F])
   }
 
   def forJson[F[_]: Sync: JsonSerializer]: Hasher[F] =
@@ -162,7 +162,7 @@ object Hasher {
         JsonSerializer[F]
           .serialize(data)
           .map(bytes => prefix ++ bytes)
-          .map(Hash.fromBytes)
+          .flatMap(Hash.fromBytesForSync[F])
     }
   }
 
@@ -187,6 +187,6 @@ object Hasher {
       JsonSerializer[F]
         .serialize(data)
         .map(bytes => prefix ++ bytes)
-        .map(Hash.fromBytes)
+        .flatMap(Hash.fromBytesForSync[F])
   }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/MerklePatriciaTrie.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/MerklePatriciaTrie.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.security.mpt
 
+import cats.Parallel
 import cats.effect.Async
 
 import scala.annotation.tailrec
@@ -26,6 +27,11 @@ object MerklePatriciaTrie {
   def make[F[_]: Hasher: Async, A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
     MerklePatriciaProducer
       .stateless[F]
+      .create(data)
+
+  def makeParallel[F[_]: Hasher: Async: Parallel, A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
+    MerklePatriciaProducer
+      .parallel[F]
       .create(data)
 
   def collectLeafNodes(trie: MerklePatriciaTrie): List[MerklePatriciaNode.Leaf] = {

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/MerklePatriciaProducer.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.security.mpt.producer
 
+import cats.Parallel
 import cats.effect.Async
 import cats.syntax.functor._
 
@@ -43,6 +44,9 @@ object MerklePatriciaProducer {
 
   def stateless[F[_]: Hasher: Async]: MerklePatriciaProducer[F] =
     new StatelessMerklePatriciaProducer[F]
+
+  def parallel[F[_]: Hasher: Async: Parallel]: MerklePatriciaProducer[F] =
+    new ParallelMerklePatriciaProducer[F]
 
   def inMemory[F[_]: Async: Hasher](
     initial: Map[Hex, Json] = Map.empty

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/ParallelMerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/ParallelMerklePatriciaProducer.scala
@@ -1,0 +1,202 @@
+package io.constellationnetwork.security.mpt.producer
+
+import cats.Parallel
+import cats.effect.{Async, Sync}
+import cats.syntax.all._
+
+import scala.collection.immutable.ArraySeq
+
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.mpt._
+import io.constellationnetwork.security.mpt.prover.MerklePatriciaSingleInclusionProver
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+/** Parallel bottom-up MPT construction.
+  *
+  * Algorithm:
+  *   1. Create all leaf nodes in parallel (independent hash computations) 2. Sort leaves by nibble path 3. Recursively group by first
+  *      nibble and merge bottom-up
+  *      - Groups at each level are independent → parallel processing
+  *      - Create Branch for multiple groups, Extension for shared prefixes
+  *
+  * This produces the SAME tree structure as sequential insertion because MPT structure is deterministic given the set of keys.
+  */
+class ParallelMerklePatriciaProducer[F[_]: Hasher: Async: Parallel] extends MerklePatriciaProducer[F] {
+
+  // Threshold for batching/blocking CPU-intensive operations to avoid starvation
+  private val blockingThreshold = 10000
+
+  def getProver(trie: MerklePatriciaTrie): F[MerklePatriciaSingleInclusionProver[F]] =
+    MerklePatriciaSingleInclusionProver.make[F](trie).pure[F]
+
+  def create[A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
+    if (data.isEmpty) {
+      MerklePatriciaNode.Branch[F](Map.empty).map(MerklePatriciaTrie(_))
+    } else {
+      for {
+        // Step 1: Create all leaves
+        leaves <- createLeavesParallel(data)
+
+        // Step 2: Sort by nibble path for grouping
+        sorted <- (leaves.size > blockingThreshold)
+          .pure[F]
+          .ifM(
+            ifTrue = Async[F].blocking(leaves.sortBy(_._1)(Nibble.nibbleSeqOrdering)),
+            ifFalse = Async[F].cede *> leaves.sortBy(_._1)(Nibble.nibbleSeqOrdering).pure[F]
+          )
+
+        // Step 3: Build tree bottom-up with parallel merging
+        _ <- Async[F].cede
+        root <- buildTreeBottomUp(sorted.toList)
+      } yield MerklePatriciaTrie(root)
+    }
+
+  def insert[A: Encoder](
+    current: MerklePatriciaTrie,
+    data: Map[Hex, A]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    new StatelessMerklePatriciaProducer[F].insert(current, data)
+
+  def remove(
+    current: MerklePatriciaTrie,
+    data: List[Hex]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    new StatelessMerklePatriciaProducer[F].remove(current, data)
+
+  // ===========================================================================
+  // Step 1: Create leaves in parallel
+  // ===========================================================================
+
+  private def createLeavesParallel[A: Encoder](
+    data: Map[Hex, A]
+  ): F[Vector[(Seq[Nibble], Json)]] =
+    // Convert to (nibblePath, json) pairs - no hashing yet, just prep
+    data.toVector.map {
+      case (hex, value) => (Nibble(hex), value.asJson)
+    }.pure[F]
+
+  // ===========================================================================
+  // Step 3: Bottom-up tree construction
+  // ===========================================================================
+
+  /** Build tree bottom-up by recursively grouping by first nibble.
+    *
+    * For sorted entries with nibble paths, group by first nibble, recursively build subtrees for each group, then combine.
+    */
+  private def buildTreeBottomUp(
+    entries: List[(Seq[Nibble], Json)]
+  ): F[MerklePatriciaNode] =
+    entries match {
+      case Nil =>
+        // Empty - return empty branch
+        MerklePatriciaNode.Branch[F](Map.empty).widen
+
+      case (path, data) :: Nil =>
+        // Single entry - create leaf with remaining path
+        MerklePatriciaNode.Leaf[F](path, data).widen
+
+      case multiple =>
+        // Multiple entries - group by first nibble and recurse
+        groupAndMerge(multiple)
+    }
+
+  /** Group entries by first nibble, recursively process each group, then create appropriate node structure.
+    */
+  private def groupAndMerge(
+    entries: List[(Seq[Nibble], Json)]
+  ): F[MerklePatriciaNode] =
+    for {
+      // Group by first nibble - process in batches with cedes for large sets
+      strippedGroups <- (entries.size > blockingThreshold)
+        .pure[F]
+        .ifM(
+          ifTrue = groupEntriesWithCede(entries),
+          ifFalse = Sync[F].delay {
+            entries.groupBy {
+              case (path, _) => path.headOption.getOrElse(Nibble.empty)
+            }.map {
+              case (nibble, group) =>
+                (nibble, group.map { case (path, data) => (path.drop(1), data) })
+            }
+          }
+        )
+
+      _ <- Async[F].cede
+      // Process each group in parallel
+      processedGroups <- strippedGroups.toList.parTraverse {
+        case (nibble, group) =>
+          buildTreeBottomUp(group).map(node => (nibble, node))
+      }
+      _ <- Async[F].cede
+      result <- createNodeFromGroups(processedGroups)
+    } yield result
+
+  /** Group entries with periodic cedes to avoid starvation */
+  private def groupEntriesWithCede(
+    entries: List[(Seq[Nibble], Json)]
+  ): F[Map[Nibble, List[(Seq[Nibble], Json)]]] = {
+    // Process in batches, ceding between batches
+    val batchSize = 50000
+    entries
+      .grouped(batchSize)
+      .toList
+      .traverse { batch =>
+        Async[F].cede *> Sync[F].delay {
+          batch.groupBy {
+            case (path, _) => path.headOption.getOrElse(Nibble.empty)
+          }.map {
+            case (nibble, group) =>
+              (nibble, group.map { case (path, data) => (path.drop(1), data) })
+          }
+        }
+      }
+      .map { batchResults =>
+        // Merge all batch results
+        batchResults.foldLeft(Map.empty[Nibble, List[(Seq[Nibble], Json)]]) { (acc, batch) =>
+          batch.foldLeft(acc) {
+            case (map, (nibble, entries)) =>
+              map.updated(nibble, map.getOrElse(nibble, List.empty) ++ entries)
+          }
+        }
+      }
+  }
+
+  /** Create appropriate node structure from processed groups.
+    *   - Single group with single-child branch: create Extension
+    *   - Multiple groups: create Branch
+    */
+  private def createNodeFromGroups(
+    groups: List[(Nibble, MerklePatriciaNode)]
+  ): F[MerklePatriciaNode] =
+    groups match {
+      case Nil =>
+        MerklePatriciaNode.Branch[F](Map.empty).widen
+
+      case (nibble, child) :: Nil =>
+        // Single group - might become extension
+        child match {
+          case branch: MerklePatriciaNode.Branch =>
+            // Single path to a branch - create extension
+            MerklePatriciaNode.Extension[F](ArraySeq(nibble), branch).widen
+          case ext: MerklePatriciaNode.Extension =>
+            // Single path to extension - merge into longer extension
+            MerklePatriciaNode.Extension[F](ArraySeq(nibble) ++ ext.shared, ext.child).widen
+          case leaf: MerklePatriciaNode.Leaf =>
+            // Single path to leaf - prepend nibble to leaf's remaining path
+            MerklePatriciaNode.Leaf[F](ArraySeq(nibble) ++ leaf.remaining, leaf.data).widen
+        }
+
+      case multiple =>
+        // Multiple groups - create branch
+        MerklePatriciaNode.Branch[F](multiple.toMap).widen
+    }
+}
+
+object ParallelMerklePatriciaProducer {
+
+  def apply[F[_]: Hasher: Async: Parallel]: ParallelMerklePatriciaProducer[F] =
+    new ParallelMerklePatriciaProducer[F]
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/StatelessMerklePatriciaProducer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/security/mpt/producer/StatelessMerklePatriciaProducer.scala
@@ -20,7 +20,7 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Async] extends MerklePatrici
   def getProver(trie: MerklePatriciaTrie): F[MerklePatriciaSingleInclusionProver[F]] =
     MerklePatriciaSingleInclusionProver.make[F](trie).pure[F]
 
-  private val yieldEveryN = 100
+  private val yieldEveryN = 50
 
   def create[A: Encoder](data: Map[Hex, A]): F[MerklePatriciaTrie] =
     NonEmptyList.fromList(data.toList) match {
@@ -31,15 +31,17 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Async] extends MerklePatrici
           initialNode <- MerklePatriciaNode.Leaf[F](Nibble(hPath), hData.asJson)
           sortedTail = nel.tail.sortBy(_._1.value.length)
 
-          resultNode <- sortedTail.zipWithIndex.foldM[F, MerklePatriciaNode](initialNode) {
-            case (acc, ((path, value), idx)) =>
-              val work = insertEncoded(acc, Nibble(path), value.asJson).flatMap {
-                case Left(err)    => err.raiseError[F, MerklePatriciaNode]
-                case Right(value) => value.pure[F]
-              }
-              if (idx % yieldEveryN == 0) Async[F].cede *> work <* Async[F].cede
-              else work
-          }
+          resultNode <- sortedTail.zipWithIndex
+            .foldM[F, MerklePatriciaNode](initialNode) {
+              case (acc, ((path, value), idx)) =>
+                val work = insertEncoded(acc, Nibble(path), value.asJson).flatMap {
+                  case Left(err)    => err.raiseError[F, MerklePatriciaNode]
+                  case Right(value) => value.pure[F]
+                }
+
+                if (idx % yieldEveryN == 0) Async[F].cede *> work <* Async[F].cede
+                else work
+            }
         } yield MerklePatriciaTrie(resultNode)
 
       case None => new RuntimeException("Empty data provided").raiseError
@@ -172,11 +174,16 @@ class StatelessMerklePatriciaProducer[F[_]: Hasher: Async] extends MerklePatrici
         ): InsertState).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]].pure[F]
       } else {
         (for {
-          newExtension <- MerklePatriciaNode.Extension[F](sharedRemaining.tail, extensionNode.child)
+          // If sharedRemaining.tail is empty, use child directly instead of wrapping in Extension([])
+          existingSubtree <-
+            if (sharedRemaining.tail.isEmpty)
+              extensionNode.child.pure[F].widen[MerklePatriciaNode]
+            else
+              MerklePatriciaNode.Extension[F](sharedRemaining.tail, extensionNode.child).widen[MerklePatriciaNode]
           newLeaf <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
           branchNode <- MerklePatriciaNode.Branch[F](
             Map(
-              sharedRemaining.head -> newExtension,
+              sharedRemaining.head -> existingSubtree,
               keyRemaining.head -> newLeaf
             )
           )


### PR DESCRIPTION
Introduced a parallel MPT constructor that builds from the bottom up by sorting the given maps keys. This was tested with the current testnet state data with approx. 800k total state entries (~100MB json encoded file) and was found to take around 33 seconds. Compared to the previous sequential constructor which took approx. 450 seconds (about 7 min). A sample run of the parallel processor is shown below:
```
  ================================================================================                                                                           
  Building MPT state proof...                                                                                                                                
  Phase 1 - State entries conversion: 1425ms                                                                                                                 
  Phase 2 - Hex conversion: 6909ms                                                                                                                           
  [Parallel MPT] Starting bottom-up construction with 803556 entries...                                                                                      
  [Parallel MPT] Created 803556 leaves in 1948ms (412503/s)                                                                                                  
  [Parallel MPT] Sorted leaves in 2492ms                                                                                                                     
  [Parallel MPT] Built tree in 20303ms                                                                                                                       
  [Parallel MPT] Complete! Total: 24746ms (24s) | 32472 entries/s                                                                                            
  Phase 3 - MPT construction: 24747ms                                                                                                                        
  ================================================================================                                                                           
  MPT Root Hash (Parallel): 2ac8c209f7d0ccb7ca049191dd28bc95b540d509cfac4d4f989f5cfda707e55b                                                                 
  ================================================================================                                                                           
  Timing Breakdown:                                                                                                                                          
  Phase 1 (State entries):        1425ms (1s)                                                                                                                
  Phase 2 (Hex conversion):       6909ms (6s)                                                                                                                
  Phase 3 (Parallel MPT build):   24747ms (24s)                                                                                                              
  TOTAL (with parallel):          33082ms (33s)                                                                                                              
  ================================================================================ 
  ```