### PR TITLE
refactor: introduce StateProofBuilder typeclass

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -66,6 +66,8 @@ object Download {
 
     val logger = Slf4jLogger.getLogger[F]
 
+    private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
+
     val minBatchSizeToStartObserving: Long = 1L
     val observationOffset = NonNegLong(4L)
     val fetchSnapshotDelayBetweenTrials = 10.seconds
@@ -350,17 +352,12 @@ object Download {
                         .hasCorrectSnapshotInfo(snapshot.ordinal, snapshot.stateProof)
                         .ifM(
                           ().pure[F],
-                          (Hasher[F].getLogic(snapshot.ordinal) match {
-                            case JsonHash => StateProofValidator.validate(snapshot, newContext, mptStore).map(_.isValid)
-                            case KryoHash =>
-                              StateProofValidator
-                                .validate(snapshot, GlobalSnapshotInfoV2.fromGlobalSnapshotInfo(newContext), mptStore)
-                                .map(_.isValid)
-                          })
-                            .ifM(
-                              snapshotStorage.persistSnapshotInfoWithCutoff(snapshot.ordinal, newContext),
-                              InvalidStateProof(snapshot.ordinal).raiseError[F, Unit]
-                            )
+                          snapshot.toHashed.flatMap { hashed =>
+                            validator.validate(hashed, newContext).map(_.isValid)
+                          }.ifM(
+                            snapshotStorage.persistSnapshotInfoWithCutoff(snapshot.ordinal, newContext),
+                            InvalidStateProof(snapshot.ordinal).raiseError[F, Unit]
+                          )
                         )
                     }
                   )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
@@ -47,6 +47,7 @@ object GlobalSnapshotTraverse {
   ): GlobalSnapshotTraverse[F] =
     new GlobalSnapshotTraverse[F] {
       implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
+      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
 
       def loadChain(): F[(GlobalSnapshotInfo, Signed[GlobalIncrementalSnapshot])] = {
         def loadIncOrErr(h: Hash) =
@@ -120,13 +121,13 @@ object GlobalSnapshotTraverse {
                     if (entries.isEmpty) firstInfo.allStateEntries[F].flatMap(mptStore.syncFull(_, firstInc.ordinal))
                     else Async[F].unit
 
-                  syncIfNeeded >> firstInfo.stateProof(mptStore.underlying, firstInc.ordinal)
+                  syncIfNeeded >> builder.buildProof(firstInfo, firstInc.ordinal)
                 }
             }
           }
 
           hashedFirstInc <- HasherSelector[F].withCurrent(implicit hasher => firstInc.toHashed)
