### PR TITLE
fix: fixing snapshot routes

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -70,7 +70,6 @@ object method {
       c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
       c.snapshotBinarySenderTimeouts,
       c.snapshot.timeouts,
-      c.combinedRouteRateLimiter,
       c.clickHouseConfig,
       c.snapshot.mptSnapshotInfoPath
     )

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
@@ -63,7 +63,6 @@ object HttpApi {
           storages.node,
           HasherSelector.alwaysCurrent[F],
           sharedConfig.snapshotTimeoutsConfig,
-          sharedConfig.combinedRouteRateLimiter.getOrElse(environment, RouteRateLimiterConfig.empty()),
           combinedSnapshotCheckpointFileSystemStorage
         )
     } yield

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/cli/method.scala
@@ -67,7 +67,6 @@ object method {
       c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
       c.snapshotBinarySenderTimeouts,
       c.snapshot.timeouts,
-      c.combinedRouteRateLimiter,
       c.clickHouseConfig,
       c.snapshot.mptSnapshotInfoPath
     )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/HttpApi.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/modules/HttpApi.scala
@@ -62,7 +62,6 @@ object HttpApi {
         storages.node,
         HasherSelector[F],
         sharedConfig.snapshotTimeoutsConfig,
-        sharedConfig.combinedRouteRateLimiter.getOrElse(environment, RouteRateLimiterConfig.empty()),
         combinedSnapshotCheckpointFileSystemStorage
       )
       .map { snapshotRoutes =>

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -262,25 +262,6 @@ price-oracle {
   }
 }
 
-combined-route-rate-limiter {
-  mainnet {
-    public = 1 second
-    peer-to-peer = 1 second
-  },
-  testnet {
-    public = 10 seconds
-    peer-to-peer = 2 second
-  },
-  integrationnet {
-    public = 1 second
-    peer-to-peer = 1 second
-  },
-  dev {
-    public = 0 second
-    peer-to-peer = 0 second
-  }
-}
-
 snapshot-binary-sender-timeouts {
  routes = 10 seconds
  client = 5 seconds

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/cli/CliMethod.scala
@@ -79,7 +79,6 @@ trait CliMethod {
     c.priceOracle.getOrElse(environment, PriceOracleConfig.default),
     c.snapshotBinarySenderTimeouts,
     c.snapshot.timeouts,
-    c.combinedRouteRateLimiter,
     c.clickHouseConfig,
     c.snapshot.mptSnapshotInfoPath
   )

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -68,7 +68,6 @@ object types {
     metagraphsSync: MetagraphsSyncConfig,
     priceOracle: Map[AppEnvironment, PriceOracleConfig],
     snapshotBinarySenderTimeouts: SnapshotBinarySenderTimeoutsConfig,
-    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig],
     clickHouseConfig: ClickHouseAppConfig
   )
 
@@ -98,7 +97,6 @@ object types {
     priceOracle: PriceOracleConfig,
     snapshotBinarySenderTimeouts: SnapshotBinarySenderTimeoutsConfig,
     snapshotTimeoutsConfig: SnapshotTimeoutsConfig,
-    combinedRouteRateLimiter: Map[AppEnvironment, RouteRateLimiterConfig],
     clickHouseConfig: ClickHouseAppConfig,
     mptSnapshotInfoPath: Path
   )

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
@@ -7,6 +7,7 @@ import scala.concurrent.duration._
 
 import io.constellationnetwork.ext.http4s.headers.negotiation.resolveEncoder
 import io.constellationnetwork.ext.http4s.{BlockingEntityEncoder, HashVar}
+import io.constellationnetwork.json.StreamingCollectionEncoder
 import io.constellationnetwork.node.shared.config.types.{RouteRateLimiterConfig, SnapshotTimeoutsConfig}
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.snapshot.storage.SnapshotStorage
@@ -16,17 +17,18 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.{
   SnapshotLocalFileSystemStorage
 }
 import io.constellationnetwork.routes.internal._
-import io.constellationnetwork.schema.GlobalSnapshot
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, SnapshotMetadata}
+import io.constellationnetwork.schema.{GlobalSnapshot, SnapshotOrdinal}
 import io.constellationnetwork.security.HasherSelector
 import io.constellationnetwork.security.signature.Signed
 
-import io.circe.Encoder
 import io.circe.shapes._
