### PR TITLE
ci: improve cluster formation robustness with wait-for-ready and retry logic

### DIFF
--- a/.github/action_scripts/check_clusters/shared.js
+++ b/.github/action_scripts/check_clusters/shared.js
@@ -26,21 +26,27 @@ const sleep = (ms) => {
 const checkIfNodeIsReady = async (url, name) => {
   console.log(`Checking if ${name} is ready`);
   const checkInterval = 10 * 1000;
-  for (let idx = 0; idx < 12; idx++) {
-    const { state } = await fetchData(url);
-    if (state === 'Ready') {
-      console.log(`Node ${name} is ready`);
-      return;
+  const maxAttempts = 24; // 240s total (increased from 120s for CI reliability)
+  for (let idx = 0; idx < maxAttempts; idx++) {
+    try {
+      const { state } = await fetchData(url);
+      if (state === 'Ready') {
+        console.log(`Node ${name} is ready`);
+        return;
+      }
+      console.log(
+        `Node ${name} state: ${state}, waiting ${checkInterval / 1000}s (${idx + 1}/${maxAttempts})`
+      );
+    } catch (e) {
+      console.log(
+        `Node ${name} not reachable: ${e.message}, waiting ${checkInterval / 1000}s (${idx + 1}/${maxAttempts})`
+      );
     }
-    console.log(
-      `Node ${name} is not ready yet, waiting ${checkInterval / 1000}s`
-    );
     await sleep(checkInterval);
   }
 
   throw Error(
-    `Node ${name} is not ready after ${(checkInterval * 12) / 1000
-    }s, check the logs.`
+    `Node ${name} is not ready after ${(checkInterval * maxAttempts) / 1000}s, check the logs.`
   );
 };
 

--- a/.github/action_scripts/check_if_node_started.js
+++ b/.github/action_scripts/check_if_node_started.js
@@ -1,51 +1,77 @@
-const axios = require( 'axios' );
+const axios = require('axios');
 
-const sleep = ( ms ) => {
-    return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+const sleep = (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const parseArgs = () => {
+  const args = {};
+  for (const arg of process.argv.slice(2)) {
+    if (arg.includes('=')) {
+      const [key, value] = arg.split('=');
+      args[key.replace('-', '')] = value;
+    }
+  }
+  return args;
 };
 
 const main = async () => {
-    const urlParam = process.argv.find( ( arg ) => arg.includes( 'url' ) );
-    const clusterNameParam = process.argv.find( ( arg ) =>
-        arg.includes( 'cluster_name' )
-    );
+  const args = parseArgs();
+  
+  if (!args.url) {
+    throw Error('Url should be provided via -url=<url>');
+  }
 
-    if( !urlParam ) {
-        throw Error( 'Url should be provided' );
-    }
+  const url = args.url;
+  const clusterName = args.cluster_name || 'Node';
+  const waitForReady = args.wait_for_ready === 'true';
+  const maxAttempts = parseInt(args.max_attempts || '30', 10);
+  const intervalSeconds = parseInt(args.interval || '10', 10);
 
-    const url = urlParam.split( '=' )[ 1 ];
-    const clusterName = clusterNameParam.split( '=' )[ 1 ];
+  console.log(`Starting to check if url: ${url} is started`);
+  if (waitForReady) {
+    console.log(`Will wait for node to reach 'Ready' state (max ${maxAttempts * intervalSeconds}s)`);
+  }
 
-    console.log(`Starting to check if url: ${url} is started`)
-    for( let idx = 0; idx < 11; idx++ ) {
-        try {
-            const response = await axios.get(url, {
-                headers: {
-                    Accept: 'application/json'
-                }
-            });
+  for (let idx = 0; idx < maxAttempts; idx++) {
+    try {
+      const response = await axios.get(url, {
+        headers: {
+          Accept: 'application/json'
+        },
+        timeout: 5000
+      });
 
-            if( response.status === 200 ) {
-                console.log( `${clusterName} started` );
-                break;
-            }
-
-            if( idx === 10 ) {
-                throw Error( `Error starting the ${clusterName}` );
-            }
-        } catch( e ) {
-            console.log(
-                `${clusterName} still booting... waiting 10s (${idx + 1} / 10)`
-            );
-
-            if( idx === 10 ) {
-                throw Error( `Error starting the ${clusterName}` );
-            }
-
-            await sleep( 10 * 1000 );
+      if (response.status === 200) {
+        const state = response.data?.state;
+        
+        if (waitForReady) {
+          if (state === 'Ready') {
+            console.log(`${clusterName} is Ready`);
+            return;
+          }
+          console.log(
+            `${clusterName} state: ${state}, waiting for Ready... (${idx + 1}/${maxAttempts})`
+          );
+        } else {
+          console.log(`${clusterName} started (state: ${state})`);
+          return;
         }
+      }
+    } catch (e) {
+      const errorMsg = e.code === 'ECONNREFUSED' ? 'connection refused' : e.message;
+      console.log(
+        `${clusterName} still booting (${errorMsg})... waiting ${intervalSeconds}s (${idx + 1}/${maxAttempts})`
+      );
     }
+
+    if (idx === maxAttempts - 1) {
+      const waitType = waitForReady ? 'reach Ready state' : 'start';
+      throw Error(`${clusterName} failed to ${waitType} after ${maxAttempts * intervalSeconds}s`);
+    }
+
+    await sleep(intervalSeconds * 1000);
+  }
 };
 
 main();

--- a/.github/templates/actions/hypergraph/dag_l0/genesis/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l0/genesis/action.yml
@@ -33,9 +33,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/hypergraph/dag-l0.jar run-genesis genesis.csv --ip 127.0.0.1 > dag-l0-genesis.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for genesis node to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L0
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L0-Genesis \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/hypergraph/dag_l0/validator/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l0/validator/action.yml
@@ -52,10 +52,44 @@ runs:
         cd $ROOT_DIRECTORY/.github/code/hypergraph/dag-l0/genesis-node
         GLOBAL_L0_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L0-Validator-${{ inputs.NODE_NUMBER }}; then
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L0-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining DAG L0 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$GLOBAL_L0_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE), retrying in 5s..."
           sleep 5
-          echo "Joining DAG L0 validator node ${{ inputs.NODE_NUMBER }} ..."
-          curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$GLOBAL_L0_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }"
-          echo "Joined"
-          exit 0
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L0-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/hypergraph/dag_l1/initial_validator/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l1/initial_validator/action.yml
@@ -41,9 +41,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/hypergraph/dag-l1.jar run-initial-validator --ip 127.0.0.1 > dag-l1-initial-validator.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for initial validator to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L1-Initial-Validator
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L1-Initial-Validator \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/hypergraph/dag_l1/validator/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l1/validator/action.yml
@@ -59,10 +59,44 @@ runs:
         cd $ROOT_DIRECTORY/.github/code/hypergraph/dag-l1/initial-validator
         DAG_L1_INITIAL_VALIDATOR_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L1-Validator-${{ inputs.NODE_NUMBER }}; then
-            sleep 5
-            echo "Joining DAG L1 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$DAG_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }"
-            echo "Joined"
-            exit 0
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L1-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining DAG L1 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$DAG_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE), retrying in 5s..."
+          sleep 5
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L1-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/currency_l1/initial_validator/action.yml
+++ b/.github/templates/actions/metagraph/currency_l1/initial_validator/action.yml
@@ -53,9 +53,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/currency-l1/currency-l1.jar run-initial-validator --ip 127.0.0.1 > currency-l1-initial-validator.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for initial validator to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Currency-L1-Initial-Validator
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Currency-L1-Initial-Validator \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/currency_l1/validator/action.yml
+++ b/.github/templates/actions/metagraph/currency_l1/validator/action.yml
@@ -57,7 +57,7 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/currency-l1/currency-l1.jar run-validator --ip 127.0.0.1 > currency-l1-${{ inputs.NODE_NUMBER }}.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Join node after started - ${{ inputs.NODE_NUMBER }}
       shell: bash
       env:
         CL_KEYSTORE: token-key.p12
@@ -66,15 +66,51 @@ runs:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
         CL_CLI_HTTP_PORT: ${{ inputs.CL_CLI_HTTP_PORT }}
         CL_L1_INITIAL_VALIDATOR_P2P_PORT: ${{ inputs.CL_L1_INITIAL_VALIDATOR_P2P_PORT }}
+        METAGRAPH_NAME: ${{ inputs.METAGRAPH_NAME }}
       run: |
         ROOT_DIRECTORY=$(pwd)
 
-        cd $ROOT_DIRECTORY/.github/code/metagraphs/${{ inputs.METAGRAPH_NAME }}/currency-l1/initial-validator
+        cd $ROOT_DIRECTORY/.github/code/metagraphs/${METAGRAPH_NAME}/currency-l1/initial-validator
         CURRENCY_L1_INITIAL_VALIDATOR_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Currency-L1-Validator-${{ inputs.NODE_NUMBER }}; then
-            sleep 5
-            echo "Joining Metagraph L1 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$CURRENCY_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }"
-            echo "Joined"
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Currency-L1-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining Currency L1 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$CURRENCY_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE), retrying in 5s..."
+          sleep 5
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Currency-L1-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/data_l1/initial_validator/action.yml
+++ b/.github/templates/actions/metagraph/data_l1/initial_validator/action.yml
@@ -53,9 +53,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/data-l1/data-l1.jar run-initial-validator --ip 127.0.0.1 > data-l1-initial-validator.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for initial validator to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Data-L1-Initial-Validator
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Data-L1-Initial-Validator \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/data_l1/validator/action.yml
+++ b/.github/templates/actions/metagraph/data_l1/validator/action.yml
@@ -57,7 +57,7 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/data-l1/data-l1.jar run-validator --ip 127.0.0.1 > data-l1-${{ inputs.NODE_NUMBER }}.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Join node after started - ${{ inputs.NODE_NUMBER }}
       shell: bash
       env:
         CL_KEYSTORE: token-key.p12
@@ -66,15 +66,51 @@ runs:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
         CL_CLI_HTTP_PORT: ${{ inputs.CL_CLI_HTTP_PORT }}
         CL_L1_INITIAL_VALIDATOR_P2P_PORT: ${{ inputs.CL_L1_INITIAL_VALIDATOR_P2P_PORT }}
+        METAGRAPH_NAME: ${{ inputs.METAGRAPH_NAME }}
       run: |
         ROOT_DIRECTORY=$(pwd)
 
-        cd $ROOT_DIRECTORY/.github/code/metagraphs/${{ inputs.METAGRAPH_NAME }}/data-l1/initial-validator
+        cd $ROOT_DIRECTORY/.github/code/metagraphs/${METAGRAPH_NAME}/data-l1/initial-validator
         DATA_L1_INITIAL_VALIDATOR_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Data-L1-Validator-${{ inputs.NODE_NUMBER }}; then
-            sleep 5
-            echo "Joining Metagraph L1 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$DATA_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }"
-            echo "Joined"
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Data-L1-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining Data L1 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$DATA_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE), retrying in 5s..."
+          sleep 5
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Data-L1-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/metagraph_l0/genesis/action.yml
+++ b/.github/templates/actions/metagraph/metagraph_l0/genesis/action.yml
@@ -80,7 +80,11 @@ runs:
       nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/metagraph-l0/metagraph-l0.jar run-genesis genesis.snapshot --ip 127.0.0.1 > metagraph-l0-run-genesis.log 2>&1 &
       sleep 5
 
-  - name: Check if node started
+  - name: Wait for genesis node to be Ready
     shell: bash
     run: |
-      node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${{ inputs.CL_PUBLIC_HTTP_PORT }}/node/info -cluster_name=${{inputs.METAGRAPH_NAME}}-Metagraph-L0-Genesis
+      node .github/action_scripts/check_if_node_started.js \
+        -url=http://127.0.0.1:${{ inputs.CL_PUBLIC_HTTP_PORT }}/node/info \
+        -cluster_name=${{inputs.METAGRAPH_NAME}}-Metagraph-L0-Genesis \
+        -wait_for_ready=true \
+        -max_attempts=30

--- a/.github/templates/actions/metagraph/metagraph_l0/validator/action.yml
+++ b/.github/templates/actions/metagraph/metagraph_l0/validator/action.yml
@@ -66,9 +66,44 @@ runs:
         cd $ROOT_DIRECTORY/.github/code/metagraphs/${METAGRAPH_NAME}/metagraph-l0/genesis-node
         CURRENCY_L0_GENESIS_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Metagraph-L0-Validator-${{ inputs.NODE_NUMBER }}; then
-            sleep 5
-            echo "Joining Metagraph L0 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$CURRENCY_L0_GENESIS_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }"
-            echo "Joined"
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Metagraph-L0-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining Metagraph L0 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$CURRENCY_L0_GENESIS_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE), retrying in 5s..."
+          sleep 5
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Metagraph-L0-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30


### PR DESCRIPTION
## Summary
Addresses frequent CI E2E test failures where nodes get stuck in 'Observing' state due to race conditions during cluster formation on GitHub runners.

## Root Cause
The existing cluster startup had several timing issues:
1. Genesis nodes only waited for HTTP 200 response, not 'Ready' state
2. Validators started joining immediately, sometimes before genesis was fully ready
3. No retry logic for `cluster/join` requests that could fail transiently
4. 120s timeout was insufficient for slow/loaded GitHub runners

## Changes

### `check_if_node_started.js`
- Added `-wait_for_ready=true` flag to wait for node to reach 'Ready' state (not just respond)
- Added configurable `-max_attempts` and `-interval` parameters
- Better error messages with attempt counts

### `shared.js`
- Increased cluster check timeout from 120s to 240s (12 → 24 attempts)
- Added error handling for unreachable nodes

### All Genesis/Initial Validator Actions
- Now wait for 'Ready' state before allowing validators to start joining

### All Validator Actions
- Added retry logic (5 attempts with 5s backoff) for `cluster/join` requests
- Added explicit wait for 'Ready' state after joining
- Better logging of join attempt status

## Testing
This change affects CI workflow infrastructure only. The fixes are defensive timing improvements that should make E2E tests more reliable without changing test behavior.

## Files Changed
- `.github/action_scripts/check_if_node_started.js`
- `.github/action_scripts/check_clusters/shared.js`
- `.github/templates/actions/hypergraph/dag_l0/genesis/action.yml`
- `.github/templates/actions/hypergraph/dag_l0/validator/action.yml`
- `.github/templates/actions/hypergraph/dag_l1/initial_validator/action.yml`
- `.github/templates/actions/hypergraph/dag_l1/validator/action.yml`
- `.github/templates/actions/metagraph/metagraph_l0/genesis/action.yml`
- `.github/templates/actions/metagraph/metagraph_l0/validator/action.yml`
- `.github/templates/actions/metagraph/currency_l1/initial_validator/action.yml`
- `.github/templates/actions/metagraph/currency_l1/validator/action.yml`
- `.github/templates/actions/metagraph/data_l1/initial_validator/action.yml`
- `.github/templates/actions/metagraph/data_l1/validator/action.yml`