### PR TITLE
ci: improve cluster robustness with wait-for-ready and retry

### DIFF
--- a/.github/action_scripts/check_clusters/shared.js
+++ b/.github/action_scripts/check_clusters/shared.js
@@ -1,12 +1,14 @@
 const axios = require('axios');
 
-const fetchData = async (url) => {
-  for (let idx = 0; idx < 12; idx++) {
+const fetchData = async (url, maxRetries = 12, retryIntervalMs = 5000) => {
+  let lastError = null;
+  for (let idx = 0; idx < maxRetries; idx++) {
     try {
       const response = await axios.get(url, {
         headers: {
           Accept: 'application/json'
-        }
+        },
+        timeout: 10000
       });
 
       const { data } = response
@@ -14,9 +16,14 @@ const fetchData = async (url) => {
 
       return data
     } catch (e) {
-      throw Error(`Error when fetching data: ${e.message}`);
+      lastError = e;
+      console.log(`fetchData attempt ${idx + 1}/${maxRetries} failed for ${url}: ${e.message}`);
+      if (idx < maxRetries - 1) {
+        await sleep(retryIntervalMs);
+      }
     }
   }
+  throw Error(`Error fetching data from ${url} after ${maxRetries} attempts: ${lastError?.message}`);
 };
 
 const sleep = (ms) => {
@@ -26,21 +33,28 @@ const sleep = (ms) => {
 const checkIfNodeIsReady = async (url, name) => {
   console.log(`Checking if ${name} is ready`);
   const checkInterval = 10 * 1000;
-  for (let idx = 0; idx < 12; idx++) {
-    const { state } = await fetchData(url);
-    if (state === 'Ready') {
-      console.log(`Node ${name} is ready`);
-      return;
+  const maxAttempts = 24; // 240s total (increased from 120s for CI reliability)
+  for (let idx = 0; idx < maxAttempts; idx++) {
+    try {
+      // Use minimal retries in fetchData since outer loop handles retry-over-time
+      const { state } = await fetchData(url, 2, 2000);
+      if (state === 'Ready') {
+        console.log(`Node ${name} is ready`);
+        return;
+      }
+      console.log(
+        `Node ${name} state: ${state}, waiting ${checkInterval / 1000}s (${idx + 1}/${maxAttempts})`
+      );
+    } catch (e) {
+      console.log(
+        `Node ${name} not reachable: ${e.message}, waiting ${checkInterval / 1000}s (${idx + 1}/${maxAttempts})`
+      );
     }
-    console.log(
-      `Node ${name} is not ready yet, waiting ${checkInterval / 1000}s`
-    );
     await sleep(checkInterval);
   }
 
   throw Error(
-    `Node ${name} is not ready after ${(checkInterval * 12) / 1000
-    }s, check the logs.`
+    `Node ${name} is not ready after ${(checkInterval * maxAttempts) / 1000}s, check the logs.`
   );
 };
 

--- a/.github/action_scripts/check_if_node_started.js
+++ b/.github/action_scripts/check_if_node_started.js
@@ -1,51 +1,79 @@
-const axios = require( 'axios' );
+const axios = require('axios');
 
-const sleep = ( ms ) => {
-    return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+const sleep = (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const parseArgs = () => {
+  const args = {};
+  for (const arg of process.argv.slice(2)) {
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex !== -1) {
+      const key = arg.slice(0, eqIndex);
+      const value = arg.slice(eqIndex + 1); // Preserve everything after first '='
+      args[key.replace(/^-+/, '')] = value;
+    }
+  }
+  return args;
 };
 
 const main = async () => {
-    const urlParam = process.argv.find( ( arg ) => arg.includes( 'url' ) );
-    const clusterNameParam = process.argv.find( ( arg ) =>
-        arg.includes( 'cluster_name' )
-    );
+  const args = parseArgs();
+  
+  if (!args.url) {
+    throw Error('Url should be provided via -url=<url>');
+  }
 
-    if( !urlParam ) {
-        throw Error( 'Url should be provided' );
-    }
+  const url = args.url;
+  const clusterName = args.cluster_name || 'Node';
+  const waitForReady = args.wait_for_ready === 'true';
+  const maxAttempts = parseInt(args.max_attempts || '30', 10);
+  const intervalSeconds = parseInt(args.interval || '10', 10);
 
-    const url = urlParam.split( '=' )[ 1 ];
-    const clusterName = clusterNameParam.split( '=' )[ 1 ];
+  console.log(`Starting to check if url: ${url} is started`);
+  if (waitForReady) {
+    console.log(`Will wait for node to reach 'Ready' state (max ${maxAttempts * intervalSeconds}s)`);
+  }
 
-    console.log(`Starting to check if url: ${url} is started`)
-    for( let idx = 0; idx < 11; idx++ ) {
-        try {
-            const response = await axios.get(url, {
-                headers: {
-                    Accept: 'application/json'
-                }
-            });
+  for (let idx = 0; idx < maxAttempts; idx++) {
+    try {
+      const response = await axios.get(url, {
+        headers: {
+          Accept: 'application/json'
+        },
+        timeout: 5000
+      });
 
-            if( response.status === 200 ) {
-                console.log( `${clusterName} started` );
-                break;
-            }
-
-            if( idx === 10 ) {
-                throw Error( `Error starting the ${clusterName}` );
-            }
-        } catch( e ) {
-            console.log(
-                `${clusterName} still booting... waiting 10s (${idx + 1} / 10)`
-            );
-
-            if( idx === 10 ) {
-                throw Error( `Error starting the ${clusterName}` );
-            }
-
-            await sleep( 10 * 1000 );
+      if (response.status === 200) {
+        const state = response.data?.state;
+        
+        if (waitForReady) {
+          if (state === 'Ready') {
+            console.log(`${clusterName} is Ready`);
+            return;
+          }
+          console.log(
+            `${clusterName} state: ${state}, waiting for Ready... (${idx + 1}/${maxAttempts})`
+          );
+        } else {
+          console.log(`${clusterName} started (state: ${state})`);
+          return;
         }
+      }
+    } catch (e) {
+      const errorMsg = e.code === 'ECONNREFUSED' ? 'connection refused' : e.message;
+      console.log(
+        `${clusterName} still booting (${errorMsg})... waiting ${intervalSeconds}s (${idx + 1}/${maxAttempts})`
+      );
     }
+
+    if (idx === maxAttempts - 1) {
+      const waitType = waitForReady ? 'reach Ready state' : 'start';
+      throw Error(`${clusterName} failed to ${waitType} after ${maxAttempts * intervalSeconds}s`);
+    }
+
+    await sleep(intervalSeconds * 1000);
+  }
 };
 
 main();

--- a/.github/action_scripts/delegated_staking/lib.js
+++ b/.github/action_scripts/delegated_staking/lib.js
@@ -5,6 +5,8 @@ const fs = require('fs')
 const {
   sleep,
   withRetry,
+  withRetryOrdinal,
+  waitForTxInclusion,
   generateProof,
   SerializerType,
   logWorkflow,
@@ -335,6 +337,107 @@ const assertTokenUnlockInSnapshot = async (
   }
 }
 
+/**
+ * Wait for a delegated stake to appear in activeDelegatedStakes using ordinal-aware retry.
+ * This is more robust than wall-clock retries because it detects dropped transactions.
+ * 
+ * @param {Object} urls - Network URLs including globalL0Url
+ * @param {string} address - Account address
+ * @param {string} stakeHash - Expected stake hash
+ * @param {Object} [options] - Additional options for withRetryOrdinal
+ * @returns {Promise<Object>} - The stake object when found
+ */
+const waitForStakeInclusion = async (urls, address, stakeHash, options = {}) => {
+  return withRetryOrdinal(
+    async () => {
+      const response = await getAccountDelegatedStakes(urls, address)
+      const stake = response.activeDelegatedStakes.find(s => s.hash === stakeHash)
+      if (!stake) {
+        throw new Error(`Stake ${stakeHash.substring(0, 16)}... not in activeDelegatedStakes`)
+      }
+      return stake
+    },
+    {
+      globalL0Url: urls.globalL0Url,
+      name: 'waitForStakeInclusion',
+      maxOrdinalMisses: 5,
+      maxStalledChecks: 15,
+      interval: 2000,
+      ...options
+    }
+  )
+}
+
+/**
+ * Wait for a delegated stake to move to pendingWithdrawals using ordinal-aware retry.
+ * 
+ * @param {Object} urls - Network URLs including globalL0Url
+ * @param {string} address - Account address
+ * @param {string} stakeHash - Expected stake hash
+ * @param {Object} [options] - Additional options for withRetryOrdinal
+ * @returns {Promise<Object>} - The pending withdrawal object when found
+ */
+const waitForStakeWithdrawal = async (urls, address, stakeHash, options = {}) => {
+  return withRetryOrdinal(
+    async () => {
+      const response = await getAccountDelegatedStakes(urls, address)
+      const pending = response.pendingWithdrawals.find(s => s.hash === stakeHash)
+      if (!pending) {
+        throw new Error(`Stake ${stakeHash.substring(0, 16)}... not in pendingWithdrawals`)
+      }
+      return pending
+    },
+    {
+      globalL0Url: urls.globalL0Url,
+      name: 'waitForStakeWithdrawal',
+      maxOrdinalMisses: 5,
+      maxStalledChecks: 15,
+      interval: 2000,
+      ...options
+    }
+  )
+}
+
+/**
+ * Wait for a token lock to appear in account's active token locks using ordinal-aware retry.
+ * 
+ * @param {Object} urls - Network URLs including globalL0Url  
+ * @param {string} address - Account address
+ * @param {string} lockHash - Expected lock hash
+ * @param {Object} [options] - Additional options for withRetryOrdinal
+ * @returns {Promise<Object>} - The token lock object when found
+ */
+const waitForTokenLockInclusion = async (urls, address, lockHash, options = {}) => {
+  return withRetryOrdinal(
+    async () => {
+      const response = await axios.get(
+        `${urls.globalL0Url}/token-locks/${address}?t=${Date.now()}`,
+        {
+          headers: {
+            'Cache-Control': 'no-cache, no-store, must-revalidate',
+            Pragma: 'no-cache',
+            Expires: '0',
+          },
+        }
+      )
+      checkOk(response)
+      const lock = response.data.find(l => l.hash === lockHash)
+      if (!lock) {
+        throw new Error(`Token lock ${lockHash.substring(0, 16)}... not found`)
+      }
+      return lock
+    },
+    {
+      globalL0Url: urls.globalL0Url,
+      name: 'waitForTokenLockInclusion',
+      maxOrdinalMisses: 5,
+      maxStalledChecks: 15,
+      interval: 2000,
+      ...options
+    }
+  )
+}
+
 module.exports = {
   checkOk,
   checkBadRequest,
@@ -352,5 +455,9 @@ module.exports = {
   getNodeParams,
   fetchSnapshot,
   assertRewardTxnInSnapshot,
-  assertTokenUnlockInSnapshot
+  assertTokenUnlockInSnapshot,
+  // Ordinal-aware helpers
+  waitForStakeInclusion,
+  waitForStakeWithdrawal,
+  waitForTokenLockInclusion,
 }

--- a/.github/action_scripts/delegated_staking/token-lock-replacement-edge-cases.js
+++ b/.github/action_scripts/delegated_staking/token-lock-replacement-edge-cases.js
@@ -1,0 +1,527 @@
+/**
+ * Token Lock Replacement Edge Cases - Extended tests for delegated stake + token lock replacement
+ *
+ * Tests edge cases not covered by the main delegated-staking.js tests:
+ * 1. Replace with same amount (should fail - ReplacementLowerThanCurrentTokenLock)
+ * 2. Replace with less amount (should fail - ReplacementLowerThanCurrentTokenLock)
+ * 3. Replace non-existent token lock ref (should fail - NothingToReplace)
+ * 4. Replace with minimum valid increase (+1 datum)
+ * 5. Multiple sequential replacements (3 in a row)
+ * 6. Replace while stake is in withdrawal (pendingWithdrawals)
+ *
+ * TODO: Add test for ReplacementIsNotSupported error (currency token locks with currencyId set)
+ *       This requires setting up a currency metagraph which is complex in the E2E environment.
+ *
+ * Key Reservation:
+ * - This test suite uses PRIVATE_KEYS.key3 to avoid conflicts with delegated-staking.js (uses key4)
+ * - If adding new test suites, use different keys to prevent cross-test contamination
+ *
+ * Usage:
+ * - CI: node token-lock-replacement-edge-cases.js 90 91 testTokenLockReplacementEdgeCases
+ * - Local: RUN_ENV=local node .github/action_scripts/delegated_staking/token-lock-replacement-edge-cases.js 90 91 testTokenLockReplacementEdgeCases
+ */
+
+const { dag4 } = require('@stardust-collective/dag4')
+
+const RUN_ENV = process.env.RUN_ENV || 'ci'
+
+const {
+  parseSharedArgs,
+  PRIVATE_KEYS,
+  sleep,
+  withRetry,
+  withRetryOrdinal,
+  createNetworkConfig,
+  logWorkflow,
+} = require('../shared')
+
+const {
+  checkOk,
+  checkBadRequest,
+  dagToDatum,
+  getPrivateKeyAndNodeIdFromFile,
+  postNodeParamsNodeId,
+  createDelegatedStake,
+  withdrawDelegatedStake,
+  getAccountDelegatedStakes,
+  assertDelegatedStakes,
+  fetchStakeWithRewardsBalance,
+  createTokenLock,
+  assertBalanceChange,
+  getNodeParams,
+  waitForStakeInclusion,
+  waitForStakeWithdrawal,
+  waitForTokenLockInclusion,
+} = require('./lib')
+
+const throwUsage = () => {
+  throw new Error(
+    'Usage: node script.js <dagl0-port-prefix> <dagl1-port-prefix> <workflow-name>',
+  )
+}
+
+const createConfig = () => {
+  const args = process.argv.slice(2)
+  if (args.length < 3) return throwUsage()
+  const sharedArgs = parseSharedArgs(args.slice(0, 3), false)
+  return { ...sharedArgs }
+}
+
+const setupDag4Account = (urls) => {
+  dag4.account.connect({
+    networkVersion: '2.0',
+    l0Url: urls.globalL0Url,
+    l1Url: urls.dagL1Url,
+  })
+  return dag4.account
+}
+
+const extractKeysAndAccount = (filePath) => {
+  const { privateKeyString, nodeId } = getPrivateKeyAndNodeIdFromFile(filePath)
+  const account = dag4.createAccount(privateKeyString)
+  return { privateKeyString, nodeId, account }
+}
+
+/**
+ * Helper to create token lock with error handling for expected failures
+ */
+const createTokenLockExpectError = async (account, urls, lockAmount, replaceRef, expectedErrorSubstring) => {
+  try {
+    await account.postTokenLock({
+      source: account.address,
+      amount: lockAmount,
+      tokenL1Url: urls.dagL1Url,
+      unlockEpoch: null,
+      currencyId: null,
+      replaceTokenLockRef: replaceRef,
+      fee: 0,
+    })
+    throw new Error(`Expected error containing "${expectedErrorSubstring}" but request succeeded`)
+  } catch (error) {
+    if (error.message.includes('Expected error')) throw error
+    
+    // dag4 SDK returns errors as JSON in error.message: {"errors":[{"message":"..."}]}
+    // or as plain text. Extract the actual error content.
+    const errorStr = error.message || ''
+    
+    // Check if this looks like an API validation error (contains error message patterns)
+    const isValidationError = errorStr.includes('"errors"') || 
+                              errorStr.includes('TokenLock') ||
+                              errorStr.includes('Replace') ||
+                              errorStr.includes('NothingTo')
+    
+    if (!isValidationError && (errorStr.includes('ECONNREFUSED') || errorStr.includes('ETIMEDOUT'))) {
+      throw new Error(`Network error: ${errorStr}`)
+    }
+    
+    if (!errorStr.includes(expectedErrorSubstring)) {
+      throw new Error(`Expected error containing "${expectedErrorSubstring}" but got: ${errorStr}`)
+    }
+    logWorkflow.info(`Got expected error: ${expectedErrorSubstring}`)
+    return true
+  }
+}
+
+/**
+ * Test 1: Replace with same amount (should fail)
+ * Also sets up the initial token lock and stake for subsequent tests
+ */
+const testReplaceSameAmount = async (urls, account, nodeIds) => {
+  logWorkflow.info('---- Start testReplaceSameAmount ----')
+
+  // Check if we already have a stake we can use
+  const existingStakes = await getAccountDelegatedStakes(urls, account.address)
+  let lockHash, stakeHash, lockAmount
+
+  if (existingStakes.activeDelegatedStakes.length > 0) {
+    // Reuse existing stake
+    const existingStake = existingStakes.activeDelegatedStakes[0]
+    lockHash = existingStake.tokenLockRef
+    stakeHash = existingStake.hash
+    lockAmount = existingStake.amount
+    logWorkflow.info(`Reusing existing stake: ${stakeHash.substring(0, 16)}...`)
+    logWorkflow.info(`  Token lock: ${lockHash.substring(0, 16)}...`)
+    logWorkflow.info(`  Amount: ${lockAmount}`)
+  } else {
+    // Create new token lock and stake
+    lockAmount = 600000000000 // 6000 DAG
+    lockHash = await createTokenLock(account, urls, lockAmount)
+    logWorkflow.info(`Created initial token lock: ${lockHash}`)
+
+    // Try each node until we find one without an existing stake
+    for (const nodeId of nodeIds) {
+      try {
+        stakeHash = await createDelegatedStake(account, lockHash, lockAmount, nodeId)
+        logWorkflow.info(`Created delegated stake on node ${nodeId.substring(0, 16)}...: ${stakeHash}`)
+        break
+      } catch (e) {
+        if (e.message.includes('StakeExistsForNode')) {
+          logWorkflow.info(`Stake already exists on node ${nodeId.substring(0, 16)}..., trying next node`)
+          continue
+        }
+        throw e
+      }
+    }
+
+    if (!stakeHash) {
+      throw new Error('Could not create stake on any node')
+    }
+
+    // Wait for stake to be included using ordinal-aware retry (detects dropped txs)
+    logWorkflow.info('Waiting for stake inclusion in global snapshot...')
+    const stake = await waitForStakeInclusion(urls, account.address, stakeHash)
+    logWorkflow.info(`Stake confirmed in snapshot: ${stake.hash.substring(0, 16)}...`)
+  }
+
+  // Try to replace with same amount - should fail with ReplacementLowerThanCurrentTokenLock
+  // Use ordinal-aware retry to handle L1 state propagation
+  await withRetryOrdinal(
+    async () => {
+      try {
+        await createTokenLockExpectError(
+          account,
+          urls,
+          lockAmount, // Same amount
+          lockHash,
+          'ReplacementLowerThanCurrentTokenLock'
+        )
+        return true
+      } catch (e) {
+        if (e.message.includes('NothingToReplace')) {
+          logWorkflow.info('Lock not yet in L1 state, waiting for ordinal progression...')
+          throw e // Retry after ordinal check
+        }
+        throw e // Other errors propagate
+      }
+    },
+    { globalL0Url: urls.globalL0Url, name: 'replaceWithSameAmount', maxOrdinalMisses: 5 }
+  )
+
+  // Verify stake unchanged using ordinal-aware retry
+  await withRetryOrdinal(
+    async () => {
+      const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+      const stake = stakeResponse.activeDelegatedStakes.find(s => s.hash === stakeHash)
+      if (!stake) throw new Error('Stake not found')
+      return true
+    },
+    { globalL0Url: urls.globalL0Url, name: 'verifyStakeExists', maxOrdinalMisses: 3 }
+  )
+
+  logWorkflow.info('---- End testReplaceSameAmount ----')
+  return { lockHash, stakeHash, lockAmount }
+}
+
+/**
+ * Test 2: Replace with less amount (should fail)
+ */
+const testReplaceLessAmount = async (urls, account, existingLockHash, existingAmount) => {
+  logWorkflow.info('---- Start testReplaceLessAmount ----')
+
+  // Use 5000 DAG (minimum) which is less than 6000 DAG but still valid amount
+  const lessAmount = 500000000000 // 5000 DAG - less than existing but above minimum
+
+  // Use ordinal-aware retry to handle L1 state propagation
+  await withRetryOrdinal(
+    async () => {
+      try {
+        await createTokenLockExpectError(
+          account,
+          urls,
+          lessAmount,
+          existingLockHash,
+          'ReplacementLowerThanCurrentTokenLock'
+        )
+        return true
+      } catch (e) {
+        if (e.message.includes('NothingToReplace')) {
+          logWorkflow.info('Lock not yet in L1 state, waiting for ordinal progression...')
+          throw e
+        }
+        throw e
+      }
+    },
+    { globalL0Url: urls.globalL0Url, name: 'replaceWithLessAmount', maxOrdinalMisses: 5 }
+  )
+
+  logWorkflow.info('---- End testReplaceLessAmount ----')
+}
+
+/**
+ * Test 3: Replace non-existent token lock ref (should fail)
+ */
+const testReplaceNonExistentRef = async (urls, account) => {
+  logWorkflow.info('---- Start testReplaceNonExistentRef ----')
+
+  const fakeRef = '0000000000000000000000000000000000000000000000000000000000000000'
+  const amount = 500000000000
+
+  await createTokenLockExpectError(
+    account,
+    urls,
+    amount,
+    fakeRef,
+    'NothingToReplace'
+  )
+
+  logWorkflow.info('---- End testReplaceNonExistentRef ----')
+}
+
+/**
+ * Test 4: Replace with minimum valid increase (+1 datum)
+ */
+const testReplaceMinimumIncrease = async (urls, account, existingLockHash, existingAmount, stakeHash) => {
+  logWorkflow.info('---- Start testReplaceMinimumIncrease ----')
+
+  const minIncrease = existingAmount + 1 // Minimum valid increase
+  
+  const newLockHash = await createTokenLock(account, urls, minIncrease, existingLockHash, existingAmount)
+  logWorkflow.info(`Created replacement with +1 datum: ${newLockHash}`)
+
+  // Verify delegated stake updated using ordinal-aware retry
+  logWorkflow.info('Waiting for snapshot inclusion and stake update...')
+  await withRetryOrdinal(
+    async () => {
+      const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+      const stake = stakeResponse.activeDelegatedStakes.find(s => s.hash === stakeHash)
+      if (!stake) throw new Error('Stake not found')
+      if (stake.tokenLockRef !== newLockHash) {
+        throw new Error(`TokenLockRef not updated: expected ${newLockHash}, got ${stake.tokenLockRef}`)
+      }
+      if (stake.amount !== minIncrease) {
+        throw new Error(`Amount not updated: expected ${minIncrease}, got ${stake.amount}`)
+      }
+      return true
+    },
+    { globalL0Url: urls.globalL0Url, name: 'verifyMinIncreaseUpdate', maxOrdinalMisses: 5, maxStalledChecks: 15 }
+  )
+  
+  // Brief wait for L1 sync after ordinal progression confirmed
+  logWorkflow.info('Lock confirmed in snapshot, waiting for GL0 sync...')
+  await sleep(5000)
+
+  logWorkflow.info('---- End testReplaceMinimumIncrease ----')
+  return { newLockHash, newAmount: minIncrease }
+}
+
+/**
+ * Test 5: Multiple sequential replacements
+ * Note: After each replacement, the OLD lock is removed and NEW lock becomes active.
+ * Subsequent replacements must reference the NEW lock hash.
+ */
+const testMultipleSequentialReplacements = async (urls, account, currentLockHash, currentAmount, stakeHash) => {
+  logWorkflow.info('---- Start testMultipleSequentialReplacements ----')
+
+  let lockHash = currentLockHash
+  let amount = currentAmount
+
+  // Do 3 sequential replacements
+  for (let i = 1; i <= 3; i++) {
+    const newAmount = amount + 100000000000 // +1000 DAG each time
+    logWorkflow.info(`Sequential replacement ${i}: ${amount} -> ${newAmount}`)
+    logWorkflow.info(`  Replacing lock: ${lockHash.substring(0, 16)}...`)
+
+    const newLockHash = await createTokenLock(account, urls, newAmount, lockHash, amount)
+    logWorkflow.info(`  Created replacement ${i}: ${newLockHash.substring(0, 16)}...`)
+
+    // Verify delegated stake updated using ordinal-aware retry
+    await withRetryOrdinal(
+      async () => {
+        const stakeResponse = await getAccountDelegatedStakes(urls, account.address)
+        const stake = stakeResponse.activeDelegatedStakes.find(s => s.hash === stakeHash)
+        if (!stake) throw new Error('Stake not found')
+        if (stake.tokenLockRef !== newLockHash) {
+          throw new Error(`Replacement ${i}: TokenLockRef not updated. Expected ${newLockHash.substring(0,16)}, got ${stake.tokenLockRef?.substring(0,16)}`)
+        }
+        if (stake.amount !== newAmount) {
+          throw new Error(`Replacement ${i}: Amount not updated. Expected ${newAmount}, got ${stake.amount}`)
+        }
+        return true
+      },
+      { globalL0Url: urls.globalL0Url, name: `verifySequentialReplacement${i}`, maxOrdinalMisses: 5 }
+    )
+
+    // IMPORTANT: Update lockHash to the NEW lock for the next iteration
+    lockHash = newLockHash
+    amount = newAmount
+    logWorkflow.info(`  Sequential replacement ${i} verified ✓`)
+    
+    // Brief wait for L1 sync before next replacement
+    if (i < 3) {
+      logWorkflow.info('  Waiting for GL0 sync before next replacement...')
+      await sleep(5000)
+    }
+  }
+
+  logWorkflow.info('---- End testMultipleSequentialReplacements ----')
+  return { finalLockHash: lockHash, finalAmount: amount }
+}
+
+/**
+ * Test 6: Replace while stake is in withdrawal (pendingWithdrawals)
+ */
+const testReplaceWhileInWithdrawal = async (urls, account, nodeId) => {
+  logWorkflow.info('---- Start testReplaceWhileInWithdrawal ----')
+
+  // Create a fresh token lock and stake for this test
+  const lockAmount = 600000000000 // 6000 DAG
+  const lockHash = await createTokenLock(account, urls, lockAmount)
+  logWorkflow.info(`Created token lock for withdrawal test: ${lockHash}`)
+
+  const stakeHash = await createDelegatedStake(account, lockHash, lockAmount, nodeId)
+  logWorkflow.info(`Created delegated stake: ${stakeHash}`)
+
+  // Wait for stake to be included using ordinal-aware retry
+  logWorkflow.info('Waiting for stake inclusion in global snapshot...')
+  const stake = await waitForStakeInclusion(urls, account.address, stakeHash)
+  logWorkflow.info(`Stake confirmed in snapshot: ${stake.hash.substring(0, 16)}...`)
+
+  // Initiate withdrawal
+  await withdrawDelegatedStake(account, stakeHash)
+  logWorkflow.info('Initiated stake withdrawal')
+
+  // Wait for stake to move to pendingWithdrawals using ordinal-aware retry
+  const pending = await waitForStakeWithdrawal(urls, account.address, stakeHash)
+  logWorkflow.info('Stake confirmed in pendingWithdrawals')
+
+  // Wait for L1 state sync (ordinal-aware retry ensures GL0 has progressed)
+  logWorkflow.info('Waiting for L1 state sync after withdrawal...')
+  await sleep(3000) // Reduced from 5s since ordinal-aware retry already waited for GL0
+
+  // When a stake is withdrawn, the associated token lock is removed from
+  // activeTokenLocks. Therefore, replacement should fail with NothingToReplace.
+  const newAmount = lockAmount + 100000000000 // +1000 DAG
+  await createTokenLockExpectError(
+    account,
+    urls,
+    newAmount,
+    lockHash,
+    'NothingToReplace'
+  )
+  logWorkflow.info('Token lock replacement correctly rejected during withdrawal')
+
+  logWorkflow.info('---- End testReplaceWhileInWithdrawal ----')
+}
+
+/**
+ * Setup node parameters for testing (required for delegated staking)
+ */
+const setupNodeParameters = async (urls) => {
+  logWorkflow.info('---- Setting up node parameters ----')
+
+  // Check if node params already exist (for local testing or re-runs)
+  const existingParams = await getNodeParams(urls)
+  
+  if (existingParams.length >= 1) {
+    logWorkflow.info(`Node parameters already configured: ${existingParams.length} nodes`)
+    return existingParams
+  }
+
+  // For CI, we need to extract keys and set up node params
+  if (RUN_ENV !== 'ci') {
+    throw new Error('Node parameters must be configured before running local tests. ' +
+      'Run the main delegated-staking.js test first, or manually set up node params.')
+  }
+
+  const {
+    privateKeyString: privateKeyString1,
+    nodeId: nodeId1,
+    account: account1,
+  } = extractKeysAndAccount('../../code/hypergraph/dag-l0/genesis-node/id_ecdsa.hex')
+
+  const {
+    privateKeyString: privateKeyString2,
+    nodeId: nodeId2,
+    account: account2,
+  } = extractKeysAndAccount('../../code/hypergraph/dag-l0/validator-1/id_ecdsa.hex')
+
+  // Set up node 1 params
+  const ur1 = await postNodeParamsNodeId(
+    urls, nodeId1, account1, privateKeyString1,
+    'EdgeCaseTestNode1', 5000000
+  )
+  checkOk(ur1)
+  
+  // Set up node 2 params
+  const ur2 = await postNodeParamsNodeId(
+    urls, nodeId2, account2, privateKeyString2,
+    'EdgeCaseTestNode2', 6000000
+  )
+  checkOk(ur2)
+  
+  await sleep(5000)
+
+  const nodeParams = await getNodeParams(urls)
+  logWorkflow.info(`Node parameters configured: ${nodeParams.length} nodes`)
+
+  return nodeParams
+}
+
+/**
+ * Main test runner
+ */
+const testTokenLockReplacementEdgeCases = async (urls) => {
+  logWorkflow.info('========================================')
+  logWorkflow.info('Token Lock Replacement Edge Cases Tests')
+  logWorkflow.info('========================================')
+
+  // Setup - use key3 to avoid conflicts with delegated-staking.js tests (which use key4)
+  // See "Key Reservation" comment at top of file for key assignment policy
+  const account = setupDag4Account(urls)
+  account.loginPrivateKey(PRIVATE_KEYS.key3)
+  logWorkflow.info(`Using account: ${account.address}`)
+
+  const nodeParams = await setupNodeParameters(urls)
+  const nodeIds = nodeParams.map(p => p.peerId)
+  const nodeId2 = nodeParams.length > 1 ? nodeParams[1].peerId : nodeParams[0].peerId
+
+  // Test 1: Replace with same amount (should fail)
+  const { lockHash, stakeHash, lockAmount } = await testReplaceSameAmount(urls, account, nodeIds)
+
+  // Test 2: Replace with less amount (should fail)
+  await testReplaceLessAmount(urls, account, lockHash, lockAmount)
+
+  // Test 3: Replace non-existent token lock ref (should fail)
+  await testReplaceNonExistentRef(urls, account)
+
+  // Test 4: Replace with minimum valid increase (+1 datum)
+  const { newLockHash, newAmount } = await testReplaceMinimumIncrease(
+    urls, account, lockHash, lockAmount, stakeHash
+  )
+
+  // Test 5: Multiple sequential replacements
+  await testMultipleSequentialReplacements(urls, account, newLockHash, newAmount, stakeHash)
+
+  // Test 6: Replace while stake is in withdrawal
+  await testReplaceWhileInWithdrawal(urls, account, nodeId2)
+
+  logWorkflow.info('========================================')
+  logWorkflow.info('All edge case tests completed!')
+  logWorkflow.info('========================================')
+}
+
+const executeWorkflowByType = async (workflowType) => {
+  const config = createConfig()
+  const urls = createNetworkConfig(config)
+
+  switch (workflowType) {
+    case 'testTokenLockReplacementEdgeCases':
+      await testTokenLockReplacementEdgeCases(urls)
+      break
+    default:
+      throw new Error(`Unknown workflow type: ${workflowType}`)
+  }
+}
+
+const workflowType = process.argv[4]
+if (!workflowType) {
+  logWorkflow.error('workflowType arg not found.')
+  throwUsage()
+}
+
+executeWorkflowByType(workflowType).catch((err) => {
+  logWorkflow.error('Test failed:', err.message)
+  if (RUN_ENV !== 'local') {
+    throw err
+  }
+})

--- a/.github/action_scripts/send_transactions/allow-spends-and-spend-transactions.js
+++ b/.github/action_scripts/send_transactions/allow-spends-and-spend-transactions.js
@@ -444,7 +444,7 @@ const sendInvalidTransaction = async (createTransactionFn, sourcePrivateKey, l0U
         };
     } catch (error) {
         if (error.response && error.response.status === 400) {
-            logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${error.response.data}`);
+            logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${JSON.stringify(error.response.data)}`);
             return {
                 address: sourceAccount.address,
                 rejected: true,
@@ -498,8 +498,8 @@ const createInvalidSignatureTransaction = async (sourcePrivateKey, l0Url, l1Url,
         signature: 'INVALID' + validProof.signature.substring(7)
     }
 
-    logWorkflow.info(`Original proof: ${validProof}`);
-    logWorkflow.info(`Tampered proof: ${invalidProof}`);
+    logWorkflow.info(`Original proof: ${JSON.stringify(validProof)}`);
+    logWorkflow.info(`Tampered proof: ${JSON.stringify(invalidProof)}`);
 
     try {
         const body = { value: allowSpend, proofs: [invalidProof] };
@@ -515,7 +515,7 @@ const createInvalidSignatureTransaction = async (sourcePrivateKey, l0Url, l1Url,
         };
     } catch (error) {
         if (error.response && error.response.status === 400) {
-            logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${error.response.data}`);
+            logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${JSON.stringify(error.response.data)}`);
             return {
                 address: sourceAccount.address,
                 rejected: true,
@@ -826,7 +826,7 @@ const createTransactionHandler = (urls) => {
             };
         } catch (error) {
             if (error.response && error.response.status === 400) {
-                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${error.response.data}`);
+                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${JSON.stringify(error.response.data)}`);
                 return {
                     address: sourceAccount.address,
                     rejected: true,
@@ -859,7 +859,7 @@ const createTransactionHandler = (urls) => {
             };
         } catch (error) {
             if (error.response && error.response.status === 400) {
-                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${error.response.data}`);
+                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${JSON.stringify(error.response.data)}`);
                 return {
                     address: sourceAccount.address,
                     rejected: true,
@@ -892,7 +892,7 @@ const createTransactionHandler = (urls) => {
             };
         } catch (error) {
             if (error.response && error.response.status === 400) {
-                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${error.response.data}`);
+                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${JSON.stringify(error.response.data)}`);
                 return {
                     address: sourceAccount.address,
                     rejected: true,
@@ -1695,7 +1695,7 @@ const executeInvalidCurrencyDestinationWorkflow = async () => {
             throw new Error('Transaction with invalid currency destination was accepted when it should have been rejected');
         } catch (error) {
             if (error.response && error.response.status === 400) {
-                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${error.response.data}`);
+                logWorkflow.success(`Transaction correctly rejected with 400 Bad Request: ${JSON.stringify(error.response.data)}`);
                 logWorkflow.success('InvalidCurrencyDestinationAllowSpend workflow completed successfully - transaction was correctly rejected');
             } else {
                 logWorkflow.error('Error in InvalidCurrencyDestinationAllowSpend workflow', error);

--- a/.github/action_scripts/shared/index.js
+++ b/.github/action_scripts/shared/index.js
@@ -1,7 +1,7 @@
 const { parseSharedArgs } = require('./validations')
 const { CONSTANTS, PRIVATE_KEYS } = require('./constants')
 const { generateProof, SerializerType, createSerializer, sortedJsonStringify } = require('./signatures')
-const { sleep, withRetry } = require('./operations')
+const { sleep, withRetry, withRetryOrdinal, waitForTxInclusion, getLatestSnapshotInfo } = require('./operations')
 const { getEpochProgress, createAndConnectAccount, createNetworkConfig } = require('./network')
 const { COLORS, logWorkflow } = require('./logging')
 
@@ -20,6 +20,9 @@ module.exports = {
 
   sleep,
   withRetry,
+  withRetryOrdinal,
+  waitForTxInclusion,
+  getLatestSnapshotInfo,
 
   getEpochProgress,
   createAndConnectAccount,

--- a/.github/action_scripts/shared/operations.js
+++ b/.github/action_scripts/shared/operations.js
@@ -1,7 +1,13 @@
+const axios = require('axios');
 const { CONSTANTS } = require("./constants");
+const { logWorkflow } = require("./logging");
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
+/**
+ * Basic retry with wall-clock timing.
+ * Use for simple operations where ordinal tracking isn't needed.
+ */
 const withRetry = async (operation, {
     name = 'operation',
     maxAttempts = CONSTANTS.MAX_VERIFICATION_ATTEMPTS,
@@ -29,7 +35,223 @@ const withRetry = async (operation, {
     }
 };
 
+/**
+ * Fetch the latest global snapshot ordinal from GL0.
+ * @param {string} globalL0Url - The GL0 URL
+ * @returns {Promise<{ordinal: number, hash: string}>}
+ */
+const getLatestSnapshotInfo = async (globalL0Url) => {
+    const response = await axios.get(
+        `${globalL0Url}/global-snapshots/latest`,
+        {
+            headers: {
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                Pragma: 'no-cache',
+                Expires: '0',
+            },
+        }
+    );
+    return {
+        ordinal: response.data.value.ordinal,
+        hash: response.data.value.hash || response.data.hash
+    };
+};
+
+/**
+ * Ordinal-aware retry for transaction verification.
+ * 
+ * This pattern is more robust than wall-clock retries because:
+ * 1. It detects if the network is progressing (ordinal increasing)
+ * 2. It can distinguish "tx dropped" (ordinal moved, tx missing) from "network stalled"
+ * 3. It allows resubmission when a transaction is detected as dropped
+ * 
+ * @param {Function} checkFn - Async function that throws if condition not met.
+ *                             Receives { ordinal, prevOrdinal } as argument.
+ * @param {Object} options - Configuration options
+ * @param {string} options.globalL0Url - GL0 URL for ordinal checks
+ * @param {string} [options.name='operation'] - Name for logging
+ * @param {number} [options.maxOrdinalMisses=5] - Max ordinal progressions without success before failing
+ * @param {number} [options.maxStalledChecks=10] - Max checks with no ordinal progress before failing
+ * @param {number} [options.interval=3000] - Polling interval in ms
+ * @param {Function} [options.onOrdinalMiss] - Called when ordinal progresses but check fails.
+ *                                              Can return a new tx hash if resubmitting.
+ * @param {Function} [options.onStalled] - Called when ordinal hasn't progressed
+ * @returns {Promise<any>} - Result from checkFn on success
+ * 
+ * @example
+ * // Wait for stake to appear, resubmit if dropped
+ * await withRetryOrdinal(
+ *   async ({ ordinal }) => {
+ *     const stakes = await getAccountDelegatedStakes(urls, address);
+ *     const stake = stakes.activeDelegatedStakes.find(s => s.hash === stakeHash);
+ *     if (!stake) throw new Error('Stake not found');
+ *     return stake;
+ *   },
+ *   {
+ *     globalL0Url: urls.globalL0Url,
+ *     name: 'waitForStake',
+ *     maxOrdinalMisses: 3,
+ *     onOrdinalMiss: async ({ ordinalsMissed }) => {
+ *       if (ordinalsMissed >= 2) {
+ *         logWorkflow.warn('Stake likely dropped, resubmitting...');
+ *         stakeHash = await resubmitStake();
+ *         return stakeHash; // Update tracked hash
+ *       }
+ *     }
+ *   }
+ * );
+ */
+const withRetryOrdinal = async (checkFn, {
+    globalL0Url,
+    name = 'operation',
+    maxOrdinalMisses = 5,
+    maxStalledChecks = 10,
+    interval = 3000,
+    onOrdinalMiss = null,
+    onStalled = null,
+} = {}) => {
+    if (!globalL0Url) {
+        throw new Error('withRetryOrdinal requires globalL0Url');
+    }
+
+    let prevOrdinal = null;
+    let ordinalMisses = 0;  // Times ordinal progressed but check still failed
+    let stalledChecks = 0;  // Times ordinal didn't progress
+    let totalChecks = 0;
+
+    while (true) {
+        totalChecks++;
+
+        // Get current ordinal
+        let currentSnapshot;
+        try {
+            currentSnapshot = await getLatestSnapshotInfo(globalL0Url);
+        } catch (error) {
+            logWorkflow.warn(`${name}: Failed to fetch snapshot ordinal: ${error.message}`);
+            await sleep(interval);
+            continue;
+        }
+
+        const currentOrdinal = currentSnapshot.ordinal;
+        const ordinalProgressed = prevOrdinal !== null && currentOrdinal > prevOrdinal;
+
+        // Try the check
+        try {
+            const result = await checkFn({ 
+                ordinal: currentOrdinal, 
+                prevOrdinal,
+                ordinalProgressed,
+                ordinalMisses,
+                stalledChecks 
+            });
+            
+            logWorkflow.info(`${name}: Success at ordinal ${currentOrdinal} (${totalChecks} checks)`);
+            return result;
+        } catch (error) {
+            // Check failed - analyze why
+            if (ordinalProgressed) {
+                ordinalMisses++;
+                stalledChecks = 0; // Reset stalled counter
+                
+                logWorkflow.info(
+                    `${name}: Ordinal progressed ${prevOrdinal} → ${currentOrdinal} but check failed ` +
+                    `(miss ${ordinalMisses}/${maxOrdinalMisses}): ${error.message}`
+                );
+
+                // Call the ordinal miss handler (e.g., to resubmit tx)
+                if (onOrdinalMiss) {
+                    try {
+                        await onOrdinalMiss({ 
+                            ordinal: currentOrdinal, 
+                            prevOrdinal, 
+                            ordinalsMissed: ordinalMisses,
+                            error 
+                        });
+                    } catch (handlerError) {
+                        logWorkflow.warn(`${name}: onOrdinalMiss handler failed: ${handlerError.message}`);
+                    }
+                }
+
+                if (ordinalMisses >= maxOrdinalMisses) {
+                    throw new Error(
+                        `${name}: Failed after ${ordinalMisses} ordinal progressions. ` +
+                        `Transaction likely dropped or invalid. Last error: ${error.message}`
+                    );
+                }
+            } else {
+                stalledChecks++;
+                
+                if (prevOrdinal !== null) {
+                    logWorkflow.info(
+                        `${name}: Ordinal stalled at ${currentOrdinal} ` +
+                        `(stalled ${stalledChecks}/${maxStalledChecks}): ${error.message}`
+                    );
+                } else {
+                    logWorkflow.info(
+                        `${name}: Initial check at ordinal ${currentOrdinal}: ${error.message}`
+                    );
+                }
+
+                if (onStalled) {
+                    try {
+                        await onStalled({ ordinal: currentOrdinal, stalledChecks });
+                    } catch (handlerError) {
+                        logWorkflow.warn(`${name}: onStalled handler failed: ${handlerError.message}`);
+                    }
+                }
+
+                if (stalledChecks >= maxStalledChecks) {
+                    throw new Error(
+                        `${name}: Network stalled at ordinal ${currentOrdinal} for ${stalledChecks} checks. ` +
+                        `Last error: ${error.message}`
+                    );
+                }
+            }
+
+            prevOrdinal = currentOrdinal;
+            await sleep(interval);
+        }
+    }
+};
+
+/**
+ * Wait for a transaction to be included in global snapshots.
+ * Convenience wrapper around withRetryOrdinal for common tx verification pattern.
+ * 
+ * @param {Function} fetchFn - Function that fetches and returns the tx/state, throws if not found
+ * @param {Object} options - Options passed to withRetryOrdinal plus:
+ * @param {Function} [options.resubmitFn] - If provided, called to resubmit tx when likely dropped
+ * @param {number} [options.resubmitAfterMisses=2] - Ordinal misses before resubmitting
+ */
+const waitForTxInclusion = async (fetchFn, {
+    globalL0Url,
+    name = 'waitForTx',
+    resubmitFn = null,
+    resubmitAfterMisses = 2,
+    maxOrdinalMisses = 5,
+    ...restOptions
+} = {}) => {
+    return withRetryOrdinal(
+        fetchFn,
+        {
+            globalL0Url,
+            name,
+            maxOrdinalMisses,
+            onOrdinalMiss: resubmitFn ? async ({ ordinalsMissed }) => {
+                if (ordinalsMissed >= resubmitAfterMisses) {
+                    logWorkflow.warn(`${name}: Resubmitting after ${ordinalsMissed} ordinal misses`);
+                    await resubmitFn();
+                }
+            } : null,
+            ...restOptions
+        }
+    );
+};
+
 module.exports = {
     sleep,
-    withRetry
+    withRetry,
+    withRetryOrdinal,
+    waitForTxInclusion,
+    getLatestSnapshotInfo
 }

--- a/.github/templates/actions/hypergraph/dag_l0/genesis/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l0/genesis/action.yml
@@ -33,9 +33,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/hypergraph/dag-l0.jar run-genesis genesis.csv --ip 127.0.0.1 > dag-l0-genesis.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for genesis node to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L0
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L0-Genesis \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/hypergraph/dag_l0/validator/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l0/validator/action.yml
@@ -52,10 +52,58 @@ runs:
         cd $ROOT_DIRECTORY/.github/code/hypergraph/dag-l0/genesis-node
         GLOBAL_L0_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L0-Validator-${{ inputs.NODE_NUMBER }}; then
-          sleep 5
-          echo "Joining DAG L0 validator node ${{ inputs.NODE_NUMBER }} ..."
-          curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$GLOBAL_L0_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }"
-          echo "Joined"
-          exit 0
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L0-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining DAG L0 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          CURL_RESPONSE=$(mktemp)
+          CURL_STDERR=$(mktemp)
+          HTTP_CODE=$(curl -s -o "$CURL_RESPONSE" -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$GLOBAL_L0_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }" \
+            2>"$CURL_STDERR")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE)"
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "  curl error: $(cat $CURL_STDERR)"
+          elif [ -s "$CURL_RESPONSE" ]; then
+            echo "  response: $(cat $CURL_RESPONSE)"
+          fi
+          rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+          
+          if [ $attempt -lt 5 ]; then
+            echo "  retrying in 5s..."
+            sleep 5
+          fi
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L0-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/hypergraph/dag_l1/initial_validator/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l1/initial_validator/action.yml
@@ -41,9 +41,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/hypergraph/dag-l1.jar run-initial-validator --ip 127.0.0.1 > dag-l1-initial-validator.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for initial validator to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L1-Initial-Validator
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L1-Initial-Validator \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/hypergraph/dag_l1/validator/action.yml
+++ b/.github/templates/actions/hypergraph/dag_l1/validator/action.yml
@@ -59,10 +59,58 @@ runs:
         cd $ROOT_DIRECTORY/.github/code/hypergraph/dag-l1/initial-validator
         DAG_L1_INITIAL_VALIDATOR_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=DAG-L1-Validator-${{ inputs.NODE_NUMBER }}; then
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L1-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining DAG L1 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          CURL_RESPONSE=$(mktemp)
+          CURL_STDERR=$(mktemp)
+          HTTP_CODE=$(curl -s -o "$CURL_RESPONSE" -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$DAG_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }" \
+            2>"$CURL_STDERR")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE)"
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "  curl error: $(cat $CURL_STDERR)"
+          elif [ -s "$CURL_RESPONSE" ]; then
+            echo "  response: $(cat $CURL_RESPONSE)"
+          fi
+          rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+          
+          if [ $attempt -lt 5 ]; then
+            echo "  retrying in 5s..."
             sleep 5
-            echo "Joining DAG L1 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$DAG_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }"
-            echo "Joined"
-            exit 0
+          fi
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=DAG-L1-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/currency_l1/initial_validator/action.yml
+++ b/.github/templates/actions/metagraph/currency_l1/initial_validator/action.yml
@@ -53,9 +53,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/currency-l1/currency-l1.jar run-initial-validator --ip 127.0.0.1 > currency-l1-initial-validator.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for initial validator to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Currency-L1-Initial-Validator
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Currency-L1-Initial-Validator \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/currency_l1/validator/action.yml
+++ b/.github/templates/actions/metagraph/currency_l1/validator/action.yml
@@ -57,7 +57,7 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/currency-l1/currency-l1.jar run-validator --ip 127.0.0.1 > currency-l1-${{ inputs.NODE_NUMBER }}.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Join node after started - ${{ inputs.NODE_NUMBER }}
       shell: bash
       env:
         CL_KEYSTORE: token-key.p12
@@ -66,15 +66,65 @@ runs:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
         CL_CLI_HTTP_PORT: ${{ inputs.CL_CLI_HTTP_PORT }}
         CL_L1_INITIAL_VALIDATOR_P2P_PORT: ${{ inputs.CL_L1_INITIAL_VALIDATOR_P2P_PORT }}
+        METAGRAPH_NAME: ${{ inputs.METAGRAPH_NAME }}
       run: |
         ROOT_DIRECTORY=$(pwd)
 
-        cd $ROOT_DIRECTORY/.github/code/metagraphs/${{ inputs.METAGRAPH_NAME }}/currency-l1/initial-validator
+        cd $ROOT_DIRECTORY/.github/code/metagraphs/${METAGRAPH_NAME}/currency-l1/initial-validator
         CURRENCY_L1_INITIAL_VALIDATOR_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Currency-L1-Validator-${{ inputs.NODE_NUMBER }}; then
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Currency-L1-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining Currency L1 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          CURL_RESPONSE=$(mktemp)
+          CURL_STDERR=$(mktemp)
+          HTTP_CODE=$(curl -s -o "$CURL_RESPONSE" -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$CURRENCY_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }" \
+            2>"$CURL_STDERR")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE)"
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "  curl error: $(cat $CURL_STDERR)"
+          elif [ -s "$CURL_RESPONSE" ]; then
+            echo "  response: $(cat $CURL_RESPONSE)"
+          fi
+          rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+          
+          if [ $attempt -lt 5 ]; then
+            echo "  retrying in 5s..."
             sleep 5
-            echo "Joining Metagraph L1 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$CURRENCY_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }"
-            echo "Joined"
+          fi
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Currency-L1-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/data_l1/initial_validator/action.yml
+++ b/.github/templates/actions/metagraph/data_l1/initial_validator/action.yml
@@ -53,9 +53,13 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/data-l1/data-l1.jar run-initial-validator --ip 127.0.0.1 > data-l1-initial-validator.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Wait for initial validator to be Ready
       shell: bash
       env:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
       run: |
-        node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Data-L1-Initial-Validator
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Data-L1-Initial-Validator \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/data_l1/validator/action.yml
+++ b/.github/templates/actions/metagraph/data_l1/validator/action.yml
@@ -57,7 +57,7 @@ runs:
         nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/data-l1/data-l1.jar run-validator --ip 127.0.0.1 > data-l1-${{ inputs.NODE_NUMBER }}.log 2>&1 &
         sleep 5
 
-    - name: Check if node started
+    - name: Join node after started - ${{ inputs.NODE_NUMBER }}
       shell: bash
       env:
         CL_KEYSTORE: token-key.p12
@@ -66,15 +66,65 @@ runs:
         CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
         CL_CLI_HTTP_PORT: ${{ inputs.CL_CLI_HTTP_PORT }}
         CL_L1_INITIAL_VALIDATOR_P2P_PORT: ${{ inputs.CL_L1_INITIAL_VALIDATOR_P2P_PORT }}
+        METAGRAPH_NAME: ${{ inputs.METAGRAPH_NAME }}
       run: |
         ROOT_DIRECTORY=$(pwd)
 
-        cd $ROOT_DIRECTORY/.github/code/metagraphs/${{ inputs.METAGRAPH_NAME }}/data-l1/initial-validator
+        cd $ROOT_DIRECTORY/.github/code/metagraphs/${METAGRAPH_NAME}/data-l1/initial-validator
         DATA_L1_INITIAL_VALIDATOR_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Data-L1-Validator-${{ inputs.NODE_NUMBER }}; then
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Data-L1-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining Data L1 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          CURL_RESPONSE=$(mktemp)
+          CURL_STDERR=$(mktemp)
+          HTTP_CODE=$(curl -s -o "$CURL_RESPONSE" -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$DATA_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }" \
+            2>"$CURL_STDERR")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE)"
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "  curl error: $(cat $CURL_STDERR)"
+          elif [ -s "$CURL_RESPONSE" ]; then
+            echo "  response: $(cat $CURL_RESPONSE)"
+          fi
+          rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+          
+          if [ $attempt -lt 5 ]; then
+            echo "  retrying in 5s..."
             sleep 5
-            echo "Joining Metagraph L1 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$DATA_L1_INITIAL_VALIDATOR_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L1_INITIAL_VALIDATOR_P2P_PORT} }"
-            echo "Joined"
+          fi
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Data-L1-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/templates/actions/metagraph/metagraph_l0/genesis/action.yml
+++ b/.github/templates/actions/metagraph/metagraph_l0/genesis/action.yml
@@ -80,7 +80,11 @@ runs:
       nohup stdbuf -o0 -e0 java -Denvironment=dev -jar $ROOT_DIRECTORY/.github/code/metagraphs/${{inputs.METAGRAPH_NAME}}/metagraph-l0/metagraph-l0.jar run-genesis genesis.snapshot --ip 127.0.0.1 > metagraph-l0-run-genesis.log 2>&1 &
       sleep 5
 
-  - name: Check if node started
+  - name: Wait for genesis node to be Ready
     shell: bash
     run: |
-      node .github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${{ inputs.CL_PUBLIC_HTTP_PORT }}/node/info -cluster_name=${{inputs.METAGRAPH_NAME}}-Metagraph-L0-Genesis
+      node .github/action_scripts/check_if_node_started.js \
+        -url=http://127.0.0.1:${{ inputs.CL_PUBLIC_HTTP_PORT }}/node/info \
+        -cluster_name=${{inputs.METAGRAPH_NAME}}-Metagraph-L0-Genesis \
+        -wait_for_ready=true \
+        -max_attempts=30

--- a/.github/templates/actions/metagraph/metagraph_l0/validator/action.yml
+++ b/.github/templates/actions/metagraph/metagraph_l0/validator/action.yml
@@ -66,9 +66,58 @@ runs:
         cd $ROOT_DIRECTORY/.github/code/metagraphs/${METAGRAPH_NAME}/metagraph-l0/genesis-node
         CURRENCY_L0_GENESIS_NODE_ID=$(java -jar $ROOT_DIRECTORY/.github/code/shared_jars/cl-wallet.jar show-id)
 
-        if node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info -cluster_name=Metagraph-L0-Validator-${{ inputs.NODE_NUMBER }}; then
+        # Wait for validator node to be responsive
+        node $ROOT_DIRECTORY/.github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Metagraph-L0-Validator-${{ inputs.NODE_NUMBER }}
+
+        sleep 5
+
+        # Join cluster with retry logic
+        echo "Joining Metagraph L0 validator node ${{ inputs.NODE_NUMBER }} ..."
+        JOIN_SUCCESS=false
+        for attempt in 1 2 3 4 5; do
+          CURL_RESPONSE=$(mktemp)
+          CURL_STDERR=$(mktemp)
+          HTTP_CODE=$(curl -s -o "$CURL_RESPONSE" -w "%{http_code}" -X POST \
+            http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join \
+            -H "Content-type: application/json" \
+            -d "{ \"id\":\"$CURRENCY_L0_GENESIS_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }" \
+            2>"$CURL_STDERR")
+          
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "Join request accepted (HTTP $HTTP_CODE)"
+            JOIN_SUCCESS=true
+            rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+            break
+          fi
+          
+          echo "Join attempt $attempt failed (HTTP $HTTP_CODE)"
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "  curl error: $(cat $CURL_STDERR)"
+          elif [ -s "$CURL_RESPONSE" ]; then
+            echo "  response: $(cat $CURL_RESPONSE)"
+          fi
+          rm -f "$CURL_RESPONSE" "$CURL_STDERR"
+          
+          if [ $attempt -lt 5 ]; then
+            echo "  retrying in 5s..."
             sleep 5
-            echo "Joining Metagraph L0 validator node ${{ inputs.NODE_NUMBER }} ..."
-            curl -X POST http://127.0.0.1:${CL_CLI_HTTP_PORT}/cluster/join -H "Content-type: application/json" -d "{ \"id\":\"$CURRENCY_L0_GENESIS_NODE_ID\", \"ip\": \"127.0.0.1\", \"p2pPort\": ${CL_L0_P2P_HTTP_PORT} }"
-            echo "Joined"
+          fi
+        done
+
+        if [ "$JOIN_SUCCESS" = "false" ]; then
+          echo "ERROR: Failed to join cluster after 5 attempts"
+          exit 1
         fi
+
+    - name: Wait for validator to be Ready - ${{ inputs.NODE_NUMBER }}
+      shell: bash
+      env:
+        CL_PUBLIC_HTTP_PORT: ${{ inputs.CL_PUBLIC_HTTP_PORT }}
+      run: |
+        node .github/action_scripts/check_if_node_started.js \
+          -url=http://127.0.0.1:${CL_PUBLIC_HTTP_PORT}/node/info \
+          -cluster_name=Metagraph-L0-Validator-${{ inputs.NODE_NUMBER }} \
+          -wait_for_ready=true \
+          -max_attempts=30

--- a/.github/workflows/e2e-functionality-tests.yml
+++ b/.github/workflows/e2e-functionality-tests.yml
@@ -84,3 +84,10 @@ jobs:
     with:
       tessellation_version: ${{ needs.calculate-version.outputs.tessellation_version }}
     secrets: inherit
+
+  call-test-token-lock-replacement:
+    needs: [calculate-version, call-workflow-setup-environment]
+    uses: ./.github/workflows/test-token-lock-replacement.yml
+    with:
+      tessellation_version: ${{ needs.calculate-version.outputs.tessellation_version }}
+    secrets: inherit

--- a/.github/workflows/test-token-lock-replacement.yml
+++ b/.github/workflows/test-token-lock-replacement.yml
@@ -1,0 +1,75 @@
+name: Test Token Lock Replacement Edge Cases
+
+on:
+  workflow_call:
+    inputs:
+      tessellation_version:
+        required: true
+        type: string
+
+jobs:
+  token-lock-replacement-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: .github/action_scripts/package-lock.json
+
+      - name: Installing node dependencies
+        shell: bash
+        run: |
+          npm i @stardust-collective/dag4@v2.8.0 
+          npm i js-sha256
+          npm i axios
+          npm i brotli
+          npm i zod
+          npm i elliptic
+
+      - name: Download shared_jars artifacts
+        uses: actions/download-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: shared_jars-${{ inputs.tessellation_version }}
+          path: .github/code/shared_jars
+
+      - name: Download Hypergraph Artifact
+        uses: actions/download-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: hypergraph-${{ inputs.tessellation_version }}
+          path: .github/code/hypergraph
+
+      - name: Download project template Artifact
+        uses: actions/download-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: project-template-metagraph-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}-${{ inputs.tessellation_version }}
+          path: .github/code/metagraphs/project-template-metagraph
+
+      - name: Start Hypergraph
+        uses: "./.github/templates/actions/hypergraph/start"
+        with:
+          INCLUDE_DAG_L1: true
+          DAG_L0_PORT_PREFIX: 90
+          DAG_L1_PORT_PREFIX: 91
+
+      - name: Test Token Lock Replacement Edge Cases
+        run: |
+          cd .github/action_scripts/delegated_staking
+          node token-lock-replacement-edge-cases.js 90 91 testTokenLockReplacementEdgeCases
+
+      - name: Upload log files
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: token-lock-replacement-node-log-files-${{ runner.os }}-${{ hashFiles('**/build.sbt', '**/project/*.sbt', '**/project/build.properties') }}-${{ inputs.tessellation_version }}
+          path: .github/code/**/*.log
+          if-no-files-found: warn
+          retention-days: 3


### PR DESCRIPTION
Addresses frequent CI E2E test failures where nodes get stuck in 'Observing' state due to race conditions during cluster formation on GitHub runners.

Changes:
- Added -wait_for_ready=true flag to wait for node to reach 'Ready' state
- Added configurable -max_attempts and -interval parameters
- Increased cluster check timeout from 120s to 240s
- Added retry logic (5 attempts with 5s backoff) for cluster/join requests
- Better error handling for unreachable nodes

Fixes argument parsing for double-dash args (--url -> url instead of -url).