+import io.circe.{Encoder, Printer}
 import org.http4s._
 import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.`Content-Type`
 import org.http4s.server.middleware.Timeout
 import shapeless.HNil
 import shapeless.syntax.singleton._
@@ -38,8 +40,7 @@ final case class SnapshotRoutes[F[_]: Async, S <: Snapshot: Encoder, SI <: Snaps
   nodeStorage: NodeStorage[F],
   hasherSelector: HasherSelector[F],
   snapshotTimeoutsConfig: SnapshotTimeoutsConfig,
-  limiterLatestCombined: RateLimiter[F],
-  limiterLatestCombinedStream: RateLimiter[F],
+  cachedCombinedResponse: CachedCombinedResponse[F, S, SI],
   combinedSnapshotCheckpointFileSystemStorage: CombinedSnapshotCheckpointFileSystemStorage[F, S, SI]
 ) extends Http4sDsl[F]
     with PublicRoutes[F]
@@ -55,12 +56,6 @@ final case class SnapshotRoutes[F[_]: Async, S <: Snapshot: Encoder, SI <: Snaps
     ServiceUnavailable(("message" ->> "Node is not ready yet") :: HNil)
 
   private def validStateForSnapshotReturn(state: NodeState): Boolean = state === NodeState.Ready
-
-  private def withRateLimit(limiter: RateLimiter[F])(action: F[Response[F]]): F[Response[F]] =
-    limiter.check.ifM(
-      action,
-      TooManyRequests(("message" ->> s"Rate limit: one request every ${limiter.getInterval} seconds") :: HNil)
-    )
 
   private def whenNodeReady(action: F[Response[F]]): F[Response[F]] =
     nodeStorage.getNodeState
@@ -99,25 +94,25 @@ final case class SnapshotRoutes[F[_]: Async, S <: Snapshot: Encoder, SI <: Snaps
             }
           }
 
