### PR TITLE
feat: add --hypergraph-release flag to use published JARs

### DIFF
--- a/docker/bin/assembly.sh
+++ b/docker/bin/assembly.sh
@@ -84,8 +84,12 @@ fi
 
 
 if [ "$PUBLISH" == "true" ]; then
-  echo "Publishing local"
-  sbt --error sdk/publishLocal
+  if [ -n "$HYPERGRAPH_RELEASE" ]; then
+    echo "Skipping sdk/publishLocal - using release $HYPERGRAPH_RELEASE (SDK should be available from Maven)"
+  else
+    echo "Publishing local"
+    sbt --error sdk/publishLocal
+  fi
 fi
 
 

--- a/docker/bin/assembly.sh
+++ b/docker/bin/assembly.sh
@@ -6,62 +6,81 @@ assemble_all() {
 
 show_time "Starting assembly"
 
-if [[ "$INCLUDE_L0" == "false" && "$INCLUDE_L1" == "false" && "$SKIP_ASSEMBLY" == "false" ]]; then
-  assemble_all
+# If HYPERGRAPH_RELEASE is set, download pre-built JARs instead of building from source
+if [ -n "$HYPERGRAPH_RELEASE" ]; then
+  echo "Using pre-built hypergraph JARs from release: ${HYPERGRAPH_RELEASE}"
+  rm -rf ./docker/jars/ > /dev/null 2>&1 || true
+  mkdir -p ./docker/jars/
+  
+  ./docker/bin/download-release-jars.sh "$HYPERGRAPH_RELEASE" ./docker/jars/
+  
+  show_time "Downloaded release JARs"
+  
+  # Skip the rest of hypergraph assembly, jump to metagraph handling
+  SKIP_HYPERGRAPH_BUILD=true
 else
-  missing=false
-
-  for module in dag-l0 dag-l1 keytool wallet; do
-    set +e
-    jar_path=$(ls -1t modules/"$module"/target/scala-2.13/tessellation-"$module"-assembly*.jar 2>/dev/null | head -n1)
-    set -e
-    if [ -z "$jar_path" ]; then
-      echo "⚠️  Missing JAR for module: $module"
-      missing=true
-      break
-    fi
-  done
-
-  if [ "$missing" = true ]; then
-    echo "▶️  One or more modules is missing. Cannot skip assembly. Running full assembly"
-    assemble_all
-  else
-    if [ "$SKIP_ASSEMBLY" == "false" ]; then
-      override_set=false
-      if [ "$INCLUDE_L0" == "true" ]; then
-        echo "Assembling L0"
-        sbt dagL0/assembly
-        override_set=true
-      fi
-      if [ "$INCLUDE_L1" == "true" ]; then
-        echo "Assembling L1"
-        sbt dagL1/assembly
-        override_set=true
-      fi
-      if [ "$override_set" == "false" ]; then
-        echo "Assembling L0 according to default behavior"
-        sbt dagL0/assembly
-      fi
-    else
-      echo "Found existing assemblies, and skip assembly was set to true"
-    fi
-  fi
+  SKIP_HYPERGRAPH_BUILD=false
 fi
 
-show_time "SBT Assembly"
+if [ "$SKIP_HYPERGRAPH_BUILD" != "true" ]; then
+  # Build hypergraph JARs from source
+  if [[ "$INCLUDE_L0" == "false" && "$INCLUDE_L1" == "false" && "$SKIP_ASSEMBLY" == "false" ]]; then
+    assemble_all
+  else
+    missing=false
 
-rm -rf ./docker/jars/ > /dev/null 2>&1 || true;
-mkdir -p ./docker/jars/
+    for module in dag-l0 dag-l1 keytool wallet; do
+      set +e
+      jar_path=$(ls -1t modules/"$module"/target/scala-2.13/tessellation-"$module"-assembly*.jar 2>/dev/null | head -n1)
+      set -e
+      if [ -z "$jar_path" ]; then
+        echo "⚠️  Missing JAR for module: $module"
+        missing=true
+        break
+      fi
+    done
 
-for module in "dag-l0" "dag-l1" "keytool" "wallet"
-do
-  path=$(ls -1t modules/${module}/target/scala-2.13/tessellation-${module}-assembly*.jar | head -n1)
-  dest="$PROJECT_ROOT/docker/jars/${module}.jar"
-  cp $path $dest
-done
+    if [ "$missing" = true ]; then
+      echo "▶️  One or more modules is missing. Cannot skip assembly. Running full assembly"
+      assemble_all
+    else
+      if [ "$SKIP_ASSEMBLY" == "false" ]; then
+        override_set=false
+        if [ "$INCLUDE_L0" == "true" ]; then
+          echo "Assembling L0"
+          sbt dagL0/assembly
+          override_set=true
+        fi
+        if [ "$INCLUDE_L1" == "true" ]; then
+          echo "Assembling L1"
+          sbt dagL1/assembly
+          override_set=true
+        fi
+        if [ "$override_set" == "false" ]; then
+          echo "Assembling L0 according to default behavior"
+          sbt dagL0/assembly
+        fi
+      else
+        echo "Found existing assemblies, and skip assembly was set to true"
+      fi
+    fi
+  fi
 
-mv ./docker/jars/dag-l0.jar ./docker/jars/gl0.jar
-mv ./docker/jars/dag-l1.jar ./docker/jars/gl1.jar
+  show_time "SBT Assembly"
+
+  rm -rf ./docker/jars/ > /dev/null 2>&1 || true;
+  mkdir -p ./docker/jars/
+
+  for module in "dag-l0" "dag-l1" "keytool" "wallet"
+  do
+    path=$(ls -1t modules/${module}/target/scala-2.13/tessellation-${module}-assembly*.jar | head -n1)
+    dest="$PROJECT_ROOT/docker/jars/${module}.jar"
+    cp $path $dest
+  done
+
+  mv ./docker/jars/dag-l0.jar ./docker/jars/gl0.jar
+  mv ./docker/jars/dag-l1.jar ./docker/jars/gl1.jar
+fi
 
 
 if [ "$PUBLISH" == "true" ]; then

--- a/docker/bin/download-release-jars.sh
+++ b/docker/bin/download-release-jars.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Downloads tessellation JARs from a GitHub release
+# Usage: ./download-release-jars.sh <release-tag> <output-dir>
+# Example: ./download-release-jars.sh v3.5.11 ./docker/jars
+#
+
+set -e
+
+RELEASE_TAG="${1:-}"
+OUTPUT_DIR="${2:-./docker/jars}"
+
+if [ -z "$RELEASE_TAG" ]; then
+    echo "Error: Release tag required"
+    echo "Usage: $0 <release-tag> [output-dir]"
+    echo "Example: $0 v3.5.11 ./docker/jars"
+    exit 1
+fi
+
+REPO="Constellation-Labs/tessellation"
+BASE_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
+
+# JAR mappings: release-name -> local-name
+declare -A JAR_MAP=(
+    ["cl-node.jar"]="gl0.jar"
+    ["cl-dag-l1.jar"]="gl1.jar"
+    ["cl-keytool.jar"]="keytool.jar"
+    ["cl-wallet.jar"]="wallet.jar"
+)
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Downloading tessellation JARs from release ${RELEASE_TAG}..."
+
+for release_name in "${!JAR_MAP[@]}"; do
+    local_name="${JAR_MAP[$release_name]}"
+    url="${BASE_URL}/${release_name}"
+    dest="${OUTPUT_DIR}/${local_name}"
+    
+    echo "  Downloading ${release_name} -> ${local_name}"
+    
+    if ! curl -fsSL -o "$dest" "$url"; then
+        echo "Error: Failed to download ${url}"
+        echo "Check that release ${RELEASE_TAG} exists and contains ${release_name}"
+        exit 1
+    fi
+    
+    # Verify download (basic size check)
+    size=$(stat -f%z "$dest" 2>/dev/null || stat -c%s "$dest" 2>/dev/null)
+    if [ "$size" -lt 1000 ]; then
+        echo "Error: Downloaded file ${local_name} is too small (${size} bytes)"
+        echo "The release may not contain this JAR or download failed"
+        rm -f "$dest"
+        exit 1
+    fi
+    
+    echo "    ✓ ${local_name} (${size} bytes)"
+done
+
+echo "Successfully downloaded all JARs to ${OUTPUT_DIR}"

--- a/docker/bin/download-release-jars.sh
+++ b/docker/bin/download-release-jars.sh
@@ -51,6 +51,14 @@ for release_name in "${!JAR_MAP[@]}"; do
     if ! curl -fsSL -o "$dest" "$url"; then
         echo "Error: Failed to download ${url}"
         echo "Check that release ${RELEASE_TAG} exists and contains ${release_name}"
+        echo ""
+        echo "Expected assets for release ${RELEASE_TAG}:"
+        for name in "${!JAR_MAP[@]}"; do
+            echo "  - ${name}"
+        done
+        echo ""
+        echo "To check available assets, run:"
+        echo "  gh release view ${RELEASE_TAG} --repo ${REPO} --json assets --jq '.assets[].name'"
         exit 1
     fi
     

--- a/docker/bin/download-release-jars.sh
+++ b/docker/bin/download-release-jars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Downloads tessellation JARs from a GitHub release
+# Downloads tessellation JARs from a GitHub release with integrity verification
 # Usage: ./download-release-jars.sh <release-tag> <output-dir>
 # Example: ./download-release-jars.sh v3.5.11 ./docker/jars
 #
@@ -14,6 +14,13 @@ if [ -z "$RELEASE_TAG" ]; then
     echo "Error: Release tag required"
     echo "Usage: $0 <release-tag> [output-dir]"
     echo "Example: $0 v3.5.11 ./docker/jars"
+    exit 1
+fi
+
+# Validate release tag format
+if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+    echo "Error: Invalid release tag format: $RELEASE_TAG"
+    echo "Expected format: v3.5.11 or v3.5.11-rc1"
     exit 1
 fi
 
@@ -35,26 +42,39 @@ echo "Downloading tessellation JARs from release ${RELEASE_TAG}..."
 for release_name in "${!JAR_MAP[@]}"; do
     local_name="${JAR_MAP[$release_name]}"
     url="${BASE_URL}/${release_name}"
+    checksum_url="${BASE_URL}/${release_name%.jar}.sha256"
     dest="${OUTPUT_DIR}/${local_name}"
     
     echo "  Downloading ${release_name} -> ${local_name}"
     
+    # Download JAR
     if ! curl -fsSL -o "$dest" "$url"; then
         echo "Error: Failed to download ${url}"
         echo "Check that release ${RELEASE_TAG} exists and contains ${release_name}"
         exit 1
     fi
     
-    # Verify download (basic size check)
-    size=$(stat -f%z "$dest" 2>/dev/null || stat -c%s "$dest" 2>/dev/null)
-    if [ "$size" -lt 1000 ]; then
-        echo "Error: Downloaded file ${local_name} is too small (${size} bytes)"
-        echo "The release may not contain this JAR or download failed"
+    # Download and verify checksum
+    echo "    Verifying checksum..."
+    if ! expected_checksum=$(curl -fsSL "$checksum_url" | awk '{print $1}'); then
+        echo "Error: Failed to download checksum from ${checksum_url}"
         rm -f "$dest"
         exit 1
     fi
     
-    echo "    ✓ ${local_name} (${size} bytes)"
+    actual_checksum=$(sha256sum "$dest" | awk '{print $1}')
+    
+    if [ "$expected_checksum" != "$actual_checksum" ]; then
+        echo "Error: Checksum verification failed for ${local_name}!"
+        echo "  Expected: ${expected_checksum}"
+        echo "  Actual:   ${actual_checksum}"
+        echo "The file may have been tampered with or corrupted during download."
+        rm -f "$dest"
+        exit 1
+    fi
+    
+    size=$(stat -f%z "$dest" 2>/dev/null || stat -c%s "$dest" 2>/dev/null)
+    echo "    ✓ ${local_name} (${size} bytes, checksum verified)"
 done
 
-echo "Successfully downloaded all JARs to ${OUTPUT_DIR}"
+echo "Successfully downloaded and verified all JARs to ${OUTPUT_DIR}"

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -50,12 +50,17 @@ export USE_TEST_METAGRAPH=${USE_TEST_METAGRAPH:-false}
 
 # Explicitly set TESSELLATION_VERSION based on the project's version
 if [ -z "${TESSELLATION_VERSION:-}" ]; then
-    if [ -n "$RELEASE_TAG" ]; then
+    if [ -n "$HYPERGRAPH_RELEASE" ]; then
+        # Use hypergraph release version for SDK resolution
+        export TESSELLATION_VERSION="${HYPERGRAPH_RELEASE#v}"
+        echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION (from --hypergraph-release)"
+    elif [ -n "$RELEASE_TAG" ]; then
         export TESSELLATION_VERSION="${RELEASE_TAG#v}"
+        echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION"
     else
         export TESSELLATION_VERSION="99.99.99-SNAPSHOT"
+        echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION"
     fi
-    echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION"
 fi
 
 

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -48,19 +48,10 @@ export DOCKER_PROFILES=${DOCKER_PROFILES:-""}
 export USE_TEST_METAGRAPH=${USE_TEST_METAGRAPH:-false}
 
 
-# Explicitly set TESSELLATION_VERSION based on the project's version
-if [ -z "${TESSELLATION_VERSION:-}" ]; then
-    if [ -n "$HYPERGRAPH_RELEASE" ]; then
-        # Use hypergraph release version for SDK resolution
-        export TESSELLATION_VERSION="${HYPERGRAPH_RELEASE#v}"
-        echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION (from --hypergraph-release)"
-    elif [ -n "$RELEASE_TAG" ]; then
-        export TESSELLATION_VERSION="${RELEASE_TAG#v}"
-        echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION"
-    else
-        export TESSELLATION_VERSION="99.99.99-SNAPSHOT"
-        echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION"
-    fi
+# Store any explicitly-set TESSELLATION_VERSION from environment
+# This will be used for precedence after args are parsed
+if [ -n "${TESSELLATION_VERSION:-}" ]; then
+    export EXPLICIT_TESSELLATION_VERSION="$TESSELLATION_VERSION"
 fi
 
 
@@ -201,10 +192,23 @@ exit_func() {
 echo "BUILD_ONLY: $BUILD_ONLY"
 echo "RELEASE_TAG: $RELEASE_TAG"
 
-# Re-check TESSELLATION_VERSION after args are parsed (in case --hypergraph-release was specified)
-if [ -n "$HYPERGRAPH_RELEASE" ] && [ "$TESSELLATION_VERSION" = "99.99.99-SNAPSHOT" ]; then
+# Set TESSELLATION_VERSION with explicit precedence (after args are parsed):
+# 1. TESSELLATION_VERSION env var (explicit override) - highest priority
+# 2. --hypergraph-release flag
+# 3. --version / RELEASE_TAG
+# 4. 99.99.99-SNAPSHOT (default, build from source)
+if [ -n "${EXPLICIT_TESSELLATION_VERSION:-}" ]; then
+    export TESSELLATION_VERSION="$EXPLICIT_TESSELLATION_VERSION"
+    echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION (from environment)"
+elif [ -n "$HYPERGRAPH_RELEASE" ]; then
     export TESSELLATION_VERSION="${HYPERGRAPH_RELEASE#v}"
-    echo "Updating TESSELLATION_VERSION=$TESSELLATION_VERSION (from --hypergraph-release)"
+    echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION (from --hypergraph-release)"
+elif [ -n "$RELEASE_TAG" ]; then
+    export TESSELLATION_VERSION="${RELEASE_TAG#v}"
+    echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION (from --version/RELEASE_TAG)"
+else
+    export TESSELLATION_VERSION="99.99.99-SNAPSHOT"
+    echo "Setting TESSELLATION_VERSION=$TESSELLATION_VERSION (default snapshot)"
 fi
 
 if [ "$DATA_ONLY_METAGRAPH" = "true" ]; then

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -201,6 +201,12 @@ exit_func() {
 echo "BUILD_ONLY: $BUILD_ONLY"
 echo "RELEASE_TAG: $RELEASE_TAG"
 
+# Re-check TESSELLATION_VERSION after args are parsed (in case --hypergraph-release was specified)
+if [ -n "$HYPERGRAPH_RELEASE" ] && [ "$TESSELLATION_VERSION" = "99.99.99-SNAPSHOT" ]; then
+    export TESSELLATION_VERSION="${HYPERGRAPH_RELEASE#v}"
+    echo "Updating TESSELLATION_VERSION=$TESSELLATION_VERSION (from --hypergraph-release)"
+fi
+
 if [ "$DATA_ONLY_METAGRAPH" = "true" ]; then
     export NUM_GL0_NODES=1
     export NUM_GL1_NODES=0

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -3,6 +3,9 @@
 export BASH_DEBUG_MODE=${BASH_DEBUG_MODE:-false}
 export DATA_ONLY_METAGRAPH=${DATA_ONLY_METAGRAPH:-false}
 
+# Hypergraph release JAR support
+# When set, downloads pre-built JARs from GitHub releases instead of building from source
+export HYPERGRAPH_RELEASE=${HYPERGRAPH_RELEASE:-""}
 
 export EXTRA_ENV_PATH=${EXTRA_ENV_PATH:-""}
 export EXIT_CODE=${EXIT_CODE:-0}
@@ -127,6 +130,9 @@ for arg in "$@"; do
       ;;
     --metagraph=*)
       export METAGRAPH="${arg#*=}"
+      ;;
+    --hypergraph-release=*)
+      export HYPERGRAPH_RELEASE="${arg#*=}"
       ;;
     --ml0-path=*)
       export METAGRAPH_ML0_RELATIVE_PATH="${arg#*=}"

