### PR TITLE
fix: add error recovery to syncFullIfNeeded and fromProducer optimiza…

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -187,7 +187,6 @@ object GlobalSnapshotAcceptanceManager {
 
     new GlobalSnapshotAcceptanceManager[F] {
       val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
-      private val builder = GlobalSnapshotInfo.stateProofBuilder(Some(mptStore.underlying))
 
       case class InitialData(
         blockResult: BlockAcceptanceResult,
@@ -1132,7 +1131,8 @@ object GlobalSnapshotAcceptanceManager {
             )
 
             _ <- mptStore.syncFromStateChanges(stateChangesAccumulator, ordinal)
-            stateProof <- builder.buildProof(gsi, ordinal)
+            // Use fromProducer directly since we just synced - avoids cache lookup overhead
+            stateProof <- GlobalSnapshotStateProof.fromProducer(mptStore.underlying)
 
             (expiredAllowSpends, expiredTokenLocks) = (
               allowSpendStateManager.filterExpiredAllowSpends(

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotStateProof.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/GlobalSnapshotStateProof.scala
@@ -1,9 +1,13 @@
 package io.constellationnetwork.schema
 
+import cats.MonadThrow
+import cats.syntax.all._
+
 import io.constellationnetwork.merkletree.MerkleRoot
 import io.constellationnetwork.schema.snapshot.StateProof
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.mpt.MptRoot
+import io.constellationnetwork.security.mpt.producer.StatefulMerklePatriciaProducer
 
 import derevo.cats.{eqv, show}
 import derevo.circe.magnolia.{decoder, encoder}
@@ -98,4 +102,39 @@ object GlobalSnapshotStateProof {
     case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17) =>
       GlobalSnapshotStateProof.apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)
   }
+
+  /** Create a GlobalSnapshotStateProof directly from a producer that has just been synced.
+    *
+    * This is an optimization for snapshot creation where the caller guarantees the producer is already synced to the correct state. It
+    * avoids the overhead of ordinal-based cache lookups when we know the producer's current state is what we need.
+    *
+    * Use this in GlobalSnapshotAcceptanceManager after syncFromStateChanges.
+    */
+  def fromProducer[F[_]: MonadThrow](producer: StatefulMerklePatriciaProducer[F]): F[GlobalSnapshotStateProof] =
+    producer.getCurrentRootHash.flatMap {
+      case Some(rootHash) =>
+        GlobalSnapshotStateProof(
+          Hash.empty,
+          Hash.empty,
+          Hash.empty,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          Some(rootHash.value)
+        ).pure[F]
+      case None =>
+        MonadThrow[F].raiseError(
+          new RuntimeException("Cannot create GlobalSnapshotStateProof: producer has no current root hash (not built yet)")
+        )
+    }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/mpt/MptStore.scala
@@ -206,15 +206,22 @@ object MptStore {
         val needsSync = lastOrdinal.forall(_ =!= ordinal)
         if (needsSync) {
           // Mark as syncing with this ordinal immediately to prevent concurrent syncs
-          (Some(ordinal), true)
+          // Return previous ordinal so we can restore on failure
+          (Some(ordinal), (true, lastOrdinal))
         } else {
-          (lastOrdinal, false)
+          (lastOrdinal, (false, lastOrdinal))
         }
-      }.flatMap { needsSync =>
-        if (needsSync)
-          newState.flatMap(syncFull(_, ordinal))
-        else
-          logger.debug(s"[MptStore] Skipping sync, already synced at ordinal $ordinal")
+      }.flatMap {
+        case (needsSync, previousOrdinal) =>
+          if (needsSync)
+            newState.flatMap(syncFull(_, ordinal)).handleErrorWith { err =>
+              // Reset ordinal on failure to allow retry from another thread
+              logger.warn(s"[MptStore] syncFull failed for ordinal $ordinal, resetting to $previousOrdinal") >>
+                lastSyncedOrdinalRef.set(previousOrdinal) >>
+                err.raiseError[F, Unit]
+            }
+          else
+            logger.debug(s"[MptStore] Skipping sync, already synced at ordinal $ordinal")
       }
 
     override def sync[V: Encoder](updates: Map[K, V], ordinal: SnapshotOrdinal): F[Unit] =


### PR DESCRIPTION
…tion

- MptStore.syncFullIfNeeded: Reset ordinal on sync failure to allow retry
- GlobalSnapshotStateProof.fromProducer: Direct creation from synced producer
- GlobalSnapshotAcceptanceManager: Use fromProducer after sync (avoids cache lookup)

Builds on top of PR #1417 fixes.