### PR TITLE
fix: state proof builder with optimistic validation

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -66,7 +66,7 @@ object Download {
 
     val logger = Slf4jLogger.getLogger[F]
 
-    private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
+    private val validator = StateProofValidator.forGlobal(mptStore)
 
     val minBatchSizeToStartObserving: Long = 1L
     val observationOffset = NonNegLong(4L)

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverse.scala
@@ -47,7 +47,7 @@ object GlobalSnapshotTraverse {
   ): GlobalSnapshotTraverse[F] =
     new GlobalSnapshotTraverse[F] {
       implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
-      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
+      private val builder = GlobalSnapshotInfo.stateProofBuilderWithStore(mptStore)
 
       def loadChain(): F[(GlobalSnapshotInfo, Signed[GlobalIncrementalSnapshot])] = {
         def loadIncOrErr(h: Hash) =

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
@@ -46,8 +46,8 @@ object SnapshotDownloadStorage {
 
       val cutoffLogic: OrdinalCutoff = LogarithmicOrdinalCutoff.make
 
-      private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
-      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
+      private val validator = StateProofValidator.forGlobal(mptStore)
+      private val builder = GlobalSnapshotInfo.stateProofBuilderWithStore(mptStore)
 
       def readPersisted(ordinal: SnapshotOrdinal): F[Option[Signed[GlobalIncrementalSnapshot]]] = persistedStorage.read(ordinal)
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/services/GlobalL0Service.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/services/GlobalL0Service.scala
@@ -68,7 +68,7 @@ object GlobalL0Service {
       private val logger = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
       private val maybeMajorityPeerIds = maybeMajorityPeerIdSet.map(_.toNonEmptyList)
       private val ordinalRange = 0L to 3L
-      private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
+      private val validator = StateProofValidator.forGlobal(mptStore)
 
       implicit val hashShow: Show[Hash] = Hash.shortShow
       implicit val peerIdShow: Show[PeerId] = PeerId.shortShow

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
@@ -52,7 +52,7 @@ object GlobalSnapshotContextFunctions {
   ) =
     new GlobalSnapshotContextFunctions[F] {
 
-      private val validator = StateProofValidator.forGlobal(Some(mptStore.underlying))
+      private val validator = StateProofValidator.forGlobal(mptStore)
 
       // todo - avoid duplication of this function here and in GlobalSnapshotConsensusFunctions
       private def acceptDelegatedStakes(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -187,7 +187,6 @@ object GlobalSnapshotAcceptanceManager {
 
     new GlobalSnapshotAcceptanceManager[F] {
       val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
-      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
 
       case class InitialData(
         blockResult: BlockAcceptanceResult,
@@ -1132,7 +1131,7 @@ object GlobalSnapshotAcceptanceManager {
             )
 
             _ <- mptStore.syncFromStateChanges(stateChangesAccumulator, ordinal)
-            stateProof <- builder.buildProof(gsi, ordinal)
+            stateProof <- GlobalSnapshotStateProof.fromProducer(mptStore.underlying)
 
             (expiredAllowSpends, expiredTokenLocks) = (
               allowSpendStateManager.filterExpiredAllowSpends(

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotInfo.scala
@@ -17,6 +17,7 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.schema.delegatedStake.{DelegatedStakeRecord, PendingDelegatedStakeWithdrawal}
 import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.UpdateNodeParameters
 import io.constellationnetwork.schema.nodeCollateral.{NodeCollateralRecord, PendingNodeCollateralWithdrawal}
 import io.constellationnetwork.schema.priceOracle.{PriceRecord, TokenPair}
@@ -197,23 +198,37 @@ case class GlobalSnapshotInfo(
 
 object GlobalSnapshotInfo {
 
-  /** Creates a StateProofBuilder for GlobalSnapshotInfo (no producer).
+  /** Creates a StateProofBuilder that always rebuilds from info (safe but slow).
     *
-    * Uses legacy Merkle trees for pre-MPT ordinals, rebuilds MPT from state for post-migration ordinals. For efficient proof building with
-    * a pre-built trie, use `stateProofBuilder(Some(producer))`.
+    * Use this when you don't have an MptStore or need guaranteed correctness regardless of store state. For optimistic validation with fast
+    * path when store is synced, use `stateProofBuilder(mptStore)`.
     */
   def stateProofBuilder[F[_]: Async: Parallel: JsonSerializer](
     implicit selector: GlobalStateProofSelector
   ): StateProofBuilder[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
-    stateProofBuilder(None)
+    StateProofBuilder.instance { (info, ordinal, hasher) =>
+      implicit val h: Hasher[F] = hasher
+      implicit val s: StateProofSelector = selector
+      selector.select(ordinal) match {
+        case LegacyFormat =>
+          info.lastCurrencySnapshots.merkleTree[F].flatMap { lastCurrencySnapshotsMerkle =>
+            legacyStateProof[F](info, lastCurrencySnapshotsMerkle)
+          }
+        case MerklePatriciaFormat =>
+          mptStateProof[F](info)
+      }
+    }
 
-  /** Creates a StateProofBuilder with optional MPT producer.
+  /** Creates an optimistic StateProofBuilder that uses the MptStore when it's at the correct ordinal.
     *
-    * @param producer
-    *   Optional MPT producer for efficient proof building from pre-built trie. When None, MPT proofs are rebuilt from snapshot state.
+    * Fast path: If the store's currentOrdinal matches the target ordinal, extracts root directly (O(1)). Safe path: Otherwise, rebuilds
+    * from info (O(n log n)).
+    *
+    * Use this for validators that maintain incremental state — they get fast validation when in sync, and correct (if slower) validation
+    * when out of sync or processing historical snapshots.
     */
-  def stateProofBuilder[F[_]: Async: Parallel: JsonSerializer](
-    producer: Option[StatefulMerklePatriciaProducer[F]]
+  def stateProofBuilderWithStore[F[_]: Async: Parallel: JsonSerializer](
+    mptStore: MptStore[F, GlobalStateKey]
   )(implicit selector: GlobalStateProofSelector): StateProofBuilder[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
     StateProofBuilder.instance { (info, ordinal, hasher) =>
       implicit val h: Hasher[F] = hasher
@@ -224,38 +239,29 @@ object GlobalSnapshotInfo {
             legacyStateProof[F](info, lastCurrencySnapshotsMerkle)
           }
         case MerklePatriciaFormat =>
-          producer match {
-            case Some(p) =>
-              p.build.flatMap {
-                case Left(err) => err.raiseError[F, GlobalSnapshotStateProof]
-                case Right(trie) =>
-                  GlobalSnapshotStateProof
-                    .apply(
-                      Hash.empty,
-                      Hash.empty,
-                      Hash.empty,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      None,
-                      Some(trie.rootHash.value)
-                    )
-                    .pure[F]
-              }
-            case None =>
+          mptStore.currentOrdinal.flatMap {
+            case Some(storeOrdinal) if storeOrdinal === ordinal =>
+              // Store is at correct ordinal — use fast path
+              GlobalSnapshotStateProof.fromProducer(mptStore.underlying)
+            case _ =>
+              // Store is at wrong ordinal — rebuild from info
               mptStateProof[F](info)
           }
       }
     }
+
+  /** Creates a StateProofBuilder for GlobalSnapshotInfo.
+    *
+    * @param producer
+    *   Ignored. This parameter exists only for API compatibility and will be removed in a future version. The builder always reconstructs
+    *   state proofs from the info parameter to ensure correctness. For efficient snapshot creation, use
+    *   `GlobalSnapshotStateProof.fromProducer` directly.
+    */
+  @deprecated("Producer parameter is ignored. Use stateProofBuilder() or stateProofBuilder(mptStore) instead.", "v4.0.0")
+  def stateProofBuilder[F[_]: Async: Parallel: JsonSerializer](
+    producer: Option[StatefulMerklePatriciaProducer[F]]
+  )(implicit selector: GlobalStateProofSelector): StateProofBuilder[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
+    stateProofBuilder[F]
 
   def mptStateProof[F[_]: Parallel: Async: Hasher: JsonSerializer](info: GlobalSnapshotInfo)(
     implicit stateProofSelector: StateProofSelector

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotStateProof.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotStateProof.scala
@@ -1,9 +1,13 @@
 package io.constellationnetwork.schema
 
+import cats.MonadThrow
+import cats.syntax.all._
+
 import io.constellationnetwork.merkletree.MerkleRoot
 import io.constellationnetwork.schema.snapshot.StateProof
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.mpt.MptRoot
+import io.constellationnetwork.security.mpt.producer.StatefulMerklePatriciaProducer
 
 import derevo.cats.{eqv, show}
 import derevo.circe.magnolia.{decoder, encoder}
@@ -98,4 +102,39 @@ object GlobalSnapshotStateProof {
     case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17) =>
       GlobalSnapshotStateProof.apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)
   }
+
+  /** Efficiently extract a state proof from an already-synced MPT producer.
+    *
+    * Use this for snapshot CREATION where the producer's current state matches the snapshot being created. For snapshot VALIDATION, use
+    * `GlobalSnapshotInfo.stateProofBuilder` which rebuilds from the snapshot's info.
+    *
+    * @param producer
+    *   The MPT producer whose current state should be used for the proof
+    * @return
+    *   The state proof with the producer's current MPT root hash
+    */
+  def fromProducer[F[_]: MonadThrow](producer: StatefulMerklePatriciaProducer[F]): F[GlobalSnapshotStateProof] =
+    producer.build.flatMap {
+      case Left(err) => err.raiseError[F, GlobalSnapshotStateProof]
+      case Right(trie) =>
+        GlobalSnapshotStateProof(
+          Hash.empty,
+          Hash.empty,
+          Hash.empty,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          Some(trie.rootHash.value)
+        ).pure[F]
+    }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
@@ -31,6 +31,11 @@ trait MptStore[F[_], K] {
   def update[V: Encoder](toUpsert: Map[K, V], toRemove: Set[K]): F[Unit]
   def underlying: StatefulMerklePatriciaProducer[F]
   def deleteAbove(ordinal: SnapshotOrdinal): F[Unit]
+
+  /** Returns the ordinal at which this store was last synced. Used for optimistic validation — if the store is at the target ordinal, we
+    * can use the producer directly instead of rebuilding from state.
+    */
+  def currentOrdinal: F[Option[SnapshotOrdinal]]
 }
 
 object MptStore {
@@ -233,5 +238,8 @@ object MptStore {
         case _ =>
           Async[F].unit
       }
+
+    override def currentOrdinal: F[Option[SnapshotOrdinal]] =
+      lastSyncedOrdinalRef.get
   }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/validator/StateProofValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/validator/StateProofValidator.scala
@@ -12,6 +12,7 @@ import scala.util.control.NoStackTrace
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.snapshot.{IncrementalSnapshot, SnapshotInfo, StateProof}
 import io.constellationnetwork.schema.stateproof.StateProofBuilder
 import io.constellationnetwork.security._
@@ -43,15 +44,37 @@ trait StateProofValidator[F[_], I <: SnapshotInfo[P], P <: StateProof] {
 
 object StateProofValidator {
 
+  /** Create a StateProofValidator that always rebuilds from info (safe but slow).
+    *
+    * Use this when you don't have an MptStore or need guaranteed correctness regardless of store state.
+    */
+  def forGlobal[F[_]: Async: Parallel: JsonSerializer](
+    implicit selector: GlobalStateProofSelector
+  ): StateProofValidator[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
+    make(GlobalSnapshotInfo.stateProofBuilder[F])
+
+  /** Create an optimistic StateProofValidator that uses the MptStore when it's at the correct ordinal.
+    *
+    * Fast path: If the store's currentOrdinal matches the snapshot being validated, extracts root directly (O(1)). Safe path: Otherwise,
+    * rebuilds from info (O(n log n)).
+    *
+    * Use this for validators that maintain incremental state.
+    */
+  def forGlobal[F[_]: Async: Parallel: JsonSerializer](
+    mptStore: MptStore[F, GlobalStateKey]
+  )(implicit selector: GlobalStateProofSelector): StateProofValidator[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
+    make(GlobalSnapshotInfo.stateProofBuilderWithStore(mptStore))
+
   /** Create a StateProofValidator for GlobalSnapshotInfo.
     *
     * @param producer
-    *   Optional MPT producer for efficient proof building from pre-built trie
+    *   Ignored. This parameter exists only for API compatibility and will be removed in a future version.
     */
+  @deprecated("Producer parameter is ignored. Use forGlobal() or forGlobal(mptStore) instead.", "v4.0.0")
   def forGlobal[F[_]: Async: Parallel: JsonSerializer](
-    producer: Option[StatefulMerklePatriciaProducer[F]] = None
+    producer: Option[StatefulMerklePatriciaProducer[F]]
   )(implicit selector: GlobalStateProofSelector): StateProofValidator[F, GlobalSnapshotInfo, GlobalSnapshotStateProof] =
-    make(GlobalSnapshotInfo.stateProofBuilder(producer))
+    forGlobal[F]
 
   /** Create a StateProofValidator for CurrencySnapshotInfo. */
   def forCurrency[F[_]: Async: Parallel: JsonSerializer](


### PR DESCRIPTION
The StateProofBuilder was incorrectly using the MPT producer's current state instead of rebuilding from the info parameter. This caused validation failures when the producer's state diverged from the snapshot being validated.

Changes:
- GlobalSnapshotInfo.stateProofBuilder (no args) always rebuilds from info
- GlobalSnapshotInfo.stateProofBuilderWithStore(mptStore) uses optimistic validation:
  - Fast path: If store.currentOrdinal matches target ordinal, use producer (O(1))
  - Safe path: Otherwise, rebuild from info (O(n log n))
- Added MptStore.currentOrdinal to track synced ordinal
- Added GlobalSnapshotStateProof.fromProducer for efficient snapshot creation
- Updated GlobalSnapshotAcceptanceManager to use fromProducer directly
- Deprecated the old producer parameter overloads
- Updated all validators to use optimistic MptStore-based validation

The semantic contract is now clear:
- stateProofBuilderWithStore: optimistic, uses producer when ordinals match
- stateProofBuilder (no args): always rebuilds (for cases without MptStore)
- fromProducer: direct extraction for snapshot creation (caller ensures sync)