--- a/justfile
+++ b/justfile
@@ -15,6 +15,8 @@ test *extra_args:
 	@bash docker/bin/compose-runner.sh {{ extra_args }}
 
 # Bring up the default test environment, starting docker images but without running any tests or checks
+# Use --hypergraph-release=<tag> to use pre-built JARs from a release (e.g., --hypergraph-release=v3.5.11)
+# This is useful for metagraph development against a stable tessellation version
 up *extra_args:
 	@just _check_deps
 	@bash docker/bin/compose-runner.sh --up {{ extra_args }}


### PR DESCRIPTION
Adds support for running a metagraph cluster against a stable tessellation release instead of building from source.

## Usage
```bash
just up --metagraph=/path/to/mymetagraph --hypergraph-release=v4.0.0-rc.2
```

What it does

1. Downloads pre-built JARs (gl0, gl1, keytool, wallet) from the specified GitHub release
2. Skips sbt sdk/publishLocal — SDK resolves from Maven Central
3. Sets TESSELLATION_VERSION from the release tag so metagraph builds against correct SDK version
4. Metagraph still builds from source (targeting the specified SDK version)
Benefits

• ~30x faster startup — 23 seconds vs ~12 minutes with full compile
• Stable targeting — Metagraph developers can target known-good tessellation releases
Testing

Tested with template metagraph against v4.0.0-rc.2 — full cluster (gl0, gl1×3, ml0, cl1×3, dl1×3) running in 23 seconds.