-          stateProofInvalid <- StateProofValidator.validate(hashedFirstInc, firstInfoCalculatedProof).map(_.isInvalid)
+          stateProofInvalid <- StateProofValidator.validateProof(hashedFirstInc, firstInfoCalculatedProof).map(_.isInvalid)
 
           _ <- (new Exception(s"Snapshot info does not match the snapshot at ordinal=${firstInc.ordinal.show}"))
             .raiseError[F, Unit]

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
@@ -46,6 +46,9 @@ object SnapshotDownloadStorage {
 
       val cutoffLogic: OrdinalCutoff = LogarithmicOrdinalCutoff.make
 
+      private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
+      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
+
       def readPersisted(ordinal: SnapshotOrdinal): F[Option[Signed[GlobalIncrementalSnapshot]]] = persistedStorage.read(ordinal)
 
       def readTmp(ordinal: SnapshotOrdinal): F[Option[Signed[GlobalIncrementalSnapshot]]] = tmpStorage.read(ordinal)
@@ -67,8 +70,9 @@ object SnapshotDownloadStorage {
         proof: GlobalSnapshotStateProof
       )(implicit hasher: Hasher[F]): F[Boolean] =
         (hashSelect.select(ordinal) match {
-          case JsonHash => snapshotInfoStorage.read(ordinal).flatMap(_.traverse(_.stateProof(mptStore.underlying, ordinal)))
-          case KryoHash => snapshotInfoKryoStorage.read(ordinal).flatMap(_.traverse(_.stateProof(mptStore.underlying, ordinal)))
+          case JsonHash => snapshotInfoStorage.read(ordinal).flatMap(_.traverse(builder.buildProof(_, ordinal)))
+          case KryoHash =>
+            snapshotInfoKryoStorage.read(ordinal).flatMap(_.traverse(i => builder.buildProof(i.toGlobalSnapshotInfo, ordinal)))
         }).map {
           case Some(calculatedProof) => calculatedProof === proof
           case _                     => false
@@ -100,15 +104,16 @@ object SnapshotDownloadStorage {
                     mptStore.syncFull(kvPairs, ordinal)
                   }
               }
-              result <- info
-                .bitraverse(_.stateProof(ordinal), _.stateProof(mptStore.underlying, ordinal))
-                .map(_.fold(identity, identity))
-                .flatMap(stateProof => StateProofValidator.validate(snapshot, stateProof).map(_.isValid))
-                .ifM(
-                  (snapshot.signed, info.leftMap(_.toGlobalSnapshotInfo).fold(identity, identity)).some.pure[F],
-                  new Exception("Persisted snapshot info does not match the persisted snapshot")
-                    .raiseError[F, Option[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
-                )
+              result <- (info match {
+                case Left(infoV2) =>
+                  infoV2.stateProof(ordinal).flatMap(proof => StateProofValidator.validateProof(snapshot, proof).map(_.isValid))
+                case Right(gsi) =>
+                  validator.validate(snapshot, gsi).map(_.isValid)
+              }).ifM(
+                (snapshot.signed, info.leftMap(_.toGlobalSnapshotInfo).fold(identity, identity)).some.pure[F],
+                new Exception("Persisted snapshot info does not match the persisted snapshot")
+                  .raiseError[F, Option[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]]
+              )
             } yield result
           case _ => none[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)].pure[F]
         }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/services/GlobalL0Service.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/services/GlobalL0Service.scala
@@ -68,6 +68,7 @@ object GlobalL0Service {
       private val logger = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
       private val maybeMajorityPeerIds = maybeMajorityPeerIdSet.map(_.toNonEmptyList)
       private val ordinalRange = 0L to 3L
+      private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
 
       implicit val hashShow: Show[Hash] = Hash.shortShow
       implicit val peerIdShow: Show[PeerId] = PeerId.shortShow
@@ -175,8 +176,8 @@ object GlobalL0Service {
         implicit hasher: Hasher[F]
       ): F[Boolean] =
         mptStore.syncFullIfNeeded[Json](info.allStateEntries[F], snapshot.ordinal) >>
-          StateProofValidator
-            .validate(snapshot, info, mptStore)
+          validator
+            .validate(snapshot, info)
             .flatTap(v => logger.debug(s"Failed StateProofValidation: $v").whenA(v.isInvalid))
             .map(_.isValid)
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotContextFunctions.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 
 import scala.util.control.NoStackTrace
 
-import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotContext}
+import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotContext, CurrencySnapshotInfo}
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.domain.snapshot.SnapshotContextFunctions
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
@@ -44,9 +44,13 @@ object CurrencySnapshotContextFunctions {
           case Validated.Valid((_, validatedContext)) => validatedContext.pure[F]
           case Validated.Invalid(e)                   => CannotCreateContext(e).raiseError[F, CurrencySnapshotContext]
         }