-        case req @ GET -> Root / "latest" / "combined" =>
-          withRateLimit(limiterLatestCombined) {
-            whenNodeReady {
-              resolveEncoder[F, (Signed[S], SI)](req) { implicit enc =>
-                snapshotStorage.head.flatMap {
-                  case Some(snapshot) => Ok(snapshot)
-                  case _              => NotFound()
+        case GET -> Root / "latest" / "combined" =>
+          whenNodeReady {
+            snapshotStorage.head.flatMap {
+              case Some((snapshot, state)) =>
+                cachedCombinedResponse.get(snapshot.ordinal, snapshot, state).flatMap { bytes =>
+                  Ok(
+                    fs2.Stream.chunk[F, Byte](fs2.Chunk.array(bytes)),
+                    `Content-Type`(MediaType.application.json)
+                  )
                 }
-              }
+              case _ => NotFound()
             }
           }
 
         case GET -> Root / "latest" / "combined" / "stream" =>
-          withRateLimit(limiterLatestCombinedStream) {
-            whenNodeReady {
-              combinedSnapshotCheckpointFileSystemStorage.getLatestAsHttpResponse.flatMap {
-                case Some(resp) => resp.pure[F]
-                case None       => NotFound()
-              }
+          whenNodeReady {
+            combinedSnapshotCheckpointFileSystemStorage.getLatestAsHttpResponse.flatMap {
+              case Some(resp) => resp.pure[F]
+              case None       => NotFound()
             }
           }
 
@@ -191,12 +186,10 @@ object SnapshotRoutes {
     nodeStorage: NodeStorage[F],
     hasherSelector: HasherSelector[F],
     snapshotTimeoutsConfig: SnapshotTimeoutsConfig,
-    combinedRouteLimiter: RouteRateLimiterConfig,
     combinedSnapshotCheckpointFileSystemStorage: CombinedSnapshotCheckpointFileSystemStorage[F, S, SI]
   ): F[SnapshotRoutes[F, S, SI]] =
     for {
-      limiterLatestCombined <- RateLimiter.make[F](combinedRouteLimiter.public)
-      limiterLatestCombinedStream <- RateLimiter.make[F](combinedRouteLimiter.peerToPeer)
+      cachedCombined <- CachedCombinedResponse.make[F, S, SI]
     } yield
       new SnapshotRoutes[F, S, SI](
         snapshotStorage,
@@ -205,32 +198,53 @@ object SnapshotRoutes {
         nodeStorage,
         hasherSelector,
         snapshotTimeoutsConfig,
-        limiterLatestCombined,
-        limiterLatestCombinedStream,
+        cachedCombined,
         combinedSnapshotCheckpointFileSystemStorage
       )
 }
 
-trait RateLimiter[F[_]] {
-  def check: F[Boolean]
-  def getInterval: String
+trait CachedCombinedResponse[F[_], S <: Snapshot, SI <: SnapshotInfo[_]] {
+  def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]]
 }
 
-object RateLimiter {
-  def make[F[_]: Async](interval: FiniteDuration): F[RateLimiter[F]] =
-    Ref[F].of(Option.empty[Long]).map { ref =>
-      new RateLimiter[F] {
-        def check: F[Boolean] =
-          for {
-            now <- Async[F].realTime.map(_.toMillis)
-            allowed <- ref.modify {
-              case Some(last) if now - last < interval.toMillis => (Some(last), false)
-              case Some(_)                                      => (Some(now), true)
-              case None                                         => (Some(now), true)
-            }
-          } yield allowed
+object CachedCombinedResponse {
+  private val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
-        def getInterval: String = interval.toSeconds.toString
+  def make[F[_]: Async, S <: Snapshot: Encoder, SI <: SnapshotInfo[_]: Encoder]: F[CachedCombinedResponse[F, S, SI]] =
+    Ref[F].of(Option.empty[(SnapshotOrdinal, Deferred[F, Either[Throwable, Array[Byte]]])]).map { ref =>
+      new CachedCombinedResponse[F, S, SI] {
+        def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
+          Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
+            ref.modify {
+              case Some((ord, existing)) if ord === currentOrdinal =>
+                (Some((ord, existing)), existing.get.flatMap(Async[F].fromEither))
+              case _ =>
+                val serialize = Async[F].blocking {
+                  // Stream directly to ByteArrayOutputStream
+                  val baos = new java.io.ByteArrayOutputStream()
+                  val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
+
+                  writer.append('[')
+                  Encoder[Signed[S]] match {
+                    case sce: StreamingCollectionEncoder[Signed[S]] =>
+                      sce.streamEncode(snapshot, printer, writer)
+                    case enc =>
+                      printer.unsafePrintToAppendable(enc(snapshot), writer)
+                  }
+                  writer.append(',')
+                  Encoder[SI] match {
+                    case sce: StreamingCollectionEncoder[SI] =>
+                      sce.streamEncode(state, printer, writer)
+                    case enc =>
+                      printer.unsafePrintToAppendable(enc(state), writer)
+                  }
+                  writer.append(']')
+                  writer.flush()
+                  baos.toByteArray
+                }
+                (Some((currentOrdinal, newDef)), serialize.attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither))
+            }.flatten
+          }
       }
     }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
@@ -213,37 +213,46 @@ object CachedCombinedResponse {
   def make[F[_]: Async, S <: Snapshot: Encoder, SI <: SnapshotInfo[_]: Encoder]: F[CachedCombinedResponse[F, S, SI]] =
     Ref[F].of(Option.empty[(SnapshotOrdinal, Deferred[F, Either[Throwable, Array[Byte]]])]).map { ref =>
       new CachedCombinedResponse[F, S, SI] {
-        def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
-          Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
-            ref.modify {
-              case Some((ord, existing)) if ord === currentOrdinal =>
-                (Some((ord, existing)), existing.get.flatMap(Async[F].fromEither))
-              case _ =>
-                val serialize = Async[F].blocking {
-                  // Stream directly to ByteArrayOutputStream
-                  val baos = new java.io.ByteArrayOutputStream()
-                  val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
+        private def serialize(snapshot: Signed[S], state: SI): F[Array[Byte]] =
+          Async[F].blocking {
+            val baos = new java.io.ByteArrayOutputStream()
+            val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
 
-                  writer.append('[')
-                  Encoder[Signed[S]] match {
-                    case sce: StreamingCollectionEncoder[Signed[S]] =>
-                      sce.streamEncode(snapshot, printer, writer)
-                    case enc =>
-                      printer.unsafePrintToAppendable(enc(snapshot), writer)
-                  }
-                  writer.append(',')
-                  Encoder[SI] match {
-                    case sce: StreamingCollectionEncoder[SI] =>
-                      sce.streamEncode(state, printer, writer)
-                    case enc =>
-                      printer.unsafePrintToAppendable(enc(state), writer)
-                  }
-                  writer.append(']')
-                  writer.flush()
-                  baos.toByteArray
-                }
-                (Some((currentOrdinal, newDef)), serialize.attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither))
-            }.flatten
+            writer.append('[')
+            Encoder[Signed[S]] match {
+              case sce: StreamingCollectionEncoder[Signed[S]] =>
+                sce.streamEncode(snapshot, printer, writer)
+              case enc =>
+                printer.unsafePrintToAppendable(enc(snapshot), writer)
+            }
+            writer.append(',')
+            Encoder[SI] match {
+              case sce: StreamingCollectionEncoder[SI] =>
+                sce.streamEncode(state, printer, writer)
+              case enc =>
+                printer.unsafePrintToAppendable(enc(state), writer)
+            }
+            writer.append(']')
+            writer.flush()
+            baos.toByteArray
+          }
+
+        def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
+          ref.get.flatMap {
+            case Some((ord, existing)) if ord === currentOrdinal =>
+              existing.get.flatMap(Async[F].fromEither)
+            case _ =>
+              Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
+                ref.modify {
+                  case Some((ord, existing)) if ord === currentOrdinal =>
+                    (Some((ord, existing)), existing.get.flatMap(Async[F].fromEither))
+                  case _ =>
+                    (
+                      Some((currentOrdinal, newDef)),
+                      serialize(snapshot, state).attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither)
+                    )
+                }.flatten
+              }
           }
       }
     }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
@@ -97,27 +97,27 @@ object StateChannelAllowanceLists {
               "75d8f472fb2bebfcefbb27a46cb60aeae1a32806c9f3f40a405d4eaf1c44e8041febf5e6eb9e6f525d6142c7df87304b9fe011863c6d8ed121fa6fcae7d5ca66",
               "e47e0ac3ebc393b61e267aa4189f7fdc36c48440b1fc0a6bad375945cabfd41ab3e7800ae1d22d80d2d4a3b0902df6aeb293b803490bf8d777da3894833f42fb"
             ),
-           // Valid Vote
-           Address("DAG55nwjLR1JhY4a2Wri6Cni2GWPL7Vupu5znnJi") ->
-             NonEmptySet.of(
-               "98e2c7ee9e4bd8aed3a22a075becbe5cad252e25724e7e14050beb69f80e9ea409777470914d21e0bca625cb3ec065a001378b62668355f60bddfc1a322292e5",
-               "7f509f5b2e4d70e9bd9852af0c064f30d95e83243896b7a5857be247a8212b121a96d913e00fe19568f18c9674ea871a8162e4d2d5d711c140be051df21d9744",
-               "08a360052a6444b55f91fdea97ecbdf251b640736e3fb61d9828be8c1a3159bcca234864a6693ba9cd57630ae90bddc2127d8ebe191243eec38aee9a00adb149"
-             ),
-            // CNS
-            Address("DAG1YTmwkBqCBrW8JLFquAmadozEqSWSxJ2mKKcT") ->
-              NonEmptySet.of(
-                "ac1243131c0b2821876e88e3a50ee30d3fb28d571cb8e4dd3f454383ea398f8859cb1159f3250c4ab9cd72e179ce681eb6c00626de21464839fae1715ee58d18",
-                "568c76f6cd690c516a1014bf1569e5680781dd72abf9d2424c77c5edfa50cc74bc6e940831eabb4872b18fbbe335a7a29f7a5ee3b71f1aad9d2257626ed7f68e",
-                "4728c6ef84521d181ffc58a602fb68a66e88f93d6c1e1e7ae0dbef6ccbade1916474d167ad8902e9dafb79677de34bcccb0dcd9fa39aa97b83958cfdbceb6668"
-              ),
-             // StarVault
-             Address("DAG2LFocye7MvTN3V2bmt4kiJG7SxhMz6sbCaJdn") ->
-               NonEmptySet.of(
-                 "b090ca464abd2d1dbd219ff6c801ec8913d88ccc1b28cb1f1acacd83e040e41e41d8d57127ee8991339dd055844bbc3659e1001e6498a9e174c6b3917b4378d5",
-                 "67060feccf1c407db4d46b156203e4b6eabc6c3dde196af1e64bb4f53d86a72420e701fc069d86635506e34c0d4cdea6089addb62213512e5b4de7fff41319c0",
-                 "1391276cd637be03331ae5914a5a063c549fbcc6515b140d1ccc0af7c67631804991ba0dae4c1d95b84f77dc812dd71ed2a1817e50c92b722e9b8182683366ed"
-               )
+          // Valid Vote
+          Address("DAG55nwjLR1JhY4a2Wri6Cni2GWPL7Vupu5znnJi") ->
+            NonEmptySet.of(
+              "98e2c7ee9e4bd8aed3a22a075becbe5cad252e25724e7e14050beb69f80e9ea409777470914d21e0bca625cb3ec065a001378b62668355f60bddfc1a322292e5",
+              "7f509f5b2e4d70e9bd9852af0c064f30d95e83243896b7a5857be247a8212b121a96d913e00fe19568f18c9674ea871a8162e4d2d5d711c140be051df21d9744",
+              "08a360052a6444b55f91fdea97ecbdf251b640736e3fb61d9828be8c1a3159bcca234864a6693ba9cd57630ae90bddc2127d8ebe191243eec38aee9a00adb149"
+            ),
+          // CNS
+          Address("DAG1YTmwkBqCBrW8JLFquAmadozEqSWSxJ2mKKcT") ->
+            NonEmptySet.of(
+              "ac1243131c0b2821876e88e3a50ee30d3fb28d571cb8e4dd3f454383ea398f8859cb1159f3250c4ab9cd72e179ce681eb6c00626de21464839fae1715ee58d18",
+              "568c76f6cd690c516a1014bf1569e5680781dd72abf9d2424c77c5edfa50cc74bc6e940831eabb4872b18fbbe335a7a29f7a5ee3b71f1aad9d2257626ed7f68e",
+              "4728c6ef84521d181ffc58a602fb68a66e88f93d6c1e1e7ae0dbef6ccbade1916474d167ad8902e9dafb79677de34bcccb0dcd9fa39aa97b83958cfdbceb6668"
+            ),
+          // StarVault
+          Address("DAG2LFocye7MvTN3V2bmt4kiJG7SxhMz6sbCaJdn") ->
+            NonEmptySet.of(
+              "b090ca464abd2d1dbd219ff6c801ec8913d88ccc1b28cb1f1acacd83e040e41e41d8d57127ee8991339dd055844bbc3659e1001e6498a9e174c6b3917b4378d5",
+              "67060feccf1c407db4d46b156203e4b6eabc6c3dde196af1e64bb4f53d86a72420e701fc069d86635506e34c0d4cdea6089addb62213512e5b4de7fff41319c0",
+              "1391276cd637be03331ae5914a5a063c549fbcc6515b140d1ccc0af7c67631804991ba0dae4c1d95b84f77dc812dd71ed2a1817e50c92b722e9b8182683366ed"
+            )
         ).some
     }
 


### PR DESCRIPTION
## Summary

- Replace the global rate limiter on `/latest/combined` with a lazy deduplicating response cache (`CachedCombinedResponse`)
- The combined snapshot response (~90MB GlobalSnapshotInfo) was being re-serialized from scratch on every request, causing high CPU and memory usage under load
- The previous rate limiter mitigated this by throttling all callers globally (1 req/N seconds total), but this blocked independent consumers from accessing snapshot data — unacceptable for a blockchain node where peers and external services need frequent access

## Approach

`CachedCombinedResponse` uses `Ref` + `Deferred` (cats-effect) for lock-free lazy deduplication:

- **Cache hit** (same ordinal as cached): returns pre-serialized bytes instantly — zero CPU cost
- **Cache miss** (new snapshot ordinal): one fiber serializes the JSON on the blocking pool, concurrent requests wait on the same `Deferred` and share the result
- **Lazy**: if no one calls the endpoint between snapshots, no serialization happens at all

This bounds the serialization cost to **at most once per snapshot per ordinal**, regardless of request volume.

## Changes

- **`SnapshotRoutes.scala`**: replaced `RateLimiter` with `CachedCombinedResponse`, removed `withRateLimit` helper, route now serves cached `Array[Byte]` directly as `application/json`
- **`config/types.scala`**: removed `combinedRouteRateLimiter` from `AppConfig` and `SharedConfig`
- **`application.conf`**: removed `combined-route-rate-limiter` config block
- **`CliMethod.scala`, `HttpApi.scala` (dag-l0, currency-l0, currency-l1)**: removed rate limiter config wiring