### PR TITLE
ci: fix stable release changelog comparing against prerelease tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           if [[ "${{ github.ref_name }}" == "release/mainnet" ]]; then
             DRY_RUN=$(npx commit-and-tag-version --dry-run)
-          else
+          elif [[ "${{ github.ref_name }}" == "release/integrationnet" ]]; then
             DRY_RUN=$(npx commit-and-tag-version --dry-run --prerelease rc)
           fi
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Remove prerelease tags for stable releases
+        if: github.ref_name == 'release/mainnet'
+        run: |
+          # Remove prerelease tags from the local clone so commit-and-tag-version
+          # compares against the last stable tag instead of the nearest rc/alpha.
+          # This only affects the ephemeral CI runner, not the remote.
+          TAGS=$(git tag -l '*-rc.*' '*-alpha.*')
+          if [ -n "$TAGS" ]; then
+            echo "$TAGS" | xargs git tag -d
+            echo "Removed $(echo "$TAGS" | wc -l) prerelease tags locally"
+          fi
+
       - name: Get the release version
         id: get_version
         run: |
@@ -63,9 +75,14 @@ jobs:
       - name: Build Changelog
         id: get_changelog
         run: |
+          if [[ "${{ github.ref_name }}" == "release/mainnet" ]]; then
+            DRY_RUN=$(npx commit-and-tag-version --dry-run)
+          else
+            DRY_RUN=$(npx commit-and-tag-version --dry-run --prerelease rc)
+          fi
           {
             echo "CHANGELOG<<EOF"
-            npx commit-and-tag-version --dry-run | sed -n '/---/,/---/p' | sed '1d;$d'
+            echo "$DRY_RUN" | sed -n '/---/,/---/p' | sed '1d;$d'
             echo EOF
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
Fix the release workflow so that stable (mainnet) releases generate a complete changelog comparing against the last stable tag, not the nearest prerelease tag.

## Changes
* **Added** - New workflow step that removes prerelease tags (rc/alpha) from the local CI clone before version computation on `release/mainnet`. This forces `commit-and-tag-version` to walk back to the last stable tag.
* **Modified** - Build Changelog step now passes `--prerelease rc` for integrationnet releases, matching the version computation step.

## Context
The v4.0.0 release changelog only showed commits since `v4.0.0-rc.7` (the nearest ancestor prerelease tag) instead of all changes since `v3.5.12`. This happened because `commit-and-tag-version` uses git ancestry to find the comparison base, and prerelease tags from the integrationnet promotion path were closer ancestors than the previous stable tag.

The fix is minimal and safe — prerelease tags are only deleted from the ephemeral CI runner clone, not from the remote repository. Integrationnet (rc) releases are unaffected since their changelog correctly walks back to the previous rc tag.

## Testing
Workflow-only change. Can be validated by running `commit-and-tag-version --dry-run` locally after deleting prerelease tags and confirming it compares against the last stable tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)