-        _ <- StateProofValidator.validate(signedArtifact, validatedContext.snapshotInfo).flatMap {
-          case Validated.Valid(_)   => Async[F].unit
-          case Validated.Invalid(e) => e.raiseError[F, Unit]
+        _ <- signedArtifact.toHashed.flatMap { hashed =>
+          CurrencySnapshotInfo.stateProofBuilder[F].buildProof(validatedContext.snapshotInfo, hashed.ordinal).flatMap { proof =>
+            StateProofValidator.validateProof(hashed, proof).flatMap {
+              case Validated.Valid(_)   => Async[F].unit
+              case Validated.Invalid(e) => e.raiseError[F, Unit]
+            }
+          }
         }
       } yield validatedContext
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
@@ -52,6 +52,8 @@ object GlobalSnapshotContextFunctions {
   ) =
     new GlobalSnapshotContextFunctions[F] {
 
+      private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
+
       // todo - avoid duplication of this function here and in GlobalSnapshotConsensusFunctions
       private def acceptDelegatedStakes(
         lastSnapshotContext: GlobalSnapshotInfo,
@@ -276,12 +278,11 @@ object GlobalSnapshotContextFunctions {
         _ <- CannotApplyStateChannelsError(returnedSCEvents).raiseError[F, Unit].whenA(returnedSCEvents.nonEmpty)
         diffRewards = acceptedRewardTxs -- signedArtifact.rewards
         _ <- CannotApplyRewardsError(diffRewards).raiseError[F, Unit].whenA(diffRewards.nonEmpty)
-        hashedArtifact <- HasherSelector[F].withCurrent(implicit hasher => signedArtifact.toHashed)
-
-        calculatedStateProof <- HasherSelector[F].withCurrent { implicit hasher =>
-          snapshotInfo.stateProof(mptStore.underlying, signedArtifact.ordinal)
+        validation <- HasherSelector[F].withCurrent { implicit hasher =>
+          signedArtifact.toHashed.flatMap { hashedArtifact =>
+            validator.validate(hashedArtifact, snapshotInfo)
+          }
         }
-        validation <- StateProofValidator.validate(hashedArtifact, calculatedStateProof)
         _ = validation match {
           case Validated.Valid(_)   => Async[F].unit
           case Validated.Invalid(e) => e.raiseError[F, Unit]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -187,6 +187,7 @@ object GlobalSnapshotAcceptanceManager {
 
     new GlobalSnapshotAcceptanceManager[F] {
       val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
 
       case class InitialData(
         blockResult: BlockAcceptanceResult,
@@ -487,10 +488,9 @@ object GlobalSnapshotAcceptanceManager {
         }
       }
 
-      /** Cleans empty entries from state maps and computes removed keys in a single pass.
-        * For each map type, we:
-        * 1. Filter out entries with empty sets (cleaning)
-        * 2. Identify keys that were non-empty in previous state but empty/missing in new state (removal tracking)
+      /** Cleans empty entries from state maps and computes removed keys in a single pass. For each map type, we:
+        *   1. Filter out entries with empty sets (cleaning) 2. Identify keys that were non-empty in previous state but empty/missing in new
+        *      state (removal tracking)
         */
       private def cleanStateMaps(
         updatedAllowSpends: SortedMap[Option[Address], SortedMap[Address, SortedSet[Signed[AllowSpend]]]],
@@ -1132,7 +1132,7 @@ object GlobalSnapshotAcceptanceManager {
             )
 
             _ <- mptStore.syncFromStateChanges(stateChangesAccumulator, ordinal)
-            stateProof <- gsi.stateProof(mptStore.underlying, ordinal)
+            stateProof <- builder.buildProof(gsi, ordinal)
 
             (expiredAllowSpends, expiredTokenLocks) = (
               allowSpendStateManager.filterExpiredAllowSpends(

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/schema/currency.scala
@@ -21,6 +21,7 @@ import io.constellationnetwork.schema.height.{Height, SubHeight}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.semver.SnapshotVersion
 import io.constellationnetwork.schema.snapshot._
+import io.constellationnetwork.schema.stateproof.StateProofBuilder
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.schema.tokenLock._
 import io.constellationnetwork.schema.transaction._
@@ -112,15 +113,32 @@ object currency {
       ).tupled
         .map(CurrencySnapshotStateProof.apply)
 
-    def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](
-      statefulMPTProducer: StatefulMerklePatriciaProducer[F],
-      ordinal: SnapshotOrdinal
-    )(
-      implicit stateProofSelector: StateProofSelector
-    ): F[CurrencySnapshotStateProof] =
-      stateProof(ordinal)
-
     override def getActiveTokenLocks: SortedMap[Address, SortedSet[Signed[TokenLock]]] = activeTokenLocks.getOrElse(SortedMap.empty)
+  }
+
+  object CurrencySnapshotInfo {
+
+    /** Creates a StateProofBuilder for CurrencySnapshotInfo.
+      *
+      * Currency snapshots always use legacy Merkle tree format.
+      */
+    def stateProofBuilder[F[_]: Async: Parallel: JsonSerializer](
+      implicit selector: CurrencyStateProofSelector
+    ): StateProofBuilder[F, CurrencySnapshotInfo, CurrencySnapshotStateProof] =
+      StateProofBuilder.instance { (info, _, hasher) =>
+        implicit val h: Hasher[F] = hasher
+        (
+          info.lastTxRefs.hash,
+          info.balances.hash,
+          info.lastMessages.traverse(_.hash),
+          info.lastFeeTxRefs.traverse(_.hash),
+          info.lastAllowSpendRefs.traverse(_.hash),
+          info.activeAllowSpends.traverse(_.hash),
+          info.globalSnapshotSyncView.traverse(_.hash),
+          info.lastTokenLockRefs.traverse(_.hash),
+          info.activeTokenLocks.traverse(_.hash)
+        ).tupled.map(CurrencySnapshotStateProof.apply)
+      }
   }
 
   @derive(encoder, decoder, eqv, show)
@@ -132,14 +150,6 @@ object currency {
       implicit stateProofSelector: StateProofSelector
     ): F[CurrencySnapshotStateProofV1] =
       (lastTxRefs.hash, balances.hash).tupled.map(CurrencySnapshotStateProofV1.apply)
-
-    def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](
-      statefulMPTProducer: StatefulMerklePatriciaProducer[F],
-      ordinal: SnapshotOrdinal
-    )(
-      implicit stateProofSelector: StateProofSelector
-    ): F[CurrencySnapshotStateProofV1] =
-      stateProof(ordinal: SnapshotOrdinal)
 
     def toCurrencySnapshotInfo: CurrencySnapshotInfo =
       CurrencySnapshotInfo(lastTxRefs, balances, None, None, None, None, None, None, None)

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
@@ -21,6 +21,7 @@ import io.constellationnetwork.schema.node.UpdateNodeParameters
 import io.constellationnetwork.schema.nodeCollateral.{NodeCollateralRecord, PendingNodeCollateralWithdrawal}
 import io.constellationnetwork.schema.priceOracle.{PriceRecord, TokenPair}
 import io.constellationnetwork.schema.snapshot.{MetagraphSyncDataInfo, SnapshotInfo, StateProof}
+import io.constellationnetwork.schema.stateproof.StateProofBuilder
 import io.constellationnetwork.schema.swap.{AllowSpend, AllowSpendReference}
 import io.constellationnetwork.schema.tokenLock.{TokenLock, TokenLockReference}
 import io.constellationnetwork.schema.transaction.TransactionReference
@@ -72,14 +73,6 @@ case class GlobalSnapshotInfoV1(
     GlobalSnapshotInfo
       .legacyStateProof[F](toGlobalSnapshotInfo, None)
       .map(GlobalSnapshotStateProofV1.fromGlobalSnapshotStateProof)
-
-  def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](
-    statefulMPTProducer: StatefulMerklePatriciaProducer[F],
-    ordinal: SnapshotOrdinal
-  )(
-    implicit stateProofSelector: StateProofSelector
-  ): F[GlobalSnapshotStateProofV1] =
-    stateProof(ordinal)
 }
 
 @derive(encoder, decoder, eqv, show)
@@ -119,14 +112,6 @@ case class GlobalSnapshotInfoV2(
     implicit stateProofSelector: StateProofSelector
   ): F[GlobalSnapshotStateProof] =
     lastCurrencySnapshots.merkleTree[F].flatMap(stateProof(_))
-
-  def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](
-    statefulMPTProducer: StatefulMerklePatriciaProducer[F],
-    ordinal: SnapshotOrdinal
-  )(
-    implicit stateProofSelector: StateProofSelector
-  ): F[GlobalSnapshotStateProof] =
-    stateProof(ordinal)
 
   def stateProof[F[_]: Parallel: Async: Hasher](lastCurrencySnapshots: Option[MerkleTree]): F[GlobalSnapshotStateProof] =
     GlobalSnapshotInfo.legacyStateProof[F](toGlobalSnapshotInfo, lastCurrencySnapshots)
@@ -204,42 +189,6 @@ case class GlobalSnapshotInfo(
   def stateProof[F[_]: Parallel: Async: Hasher](lastCurrencySnapshots: Option[MerkleTree]): F[GlobalSnapshotStateProof] =
     GlobalSnapshotInfo.legacyStateProof[F](toGlobalSnapshotInfo, lastCurrencySnapshots)
 
-  def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](
-    statefulMPTProducer: StatefulMerklePatriciaProducer[F],
-    ordinal: SnapshotOrdinal
-  )(
-    implicit stateProofSelector: StateProofSelector
-  ): F[GlobalSnapshotStateProof] =
-    stateProofSelector.select(ordinal) match {
-      case LegacyFormat => lastCurrencySnapshots.merkleTree[F].flatMap(stateProof(_))
-      case MerklePatriciaFormat =>
-        statefulMPTProducer.build.flatMap {
-          case Left(err) => err.raiseError[F, GlobalSnapshotStateProof]
-          case Right(value) =>
-            GlobalSnapshotStateProof
-              .apply(
-                Hash.empty,
-                Hash.empty,
-                Hash.empty,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                Some(value.rootHash.value)
-              )
-              .pure
-        }
-    }
-
   override def getActiveTokenLocks: SortedMap[Address, SortedSet[Signed[TokenLock]]] = activeTokenLocks.getOrElse(SortedMap.empty)
 
   override def getActiveDelegatedStakes: SortedMap[Address, SortedSet[DelegatedStakeRecord]] =
@@ -247,6 +196,66 @@ case class GlobalSnapshotInfo(
 }
 
 object GlobalSnapshotInfo {
+
+  /** Creates a StateProofBuilder for GlobalSnapshotInfo (no producer).
+    *
+    * Uses legacy Merkle trees for pre-MPT ordinals, rebuilds MPT from state for post-migration ordinals. For efficient proof building with
+    * a pre-built trie, use `stateProofBuilder(Some(producer))`.
+    */
+  def stateProofBuilder[F[_]: Async: Parallel: JsonSerializer](
+    implicit selector: GlobalStateProofSelector
+  ): StateProofBuilder[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
+    stateProofBuilder(None)
+
+  /** Creates a StateProofBuilder with optional MPT producer.
+    *
+    * @param producer
+    *   Optional MPT producer for efficient proof building from pre-built trie. When None, MPT proofs are rebuilt from snapshot state.
+    */
+  def stateProofBuilder[F[_]: Async: Parallel: JsonSerializer](
+    producer: Option[StatefulMerklePatriciaProducer[F]]
+  )(implicit selector: GlobalStateProofSelector): StateProofBuilder[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
+    StateProofBuilder.instance { (info, ordinal, hasher) =>
+      implicit val h: Hasher[F] = hasher
+      implicit val s: StateProofSelector = selector
+      selector.select(ordinal) match {
+        case LegacyFormat =>
+          info.lastCurrencySnapshots.merkleTree[F].flatMap { lastCurrencySnapshotsMerkle =>
+            legacyStateProof[F](info, lastCurrencySnapshotsMerkle)
+          }
+        case MerklePatriciaFormat =>
+          producer match {
+            case Some(p) =>
+              p.build.flatMap {
+                case Left(err) => err.raiseError[F, GlobalSnapshotStateProof]
+                case Right(trie) =>
+                  GlobalSnapshotStateProof
+                    .apply(
+                      Hash.empty,
+                      Hash.empty,
+                      Hash.empty,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      None,
+                      Some(trie.rootHash.value)
+                    )
+                    .pure[F]
+              }
+            case None =>
+              mptStateProof[F](info)
+          }
+      }
+    }
 
   def mptStateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](info: GlobalSnapshotInfo)(
     implicit stateProofSelector: StateProofSelector

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/snapshot.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/snapshot.scala
@@ -18,7 +18,6 @@ import io.constellationnetwork.schema.tokenLock.TokenLock
 import io.constellationnetwork.schema.transaction.TransactionReference
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.hash.Hash
-import io.constellationnetwork.security.mpt.producer.StatefulMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.syntax.sortedCollection._
 
@@ -56,20 +55,14 @@ object snapshot {
       }.map(_.toSortedSet.union(tips.remainedActive))
   }
 
+  /** Base trait for snapshot state information.
+    *
+    * State proof construction is decoupled from this trait. Use the `stateProofBuilder` factory methods in the companion objects of
+    * concrete implementations (e.g., `GlobalSnapshotInfo.stateProofBuilder`, `CurrencySnapshotInfo.stateProofBuilder`).
+    */
   trait SnapshotInfo[P <: StateProof] {
     val lastTxRefs: SortedMap[Address, TransactionReference]
     val balances: SortedMap[Address, Balance]
-
-    def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](ordinal: SnapshotOrdinal)(
-      implicit stateProofSelector: StateProofSelector
-    ): F[P]
-
-    def stateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](
-      statefulMPTProducer: StatefulMerklePatriciaProducer[F],
-      ordinal: SnapshotOrdinal
-    )(
-      implicit stateProofSelector: StateProofSelector
-    ): F[P]
 
     def getActiveTokenLocks: SortedMap[Address, SortedSet[Signed[TokenLock]]] = SortedMap.empty
     def getActiveDelegatedStakes: SortedMap[Address, SortedSet[DelegatedStakeRecord]] = SortedMap.empty

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/stateproof/StateProofBuilder.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/stateproof/StateProofBuilder.scala
@@ -1,0 +1,37 @@
+package io.constellationnetwork.schema.stateproof
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.snapshot.{SnapshotInfo, StateProof}
+import io.constellationnetwork.security.Hasher
+
+/** Typeclass for building state proofs from snapshot info.
+  *
+  * This abstraction allows different proof strategies (legacy Merkle trees vs MPT) to be selected at runtime based on ordinal, without
+  * requiring unused dependencies to be passed through the call stack.
+  *
+  * @tparam F
+  *   Effect type
+  * @tparam I
+  *   Snapshot info type (e.g., GlobalSnapshotInfo, CurrencySnapshotInfo)
+  * @tparam P
+  *   State proof type (e.g., GlobalSnapshotStateProof, CurrencySnapshotStateProof)
+  */
+trait StateProofBuilder[F[_], I <: SnapshotInfo[P], P <: StateProof] {
+
+  /** Build a state proof from snapshot info at the given ordinal.
+    *
+    * The ordinal is used to determine which proof format to use when the builder supports multiple formats (e.g., legacy vs MPT).
+    */
+  def buildProof(info: I, ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[P]
+}
+
+object StateProofBuilder {
+
+  /** Create a StateProofBuilder instance from a function. */
+  def instance[F[_], I <: SnapshotInfo[P], P <: StateProof](
+    f: (I, SnapshotOrdinal, Hasher[F]) => F[P]
+  ): StateProofBuilder[F, I, P] =
+    new StateProofBuilder[F, I, P] {
+      def buildProof(info: I, ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[P] = f(info, ordinal, hasher)
+    }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/validator/StateProofValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/validator/StateProofValidator.scala
@@ -9,12 +9,14 @@ import cats.{Parallel, Show}
 
 import scala.util.control.NoStackTrace
 
+import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.json.JsonSerializer
-import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
+import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.snapshot.{IncrementalSnapshot, SnapshotInfo, StateProof}
-import io.constellationnetwork.schema.{SnapshotOrdinal, StateProofSelector}
+import io.constellationnetwork.schema.stateproof.StateProofBuilder
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.mpt.producer.StatefulMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed
 
 import derevo.cats.{eqv, show}
@@ -23,45 +25,64 @@ import io.circe.Encoder
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
+/** State proof validator trait.
+  *
+  * Use factory methods to create instances:
+  *   - `StateProofValidator.forGlobal` for GlobalSnapshotInfo
+  *   - `StateProofValidator.forCurrency` for CurrencySnapshotInfo
+  */
+trait StateProofValidator[F[_], I <: SnapshotInfo[P], P <: StateProof] {
+  def validate[A <: IncrementalSnapshot[P]: Encoder](snapshot: Signed[A], info: I)(
+    implicit hasher: Hasher[F]
+  ): F[Validated[StateProofValidator.StateBroken, Unit]]
+
+  def validate[A <: IncrementalSnapshot[P]](snapshot: Hashed[A], info: I)(
+    implicit hasher: Hasher[F]
+  ): F[Validated[StateProofValidator.StateBroken, Unit]]
+}
+
 object StateProofValidator {
 
-  def validate[F[_]: Async: Parallel: Hasher: JsonSerializer, P <: StateProof: Eq, A <: IncrementalSnapshot[P]: Encoder](
-    snapshot: Signed[A],
-    snapshotInfo: SnapshotInfo[P]
-  )(implicit stateProofSelector: StateProofSelector): F[Validated[StateBroken, Unit]] =
-    (snapshot.toHashed, snapshotInfo.stateProof(snapshot.ordinal)).flatMapN {
-      case (hashedSnapshot, stateProof) =>
-        validate(hashedSnapshot, stateProof)
+  /** Create a StateProofValidator for GlobalSnapshotInfo.
+    *
+    * @param producer
+    *   Optional MPT producer for efficient proof building from pre-built trie
+    */
+  def forGlobal[F[_]: Async: Parallel: JsonSerializer](
+    producer: Option[StatefulMerklePatriciaProducer[F]] = None
+  )(implicit selector: GlobalStateProofSelector): StateProofValidator[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
+    make(GlobalSnapshotInfo.stateProofBuilder(producer))
+
+  /** Create a StateProofValidator for CurrencySnapshotInfo. */
+  def forCurrency[F[_]: Async: Parallel: JsonSerializer](
+    implicit selector: CurrencyStateProofSelector
+  ): StateProofValidator[F, CurrencySnapshotInfo, CurrencySnapshotStateProof] =
+    make(CurrencySnapshotInfo.stateProofBuilder[F])
+
+  /** Create a StateProofValidator from a custom StateProofBuilder. */
+  def make[F[_]: Async: Parallel: JsonSerializer, I <: SnapshotInfo[P], P <: StateProof: Eq](
+    builder: StateProofBuilder[F, I, P]
+  ): StateProofValidator[F, I, P] =
+    new StateProofValidator[F, I, P] {
+      def validate[A <: IncrementalSnapshot[P]: Encoder](snapshot: Signed[A], info: I)(
+        implicit hasher: Hasher[F]
+      ): F[Validated[StateBroken, Unit]] =
+        (snapshot.toHashed, builder.buildProof(info, snapshot.ordinal)).flatMapN {
+          case (hashed, proof) =>
+            validateProof(hashed, proof)
+        }
+
+      def validate[A <: IncrementalSnapshot[P]](snapshot: Hashed[A], info: I)(
+        implicit hasher: Hasher[F]
+      ): F[Validated[StateBroken, Unit]] =
+        builder.buildProof(info, snapshot.ordinal).flatMap(validateProof(snapshot, _))
     }
 
-  def validate[F[_]: Async: Parallel: Hasher: JsonSerializer, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
-    snapshot: Hashed[A],
-    snapshotInfo: SnapshotInfo[P]
-  )(implicit stateProofSelector: StateProofSelector): F[Validated[StateBroken, Unit]] =
-    snapshotInfo.stateProof(snapshot.ordinal).flatMap(validate(snapshot, _))
-
-  def validate[F[_]: Async: Parallel: Hasher: JsonSerializer, P <: StateProof: Eq, A <: IncrementalSnapshot[P]: Encoder](
-    snapshot: Signed[A],
-    snapshotInfo: SnapshotInfo[P],
-    mptStore: MptStore[F, GlobalStateKey]
-  )(implicit stateProofSelector: StateProofSelector): F[Validated[StateBroken, Unit]] =
-    (snapshot.toHashed, snapshotInfo.stateProof(mptStore.underlying, snapshot.ordinal)).flatMapN {
-      case (hashedSnapshot, stateProof) =>
-        validate(hashedSnapshot, stateProof)
-    }
-
-  def validate[F[_]: Async: Parallel: Hasher: JsonSerializer, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
-    snapshot: Hashed[A],
-    snapshotInfo: SnapshotInfo[P],
-    mptStore: MptStore[F, GlobalStateKey]
-  )(implicit stateProofSelector: StateProofSelector): F[Validated[StateBroken, Unit]] =
-    snapshotInfo.stateProof(mptStore.underlying, snapshot.ordinal).flatMap(validate(snapshot, _))
-
-  def validate[F[_]: Async: Parallel: JsonSerializer, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
+  /** Validate a pre-computed state proof against the snapshot. */
+  def validateProof[F[_]: Async, P <: StateProof: Eq, A <: IncrementalSnapshot[P]](
     snapshot: Hashed[A],
     stateProof: P
   ): F[Validated[StateBroken, Unit]] = {
-
     val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLogger[F]
     val expectedStateProof = snapshot.signed.value.stateProof
 

--- a/modules/shared/src/test/scala/io/constellationnetwork/merkletree/MerkleTreeValidatorSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/merkletree/MerkleTreeValidatorSuite.scala
@@ -15,7 +15,7 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.height.{Height, SubHeight}
-import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
+import io.constellationnetwork.schema.mpt.GlobalStateKey
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
@@ -65,12 +65,9 @@ object MerkleTreeValidatorSuite extends MutableIOSuite {
     for {
       implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
-      mptStore <- MptStore.make[IO, GlobalStateKey](
-        mptProducer,
-        GlobalStateKey.toHex[IO]
-      )
       snapshot <- globalIncrementalSnapshot(globalSnapshotInfo)
-      result <- StateProofValidator.validate(snapshot, globalSnapshotInfo, mptStore)
+      validator = StateProofValidator.forGlobal[IO](Some(mptProducer))
+      result <- validator.validate(snapshot, globalSnapshotInfo)
     } yield expect.same(Validated.Valid(()), result)
   }
 
@@ -100,11 +97,8 @@ object MerkleTreeValidatorSuite extends MutableIOSuite {
       implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
       snapshot <- globalIncrementalSnapshot(globalSnapshotInfo)
       mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
-      mptStore <- MptStore.make[IO, GlobalStateKey](
-        mptProducer,
-        GlobalStateKey.toHex[IO]
-      )
-      result <- StateProofValidator.validate(snapshot, GlobalSnapshotInfo.empty, mptStore)
+      validator = StateProofValidator.forGlobal[IO](Some(mptProducer))
+      result <- validator.validate(snapshot, GlobalSnapshotInfo.empty)
     } yield expect.same(Validated.Invalid(StateProofValidator.StateBroken(SnapshotOrdinal(NonNegLong(1L)), snapshot.hash)), result)
   }
 


### PR DESCRIPTION
Decouple state proof construction from SnapshotInfo trait by introducing a StateProofBuilder[F, I, P] typeclass with factory methods in companion objects.

Changes:
- Add StateProofBuilder typeclass in schema.stateproof package
- Add GlobalSnapshotInfo.stateProofBuilder(producer) factory
  - No-arg version rebuilds MPT from state
  - With producer for efficient proof building from pre-built trie
- Add CurrencySnapshotInfo.stateProofBuilder factory (always legacy format)
- Remove stateProof(ordinal) abstract method from SnapshotInfo trait
- Remove stateProof(producer, ordinal) deprecated method
- Update StateProofValidator to use builder pattern
- Update all call sites to use explicit builders

Usage:
  val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying)) val proof = builder.buildProof(info, ordinal) StateProofValidator.validateProof(snapshot, proof)
  
  -- This is follow on work to a previous PR that encountered permissions issues during CI evaluation
  https://github.com/Constellation-Labs/tessellation/pull/1414