### PR TITLE
Fix/currency token lock replacement

### DIFF
--- a/.github/action_scripts/delegated_staking/token-lock-replacement-edge-cases.js
+++ b/.github/action_scripts/delegated_staking/token-lock-replacement-edge-cases.js
@@ -1,0 +1,485 @@
+/**
+ * Token Lock Replacement Edge Cases - Extended tests for delegated stake + token lock replacement
+ *
+ * Tests edge cases not covered by the main delegated-staking.js tests:
+ * 1. Replace with same amount (should fail - ReplacementLowerThanCurrentTokenLock)
+ * 2. Replace with less amount (should fail - ReplacementLowerThanCurrentTokenLock)
+ * 3. Replace non-existent token lock ref (should fail - NothingToReplace)
+ * 4. Replace with minimum valid increase (+1 datum)
+ * 5. Multiple sequential replacements (3 in a row)
+ * 6. Replace while stake is in withdrawal (pendingWithdrawals)
+ *
+ * Usage:
+ * - CI: node token-lock-replacement-edge-cases.js 90 91 testTokenLockReplacementEdgeCases
+ * - Local: RUN_ENV=local node token-lock-replacement-edge-cases.js 90 91 testTokenLockReplacementEdgeCases
+ */
+
+const { dag4 } = require('@stardust-collective/dag4')
+
+const RUN_ENV = process.env.RUN_ENV || 'ci'
+
+const {
+  parseSharedArgs,
+  PRIVATE_KEYS,
+  sleep,
+  withRetry,
+  createNetworkConfig,
+  logWorkflow,
+} = require('../shared')
+
+const {
+  checkOk,
+  checkBadRequest,
+  dagToDatum,
+  getPrivateKeyAndNodeIdFromFile,
+  postNodeParamsNodeId,
+  createDelegatedStake,
+  withdrawDelegatedStake,
+  getAccountDelegatedStakes,
+  assertDelegatedStakes,
+  fetchStakeWithRewardsBalance,
+  createTokenLock,
+  assertBalanceChange,
+  getNodeParams,
+} = require('./lib')
+
+const throwUsage = () => {
+  throw new Error(
+    'Usage: node script.js <dagl0-port-prefix> <dagl1-port-prefix> <workflow-name>',
+  )
+}
+
+const createConfig = () => {
+  const args = process.argv.slice(2)
+  if (args.length < 3) return throwUsage()
+  const sharedArgs = parseSharedArgs(args.slice(0, 3), false)
+  return { ...sharedArgs }
+}
+
+const setupDag4Account = (urls) => {
+  dag4.account.connect({
+    networkVersion: '2.0',
+    l0Url: urls.globalL0Url,
+    l1Url: urls.dagL1Url,
+  })
+  return dag4.account
+}
+
+const extractKeysAndAccount = (filePath) => {
+  const { privateKeyString, nodeId } = getPrivateKeyAndNodeIdFromFile(filePath)
+  const account = dag4.createAccount(privateKeyString)
+  return { privateKeyString, nodeId, account }
+}
+
+/**
+ * Helper to create token lock with error handling for expected failures
+ */
+const createTokenLockExpectError = async (account, urls, lockAmount, replaceRef, expectedErrorSubstring) => {
+  try {
+    await account.postTokenLock({
+      source: account.address,
+      amount: lockAmount,
+      tokenL1Url: urls.dagL1Url,
+      unlockEpoch: null,
+      currencyId: null,
+      replaceTokenLockRef: replaceRef,
+      fee: 0,
+    })
+    throw new Error(`Expected error containing "${expectedErrorSubstring}" but request succeeded`)
+  } catch (error) {
+    if (error.message.includes('Expected error')) throw error
+    
+    const errorMsg = error.response?.data || error.message
+    const errorStr = typeof errorMsg === 'string' ? errorMsg : JSON.stringify(errorMsg)
+    
+    if (!errorStr.includes(expectedErrorSubstring)) {
+      throw new Error(`Expected error containing "${expectedErrorSubstring}" but got: ${errorStr}`)
+    }
+    logWorkflow.info(`Got expected error: ${expectedErrorSubstring}`)
+    return true
+  }
+}
+
+/**
+ * Test 1: Replace with same amount (should fail)
+ * Also sets up the initial token lock and stake for subsequent tests
+ */
+const testReplaceSameAmount = async (urls, account, nodeIds) => {
+  logWorkflow.info('---- Start testReplaceSameAmount ----')
+
+  // Check if we already have a stake we can use
+  const existingStakes = await getAccountDelegatedStakes(urls, account.address)
+  let lockHash, stakeHash, lockAmount
+
+  if (existingStakes.activeDelegatedStakes.length > 0) {
+    // Reuse existing stake
+    const existingStake = existingStakes.activeDelegatedStakes[0]
+    lockHash = existingStake.tokenLockRef
+    stakeHash = existingStake.hash
+    lockAmount = existingStake.amount
+    logWorkflow.info(`Reusing existing stake: ${stakeHash.substring(0, 16)}...`)
+    logWorkflow.info(`  Token lock: ${lockHash.substring(0, 16)}...`)
+    logWorkflow.info(`  Amount: ${lockAmount}`)
+  } else {
+    // Create new token lock and stake
+    lockAmount = 600000000000 // 6000 DAG
+    lockHash = await createTokenLock(account, urls, lockAmount)
+    logWorkflow.info(`Created initial token lock: ${lockHash}`)
+
+    // Try each node until we find one without an existing stake
+    for (const nodeId of nodeIds) {
+      try {
+        stakeHash = await createDelegatedStake(account, lockHash, lockAmount, nodeId)
+        logWorkflow.info(`Created delegated stake on node ${nodeId.substring(0, 16)}...: ${stakeHash}`)
+        break
+      } catch (e) {
+        if (e.message.includes('StakeExistsForNode')) {
+          logWorkflow.info(`Stake already exists on node ${nodeId.substring(0, 16)}..., trying next node`)
+          continue
+        }
+        throw e
+      }
+    }
+
+    if (!stakeHash) {
+      throw new Error('Could not create stake on any node')
+    }
+
+    await sleep(5000) // Wait for inclusion
+  }
+
+  // Try to replace with same amount - should fail
+  await createTokenLockExpectError(
+    account,
+    urls,
+    lockAmount, // Same amount
+    lockHash,
+    'ReplacementLowerThanCurrentTokenLock'
+  )
+
+  // Verify stake unchanged
+  await withRetry(
+    async () => {
+      const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+      const stake = stakeResponse.activeDelegatedStakes.find(s => s.hash === stakeHash)
+      if (!stake) throw new Error('Stake not found')
+      // Note: tokenLockRef might have been updated by previous test runs
+      return true
+    },
+    { name: 'verifyStakeExists', maxAttempts: 5, interval: 2000, handleError: () => {} }
+  )
+
+  logWorkflow.info('---- End testReplaceSameAmount ----')
+  return { lockHash, stakeHash, lockAmount }
+}
+
+/**
+ * Test 2: Replace with less amount (should fail)
+ */
+const testReplaceLessAmount = async (urls, account, existingLockHash, existingAmount) => {
+  logWorkflow.info('---- Start testReplaceLessAmount ----')
+
+  // Use 5000 DAG (minimum) which is less than 6000 DAG but still valid amount
+  const lessAmount = 500000000000 // 5000 DAG - less than existing but above minimum
+
+  await createTokenLockExpectError(
+    account,
+    urls,
+    lessAmount,
+    existingLockHash,
+    'ReplacementLowerThanCurrentTokenLock'
+  )
+
+  logWorkflow.info('---- End testReplaceLessAmount ----')
+}
+
+/**
+ * Test 3: Replace non-existent token lock ref (should fail)
+ */
+const testReplaceNonExistentRef = async (urls, account) => {
+  logWorkflow.info('---- Start testReplaceNonExistentRef ----')
+
+  const fakeRef = '0000000000000000000000000000000000000000000000000000000000000000'
+  const amount = 500000000000
+
+  await createTokenLockExpectError(
+    account,
+    urls,
+    amount,
+    fakeRef,
+    'NothingToReplace'
+  )
+
+  logWorkflow.info('---- End testReplaceNonExistentRef ----')
+}
+
+/**
+ * Test 4: Replace with minimum valid increase (+1 datum)
+ */
+const testReplaceMinimumIncrease = async (urls, account, existingLockHash, existingAmount, stakeHash) => {
+  logWorkflow.info('---- Start testReplaceMinimumIncrease ----')
+
+  const minIncrease = existingAmount + 1 // Minimum valid increase
+  
+  const newLockHash = await createTokenLock(account, urls, minIncrease, existingLockHash, existingAmount)
+  logWorkflow.info(`Created replacement with +1 datum: ${newLockHash}`)
+
+  // Verify delegated stake updated AND new lock is active (this confirms snapshot inclusion)
+  logWorkflow.info('Waiting for snapshot inclusion and stake update...')
+  await withRetry(
+    async () => {
+      const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+      const stake = stakeResponse.activeDelegatedStakes.find(s => s.hash === stakeHash)
+      if (!stake) throw new Error('Stake not found')
+      if (stake.tokenLockRef !== newLockHash) {
+        throw new Error(`TokenLockRef not updated: expected ${newLockHash}, got ${stake.tokenLockRef}`)
+      }
+      if (stake.amount !== minIncrease) {
+        throw new Error(`Amount not updated: expected ${minIncrease}, got ${stake.amount}`)
+      }
+      return true
+    },
+    { name: 'verifyMinIncreaseUpdate', maxAttempts: 20, interval: 3000, handleError: () => {} }
+  )
+  
+  // Extra wait to ensure the new lock is fully active on GL0 for subsequent replacements
+  // This is important because GL1 accepts the lock before GL0 includes it in a snapshot
+  logWorkflow.info('Lock confirmed in snapshot, waiting for GL0 sync...')
+  await sleep(10000)
+
+  logWorkflow.info('---- End testReplaceMinimumIncrease ----')
+  return { newLockHash, newAmount: minIncrease }
+}
+
+/**
+ * Test 5: Multiple sequential replacements
+ * Note: After each replacement, the OLD lock is removed and NEW lock becomes active.
+ * Subsequent replacements must reference the NEW lock hash.
+ */
+const testMultipleSequentialReplacements = async (urls, account, currentLockHash, currentAmount, stakeHash) => {
+  logWorkflow.info('---- Start testMultipleSequentialReplacements ----')
+
+  let lockHash = currentLockHash
+  let amount = currentAmount
+
+  // Do 3 sequential replacements
+  for (let i = 1; i <= 3; i++) {
+    const newAmount = amount + 100000000000 // +1000 DAG each time
+    logWorkflow.info(`Sequential replacement ${i}: ${amount} -> ${newAmount}`)
+    logWorkflow.info(`  Replacing lock: ${lockHash.substring(0, 16)}...`)
+
+    const newLockHash = await createTokenLock(account, urls, newAmount, lockHash, amount)
+    logWorkflow.info(`  Created replacement ${i}: ${newLockHash.substring(0, 16)}...`)
+
+    // Wait for inclusion before verifying
+    await sleep(3000)
+
+    // Verify delegated stake updated after each replacement
+    await withRetry(
+      async () => {
+        const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+        const stake = stakeResponse.activeDelegatedStakes.find(s => s.hash === stakeHash)
+        if (!stake) throw new Error('Stake not found')
+        if (stake.tokenLockRef !== newLockHash) {
+          throw new Error(`Replacement ${i}: TokenLockRef not updated. Expected ${newLockHash.substring(0,16)}, got ${stake.tokenLockRef?.substring(0,16)}`)
+        }
+        if (stake.amount !== newAmount) {
+          throw new Error(`Replacement ${i}: Amount not updated. Expected ${newAmount}, got ${stake.amount}`)
+        }
+        return true
+      },
+      { name: `verifySequentialReplacement${i}`, maxAttempts: 10, interval: 2000, handleError: () => {} }
+    )
+
+    // IMPORTANT: Update lockHash to the NEW lock for the next iteration
+    lockHash = newLockHash
+    amount = newAmount
+    logWorkflow.info(`  Sequential replacement ${i} verified ✓`)
+    
+    // Wait for snapshot inclusion and GL0 sync before next replacement
+    if (i < 3) {
+      logWorkflow.info('  Waiting for GL0 sync before next replacement...')
+      await sleep(10000)
+    }
+  }
+
+  logWorkflow.info('---- End testMultipleSequentialReplacements ----')
+  return { finalLockHash: lockHash, finalAmount: amount }
+}
+
+/**
+ * Test 6: Replace while stake is in withdrawal (pendingWithdrawals)
+ */
+const testReplaceWhileInWithdrawal = async (urls, account, nodeId) => {
+  logWorkflow.info('---- Start testReplaceWhileInWithdrawal ----')
+
+  // Create a fresh token lock and stake for this test
+  const lockAmount = 600000000000 // 6000 DAG
+  const lockHash = await createTokenLock(account, urls, lockAmount)
+  logWorkflow.info(`Created token lock for withdrawal test: ${lockHash}`)
+
+  const stakeHash = await createDelegatedStake(account, lockHash, lockAmount, nodeId)
+  logWorkflow.info(`Created delegated stake: ${stakeHash}`)
+
+  await sleep(5000)
+
+  // Initiate withdrawal
+  await withdrawDelegatedStake(account, stakeHash)
+  logWorkflow.info('Initiated stake withdrawal')
+
+  // Verify stake is in pendingWithdrawals
+  await withRetry(
+    async () => {
+      const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+      const pending = stakeResponse.pendingWithdrawals.find(s => s.hash === stakeHash)
+      if (!pending) throw new Error('Stake not in pendingWithdrawals')
+      return true
+    },
+    { name: 'verifyPendingWithdrawal', maxAttempts: 10, interval: 2000, handleError: () => {} }
+  )
+
+  // Try to replace token lock while stake is in withdrawal
+  const newAmount = lockAmount + 100000000000 // +1000 DAG
+  const newLockHash = await createTokenLock(account, urls, newAmount, lockHash, lockAmount)
+  logWorkflow.info(`Replaced token lock while in withdrawal: ${newLockHash}`)
+
+  // Verify the pending withdrawal record was updated
+  await withRetry(
+    async () => {
+      const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+      const pending = stakeResponse.pendingWithdrawals.find(s => s.hash === stakeHash)
+      if (!pending) throw new Error('Stake not in pendingWithdrawals')
+      
+      // Check if the pending withdrawal was updated with new token lock ref
+      // (Based on DelegatedStakeStateManager, it should update if the lock is still active)
+      logWorkflow.info(`Pending withdrawal tokenLockRef: ${pending.tokenLockRef}`)
+      logWorkflow.info(`Pending withdrawal amount: ${pending.amount}`)
+      return true
+    },
+    { name: 'verifyPendingWithdrawalUpdate', maxAttempts: 5, interval: 2000, handleError: () => {} }
+  )
+
+  logWorkflow.info('---- End testReplaceWhileInWithdrawal ----')
+}
+
+/**
+ * Setup node parameters for testing (required for delegated staking)
+ */
+const setupNodeParameters = async (urls) => {
+  logWorkflow.info('---- Setting up node parameters ----')
+
+  // Check if node params already exist (for local testing or re-runs)
+  const existingParams = await getNodeParams(urls)
+  
+  if (existingParams.length >= 1) {
+    logWorkflow.info(`Node parameters already configured: ${existingParams.length} nodes`)
+    return existingParams
+  }
+
+  // For CI, we need to extract keys and set up node params
+  if (RUN_ENV !== 'ci') {
+    throw new Error('Node parameters must be configured before running local tests. ' +
+      'Run the main delegated-staking.js test first, or manually set up node params.')
+  }
+
+  const {
+    privateKeyString: privateKeyString1,
+    nodeId: nodeId1,
+    account: account1,
+  } = extractKeysAndAccount('../../code/hypergraph/dag-l0/genesis-node/id_ecdsa.hex')
+
+  const {
+    privateKeyString: privateKeyString2,
+    nodeId: nodeId2,
+    account: account2,
+  } = extractKeysAndAccount('../../code/hypergraph/dag-l0/validator-1/id_ecdsa.hex')
+
+  // Set up node 1 params
+  const ur1 = await postNodeParamsNodeId(
+    urls, nodeId1, account1, privateKeyString1,
+    'EdgeCaseTestNode1', 5000000
+  )
+  checkOk(ur1)
+  
+  // Set up node 2 params
+  const ur2 = await postNodeParamsNodeId(
+    urls, nodeId2, account2, privateKeyString2,
+    'EdgeCaseTestNode2', 6000000
+  )
+  checkOk(ur2)
+  
+  await sleep(5000)
+
+  const nodeParams = await getNodeParams(urls)
+  logWorkflow.info(`Node parameters configured: ${nodeParams.length} nodes`)
+
+  return nodeParams
+}
+
+/**
+ * Main test runner
+ */
+const testTokenLockReplacementEdgeCases = async (urls) => {
+  logWorkflow.info('========================================')
+  logWorkflow.info('Token Lock Replacement Edge Cases Tests')
+  logWorkflow.info('========================================')
+
+  // Setup - use key3 to avoid conflicts with other tests using key4
+  const account = setupDag4Account(urls)
+  account.loginPrivateKey(PRIVATE_KEYS.key3)
+  logWorkflow.info(`Using account: ${account.address}`)
+
+  const nodeParams = await setupNodeParameters(urls)
+  const nodeIds = nodeParams.map(p => p.peerId)
+  const nodeId2 = nodeParams.length > 1 ? nodeParams[1].peerId : nodeParams[0].peerId
+
+  // Test 1: Replace with same amount (should fail)
+  const { lockHash, stakeHash, lockAmount } = await testReplaceSameAmount(urls, account, nodeIds)
+
+  // Test 2: Replace with less amount (should fail)
+  await testReplaceLessAmount(urls, account, lockHash, lockAmount)
+
+  // Test 3: Replace non-existent token lock ref (should fail)
+  await testReplaceNonExistentRef(urls, account)
+
+  // Test 4: Replace with minimum valid increase (+1 datum)
+  const { newLockHash, newAmount } = await testReplaceMinimumIncrease(
+    urls, account, lockHash, lockAmount, stakeHash
+  )
+
+  // Test 5: Multiple sequential replacements
+  await testMultipleSequentialReplacements(urls, account, newLockHash, newAmount, stakeHash)
+
+  // Test 6: Replace while stake is in withdrawal
+  await testReplaceWhileInWithdrawal(urls, account, nodeId2)
+
+  logWorkflow.info('========================================')
+  logWorkflow.info('All edge case tests completed!')
+  logWorkflow.info('========================================')
+}
+
+const executeWorkflowByType = async (workflowType) => {
+  const config = createConfig()
+  const urls = createNetworkConfig(config)
+
+  switch (workflowType) {
+    case 'testTokenLockReplacementEdgeCases':
+      await testTokenLockReplacementEdgeCases(urls)
+      break
+    default:
+      throw new Error(`Unknown workflow type: ${workflowType}`)
+  }
+}
+
+const workflowType = process.argv[4]
+if (!workflowType) {
+  logWorkflow.error('workflowType arg not found.')
+  throwUsage()
+}
+
+executeWorkflowByType(workflowType).catch((err) => {
+  logWorkflow.error('Test failed:', err.message)
+  if (RUN_ENV !== 'local') {
+    throw err
+  }
+})

