### PR TITLE
docs: minor update to metagraph upgrade instructions

### DIFF
--- a/docs/release/metagraph-upgrade-guide.md
+++ b/docs/release/metagraph-upgrade-guide.md
@@ -25,7 +25,7 @@ BouncyCastle JARs in newer versions include OSGI-INF metadata that conflicts dur
 assembly / assemblyMergeStrategy := {
   case "META-INF/io.netty.versions.properties" => MergeStrategy.first
   case "META-INF/versions/9/module-info.class" => MergeStrategy.first
-  case PathList("OSGI-INF", "bundle.info")     => MergeStrategy.first
+  case PathList("META-INF", "versions", _, "OSGI-INF", _ @_*)    => MergeStrategy.discard
   case PathList(xs@_*) if xs.last == "module-info.class" => MergeStrategy.first
   case x if x.endsWith("/module-info.class") => MergeStrategy.first
   case x =>


### PR DESCRIPTION
The previous merge strategy was still failing on digital evidence so I've aligned with the template metagraph from tessellation that is used in testing.