### PR TITLE
fix: bug in facilitator subset removing healthy L0 peers

### DIFF
--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
@@ -113,6 +113,8 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
         def addPeers(l0Peers: Set[L0Peer]): IO[Unit] = ???
 
         def setPeers(l0Peers: NonEmptySet[L0Peer]): IO[Unit] = ???
+
+        def removePeer(id: PeerId): IO[Unit] = IO.unit
       }
 
       lastSnapshotStorage = new LastSnapshotStorage[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutesSuite.scala
@@ -148,6 +148,8 @@ object DataApplicationRoutesSuite extends HttpSuite {
       override def setPeers(l0Peers: NonEmptySet[L0Peer]): IO[Unit] = ???
 
       override def getRandomPeerExistentOnList(peers: List[peer.PeerId]): IO[Option[L0Peer]] = ???
+
+      override def removePeer(id: peer.PeerId): IO[Unit] = IO.unit
     }
   )
 

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/TokenLockRoutesSuite.scala
@@ -99,6 +99,8 @@ object TokenLockRoutesSuite extends HttpSuite {
       override def setPeers(l0Peers: NonEmptySet[L0Peer]): IO[Unit] = ???
 
       override def getRandomPeerExistentOnList(peers: List[peer.PeerId]): IO[Option[L0Peer]] = ???
+
+      override def removePeer(id: peer.PeerId): IO[Unit] = IO.unit
     }
   )
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/L0PeerDiscovery.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/L0PeerDiscovery.scala
@@ -46,9 +46,7 @@ sealed abstract class L0PeerDiscovery[F[_]: Sync: Random] private (
       .flatMap {
         case Some(facilitatorPeer) =>
           getPeersFrom(facilitatorPeer)
-            .map(_.filter(peer => lastFacilitators.contains(peer.id)))
-            .map(NonEmptySet.fromSet(_))
-            .flatMap(_.traverse_(l0ClusterStorage.setPeers))
+            .flatMap(l0ClusterStorage.setPeers)
         case None =>
           logger.warn("No known peers found among last facilitators, falling back to random peer") >>
             l0ClusterStorage.getPeers

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/storage/L0ClusterStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/storage/L0ClusterStorage.scala
@@ -11,4 +11,5 @@ trait L0ClusterStorage[F[_]] {
   def getRandomPeerExistentOnList(peers: List[PeerId]): F[Option[L0Peer]]
   def addPeers(l0Peers: Set[L0Peer]): F[Unit]
   def setPeers(l0Peers: NonEmptySet[L0Peer]): F[Unit]
+  def removePeer(id: PeerId): F[Unit]
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/services/GlobalL0Service.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/services/GlobalL0Service.scala
@@ -9,6 +9,7 @@ import cats.syntax.all._
 import cats.{Applicative, Parallel, Show}
 
 import scala.collection.immutable.SortedSet
+import scala.concurrent.duration._
 import scala.util.Random
 import scala.util.control.NoStackTrace
 
@@ -328,13 +329,23 @@ object GlobalL0Service {
         }
       }
 
+      private val peerQueryRetries = 3
+
+      private def withPeerRetry[A](peer: L0Peer, fa: F[A], remaining: Int = peerQueryRetries): F[A] =
+        fa.handleErrorWith { err =>
+          if (remaining <= 1)
+            logger.warn(err)(s"Peer ${peer.show} unreachable after $peerQueryRetries attempts, removing from storage") >>
+              globalL0ClusterStorage.removePeer(peer.id) >>
+              Async[F].raiseError(err)
+          else
+            Async[F].sleep(200.millis) >> withPeerRetry(peer, fa, remaining - 1)
+        }
+
       private def getMajorityHash(peers: NonEmptyList[L0Peer], ordinal: SnapshotOrdinal): F[Option[Hash]] =
         peers.toList
           .parTraverseN(numConcurrentQueries) { p =>
-            l0GlobalSnapshotClient
-              .getHash(ordinal)
-              .run(p)
-              .handleErrorWith(logger.warn(_)(s"Unable to obtain hash for majority peer ${p.show}").as(none[Hash]))
+            withPeerRetry(p, l0GlobalSnapshotClient.getHash(ordinal).run(p))
+              .handleErrorWith(_ => none[Hash].pure[F])
           }
           .map(_.flatten)
           .flatTap(hashes => logger.debug(s"Majority Hashes ${hashes.map(_.show)}"))
@@ -385,10 +396,9 @@ object GlobalL0Service {
       private def getMajorityOrdinal(peers: NonEmptyList[L0Peer]): F[Option[SnapshotOrdinal]] =
         peers.toList
           .parTraverseN(numConcurrentQueries) { p =>
-            l0GlobalSnapshotClient.getLatestOrdinal
-              .run(p)
+            withPeerRetry(p, l0GlobalSnapshotClient.getLatestOrdinal.run(p))
               .map(_.some)
-              .handleErrorWith(logger.warn(_)(s"Unable to retrieve ordinal for majority peer ${p.show}").as(none[SnapshotOrdinal]))
+              .handleErrorWith(_ => none[SnapshotOrdinal].pure[F])
           }
           .map(_.flatten)
           .map(pickMajority[List, SnapshotOrdinal])

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/cluster/storage/L0ClusterStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/cluster/storage/L0ClusterStorage.scala
@@ -6,11 +6,14 @@ import cats.effect.{Ref, Sync}
 import cats.syntax.contravariant._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.{Monad, Order}
+import cats.syntax.show._
+import cats.{Order, Show}
 
 import io.constellationnetwork.ext.cats.data.NonEmptyMapOps
 import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.schema.peer.{L0Peer, PeerId}
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object L0ClusterStorage {
 
@@ -22,8 +25,11 @@ object L0ClusterStorage {
       .of[F, NonEmptyMap[PeerId, L0Peer]](NonEmptyMap.one(l0Peer.id, l0Peer))
       .map(make(_))
 
-  def make[F[_]: Monad: Random](peers: Ref[F, NonEmptyMap[PeerId, L0Peer]]): L0ClusterStorage[F] =
+  def make[F[_]: Sync: Random](peers: Ref[F, NonEmptyMap[PeerId, L0Peer]]): L0ClusterStorage[F] =
     new L0ClusterStorage[F] {
+
+      private val logger = Slf4jLogger.getLogger[F]
+      private implicit val peerIdShow: Show[PeerId] = PeerId.shortShow
 
       def getPeers: F[NonEmptySet[L0Peer]] =
         peers.get.map(_.values)
@@ -59,5 +65,16 @@ object L0ClusterStorage {
           NonEmptyMap.of((head.id, head), l0Peers.tail.map(p => p.id -> p).toSeq: _*)
         }
       }
+
+      def removePeer(id: PeerId): F[Unit] =
+        peers.modify { current =>
+          NonEmptyMap.fromMap(current.toSortedMap - id) match {
+            case Some(remaining) => (remaining, true)
+            case None            => (current, false)
+          }
+        }.flatMap {
+          case true  => logger.info(s"Removed unresponsive peer ${id.show} from L0 cluster storage")
+          case false => logger.warn(s"Cannot remove peer ${id.show}, it is the last peer in L0 cluster storage")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes an interaction between the facilitator subsetting feature (introduced in rc.6) and L0 peer discovery that caused currency-l0 and dag-l1 nodes to intermittently fail when pulling global snapshots. The peer discovery mechanism was incorrectly pruning the Global L0 cluster storage to only include peers that signed the most recent snapshot, which with facilitator rotation meant most peers were evicted every 10 seconds.

## Root Cause Analysis

### Symptom

Currency-l0 nodes running v4.0.0-rc.6 intermittently log:

```
WARN  - No majority hash found among 1 peers for ordinal: SnapshotOrdinal(5076410)
ERROR - Failed to get majority snapshot data. Either majority ordinal or majority hash consensus
        could not be achieved among peers: List(3458a688..., 46daea11..., e2f4496e...)
```

The node has 3 configured majority peer IDs but can only find 1 in `L0ClusterStorage`, making it impossible to meet the quorum threshold of `ceil(0.5 * (1 + 3)) = 2`.

### Root Cause

Two mechanisms interact to produce the failure:

**1. `L0PeerDiscovery.discover()` filters and replaces peers based on snapshot proofs**

In `StateChannel.performGlobalL0PeerDiscovery`, once a global snapshot has been synced, peer discovery switches from `discoverFrom()` (additive) to `discover(lastFacilitators)` (replacing). The `discover()` method:

1. Queries a facilitator peer for its cluster info
2. **Filters the response to only peers whose IDs match the snapshot's proof signers** (the facilitators)
3. Calls `L0ClusterStorage.setPeers()` which **replaces the entire peer set**

This was originally safe because all eligible peers participated in every consensus round, so the proof signers included the full validator set.

**2. Facilitator subsetting (rc.6) rotates which peers sign each snapshot**

The `FacilitatorSelector` feature (commit `a08496d4`) selects a deterministic subset of peers for each consensus round based on `maxFacilitatorCount`. Only this subset signs the snapshot. With ~73 Global L0 peers and a subset of ~20 per round, the proof signers in any given snapshot represent only ~27% of the network.

**The interaction**: Every 10 seconds, `discover()` replaces `L0ClusterStorage` with only the ~20 peers that signed the latest snapshot. If 2 of the 3 configured majority peer IDs were not in that particular subset, `GlobalL0Service.getL0Peers()` can only resolve 1 peer, failing the quorum check.

### Timeline on an affected node

| Time | Event |
|------|-------|
| T+0s | Startup. Initial discovery finds all ~73 Global L0 peers via `discoverFrom()` (additive). |
| T+2s | `pullLatestSnapshot` succeeds. All 3 majority hashes match. First snapshot stored in `lastSyncGlobalSnapshot`. |
| T+10s | Peer discovery runs. Now has a synced snapshot, so calls `discover(proofs)`. Filters to ~20 facilitators, calls `setPeers()`. Storage drops from ~73 to ~20 peers. |
| T+18s | `getMajoritySnapshotData` looks up 3 majority peer IDs. Only 1 is among the ~20 facilitators. Quorum requires 2. **Fails.** |
| T+20s | Discovery runs again with new snapshot proofs (different subset). Maybe 2 of 3 are present this time. **Succeeds intermittently.** |

### Why it worked on rc.2

No facilitator subsetting existed. Every consensus round included all eligible peers as facilitators. Snapshot proofs contained all ~73 signatures. The `discover()` filter was effectively a no-op since all peers were facilitators.

## Changes

* **Modified** `L0PeerDiscovery.discover()` - Removed the facilitator filter on discovered peers. The method still prefers querying a recent facilitator as the discovery source (they are known to be active), but no longer restricts the results to only facilitators. All healthy (`Ready` state) peers reported by the queried node are now kept in storage.

* **Added** `L0ClusterStorage.removePeer(id)` - Safely removes a peer from the `NonEmptyMap`-backed storage. If removal would empty the storage, the operation is a no-op (preserves the non-empty invariant).

* **Modified** `GlobalL0Service.getMajorityHash()` and `getMajorityOrdinal()` - Error handlers now reactively remove unresponsive peers from `L0ClusterStorage` when they fail to respond. This mirrors the consensus pattern where peers are removed through failure detection rather than preemptive filtering. The next discovery cycle (every 10s) will re-add recovered peers.

## Approach

The facilitator subsetting feature was designed to rotate **consensus participation**, not to control **peer visibility**. The fix restores that separation:

- **Consensus** decides which peers sign a given snapshot (facilitator rotation via `FacilitatorSelector`)
- **Peer discovery** maintains a view of all healthy Global L0 peers regardless of their consensus role

For health management, rather than proactively probing peers during discovery (which would add N HTTP calls every 10s), we use **reactive removal**: peers are removed from storage when they actually fail to respond during production use (`getMajorityHash`/`getMajorityOrdinal`). This approach:

1. Adds zero extra network traffic (real production calls serve as the health signal)
2. Mirrors the consensus pattern (start trusted, remove on failure)
3. Self-heals via the discovery cycle (peers are re-added when they recover)

### Affected call sites

`L0PeerDiscovery.discover()` is called from two locations, both of which benefit from this fix:
- `currency-l0/StateChannel.performGlobalL0PeerDiscovery`
- `dag-l1/GlobalSnapshotAlignment.performL0PeerDiscovery`

## Testing

- Verified compilation of `nodeShared`, `currencyL0`, and `dagL1` modules
- Manual verification against live integrationnet node (13.52.64.163:9100) confirmed the failure pattern matches the root cause analysis