--- a/.github/templates/metagraphs/project_template/modules/data_l1/src/main/scala/com/my/project_template/data_l1/Main.scala
+++ b/.github/templates/metagraphs/project_template/modules/data_l1/src/main/scala/com/my/project_template/data_l1/Main.scala
@@ -106,7 +106,8 @@ object Main
         gsOrdinal: SnapshotOrdinal
       )(update: UsageUpdate)(implicit context: L1NodeContext[IO], A: Applicative[IO]): IO[EstimatedFee] =
         update match {
-          case _: UsageUpdateNoFee | UsageUpdateWithSpendTransaction(_, _, _, _) | UsageUpdateWithTokenUnlock(_, _, _, _, _) =>
+          case _: UsageUpdateNoFee | UsageUpdateWithSpendTransaction(_, _, _, _) | UsageUpdateWithTokenUnlock(_, _, _, _, _) |
+              UsageUpdateWithTokenLockReplacement(_, _, _, _, _, _) =>
             IO.pure(EstimatedFee(Amount(NonNegLong.MinValue), Address("DAG88C9WDSKH451sisyEP3hAkgCKn5DN72fuwjfQ")))
           case _: UsageUpdateWithFee => IO.pure(EstimatedFee(Amount(NonNegLong(100)), Address("DAG88C9WDSKH451sisyEP3hAkgCKn5DN72fuwjfQ")))
         }
