### PR TITLE
fix: enforce a gate on setting owner msg on startup in public networks

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -16,6 +16,7 @@ import io.constellationnetwork.currency.l0.modules._
 import io.constellationnetwork.currency.l0.node.L0NodeContext
 import io.constellationnetwork.currency.l0.snapshot.schema.{CurrencyConsensusOutcome, Finished}
 import io.constellationnetwork.currency.schema.currency._
+import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.kryo._
 import io.constellationnetwork.node.shared.app._
@@ -31,6 +32,7 @@ import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEve
 import io.constellationnetwork.node.shared.{NodeSharedOrSharedRegistrationIdRange, nodeSharedKryoRegistrar}
 import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.gossip.{Ordinal => GossipOrdinal}
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
 import io.constellationnetwork.security._
@@ -417,6 +419,19 @@ abstract class CurrencyL0App(
                       keyPair,
                       mkCell
                     )
+                    _ <-
+                      if (cfg.environment =!= AppEnvironment.Dev) {
+                        for {
+                          _ <- logger.info(s"Setting owner address filled on path: ${m.metagraphOwnerMessagePath}")
+                          maybeOwnerEvent <- services.currencyMessages.setInitialCurrencyOwner(m.metagraphOwnerMessagePath)
+                          _ <- logger.info(s"Owner address set")
+                          _ <- maybeOwnerEvent.traverse_ { event =>
+                            services.consensus.storage.addEvents(
+                              Map(nodeId -> List((GossipOrdinal.MinValue, event)))
+                            )
+                          }
+                        } yield ()
+                      } else IO.unit
                     hashedSnapshot <- currencySnapshot.toHashed[IO]
                     _ <- services.consensus.manager.startFacilitatingAfterRollback(
                       currencySnapshot.ordinal,
@@ -443,9 +458,11 @@ abstract class CurrencyL0App(
                   services.cluster.createSession >>
                   services.session.createSession >>
                   programs.globalL0PeerDiscovery.discoverFrom(cfg.globalL0Peer) >>
-                  logger.info(s"Setting owner address filled on path: ${m.metagraphOwnerMessagePath}") >>
-                  services.currencyMessages.setInitialCurrencyOwner(m.metagraphOwnerMessagePath) >>
-                  logger.info(s"Owner address set") >>
+                  (
+                    logger.info(s"Setting owner address filled on path: ${m.metagraphOwnerMessagePath}") >>
+                      services.currencyMessages.setInitialCurrencyOwner(m.metagraphOwnerMessagePath).void >>
+                      logger.info(s"Owner address set")
+                  ).whenA(cfg.environment === AppEnvironment.Dev) >>
                   storages.node.setNodeState(NodeState.Ready) >>
                   storages.identifier.get.flatMap { identifier =>
                     services.restart.setClusterLeaveRestartMethod(

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -423,7 +423,7 @@ abstract class CurrencyL0App(
                       if (cfg.environment =!= AppEnvironment.Dev) {
                         for {
                           _ <- logger.info(s"Setting owner address filled on path: ${m.metagraphOwnerMessagePath}")
-                          maybeOwnerEvent <- services.currencyMessages.setInitialCurrencyOwner(m.metagraphOwnerMessagePath)
+                          maybeOwnerEvent <- services.currencyMessages.validateInitialCurrencyOwner(m.metagraphOwnerMessagePath)
                           _ <- logger.info(s"Owner address set")
                           _ <- maybeOwnerEvent.traverse_ { event =>
                             services.consensus.storage.addEvents(
@@ -460,7 +460,9 @@ abstract class CurrencyL0App(
                   programs.globalL0PeerDiscovery.discoverFrom(cfg.globalL0Peer) >>
                   (
                     logger.info(s"Setting owner address filled on path: ${m.metagraphOwnerMessagePath}") >>
-                      services.currencyMessages.setInitialCurrencyOwner(m.metagraphOwnerMessagePath).void >>
+                      services.currencyMessages
+                        .validateInitialCurrencyOwner(m.metagraphOwnerMessagePath)
+                        .flatMap(_.traverse_(mkCell(_).run())) >>
                       logger.info(s"Owner address set")
                   ).whenA(cfg.environment === AppEnvironment.Dev) >>
                   storages.node.setNodeState(NodeState.Ready) >>

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/infrastructure/snapshot/services/CurrencyMessagesService.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/infrastructure/snapshot/services/CurrencyMessagesService.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.currency.cli.MetagraphOwnerMessageOpts.MetagraphOwnerMessagePath
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
-import io.constellationnetwork.kernel._
 import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSnapshotStorage, SnapshotStorage}
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelValidator.getFeeAddresses
 import io.constellationnetwork.node.shared.infrastructure.currencyMessage.CurrencyMessageLoader
@@ -26,12 +25,11 @@ import io.constellationnetwork.security.signature.Signed
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 trait CurrencyMessagesService[F[_]] {
-  def setInitialCurrencyOwner(ownerMessagePath: Option[MetagraphOwnerMessagePath]): F[Option[CurrencySnapshotEvent]]
+  def validateInitialCurrencyOwner(ownerMessagePath: Option[MetagraphOwnerMessagePath]): F[Option[CurrencySnapshotEvent]]
 }
 
 object CurrencyMessagesService {
   def make[F[_]: Async: Hasher](
-    mkCell: CurrencySnapshotEvent => Cell[F, StackF, _, Either[CellError, Ω], _],
     validator: CurrencyMessageValidator[F],
     identifierStorage: IdentifierStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo]
@@ -42,7 +40,7 @@ object CurrencyMessagesService {
       def currencyMessageLoader(ownerMessagePath: MetagraphOwnerMessagePath): F[Signed[CurrencyMessage]] =
         CurrencyMessageLoader.make[F].load(ownerMessagePath)
 
-      override def setInitialCurrencyOwner(
+      override def validateInitialCurrencyOwner(
         maybeOwnerMessagePath: Option[MetagraphOwnerMessagePath]
       ): F[Option[CurrencySnapshotEvent]] =
         maybeOwnerMessagePath match {
@@ -69,8 +67,7 @@ object CurrencyMessagesService {
                     Async[F].raiseError[CurrencySnapshotEvent](new RuntimeException(s"Invalid message: $msg"))
 
                 case Valid(message) =>
-                  val event: CurrencySnapshotEvent = CurrencyMessageEvent(message)
-                  mkCell(event).run().as(event)
+                  (CurrencyMessageEvent(message): CurrencySnapshotEvent).pure[F]
               }
             } yield event.some
           case None => none[CurrencySnapshotEvent].pure[F]

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/infrastructure/snapshot/services/CurrencyMessagesService.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/infrastructure/snapshot/services/CurrencyMessagesService.scala
@@ -26,7 +26,7 @@ import io.constellationnetwork.security.signature.Signed
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 trait CurrencyMessagesService[F[_]] {
-  def setInitialCurrencyOwner(ownerMessagePath: Option[MetagraphOwnerMessagePath]): F[Unit]
+  def setInitialCurrencyOwner(ownerMessagePath: Option[MetagraphOwnerMessagePath]): F[Option[CurrencySnapshotEvent]]
 }
 
 object CurrencyMessagesService {
@@ -42,7 +42,9 @@ object CurrencyMessagesService {
       def currencyMessageLoader(ownerMessagePath: MetagraphOwnerMessagePath): F[Signed[CurrencyMessage]] =
         CurrencyMessageLoader.make[F].load(ownerMessagePath)
 
-      override def setInitialCurrencyOwner(maybeOwnerMessagePath: Option[MetagraphOwnerMessagePath]): F[Unit] =
+      override def setInitialCurrencyOwner(
+        maybeOwnerMessagePath: Option[MetagraphOwnerMessagePath]
+      ): F[Option[CurrencySnapshotEvent]] =
         maybeOwnerMessagePath match {
           case Some(ownerMessagePath) =>
             for {
@@ -60,17 +62,18 @@ object CurrencyMessagesService {
                 shouldPerformMetagraphSpecificValidations = false
               )
 
-              _ <- validation match {
+              event <- validation match {
                 case Invalid(errors) =>
                   val msg = errors.toNonEmptyList.toList.map(_.show).mkString(", ")
                   logger.warn(s"Message is invalid, reason: ${errors.show}") *>
-                    Async[F].raiseError[Unit](new RuntimeException(s"Invalid message: $msg"))
+                    Async[F].raiseError[CurrencySnapshotEvent](new RuntimeException(s"Invalid message: $msg"))
 
                 case Valid(message) =>
-                  mkCell(CurrencyMessageEvent(message)).run()
+                  val event: CurrencySnapshotEvent = CurrencyMessageEvent(message)
+                  mkCell(event).run().as(event)
               }
-            } yield ()
-          case None => ().pure[F]
+            } yield event.some
+          case None => none[CurrencySnapshotEvent].pure[F]
         }
 
     }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -148,7 +148,6 @@ object Services {
         )
 
       currencyMessagesService = CurrencyMessagesService.make[F](
-        mkCell,
         sharedValidators.currencyMessageValidator,
         storages.identifier,
         sharedStorages.lastGlobalSnapshot


### PR DESCRIPTION
addresses a race condition where the owner message was not set until after ordinal 2 was created