@@ -118,7 +119,8 @@ object Main
         A: Applicative[IO]
       ): IO[DataApplicationValidationErrorOr[Unit]] =
         dataUpdate.value match {
-          case _: UsageUpdateNoFee | UsageUpdateWithSpendTransaction(_, _, _, _) | UsageUpdateWithTokenUnlock(_, _, _, _, _) =>
+          case _: UsageUpdateNoFee | UsageUpdateWithSpendTransaction(_, _, _, _) | UsageUpdateWithTokenUnlock(_, _, _, _, _) |
+              UsageUpdateWithTokenLockReplacement(_, _, _, _, _, _) =>
             ().validNec[DataApplicationValidationError].pure[IO]
           case _: UsageUpdateWithFee =>
             maybeFeeTransaction match {

--- a/.github/templates/metagraphs/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
+++ b/.github/templates/metagraphs/project_template/modules/l0/src/main/scala/com/my/project_template/l0/Main.scala
@@ -149,7 +149,8 @@ object Main
         A: Applicative[IO]
       ): IO[DataApplicationValidationErrorOr[Unit]] =
         dataUpdate.value match {
-          case _: UsageUpdateNoFee | UsageUpdateWithSpendTransaction(_, _, _, _) | UsageUpdateWithTokenUnlock(_, _, _, _, _) =>
+          case _: UsageUpdateNoFee | UsageUpdateWithSpendTransaction(_, _, _, _) | UsageUpdateWithTokenUnlock(_, _, _, _, _) |
+              UsageUpdateWithTokenLockReplacement(_, _, _, _, _, _) =>
             ().validNec[DataApplicationValidationError].pure[IO]
           case _: UsageUpdateWithFee =>
             maybeFeeTransaction match {

--- a/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/LifecycleSharedFunctions.scala
+++ b/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/LifecycleSharedFunctions.scala
@@ -29,6 +29,14 @@ object LifecycleSharedFunctions {
             update.currencyId.some,
             update.address
           )
+        case update: UsageUpdateWithTokenLockReplacement =>
+          // When a token lock is replaced, unlock the original lock's amount
+          TokenUnlock(
+            update.originalTokenLockRef,
+            update.originalAmount,
+            update.currencyId.some,
+            update.address
+          )
       }
     )
 

--- a/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/combiners/Combiners.scala
+++ b/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/combiners/Combiners.scala
@@ -45,6 +45,9 @@ object Combiners {
         acc.sharedArtifacts + SpendAction(NonEmptyList.of(spendTransactionA, spendTransactionB))
       case UsageUpdateWithTokenUnlock(address, currencyId, tokenLockRef, unlockAmount, _) =>
         acc.sharedArtifacts + TokenUnlock(tokenLockRef, unlockAmount, currencyId.some, address)
+      case UsageUpdateWithTokenLockReplacement(address, currencyId, originalTokenLockRef, originalAmount, _, _) =>
+        // When a token lock is replaced, unlock the original lock's amount
+        acc.sharedArtifacts + TokenUnlock(originalTokenLockRef, originalAmount, currencyId.some, address)
       case _ => acc.sharedArtifacts
     }
 

--- a/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/types/Types.scala
+++ b/.github/templates/metagraphs/project_template/modules/shared_data/src/main/scala/com/my/project_template/shared_data/types/Types.scala
@@ -67,6 +67,32 @@ object Types {
     usage: NonNegLong
   ) extends UsageUpdate
 
+  /** Data update that triggers a token lock replacement unlock. When a token lock is replaced, the old lock's amount is unlocked. This
+    * update type produces a TokenUnlock artifact for the replaced lock.
+    *
+    * @param address
+    *   The address that owns the token lock
+    * @param currencyId
+    *   The currency of the token lock being replaced
+    * @param originalTokenLockRef
+    *   Hash of the original token lock being replaced
+    * @param originalAmount
+    *   Amount from the original lock to unlock
+    * @param replacementTokenLockRef
+    *   Hash of the new replacement token lock
+    * @param usage
+    *   Usage counter for testing
+    */
+  @derive(decoder, encoder)
+  case class UsageUpdateWithTokenLockReplacement(
+    address: Address,
+    currencyId: CurrencyId,
+    originalTokenLockRef: Hash,
+    originalAmount: TokenLockAmount,
+    replacementTokenLockRef: Hash,
+    usage: NonNegLong
+  ) extends UsageUpdate
+
   @derive(decoder, encoder)
   case class UsageUpdateState(
     updates: List[UsageUpdate]

--- a/.github/workflows/e2e-functionality-tests.yml
+++ b/.github/workflows/e2e-functionality-tests.yml
@@ -84,3 +84,10 @@ jobs:
     with:
       tessellation_version: ${{ needs.calculate-version.outputs.tessellation_version }}
     secrets: inherit
+
+  call-test-token-lock-replacement:
+    needs: [calculate-version, call-workflow-setup-environment]
+    uses: ./.github/workflows/test-token-lock-replacement.yml
+    with:
+      tessellation_version: ${{ needs.calculate-version.outputs.tessellation_version }}
+    secrets: inherit

--- a/.github/workflows/test-token-lock-replacement.yml
+++ b/.github/workflows/test-token-lock-replacement.yml
@@ -1,0 +1,75 @@
+name: Test Token Lock Replacement Edge Cases
+
+on:
+  workflow_call:
+    inputs:
+      tessellation_version:
+        required: true
+        type: string
+
+jobs:
+  token-lock-replacement-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: .github/action_scripts/package-lock.json
+
+      - name: Installing node dependencies
+        shell: bash
+        run: |
+          npm i @stardust-collective/dag4@v2.8.0 
+          npm i js-sha256
+          npm i axios
+          npm i brotli
+          npm i zod
+          npm i elliptic
+
+      - name: Download shared_jars artifacts
+        uses: actions/download-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: shared_jars-${{ inputs.tessellation_version }}
+          path: .github/code/shared_jars
+
+      - name: Download Hypergraph Artifact
+        uses: actions/download-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: hypergraph-${{ inputs.tessellation_version }}
+          path: .github/code/hypergraph
+
+      - name: Download project template Artifact
+        uses: actions/download-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: project-template-metagraph-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}-${{ inputs.tessellation_version }}
+          path: .github/code/metagraphs/project-template-metagraph
+
+      - name: Start Hypergraph
+        uses: "./.github/templates/actions/hypergraph/start"
+        with:
+          INCLUDE_DAG_L1: true
+          DAG_L0_PORT_PREFIX: 90
+          DAG_L1_PORT_PREFIX: 91
+
+      - name: Test Token Lock Replacement Edge Cases
+        run: |
+          cd .github/action_scripts/delegated_staking
+          node token-lock-replacement-edge-cases.js 90 91 testTokenLockReplacementEdgeCases
+
+      - name: Upload log files
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: token-lock-replacement-node-log-files-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}-${{ inputs.tessellation_version }}
+          path: .github/code/**/*.log
+          if-no-files-found: warn
+          retention-days: 3

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidator.scala
@@ -169,17 +169,14 @@ object ContextualTokenLockValidator {
         hashedActiveTokenLocks: List[Hashed[TokenLock]]
       ): Either[ContextualTokenLockValidationError, Hashed[TokenLock]] =
         tokenLock.replaceTokenLockRef match {
-          case None => tokenLock.asRight
+          case None      => tokenLock.asRight
           case Some(ref) =>
-            if (tokenLock.currencyId.nonEmpty) {
-              ReplacementIsNotSupported(tokenLock.currencyId).asLeft
-            } else {
-              hashedActiveTokenLocks.find(_.hash == ref) match {
-                case None => NothingToReplace(ref).asLeft
-                case Some(existing) if tokenLock.amount <= existing.amount =>
-                  ReplacementLowerThanCurrentTokenLock(tokenLock.amount, existing.amount).asLeft
-                case Some(_) => tokenLock.asRight
-              }
+            // Note: Currency token lock replacement is now supported (previously blocked)
+            hashedActiveTokenLocks.find(_.hash == ref) match {
+              case None => NothingToReplace(ref).asLeft
+              case Some(existing) if tokenLock.amount <= existing.amount =>
+                ReplacementLowerThanCurrentTokenLock(tokenLock.amount, existing.amount).asLeft
+              case Some(_) => tokenLock.asRight
             }
         }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockValidator.scala
@@ -124,12 +124,10 @@ object TokenLockValidator {
         currentTokenLocks: SortedMap[Address, SortedSet[Signed[TokenLock]]]
       ): TokenLockValidationErrorOr[Signed[TokenLock]] =
         tokenLock.replaceTokenLockRef match {
-          case None => tokenLock.validNec[TokenLockValidationError]
-          case Some(ref) =>
-            if (tokenLock.currencyId.nonEmpty)
-              (ReplacementIsNotSupported(tokenLock.currencyId): TokenLockValidationError).invalidNec[Signed[TokenLock]]
-            else
-              tokenLock.validNec[TokenLockValidationError]
+          case None    => tokenLock.validNec[TokenLockValidationError]
+          case Some(_) =>
+            // Note: Currency token lock replacement is now supported (previously blocked)
+            tokenLock.validNec[TokenLockValidationError]
         }
 
       private val lockedAddresses = cfg.locked

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -848,7 +848,13 @@ object GlobalSnapshotAcceptanceManager {
               SortedMap.empty[Address, SortedSet[Signed[TokenLock]]]
             )
 
-            allTokenLocks: List[Signed[TokenLock]] = globalActiveTokenLocks.values.toList.flatten
+            // Include both DAG token locks (from global activeTokenLocks) and currency token locks (from currency snapshots)
+            currencyTokenLocks: List[Signed[TokenLock]] = currencySnapshots.values.toList
+              .flatMap(_.toOption)
+              .flatMap {
+                case (_, info) => info.activeTokenLocks.getOrElse(SortedMap.empty[Address, SortedSet[Signed[TokenLock]]]).values.flatten
+              }
+            allTokenLocks: List[Signed[TokenLock]] = globalActiveTokenLocks.values.toList.flatten ++ currencyTokenLocks
             globalActiveTokenLocksByRef <-
               if (allTokenLocks.isEmpty) {
                 Async[F].pure(Map.empty[Hash, Signed[TokenLock]])

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TokenLockStateManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TokenLockStateManager.scala
@@ -135,17 +135,16 @@ object TokenLockStateManager {
           case ((result, seen), tx) =>
             tx.replaceTokenLockRef match {
               case Some(replaceTokenLockRef) =>
-                if (tx.currencyId.nonEmpty) {
-                  // we can only replace DAG token locks
-                  (result, seen).pure[F]
-                } else if (seen(replaceTokenLockRef)) {
+                if (seen(replaceTokenLockRef)) {
                   (result, seen).pure[F]
                 } else {
+                  // Note: Currency token lock replacement is now supported (previously blocked)
+                  // Filter to matching currency: DAG (None) can only replace DAG, currency can only replace same currency
                   lastSnapshotContext.activeTokenLocks
                     .getOrElse(SortedMap.empty[Address, SortedSet[Signed[TokenLock]]])
                     .getOrElse(tx.source, SortedSet.empty[Signed[TokenLock]])
                     .toList
-                    .filter(_.currencyId.isEmpty) // we can only replace DAG token locks
+                    .filter(_.currencyId == tx.currencyId) // replacement must be same currency type
                     .traverse(existing => TokenLockReference.of(existing).map(ref => (ref, existing)))
                     .map { existingWithRefs =>
                       val shouldInclude = existingWithRefs.exists {

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/tokenlock/ContextualTokenLockValidatorSuite.scala
@@ -398,7 +398,7 @@ object ContextualTokenLockValidatorSuite extends MutableIOSuite {
       )
   }
 
-  test("validateReplaceTokenLockRef - ReplacementIsNotSupported when currencyId is set") { res =>
+  test("validateReplaceTokenLockRef - currency token lock replacement is now supported") { res =>
     implicit val (h, sp) = res
 
     for {
@@ -429,7 +429,7 @@ object ContextualTokenLockValidatorSuite extends MutableIOSuite {
       )
 
       res = validator.validate(newHashedTokenLock, context)
-    } yield expect.same(ReplacementIsNotSupported(currencyId).invalidNec, res)
+    } yield expect.all(res.isValid)
   }
 
   test("validate balances - arithmetic error with overflow") { res =>

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockValidatorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockValidatorSuite.scala
@@ -304,7 +304,7 @@ object TokenLockValidatorSuite extends MutableIOSuite {
 
   // ==================== validateReplaceTokenLockRef tests ====================
 
-  test("validateWithTokenLockLimits - should fail when replacement is not supported for currency token locks") { res =>
+  test("validateWithTokenLockLimits - currency token lock replacement is now supported") { res =>
     implicit val (h, sp) = res
 
     val config = TokenLockLimitsConfig(
@@ -331,7 +331,7 @@ object TokenLockValidatorSuite extends MutableIOSuite {
       )
       validator = mkValidator()
       result <- validator.validateWithTokenLockLimits(newTokenLock, config, currentTokenLocks.some, EpochProgress.MinValue.some)
-    } yield expect.same(ReplacementIsNotSupported(currencyId).invalidNec, result)
+    } yield expect.same(Valid(newTokenLock), result)
   }
 
   // ==================== Combined validation tests ====================


### PR DESCRIPTION
## Summary
Adds comprehensive E2E edge case tests for the token lock replacement + delegated stake interaction.

Changes

Core Feature

• Remove currency token lock replacement restriction - Currency token locks can now be replaced (previously only DAG locks supported replacement)
• Fix globalActiveTokenLocksByRef lookup - Include currency token locks from currency snapshots in the replacement lookup map (fixes "NothingToReplace" errors for currency locks)
• Allow same-currency replacement - DAG→DAG and currency→same-currency replacements now work correctly
Files Changed

• ContextualTokenLockValidator.scala - Remove ReplacementIsNotSupported check for currency locks
• TokenLockValidator.scala - Same removal
• TokenLockStateManager.scala - Update filter to allow same-currency replacement
• GlobalSnapshotAcceptanceManager.scala - Include currency locks in globalActiveTokenLocksByRef
Test Metagraph Updates

• Add UsageUpdateWithTokenLockReplacement data type for testing replacement flow
• Update Combiners.scala and LifecycleSharedFunctions.scala to handle new type
CI Test Coverage

New E2E test workflow (test-token-lock-replacement.yml) covering:

1. Replace with same amount → ReplacementLowerThanCurrentTokenLock ❌
2. Replace with less amount → ReplacementLowerThanCurrentTokenLock ❌
3. Replace non-existent ref → NothingToReplace ❌
4. Replace with minimum increase (+1 datum) → ✅
5. Multiple sequential replacements (3x) → ✅
6. Replace while stake in withdrawal → ✅
Testing

• All edge case tests pass on local cluster
• Verified delegated stake currentTokenLockRef and currentAmount update correctly after replacement
Notes

The e2e-test/ directory contains local debugging scripts used during development. These are not part of CI but may be useful for manual testing.