### PR TITLE
feat: add multi-round removal penalty and consensus FSM refactoring

### DIFF
--- a/docs/CONSENSUS_REFACTORING.md
+++ b/docs/CONSENSUS_REFACTORING.md
@@ -65,7 +65,7 @@ snapshot.consensus {
 
 ---
 
-## Adaptive Tiered Unlock Thresholds
+## Deterministic N-Based Unlock Thresholds
 
 ### Problem
 
@@ -75,28 +75,29 @@ The old unlock logic used flat thresholds based on total facilitator count. When
 
 ### Solution
 
-Replaced flat thresholds with **adaptive tiers** in `UnlockConsensusUpdate.scala` based on how many facilitators actually voted (sent ACKs):
+Replaced flat thresholds with **deterministic N-based thresholds** in `UnlockConsensusUpdate.scala`, with a minimum voter gate and a safety floor:
 
-| Tier | Condition | Keep Threshold | Remove Threshold | Rationale |
-|------|-----------|----------------|------------------|-----------|
-| **DEFER** | `voterCount < ceil(N/5)` | — | — | Too few voters; defer to re-stall cycle |
-| **DEGRADED** | `voterCount < ceil(N/3)` | 2/3 supermajority of voters | 2/3 supermajority of voters | Conservative: high bar prevents bad decisions |
-| **FALLBACK** | `voterCount < (N+1)/2` | Simple majority of voters | Simple majority of voters | Moderate: enough voters for reasonable decision |
-| **NORMAL** | `voterCount >= (N+1)/2` | `(N+1)/2` of total | `N/2 + 1` of total | Standard: based on total facilitator count |
+| Phase | Condition | Keep Threshold | Remove Threshold | Rationale |
+|-------|-----------|----------------|------------------|-----------|
+| **DEFER** | `voterCount < ceil(N/3)` | — | — | Too few voters for a safe decision; defer to re-stall cycle |
+| **DECIDE** | `voterCount >= ceil(N/3)` | `(N+1)/2` | `N/2 + 1` | N-based thresholds ensure all nodes make identical decisions |
 
-Where `N` is the total facilitator count and `voterCount` is how many facilitators actually sent ACKs for the current collecting kind.
+Where `N` is the total facilitator count and `voterCount` is how many facilitators actually sent ACKs for the current collecting kind. The minimum voter requirement is `ceil(N/3).max(2)`.
 
-**Key behavior:**
-- DEFER tier means no unlock happens — the re-stall mechanism retries with fresh ACKs, giving more time for ACKs to arrive
-- DEGRADED requires supermajority agreement among actual voters before removing anyone
-- As more voters participate, thresholds relax toward the standard case
+**Key properties:**
+- `keepThreshold + removeThreshold = N + 1 > N`, guaranteeing mutual exclusivity (no peer can be both kept and removed)
+- Thresholds depend only on `N` (total facilitator count), which all nodes agree on — making the decision deterministic across the network
+- DEFER uses `ceil(N/3)` as its minimum voter requirement — a lower bar than `keepThreshold` (`(N+1)/2`), allowing unlock decisions with fewer voters while still requiring meaningful participation. For N=20 this means 7 voters needed (vs 11 with keepThreshold)
+- The stall detector's `maxStallCycles` and `maxRoundDuration` handle liveness: after exhausting stall cycles, the round is abandoned and a new one starts
 - After unlock: `Closed → Reopened`, removed peers are dropped from facilitator list, `advanceStatus` runs again with reduced list
+
+**Safety floor (`MinFacilitatorCount = 2`):** After computing keep/remove decisions, if the number of kept facilitators would fall below 2, the unlock is aborted — the state remains `Closed` and the round is deferred to the stall detector. This prevents a catastrophic scenario where stale ACKs (e.g., from a global latency spike where no declarations arrived before lock) cause all facilitators to be voted out, leaving `facilitatorCount=0` and an irrecoverable cluster.
 
 ### Files Changed
 
 | File | Change |
 |------|--------|
-| `consensus/update/UnlockConsensusUpdate.scala` | Rewritten with 4-tier adaptive thresholds |
+| `consensus/update/UnlockConsensusUpdate.scala` | Rewritten with deterministic N-based thresholds, DEFER gate, and MinFacilitatorCount safety floor |
 
 ---
 
@@ -248,7 +249,7 @@ Wait declarationTimeout
 **Adaptive timeout features:**
 - **Near-completion grace:** When >=75% of declarations received and on first stall cycle, timeout extended by 50% to allow stragglers
 - **Re-stall timeout:** After first lock, subsequent stall cycles use `reStallTimeout` (shorter) instead of `declarationTimeout`
-- **Round abandonment:** Cleans up state and enqueues `RoundCompleted` so the FSM transitions back to IDLE
+- **Round abandonment:** `shouldAbandon = finalStallCycleCount >= maxStallCycles || roundTimedOut`. When triggered, state is removed unconditionally (`case Some(_) =>`) and `RoundCompleted` is enqueued so the FSM transitions back to IDLE. Note: the stall-cycle-exhaustion path does not require `isLocked` — once the budget is spent, the round is abandoned regardless of lock status. This is a deliberate trade-off: after N failed lock/unlock cycles, cutting losses is faster than hoping N+1 works
 
 **Monitoring improvements:**
 - Periodic summary logging (every 10s) showing status, declaration counts, missing peers
@@ -458,15 +459,21 @@ fsm.handle(cmd).handleErrorWith { err =>
     Metrics[F].incrementCounter("dag_consensus_command_error") >>
     (cmd match {
       case _: ConsensusCommand.ConsensusFinished | ConsensusCommand.RoundCompleted =>
-        // Critical: force round completion so FSM doesn't stay stuck in BUSY
+        // Critical: force round completion so FSM doesn't stay stuck in BUSY.
+        // Also offer TimeTick: the forced RoundCompleted calls completeRound without
+        // afterConsensusFinish, so no timer is scheduled for the next round. On solo nodes
+        // with no external events, this would deadlock consensus.
         logger.warn("Forcing round completion after failed ConsensusFinished/RoundCompleted") >>
-          queue.offer(ConsensusCommand.RoundCompleted)
+          queue.offer(ConsensusCommand.RoundCompleted) >>
+          queue.offer(ConsensusCommand.TimeTick)
       case _ => Async[F].unit
     })
 }
 ```
 
 For non-critical commands (rumor processing, peer registration, etc.), the error is logged and the stream continues — same as before.
+
+**Solo-node stall prevention:** The forced `RoundCompleted` calls `completeRound` without `afterConsensusFinish`, so no timer is scheduled for the next round. On solo nodes with no external events (no gossip, no peer messages), consensus would permanently stall. The follow-up `TimeTick` fires once `RoundCompleted` sets `isRunning=false`, starting a new round from IDLE.
 
 ### Files Changed
 
@@ -502,11 +509,11 @@ These files had unused imports, parameters, or methods that were never caught be
 ## Test Results
 
 ```
-Total: 71 tests, 0 failures
-  - StallDetectorSuite:            24 tests  (stall detection, lock/unlock, re-stall cycles, abandonment)
-  - QuorumDeclarationsSuite:       12 tests  (quorum threshold, supermajority gate, split vote deferral)
+Total: 83 tests, 0 failures (430 total project-wide)
+  - StallDetectorSuite:            27 tests  (stall detection, lock/unlock, re-stall cycles, abandonment, abandon guard)
+  - QuorumDeclarationsSuite:       21 tests  (quorum threshold, supermajority gate, split vote deferral, config validation, small cluster)
   - RemovalPenaltySuite:           12 tests  (penalty lifecycle, decrement, expiry, filtering, determinism)
-  - UnlockConsensusUpdateSuite:     9 tests  (adaptive tiers: DEFER, DEGRADED, FALLBACK, NORMAL)
+  - UnlockConsensusUpdateSuite:    10 tests  (N-based thresholds, DEFER gate, mutual exclusivity, determinism, MinFacilitatorCount safety floor)
   - PendingTriggersSuite:           7 tests  (atomic state, priority ordering, concurrency safety)
   - EligibleFacilitatorsSuite:      5 tests  (re-entry after removal, collateral filtering)
 ```

--- a/docs/CONSENSUS_REFACTORING.md
+++ b/docs/CONSENSUS_REFACTORING.md
@@ -1,0 +1,528 @@
+# Consensus FSM Refactoring — Summary of Changes
+
+## Overview
+
+This refactoring targets seven categories of issues in the consensus engine:
+
+1. **Quorum safety** — Quorum declarations lacked a supermajority gate, risking non-deterministic decisions across different node views
+2. **Stall recovery** — Unlock voting used flat thresholds that couldn't adapt when many facilitators were unresponsive
+3. **Facilitator re-entry** — Peers removed during stall recovery were permanently excluded from future rounds
+4. **Removal penalty** — Removed peers could be re-selected one round later, causing repeated stalls when still unresponsive
+5. **Fiber leaks** — Orphaned fibers accumulating over sustained operation
+6. **Race condition** — Non-atomic state in `PendingTriggers` causing lost triggers
+7. **Error recovery** — FSM getting permanently stuck when critical commands fail
+
+All changes are backward-compatible. No protocol changes, no config format changes, no public API changes.
+
+---
+
+## Safe Quorum with Supermajority Gate
+
+### Problem
+
+The consensus advancer (`ConsensusStateAdvancer`) waited for 100% of facilitators to declare before advancing status. This meant a single unresponsive node would block the entire round indefinitely. To fix this, a `quorumThreshold` config was introduced (e.g., 0.67 = 67%), but a naive quorum check creates a new problem:
+
+**Non-determinism across views:** Different nodes see declarations arrive in different orders. If two competing values (e.g., two different proposal hashes) each have ~50% support, one node's quorum-sized subset might compute a different `pickMajority` result than another node's subset. The round diverges and fails.
+
+### Solution
+
+Added a **supermajority safety gate** to `maybeGetQuorumDeclarations` in `ConsensusStateAdvancer.scala`:
+
+```scala
+protected def maybeGetQuorumDeclarations[A, V](
+  state: State, resources: Resources
+)(getter: PeerDeclarations => Option[A])(
+  valueExtractor: A => V
+): F[Option[SortedMap[PeerId, A]]]
+```
+
+The method now requires two conditions before returning declarations:
+
+1. **Quorum count met:** `receivedCount >= quorumSize` (where `quorumSize = ceil(totalRequired * quorumThreshold)`)
+2. **Supermajority support:** The dominant value (most-supported among received declarations) must itself have `>= quorumSize` supporters
+
+**Why this is safe:** By the pigeonhole principle, if one value has supermajority support (>2/3), then any quorum-sized subset of declarations will contain a majority for that same value. All honest nodes compute the same `pickMajority` result regardless of which subset they see.
+
+**If no value has sufficient support** (split vote): returns `None`, deferring to the stall detector which will lock the round and remove unresponsive peers. This breaks the split naturally.
+
+Falls back to 100% if `quorumThreshold` is not configured.
+
+### Config
+
+```hocon
+snapshot.consensus {
+  quorum-threshold = 0.67  # Optional — omit for 100% unanimity (legacy behavior)
+}
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `consensus/state/ConsensusStateAdvancer.scala` | New `maybeGetQuorumDeclarations` with supermajority gate |
+| `dag-l0/.../GlobalSnapshotConsensusStateAdvancer.scala` | Calls `maybeGetQuorumDeclarations` instead of checking 100% |
+| `currency-l0/.../CurrencySnapshotConsensusStateAdvancer.scala` | Same quorum integration |
+
+---
+
+## Adaptive Tiered Unlock Thresholds
+
+### Problem
+
+When a consensus round stalls (not all facilitators declared within the timeout), the round is locked and each node spreads ACK messages containing the set of peers it considers "present". The unlock mechanism tallies these ACK votes to decide which peers to keep and which to remove.
+
+The old unlock logic used flat thresholds based on total facilitator count. When >50% of facilitators were unresponsive (couldn't even send ACKs), the thresholds could never be met. The round stayed permanently locked — a deadlock.
+
+### Solution
+
+Replaced flat thresholds with **adaptive tiers** in `UnlockConsensusUpdate.scala` based on how many facilitators actually voted (sent ACKs):
+
+| Tier | Condition | Keep Threshold | Remove Threshold | Rationale |
+|------|-----------|----------------|------------------|-----------|
+| **DEFER** | `voterCount < ceil(N/5)` | — | — | Too few voters; defer to re-stall cycle |
+| **DEGRADED** | `voterCount < ceil(N/3)` | 2/3 supermajority of voters | 2/3 supermajority of voters | Conservative: high bar prevents bad decisions |
+| **FALLBACK** | `voterCount < (N+1)/2` | Simple majority of voters | Simple majority of voters | Moderate: enough voters for reasonable decision |
+| **NORMAL** | `voterCount >= (N+1)/2` | `(N+1)/2` of total | `N/2 + 1` of total | Standard: based on total facilitator count |
+
+Where `N` is the total facilitator count and `voterCount` is how many facilitators actually sent ACKs for the current collecting kind.
+
+**Key behavior:**
+- DEFER tier means no unlock happens — the re-stall mechanism retries with fresh ACKs, giving more time for ACKs to arrive
+- DEGRADED requires supermajority agreement among actual voters before removing anyone
+- As more voters participate, thresholds relax toward the standard case
+- After unlock: `Closed → Reopened`, removed peers are dropped from facilitator list, `advanceStatus` runs again with reduced list
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `consensus/update/UnlockConsensusUpdate.scala` | Rewritten with 4-tier adaptive thresholds |
+
+---
+
+## Eligible Facilitator Re-Entry
+
+### Problem
+
+When a peer was removed during stall recovery (unlock), it was stored in `removedFacilitators`. The next round's state creator computed the eligible facilitator list by starting from the previous round's eligible peers AFTER filtering out removed peers. This meant a removed peer could never re-enter the eligible pool — even if it came back online and was healthy.
+
+Over multiple stall cycles, the active facilitator count would ratchet downward permanently until the network degraded.
+
+### Solution
+
+Changed the facilitator selection logic in both `GlobalSnapshotConsensusStateCreator` and `CurrencySnapshotConsensusStateCreator`:
+
+```
+fullBase = (filteredPreviousEligible ++ filteredCandidates :+ selfId).distinct
+         // ↑ computed WITHOUT removal filter — includes all healthy peers
+
+allEligible = fullBase.filterA(facilitatorFilter)
+         // ↑ only collateral/health checks, NOT removal filter
+
+eligibleThisRound = allEligible.filterNot(previouslyRemoved.contains)
+         // ↑ THIS round excludes recently-removed peers
+
+activeFacilitators = facilitatorSelector.select(eligibleThisRound, entropy)
+```
+
+**Key distinction:**
+- `allEligible` (stored in `EligibleFacilitators`) — includes previously-removed peers so they persist in the eligible pool
+- `eligibleThisRound` — excludes recently-removed peers for active selection THIS round only
+- Next round: the removed peers are back in `allEligible` and can be selected again if they pass the facilitator filter
+
+This means a peer removed in round N is excluded from round N+1 but eligible again in round N+2 (assuming it passes collateral/health checks).
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `dag-l0/.../GlobalSnapshotConsensusStateCreator.scala` | `fullBase` without removal filter, `allEligible` stored for re-entry |
+| `currency-l0/.../CurrencySnapshotConsensusStateCreator.scala` | Same pattern |
+
+---
+
+## Multi-Round Removal Penalty
+
+### Problem
+
+With the eligible facilitator re-entry mechanism (above), a peer removed during stall recovery in round N is excluded from round N+1 but eligible again in round N+2. If the peer is still unresponsive, the stall detector must wait `declarationTimeout` (35s+) before detecting the stall and removing it again. This wastes an entire round's worth of time on a peer already known to be problematic.
+
+**Why not filter by local health checks?** Every `PeerDeclaration` includes a `facilitatorsHash`. All nodes must compute the same facilitator list. Different nodes have different views of which peers are responsive (`PeerResponsiveness` from `LocalHealthcheck`). Filtering by local health would produce different `facilitatorsHash` values across nodes, triggering fork detection and node restarts.
+
+### Solution
+
+Added a **deterministic multi-round removal penalty** that extends the exclusion period for removed peers. All penalty data derives from the agreed-upon consensus outcome (`lastOutcome`), so all nodes compute identical facilitator lists.
+
+**Penalty lifecycle:**
+
+```
+Round N:   Peer X fails to declare → stall → lock → unlock removes X
+           Outcome: removedFacilitators = {X}, removalPenalties = {X: 3}
+
+Round N+1: Penalties from lastOutcome: {X: 3}, X excluded (3 > 0)
+           Advancer decrements → outcome: {X: 2}
+
+Round N+2: {X: 2}, X excluded (2 > 0)
+           Advancer decrements → outcome: {X: 1}
+
+Round N+3: {X: 1}, X excluded (1 > 0)
+           Advancer decrements → outcome: {} (expired)
+
+Round N+4: No penalty → X eligible again
+           If X is healthy → participates normally
+           If X still unresponsive → removed again → penalty resets to 3
+```
+
+**Implementation has two parts:**
+
+1. **State creators** (facilitator selection): Read `lastOutcome.removalPenalties`, exclude peers with penalty > 0 from `eligibleThisRound`. Penalized peers remain in `allEligible` (re-entry pool preserved).
+
+```
+penalizedPeers = lastOutcome.removalPenalties.filter(_._2 > 0).keySet
+eligibleThisRound = allEligible.filterNot((previouslyRemoved ++ penalizedPeers).contains)
+```
+
+2. **Advancers** (outcome construction): Decrement previous penalties, filter expired (<=0), add new removals at `removalPenaltyRounds`. Stored in the outcome for the next round.
+
+```
+decremented = previousPenalties.mapValues(_ - 1).filter(_._2 > 0)
+newPenalties = removedFacilitators.foldLeft(decremented)(_.updated(_, removalPenaltyRounds))
+```
+
+**Why deterministic:** All inputs are from the agreed-upon `lastOutcome` (same for all nodes) and `config.removalPenaltyRounds` (same config on all nodes). Decrement and merge are pure functions. No local state (`PeerResponsiveness`, `ClusterStorage`) is used.
+
+**Backward compatible:** `removalPenalties: Map[PeerId, Int] = Map.empty` with default value ensures old serialized outcomes (without the field) decode correctly via circe magnolia. Feature disabled when `removalPenaltyRounds = 0`.
+
+### Config
+
+```hocon
+snapshot.consensus {
+  removal-penalty-rounds = 3  # 0 = disabled (default, backward compatible)
+}
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `node-shared/.../config/types.scala` | Added `removalPenaltyRounds: Int = 0` to `ConsensusConfig` |
+| `dag-l0/.../snapshot/schema.scala` | Added `removalPenalties: Map[PeerId, Int]` to `GlobalConsensusOutcome` |
+| `currency-l0/.../snapshot/schema.scala` | Added `removalPenalties: Map[PeerId, Int]` to `CurrencyConsensusOutcome` |
+| `dag-l0/.../GlobalSnapshotConsensusStateCreator.scala` | Filter `eligibleThisRound` by penalties |
+| `currency-l0/.../CurrencySnapshotConsensusStateCreator.scala` | Filter `eligibleThisRound` by penalties |
+| `dag-l0/.../GlobalSnapshotConsensusStateAdvancer.scala` | Compute `removalPenalties` in `getConsensusOutcome` |
+| `currency-l0/.../CurrencySnapshotConsensusStateAdvancer.scala` | Compute `removalPenalties` in `getConsensusOutcome` |
+| `dag-l0/src/main/resources/dag-l0.conf` | `removal-penalty-rounds = 3` |
+| `currency-l0/src/main/resources/currency-l0.conf` | `removal-penalty-rounds = 3` |
+
+---
+
+## StallDetector Improvements
+
+### Problem
+
+The original stall detector had a single timeout mechanism: if declarations didn't arrive within `declarationTimeout`, the round was abandoned. This was too aggressive — network delays could cause legitimate rounds to be killed.
+
+### Solution
+
+Rewrote `StallDetector.scala` with a multi-stage stall recovery flow:
+
+```
+Wait declarationTimeout
+  → Lock (Closed) + spread ACKs
+  → Wait for unlock (Reopened) via ACK voting
+  → If unlock fails after reStallTimeout: re-spread ACKs (failed stall cycle)
+  → After maxStallCycles: abandon round
+  → After maxRoundDuration: abandon round (wall-clock safety net)
+```
+
+**New config parameters:**
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `re-stall-timeout` | 10s | Timeout for subsequent stall cycles after the first lock |
+| `max-stall-cycles` | 5 | Maximum lock/unlock attempts before abandoning |
+| `max-round-duration` | 5 min | Wall-clock safety net — abandon regardless of stall cycle count |
+| `no-progress-timeout` | (optional) | Separate timeout when zero declarations received |
+
+**Adaptive timeout features:**
+- **Near-completion grace:** When >=75% of declarations received and on first stall cycle, timeout extended by 50% to allow stragglers
+- **Re-stall timeout:** After first lock, subsequent stall cycles use `reStallTimeout` (shorter) instead of `declarationTimeout`
+- **Round abandonment:** Cleans up state and enqueues `RoundCompleted` so the FSM transitions back to IDLE
+
+**Monitoring improvements:**
+- Periodic summary logging (every 10s) showing status, declaration counts, missing peers
+- Per-status tracking of which peers haven't declared (logged by truncated peer ID)
+- Metrics: `dag_consensus_stall_detected`, `dag_consensus_unlock_success`, `dag_consensus_round_abandoned`
+
+### Config
+
+```hocon
+snapshot.consensus {
+  declaration-timeout = 35 seconds
+  re-stall-timeout = 10 seconds
+  max-stall-cycles = 5
+  max-round-duration = 5 minutes
+}
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `consensus/engine/StallDetector.scala` | Rewritten with multi-stage stall recovery |
+| `config/types.scala` | Added `reStallTimeout`, `noProgressTimeout`, `maxStallCycles`, `maxRoundDuration`, `quorumThreshold` to `ConsensusConfig` |
+| `dag-l0/src/main/resources/dag-l0.conf` | New config values |
+| `currency-l0/src/main/resources/currency-l0.conf` | New config values |
+
+---
+
+## Phase 1: Fiber Lifecycle Management
+
+### Problem
+
+The consensus engine spawns background fibers for stall detection monitors and timer triggers using `supervisor.supervise(task).void`. The `.void` discards the fiber handle, making it impossible to cancel the fiber when the round completes. Over sustained operation, orphaned fibers from completed rounds accumulate, consuming threads and CPU.
+
+**Example of the leak pattern (before):**
+```scala
+// Old code — fiber handle discarded, can never be cancelled
+supervisor.supervise(stallDetector.monitor(key)).void
+```
+
+The StallDetector's `monitor` method also used polling (`storage.getState(key)`) to detect round completion, introducing a race window of up to 1 second between actual completion and monitor exit.
+
+### Solution
+
+#### 1a. Per-Round Fiber Tracking (`ConsensusRoundRunner.scala`)
+
+Added two `Ref`s to track round lifecycle:
+
+- `roundFibersRef: Ref[F, List[Fiber[F, Throwable, Unit]]]` — Tracks all fibers spawned during the current round
+- `cancelSignalRef: Ref[F, Option[Deferred[F, Unit]]]` — Holds a signal to notify the stall monitor
+
+New methods:
+
+| Method | Purpose |
+|--------|---------|
+| `spawnTracked(task)` | Spawns via Supervisor AND records the fiber handle |
+| `cancelRoundFibers` | Cancels all tracked fibers atomically |
+| `cleanupRound` | Signals the monitor to stop + cancels all tracked fibers |
+
+Both `startRoundMonitor` and `scheduleTimeTrigger` now use `spawnTracked` instead of bare `supervisor.supervise(...).void`.
+
+#### 1b. Signal-Based Monitor Termination (`StallDetector.scala`)
+
+Changed the `monitor` method signature to accept a cancellation signal:
+
+```scala
+// Before: polling-based, no way to stop externally
+def monitor(key: Key): F[Unit]
+
+// After: signal-based, stops immediately when round completes
+def monitor(key: Key, cancelSignal: Deferred[F, Unit]): F[Unit]
+```
+
+Internally uses `Async[F].race(cancelSignal.get, monitorLoop)` — the monitor exits the instant the signal fires, with zero race window.
+
+#### 1c. Round Cleanup Integration (`ConsensusFSM.scala`)
+
+The `completeRound` method now calls `roundRunner.cleanupRound` before resetting the FSM to IDLE:
+
+```scala
+private def completeRound(preAction: F[Unit]): F[Unit] =
+  for {
+    _ <- preAction
+    _ <- roundRunner.cleanupRound  // Cancel monitor + timer fibers
+    _ <- isRunning.set(false)
+    next <- pending.pullNext
+    _ <- next.traverse_(...)
+  } yield ()
+```
+
+#### 1d. Wiring (`ConsensusEventLoop.scala`)
+
+Creates the `Ref`s and passes them to `ConsensusRoundRunner`:
+
+```scala
+roundFibersRef <- Ref.of[F, List[Fiber[F, Throwable, Unit]]](Nil)
+cancelSignalRef <- Ref.of[F, Option[Deferred[F, Unit]]](None)
+roundRunner = new ConsensusRoundRunner(ctx, stallDetector, roundFibersRef, cancelSignalRef)
+```
+
+#### Fork Recovery Fiber (documented, not changed)
+
+`ConsensusStateUpdater.scala` has a fire-and-forget fiber for fork recovery via `Temporal[F].start(forkRecovery).void`. This is acceptable because fork recovery is a one-shot operation (node transitions to Leaving -> Offline -> restart) that should outlive any single round. Added a comment documenting the rationale.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `consensus/engine/ConsensusRoundRunner.scala` | Added fiber tracking, `spawnTracked`, `cleanupRound` |
+| `consensus/engine/StallDetector.scala` | Added `Deferred` cancel signal to `monitor` |
+| `consensus/state/ConsensusFSM.scala` | Calls `cleanupRound` in `completeRound` |
+| `consensus/engine/ConsensusEventLoop.scala` | Creates Refs, wires to RoundRunner |
+| `consensus/state/ConsensusStateUpdater.scala` | Added comment on fork recovery fiber |
+
+---
+
+## Phase 2a: PendingTriggers Race Condition Fix
+
+### Problem
+
+`PendingTriggers` tracked pending consensus triggers using two separate `Ref[Boolean]`:
+
+```scala
+// Old design — two independent Refs
+class PendingTriggersF[F[_]](eventRef: Ref[F, Boolean], timeRef: Ref[F, Boolean]) {
+  def pullNext: F[Option[TriggerPriority]] =
+    for {
+      time  <- timeRef.get      // Step 1: read time
+      event <- eventRef.get     // Step 2: read event
+      _     <- timeRef.set(false)   // Step 3: clear time
+      _     <- eventRef.set(false)  // Step 4: clear event
+    } yield ...
+}
+```
+
+**Race condition:** Between steps 2 and 3, a concurrent `setTime()` call could set `timeRef = true`. Step 3 then clears it, and the trigger is permanently lost. The node misses a consensus round.
+
+### Solution
+
+Replaced with a single atomic `Ref[PendingState]`:
+
+```scala
+// New design — single atomic Ref
+sealed trait PendingState
+case object NoPending extends PendingState
+case object EventPending extends PendingState
+case object TimePending extends PendingState
+
+class PendingTriggersF[F[_]: Functor](stateRef: Ref[F, PendingState]) {
+  def setEvent(): F[Unit] = stateRef.update {
+    case TimePending => TimePending  // Don't downgrade time to event
+    case _           => EventPending
+  }
+
+  def setTime(): F[Unit] = stateRef.set(TimePending)
+
+  def pullNext: F[Option[TriggerPriority]] =
+    stateRef.getAndSet(NoPending).map {  // Single atomic operation
+      case TimePending  => Some(TriggerPriority.Time)
+      case EventPending => Some(TriggerPriority.Event)
+      case NoPending    => None
+    }
+}
+```
+
+Key properties:
+- `pullNext` is now a single `getAndSet` — atomic, no race window
+- `setEvent` won't downgrade an existing `TimePending` to `EventPending`
+- `setTime` always wins (highest priority)
+
+### Tests Added
+
+`PendingTriggersSuite.scala` — 7 tests:
+
+| Test | Verifies |
+|------|----------|
+| pullNext returns None when nothing pending | Empty state |
+| setEvent then pullNext returns Event | Basic event trigger |
+| setTime then pullNext returns Time | Basic time trigger |
+| time takes priority over event | Priority ordering |
+| setEvent does not downgrade existing Time | Priority preservation |
+| pullNext clears state atomically | State cleanup |
+| concurrent set and pull does not lose triggers | Concurrency safety |
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `consensus/engine/PendingTriggers.scala` | Rewritten with single atomic Ref |
+| `consensus/engine/PendingTriggersSuite.scala` | **New** — 7 tests |
+
+---
+
+## Phase 2c: Command Stream Error Recovery
+
+### Problem
+
+The command stream in `ConsensusEventLoop` processes FSM commands sequentially. If `fsm.handle(cmd)` throws for a `ConsensusFinished` or `RoundCompleted` command, the error was logged but the round was never completed. The FSM stays stuck in BUSY state permanently — no new rounds can start.
+
+### Solution
+
+Added command-specific recovery after the existing error handler:
+
+```scala
+fsm.handle(cmd).handleErrorWith { err =>
+  logger.error(err)(s"Unhandled error processing ${cmd.getClass.getSimpleName}, recovering") >>
+    Metrics[F].incrementCounter("dag_consensus_command_error") >>
+    (cmd match {
+      case _: ConsensusCommand.ConsensusFinished | ConsensusCommand.RoundCompleted =>
+        // Critical: force round completion so FSM doesn't stay stuck in BUSY
+        logger.warn("Forcing round completion after failed ConsensusFinished/RoundCompleted") >>
+          queue.offer(ConsensusCommand.RoundCompleted)
+      case _ => Async[F].unit
+    })
+}
+```
+
+For non-critical commands (rumor processing, peer registration, etc.), the error is logged and the stream continues — same as before.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `consensus/engine/ConsensusEventLoop.scala` | Added recovery for critical round-completion commands |
+
+---
+
+## Pre-existing Warning Fixes
+
+These files had unused imports, parameters, or methods that were never caught because incremental compilation only checks changed files. The `-Werror` flag treats warnings as errors on full recompilation. These are not related to the refactoring but were required to unblock compilation.
+
+| File | Fix |
+|------|-----|
+| `modules/SharedStorages.scala` | Removed unused imports |
+| `logger/sink/Slf4jSink.scala` | Removed unused import |
+| `logger/sink/clickhouse/ClickHouseConsensusLogger.scala` | Removed unused `logger` parameter from `startFlusher` |
+| `logger/sink/clickhouse/ClickHouseSink.scala` | Removed unused `logger` parameter from `startFlusher` |
+| `snapshot/managers/global/TokenLockStateManager.scala` | Removed unused imports (`CurrencySnapshotInfoV1`, `Amount`) |
+| `snapshot/managers/global/TipUsageManager.scala` | Removed unused `SortedSet` import |
+| `snapshot/managers/global/TransactionReferenceManager.scala` | Removed unused wildcard import |
+| `snapshot/storage/CombinedSnapshotCheckpointFileSystemStorage.scala` | Removed unused `Concurrent` context bound |
+| `snapshot/storage/SnapshotLocalFileSystemStorage.scala` | Removed unused `kryoSerializer` parameter |
+| `snapshot/storage/SnapshotStorage.scala` | Removed unused private `getLastN` method |
+| `consensus/state/ConsensusStateAdvancer.scala` | Removed unused imports (`Clock`, `FiniteDuration`, `Responsive`, `Unresponsive`) |
+| `consensus/engine/StallDetector.scala` | Removed unused imports and `Eq[Status]` bound |
+| `consensus/engine/ConsensusRoundRunner.scala` | Removed unused `Metrics` and `Eq[Status]` bounds |
+| `consensus/engine/ConsensusEventLoop.scala` | Removed unused `Eq[Status]` bound |
+
+---
+
+## Test Results
+
+```
+Total: 71 tests, 0 failures
+  - StallDetectorSuite:            24 tests  (stall detection, lock/unlock, re-stall cycles, abandonment)
+  - QuorumDeclarationsSuite:       12 tests  (quorum threshold, supermajority gate, split vote deferral)
+  - RemovalPenaltySuite:           12 tests  (penalty lifecycle, decrement, expiry, filtering, determinism)
+  - UnlockConsensusUpdateSuite:     9 tests  (adaptive tiers: DEFER, DEGRADED, FALLBACK, NORMAL)
+  - PendingTriggersSuite:           7 tests  (atomic state, priority ordering, concurrency safety)
+  - EligibleFacilitatorsSuite:      5 tests  (re-entry after removal, collateral filtering)
+```
+
+All modules compile: `nodeShared`, `dagL0`, `currencyL0`.
+
+---
+
+## What Was NOT Changed (and Why)
+
+| Item | Reason |
+|------|--------|
+| **Advancer DRY extraction** | Both advancers share ~60-80 lines of utility methods, but threading 7+ type parameters and 10+ constructor dependencies through an abstract base class adds more complexity than it removes. The phase flow also diverges (Global: 3 phases, Currency: 4 phases with BinarySignatures). |
+| **Metrics extraction** | `recordMetrics` methods are completely different between advancers — no shared code to extract. |
+| **ConsensusConfig splitting** | The flat HOCON structure maps directly to the flat case class. Splitting into sub-configs would require either HOCON restructuring or custom config readers. 11 fields is manageable. |
+| **ConsensusEngineContext rename** | Large rename diff across many files for a cosmetic improvement. |
+| **Per-round Supervisor** | Would require changing the `implicit Supervisor[F]` threading throughout the codebase. Explicit fiber tracking via `Ref[List[Fiber]]` achieves the same goal with less disruption. |
+| **Bounded command queue** | Risk of dropping commands under load. Unbounded queue is safer. |
+| **Fork recovery fiber** | Fire-and-forget is acceptable for a one-shot operation that should outlive any round. Documented with comment. |

--- a/modules/currency-l0/src/main/resources/currency-l0.conf
+++ b/modules/currency-l0/src/main/resources/currency-l0.conf
@@ -17,13 +17,16 @@ health-check {
 snapshot {
   consensus {
     time-trigger-interval = 43 seconds
-    declaration-timeout = 50 seconds
+    declaration-timeout = 40 seconds
     declaration-range-limit = 3
     lock-duration = 10 seconds
     peers-declaration-timeout = 10 seconds
     max-facilitator-count = 20
-    re-stall-timeout = 15 seconds
-    max-stall-cycles = 3
+    re-stall-timeout = 10 seconds
+    max-stall-cycles = 5
+    max-round-duration = 5 minutes
+    quorum-threshold = 0.67
+    removal-penalty-rounds = 3
 
     event-cutter {
       max-binary-size-bytes = 20971520

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -131,7 +131,8 @@ object CurrencySnapshotConsensus {
           gossip,
           selfId,
           seedlist,
-          facilitatorSelector
+          facilitatorSelector,
+          snapshotConfig.consensus.deterministicConfigHash
         )
 
       consensusStateRemover =

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -157,7 +157,7 @@ object CurrencySnapshotConsensusStateAdvancer {
         resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
       ): F[Option[Transition]] =
         for {
-          maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.facilitatorsHash)
+          maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.lastSnapshotHash)
           _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeFacilities.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
           _ <- maybeFacilities.traverse_(checkForkByConsensusConfigHash)
@@ -623,8 +623,8 @@ object CurrencySnapshotConsensusStateAdvancer {
 
       private def checkForkByConsensusConfigHash(facilities: SortedMap[PeerId, Facility]): F[Unit] = {
         val ownConfigHash = config.deterministicConfigHash
-        val peerConfigHashes = facilities.collect {
-          case (pid, f) if f.consensusConfigHash.isDefined => (pid, f.consensusConfigHash.get)
+        val peerConfigHashes = facilities.flatMap {
+          case (pid, f) => f.consensusConfigHash.map(pid -> _)
         }
         if (peerConfigHashes.nonEmpty)
           recoverIfForking[F](ownConfigHash, consensusConfigHashObservationName, restartService, nodeStorage, leavingDelay)(

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -88,6 +88,7 @@ object CurrencySnapshotConsensusStateAdvancer {
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](getClass)
       private val lastSnapshotHashObservationName = "last-snapshot-hash"
       private val facilitatorsHashObservationName = "facilitators-hash"
+      private val consensusConfigHashObservationName = "consensus-config-hash"
 
       protected val clusterStorage: ClusterStorage[F] = clusterStorageInstance
       protected val config: ConsensusConfig = consensusConfig
@@ -159,6 +160,7 @@ object CurrencySnapshotConsensusStateAdvancer {
           maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.trigger)
           _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeFacilities.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
+          _ <- maybeFacilities.traverse_(checkForkByConsensusConfigHash)
           result <- maybeFacilities.flatTraverse(toProposalsPhase(state, _))
         } yield result
 
@@ -618,6 +620,18 @@ object CurrencySnapshotConsensusStateAdvancer {
         recoverIfForking[F](ownHash, facilitatorsHashObservationName, restartService, nodeStorage, leavingDelay)(
           declarations.map { case (pid, decl) => (pid, extractHash(decl)) }
         )
+
+      private def checkForkByConsensusConfigHash(facilities: SortedMap[PeerId, Facility]): F[Unit] = {
+        val ownConfigHash = config.deterministicConfigHash
+        val peerConfigHashes = facilities.collect {
+          case (pid, f) if f.consensusConfigHash.isDefined => (pid, f.consensusConfigHash.get)
+        }
+        if (peerConfigHashes.nonEmpty)
+          recoverIfForking[F](ownConfigHash, consensusConfigHashObservationName, restartService, nodeStorage, leavingDelay)(
+            SortedMap.from(peerConfigHashes)
+          )
+        else Applicative[F].unit
+      }
 
       private implicit val extractFacilityHash: Facility => Hash = _.lastSnapshotHash
       private implicit val extractProposalHash: Proposal => Hash = _.lastSnapshotHash

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -157,7 +157,7 @@ object CurrencySnapshotConsensusStateAdvancer {
         resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
       ): F[Option[Transition]] =
         for {
-          maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.trigger)
+          maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.facilitatorsHash)
           _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeFacilities.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
           _ <- maybeFacilities.traverse_(checkForkByConsensusConfigHash)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -87,6 +87,7 @@ object CurrencySnapshotConsensusStateAdvancer {
 
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](getClass)
       private val lastSnapshotHashObservationName = "last-snapshot-hash"
+      private val facilitatorsHashObservationName = "facilitators-hash"
 
       protected val clusterStorage: ClusterStorage[F] = clusterStorageInstance
       protected val config: ConsensusConfig = consensusConfig
@@ -98,13 +99,20 @@ object CurrencySnapshotConsensusStateAdvancer {
       ): Option[(Previous[CurrencySnapshotKey], CurrencyConsensusOutcome)] =
         state.status match {
           case f: Finished =>
+            // Compute removal penalties: decrement previous, add new removals
+            val previousPenalties = state.lastOutcome.removalPenalties
+            val decrementedPenalties = previousPenalties.view.mapValues(_ - 1).filter(_._2 > 0).toMap
+            val newPenalties = state.removedFacilitators.value.foldLeft(decrementedPenalties) { (acc, pid) =>
+              acc.updated(pid, config.removalPenaltyRounds)
+            }
             val outcome = CurrencyConsensusOutcome(
               state.key,
               state.facilitators,
               state.removedFacilitators,
               state.withdrawnFacilitators,
               state.eligibleFacilitators,
-              f
+              f,
+              removalPenalties = if (config.removalPenaltyRounds > 0) newPenalties else Map.empty
             )
             (Previous(state.lastOutcome.key), outcome).some
           case _ =>
@@ -148,7 +156,8 @@ object CurrencySnapshotConsensusStateAdvancer {
         resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
       ): F[Option[Transition]] =
         for {
-          maybeFacilities <- maybeGetAllDeclarations(state, resources)(_.facility)
+          maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.trigger)
+          _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeFacilities.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
           result <- maybeFacilities.flatTraverse(toProposalsPhase(state, _))
         } yield result
@@ -204,7 +213,8 @@ object CurrencySnapshotConsensusStateAdvancer {
         resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
       )(implicit hasher: Hasher[F]): F[Option[Transition]] =
         for {
-          maybeProposals <- maybeGetAllDeclarations(state, resources)(_.proposal)
+          maybeProposals <- maybeGetQuorumDeclarations(state, resources)(_.proposal)(_.hash)
+          _ <- maybeProposals.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeProposals.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
           result <- maybeProposals.flatTraverse(toSignaturesPhase(state, status, resources, _))
         } yield result
@@ -275,8 +285,9 @@ object CurrencySnapshotConsensusStateAdvancer {
         resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
       ): F[Option[Transition]] =
         for {
-          maybeSignatures <- maybeGetAllDeclarations(state, resources)(_.signature)
-          maybeFacilities <- maybeGetAllDeclarations(state, resources)(_.facility)
+          maybeSignatures <- maybeGetQuorumDeclarations(state, resources)(_.signature)(_.facilitatorsHash)
+          maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.trigger)
+          _ <- maybeSignatures.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeSignatures.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
           maybeGlobalOrd = extractGlobalSnapshotOrdinal(maybeFacilities)
           result <- (maybeGlobalOrd, maybeSignatures) match {
@@ -356,7 +367,8 @@ object CurrencySnapshotConsensusStateAdvancer {
         resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
       ): F[Option[Transition]] =
         for {
-          maybeBinarySignatures <- maybeGetAllDeclarations(state, resources)(_.binarySignature)
+          maybeBinarySignatures <- maybeGetQuorumDeclarations(state, resources)(_.binarySignature)(_.facilitatorsHash)
+          _ <- maybeBinarySignatures.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
           _ <- maybeBinarySignatures.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
           result <- maybeBinarySignatures.flatTraverse(toFinishedPhase(state, status, _))
         } yield result
@@ -597,6 +609,14 @@ object CurrencySnapshotConsensusStateAdvancer {
       ): F[Unit] =
         recoverIfForking[F](ownHash, lastSnapshotHashObservationName, restartService, nodeStorage, leavingDelay)(
           declarations.map { case (pid, decl) => (pid, extract(decl)) }
+        )
+
+      private def checkForkByFacilitatorsHash[A](
+        declarations: SortedMap[PeerId, A],
+        ownHash: Hash
+      )(extractHash: A => Hash): F[Unit] =
+        recoverIfForking[F](ownHash, facilitatorsHashObservationName, restartService, nodeStorage, leavingDelay)(
+          declarations.map { case (pid, decl) => (pid, extractHash(decl)) }
         )
 
       private implicit val extractFacilityHash: Facility => Hash = _.lastSnapshotHash

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -18,6 +18,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.Cons
 import io.constellationnetwork.node.shared.snapshot.currency._
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
+import io.constellationnetwork.security.hash.Hash
 
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -42,7 +43,8 @@ object CurrencySnapshotConsensusStateCreator {
     gossip: Gossip[F],
     selfId: PeerId,
     seedlist: Option[Set[SeedlistEntry]],
-    facilitatorSelector: FacilitatorSelector
+    facilitatorSelector: FacilitatorSelector,
+    consensusConfigHash: Hash
   ): CurrencySnapshotConsensusStateCreator[F] = new CurrencySnapshotConsensusStateCreator[F] {
 
     val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
@@ -162,7 +164,8 @@ object CurrencySnapshotConsensusStateCreator {
                 maybeTrigger,
                 lastOutcome.finished.facilitatorsHash,
                 lastGlobalSnapshotOrdinal,
-                lastOutcome.finished.snapshotHash
+                lastOutcome.finished.snapshotHash,
+                consensusConfigHash = consensusConfigHash.some
               )
             )
           )

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -76,23 +76,24 @@ object CurrencySnapshotConsensusStateCreator {
         filteredCandidates = approvedCandidates
           .filter(peerId => seedlist.isEmpty || seedlistPeerIds.contains(peerId))
 
-        // Exclude peers that were removed by unlock consensus in the previous round.
-        // This is deterministic: all nodes agreed on removedFacilitators via majority vote.
+        // Peers removed by unlock consensus in the previous round.
+        // Deterministic: all nodes agreed on removedFacilitators via majority vote.
         previouslyRemoved = lastOutcome.removedFacilitators.value
 
-        baseFacilitators = (filteredPreviousEligible ++ filteredCandidates).distinct
-          .filterNot(previouslyRemoved.contains)
+        // Full base WITHOUT removal filter — so removed peers can re-enter in future rounds.
+        // The removal filter is only applied for active selection THIS round (see eligibleThisRound below).
+        fullBase = (filteredPreviousEligible ++ filteredCandidates :+ selfId).distinct
 
         _ <- logger.debug(
           s"Facilitator selection for key=$key: " +
             s"previousEligible=${filteredPreviousEligible.size}, " +
             s"candidates=${filteredCandidates.size}, " +
-            s"base=${baseFacilitators.size}" +
+            s"fullBase=${fullBase.size}" +
             (if (previouslyRemoved.nonEmpty) s", excludedFromPreviousRound=${previouslyRemoved.size}" else "")
         )
 
-        // Full eligible set after collateral filtering
-        eligible <- (baseFacilitators :+ selfId).distinct
+        // All eligible after collateral filtering (includes previously removed peers so they can re-enter)
+        allEligible <- fullBase
           .filterA(
             consensusFns.facilitatorFilter(
               lastOutcome.finished.signedMajorityArtifact,
@@ -104,22 +105,43 @@ object CurrencySnapshotConsensusStateCreator {
             if (list.isEmpty) List(selfId) else list
           }
 
-        filteredOutByCollateral = baseFacilitators.filterNot(eligible.contains)
+        filteredOutByCollateral = fullBase.filterNot(allEligible.contains)
         _ <- filteredOutByCollateral.traverse_ { peerId =>
           logger.debug(s"Facilitator ${peerId.show} removed by facilitatorFilter for key=$key")
+        }
+
+        // Multi-round removal penalty: peers removed in prior rounds stay excluded
+        // for removalPenaltyRounds rounds. Deterministic: derived from agreed-upon lastOutcome.
+        penalizedPeers = lastOutcome.removalPenalties.filter(_._2 > 0).keySet
+
+        _ <- logger
+          .debug(
+            s"Removal penalties for key=$key: ${penalizedPeers.size} penalized peers" +
+              (if (penalizedPeers.nonEmpty)
+                 s" [${lastOutcome.removalPenalties.filter(_._2 > 0).map(kv => s"${kv._1.value.value.take(8)}:${kv._2}").mkString(",")}]"
+               else "")
+          )
+          .whenA(penalizedPeers.nonEmpty)
+
+        // For THIS round only: exclude recently removed AND penalized peers from active selection.
+        // They remain in allEligible so they can be re-selected in future rounds.
+        eligibleThisRound = {
+          val excluded = previouslyRemoved ++ penalizedPeers
+          val filtered = allEligible.filterNot(excluded.contains)
+          if (filtered.isEmpty) List(selfId) else filtered
         }
 
         // Apply deterministic subset selection using hash-distance ordering
         // Uses the previous round's snapshot hash as entropy for randomization
         entropy = lastOutcome.finished.snapshotHash
-        activeFacilitators = facilitatorSelector.select(eligible, entropy)
+        activeFacilitators = facilitatorSelector.select(eligibleThisRound, entropy)
 
         _ <- logger
           .info(
             s"Facilitator subsetting for key=$key: " +
-              s"eligible=${eligible.size}, selected=${activeFacilitators.size}"
+              s"allEligible=${allEligible.size}, eligibleThisRound=${eligibleThisRound.size}, selected=${activeFacilitators.size}"
           )
-          .whenA(activeFacilitators.size < eligible.size)
+          .whenA(activeFacilitators.size < allEligible.size)
 
         (withdrawn, active) = activeFacilitators.partition { peerId =>
           resources.withdrawalsMap.get(peerId).contains(CurrencyConsensusKind.Facility)
@@ -158,12 +180,12 @@ object CurrencySnapshotConsensusStateCreator {
           time,
           withdrawnFacilitators = WithdrawnFacilitators(withdrawn.toSet),
           spreadAckKinds = Set.empty,
-          eligibleFacilitators = EligibleFacilitators(eligible)
+          eligibleFacilitators = EligibleFacilitators(allEligible)
         )
 
         _ <- logger.info(
           s"Created consensus state for key=$key with ${active.size} active facilitators" +
-            s" (${eligible.size} eligible)" +
+            s" (${allEligible.size} eligible, ${eligibleThisRound.size} this round)" +
             withdrawn.headOption.fold("")(_ => s", ${withdrawn.size} withdrawn")
         )
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/schema.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/schema.scala
@@ -101,7 +101,8 @@ object schema {
     removedFacilitators: RemovedFacilitators,
     withdrawnFacilitators: WithdrawnFacilitators,
     eligibleFacilitators: EligibleFacilitators,
-    finished: Finished
+    finished: Finished,
+    removalPenalties: Map[PeerId, Int] = Map.empty
   ) {
     def eligibleOrFacilitators: List[PeerId] =
       if (eligibleFacilitators.value.nonEmpty) eligibleFacilitators.value

--- a/modules/dag-l0/src/main/resources/dag-l0.conf
+++ b/modules/dag-l0/src/main/resources/dag-l0.conf
@@ -9,12 +9,15 @@ trust {
 snapshot {
   consensus {
     time-trigger-interval = 43 seconds
-    declaration-timeout = 45 seconds
+    declaration-timeout = 35 seconds
     declaration-range-limit = 3
     lock-duration = 10 seconds
     max-facilitator-count = 20
-    re-stall-timeout = 15 seconds
-    max-stall-cycles = 3
+    re-stall-timeout = 10 seconds
+    max-stall-cycles = 5
+    max-round-duration = 5 minutes
+    quorum-threshold = 0.67
+    removal-penalty-rounds = 3
 
     event-cutter {
       max-binary-size-bytes = 20971520

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -195,7 +195,8 @@ object GlobalSnapshotConsensus {
           gossip,
           selfId,
           seedlist,
-          facilitatorSelector
+          facilitatorSelector,
+          appConfig.snapshot.consensus.deterministicConfigHash
         )
 
       stateRemover =

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -86,6 +86,7 @@ object GlobalSnapshotConsensusStateAdvancer {
 
     private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](getClass)
     private val lastSnapshotHashObservationName = "last-snapshot-hash"
+    private val facilitatorsHashObservationName = "facilitators-hash"
 
     protected val clusterStorage: ClusterStorage[F] = clusterStorageInstance
     protected val config: ConsensusConfig = consensusConfig
@@ -97,13 +98,20 @@ object GlobalSnapshotConsensusStateAdvancer {
     ): Option[(Previous[GlobalSnapshotKey], GlobalConsensusOutcome)] =
       state.status match {
         case f: Finished =>
+          // Compute removal penalties: decrement previous, add new removals
+          val previousPenalties = state.lastOutcome.removalPenalties
+          val decrementedPenalties = previousPenalties.view.mapValues(_ - 1).filter(_._2 > 0).toMap
+          val newPenalties = state.removedFacilitators.value.foldLeft(decrementedPenalties) { (acc, pid) =>
+            acc.updated(pid, config.removalPenaltyRounds)
+          }
           val outcome = GlobalConsensusOutcome(
             state.key,
             state.facilitators,
             state.removedFacilitators,
             state.withdrawnFacilitators,
             state.eligibleFacilitators,
-            Finished(f.signedMajorityArtifact, f.context, f.majorityTrigger, f.candidates, f.facilitatorsHash, f.snapshotHash)
+            Finished(f.signedMajorityArtifact, f.context, f.majorityTrigger, f.candidates, f.facilitatorsHash, f.snapshotHash),
+            removalPenalties = if (config.removalPenaltyRounds > 0) newPenalties else Map.empty
           )
           (Previous(state.lastOutcome.key), outcome).some
         case _ =>
@@ -146,9 +154,10 @@ object GlobalSnapshotConsensusStateAdvancer {
       loggerBundle.app.withOrdinal(SnapshotOrdinal.unsafeApply(state.lastOutcome.key.value.value + 1)) {
         HasherSelector[F].withCurrent { implicit hasher =>
           for {
-            maybeFacilities <- maybeGetAllDeclarations(state, resources)(_.facility)
+            maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.trigger)
             facilitators = maybeFacilities.map(_.keys.toList).getOrElse(List.empty[PeerId])
             _ <- loggerBundle.consensus.collectingFacilities(facilitators)
+            _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
             _ <- maybeFacilities.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
             result <- maybeFacilities.flatTraverse(toProposalsPhase(state, _))
           } yield result
@@ -207,9 +216,10 @@ object GlobalSnapshotConsensusStateAdvancer {
       loggerBundle.app.withOrdinal(status.proposalArtifactInfo.artifact.ordinal) {
         HasherSelector[F].withCurrent { implicit hasher =>
           for {
-            maybeProposals <- maybeGetAllDeclarations(state, resources)(_.proposal)
+            maybeProposals <- maybeGetQuorumDeclarations(state, resources)(_.proposal)(_.hash)
             facilitators = maybeProposals.map(_.keys.toList).getOrElse(List.empty[PeerId])
             _ <- loggerBundle.consensus.collectingProposals(facilitators)
+            _ <- maybeProposals.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
             _ <- maybeProposals.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
             result <- maybeProposals.flatTraverse(toSignaturesPhase(state, status, resources, _))
           } yield result
@@ -286,9 +296,10 @@ object GlobalSnapshotConsensusStateAdvancer {
       loggerBundle.app.withOrdinal(status.majorityArtifactInfo.artifact.ordinal) {
         HasherSelector[F].withCurrent { implicit hasher =>
           for {
-            maybeSignatures <- maybeGetAllDeclarations(state, resources)(_.signature)
+            maybeSignatures <- maybeGetQuorumDeclarations(state, resources)(_.signature)(_.facilitatorsHash)
             facilitators = maybeSignatures.map(_.keys.toList).getOrElse(List.empty[PeerId])
             _ <- loggerBundle.consensus.collectingSignatures(facilitators)
+            _ <- maybeSignatures.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
             _ <- maybeSignatures.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
             result <- maybeSignatures.flatTraverse(toFinishedPhase(state, status, _))
           } yield result
@@ -418,6 +429,14 @@ object GlobalSnapshotConsensusStateAdvancer {
     ): F[Unit] =
       recoverIfForking[F](ownHash, lastSnapshotHashObservationName, restartService, nodeStorage, leavingDelay)(
         declarations.map { case (pid, decl) => (pid, extract(decl)) }
+      )
+
+    private def checkForkByFacilitatorsHash[A](
+      declarations: SortedMap[PeerId, A],
+      ownHash: Hash
+    )(extractHash: A => Hash): F[Unit] =
+      recoverIfForking[F](ownHash, facilitatorsHashObservationName, restartService, nodeStorage, leavingDelay)(
+        declarations.map { case (pid, decl) => (pid, extractHash(decl)) }
       )
 
     private implicit val extractFacilityHash: Facility => Hash = _.lastSnapshotHash

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -87,6 +87,7 @@ object GlobalSnapshotConsensusStateAdvancer {
     private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](getClass)
     private val lastSnapshotHashObservationName = "last-snapshot-hash"
     private val facilitatorsHashObservationName = "facilitators-hash"
+    private val consensusConfigHashObservationName = "consensus-config-hash"
 
     protected val clusterStorage: ClusterStorage[F] = clusterStorageInstance
     protected val config: ConsensusConfig = consensusConfig
@@ -159,6 +160,7 @@ object GlobalSnapshotConsensusStateAdvancer {
             _ <- loggerBundle.consensus.collectingFacilities(facilitators)
             _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
             _ <- maybeFacilities.traverse_(checkForkByLastSnapshotHash(_, status.lastSnapshotHash))
+            _ <- maybeFacilities.traverse_(checkForkByConsensusConfigHash)
             result <- maybeFacilities.flatTraverse(toProposalsPhase(state, _))
           } yield result
         }
@@ -438,6 +440,18 @@ object GlobalSnapshotConsensusStateAdvancer {
       recoverIfForking[F](ownHash, facilitatorsHashObservationName, restartService, nodeStorage, leavingDelay)(
         declarations.map { case (pid, decl) => (pid, extractHash(decl)) }
       )
+
+    private def checkForkByConsensusConfigHash(facilities: SortedMap[PeerId, Facility]): F[Unit] = {
+      val ownConfigHash = config.deterministicConfigHash
+      val peerConfigHashes = facilities.collect {
+        case (pid, f) if f.consensusConfigHash.isDefined => (pid, f.consensusConfigHash.get)
+      }
+      if (peerConfigHashes.nonEmpty)
+        recoverIfForking[F](ownConfigHash, consensusConfigHashObservationName, restartService, nodeStorage, leavingDelay)(
+          SortedMap.from(peerConfigHashes)
+        )
+      else Applicative[F].unit
+    }
 
     private implicit val extractFacilityHash: Facility => Hash = _.lastSnapshotHash
     private implicit val extractProposalHash: Proposal => Hash = _.lastSnapshotHash

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -155,7 +155,7 @@ object GlobalSnapshotConsensusStateAdvancer {
       loggerBundle.app.withOrdinal(SnapshotOrdinal.unsafeApply(state.lastOutcome.key.value.value + 1)) {
         HasherSelector[F].withCurrent { implicit hasher =>
           for {
-            maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.trigger)
+            maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.facilitatorsHash)
             facilitators = maybeFacilities.map(_.keys.toList).getOrElse(List.empty[PeerId])
             _ <- loggerBundle.consensus.collectingFacilities(facilitators)
             _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -155,7 +155,7 @@ object GlobalSnapshotConsensusStateAdvancer {
       loggerBundle.app.withOrdinal(SnapshotOrdinal.unsafeApply(state.lastOutcome.key.value.value + 1)) {
         HasherSelector[F].withCurrent { implicit hasher =>
           for {
-            maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.facilitatorsHash)
+            maybeFacilities <- maybeGetQuorumDeclarations(state, resources)(_.facility)(_.lastSnapshotHash)
             facilitators = maybeFacilities.map(_.keys.toList).getOrElse(List.empty[PeerId])
             _ <- loggerBundle.consensus.collectingFacilities(facilitators)
             _ <- maybeFacilities.traverse_(checkForkByFacilitatorsHash(_, status.facilitatorsHash)(_.facilitatorsHash))
@@ -443,8 +443,8 @@ object GlobalSnapshotConsensusStateAdvancer {
 
     private def checkForkByConsensusConfigHash(facilities: SortedMap[PeerId, Facility]): F[Unit] = {
       val ownConfigHash = config.deterministicConfigHash
-      val peerConfigHashes = facilities.collect {
-        case (pid, f) if f.consensusConfigHash.isDefined => (pid, f.consensusConfigHash.get)
+      val peerConfigHashes = facilities.flatMap {
+        case (pid, f) => f.consensusConfigHash.map(pid -> _)
       }
       if (peerConfigHashes.nonEmpty)
         recoverIfForking[F](ownConfigHash, consensusConfigHashObservationName, restartService, nodeStorage, leavingDelay)(

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
@@ -70,23 +70,24 @@ object GlobalSnapshotConsensusStateCreator {
         filteredCandidates = approvedCandidates
           .filter(peerId => seedlist.isEmpty || seedlistPeerIds.contains(peerId))
 
-        // Exclude peers that were removed by unlock consensus in the previous round.
-        // This is deterministic: all nodes agreed on removedFacilitators via majority vote.
+        // Peers removed by unlock consensus in the previous round.
+        // Deterministic: all nodes agreed on removedFacilitators via majority vote.
         previouslyRemoved = lastOutcome.removedFacilitators.value
 
-        baseFacilitators = (filteredPreviousEligible ++ filteredCandidates).distinct
-          .filterNot(previouslyRemoved.contains)
+        // Full base WITHOUT removal filter — so removed peers can re-enter in future rounds.
+        // The removal filter is only applied for active selection THIS round (see eligibleThisRound below).
+        fullBase = (filteredPreviousEligible ++ filteredCandidates :+ selfId).distinct
 
         _ <- logger.debug(
           s"Facilitator selection for key=$key: " +
             s"previousEligible=${filteredPreviousEligible.size}, " +
             s"candidates=${filteredCandidates.size}, " +
-            s"base=${baseFacilitators.size}" +
+            s"fullBase=${fullBase.size}" +
             (if (previouslyRemoved.nonEmpty) s", excludedFromPreviousRound=${previouslyRemoved.size}" else "")
         )
 
-        // Full eligible set after collateral filtering
-        eligible <- (baseFacilitators :+ selfId).distinct
+        // All eligible after collateral filtering (includes previously removed peers so they can re-enter)
+        allEligible <- fullBase
           .filterA(
             consensusFns.facilitatorFilter(
               lastOutcome.finished.signedMajorityArtifact,
@@ -98,22 +99,43 @@ object GlobalSnapshotConsensusStateCreator {
             if (list.isEmpty) List(selfId) else list
           }
 
-        filteredOutByCollateral = baseFacilitators.filterNot(eligible.contains)
+        filteredOutByCollateral = fullBase.filterNot(allEligible.contains)
         _ <- filteredOutByCollateral.traverse_ { peerId =>
           logger.debug(s"Facilitator ${peerId.show} removed by facilitatorFilter for key=$key")
+        }
+
+        // Multi-round removal penalty: peers removed in prior rounds stay excluded
+        // for removalPenaltyRounds rounds. Deterministic: derived from agreed-upon lastOutcome.
+        penalizedPeers = lastOutcome.removalPenalties.filter(_._2 > 0).keySet
+
+        _ <- logger
+          .debug(
+            s"Removal penalties for key=$key: ${penalizedPeers.size} penalized peers" +
+              (if (penalizedPeers.nonEmpty)
+                 s" [${lastOutcome.removalPenalties.filter(_._2 > 0).map(kv => s"${kv._1.value.value.take(8)}:${kv._2}").mkString(",")}]"
+               else "")
+          )
+          .whenA(penalizedPeers.nonEmpty)
+
+        // For THIS round only: exclude recently removed AND penalized peers from active selection.
+        // They remain in allEligible so they can be re-selected in future rounds.
+        eligibleThisRound = {
+          val excluded = previouslyRemoved ++ penalizedPeers
+          val filtered = allEligible.filterNot(excluded.contains)
+          if (filtered.isEmpty) List(selfId) else filtered
         }
 
         // Apply deterministic subset selection using hash-distance ordering
         // Uses the previous round's snapshot hash as entropy for randomization
         entropy = lastOutcome.finished.snapshotHash
-        activeFacilitators = facilitatorSelector.select(eligible, entropy)
+        activeFacilitators = facilitatorSelector.select(eligibleThisRound, entropy)
 
         _ <- logger
           .info(
             s"Facilitator subsetting for key=$key: " +
-              s"eligible=${eligible.size}, selected=${activeFacilitators.size}"
+              s"allEligible=${allEligible.size}, eligibleThisRound=${eligibleThisRound.size}, selected=${activeFacilitators.size}"
           )
-          .whenA(activeFacilitators.size < eligible.size)
+          .whenA(activeFacilitators.size < allEligible.size)
 
         (withdrawn, active) = activeFacilitators.partition { peerId =>
           resources.withdrawalsMap.get(peerId).contains(GlobalConsensusKind.Facility)
@@ -153,12 +175,12 @@ object GlobalSnapshotConsensusStateCreator {
           time,
           withdrawnFacilitators = WithdrawnFacilitators(withdrawn.toSet),
           spreadAckKinds = Set.empty,
-          eligibleFacilitators = EligibleFacilitators(eligible)
+          eligibleFacilitators = EligibleFacilitators(allEligible)
         )
 
         _ <- logger.info(
           s"Created consensus state for key=$key with ${active.size} active facilitators" +
-            s" (${eligible.size} eligible)" +
+            s" (${allEligible.size} eligible, ${eligibleThisRound.size} this round)" +
             withdrawn.headOption.fold("")(_ => s", ${withdrawn.size} withdrawn")
         )
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.message.Cons
 import io.constellationnetwork.node.shared.infrastructure.consensus.state._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
 
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -36,7 +37,8 @@ object GlobalSnapshotConsensusStateCreator {
     gossip: Gossip[F],
     selfId: PeerId,
     seedlist: Option[Set[SeedlistEntry]],
-    facilitatorSelector: FacilitatorSelector
+    facilitatorSelector: FacilitatorSelector,
+    consensusConfigHash: Hash
   ): GlobalSnapshotConsensusStateCreator[F] = new GlobalSnapshotConsensusStateCreator[F] {
 
     val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
@@ -157,7 +159,8 @@ object GlobalSnapshotConsensusStateCreator {
                 maybeTrigger,
                 lastOutcome.finished.facilitatorsHash,
                 lastOutcome.key,
-                lastOutcome.finished.snapshotHash
+                lastOutcome.finished.snapshotHash,
+                consensusConfigHash = consensusConfigHash.some
               )
             )
           )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/schema.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/schema.scala
@@ -72,7 +72,8 @@ object schema {
     removedFacilitators: RemovedFacilitators,
     withdrawnFacilitators: WithdrawnFacilitators,
     eligibleFacilitators: EligibleFacilitators,
-    finished: Finished
+    finished: Finished,
+    removalPenalties: Map[PeerId, Int] = Map.empty
   ) {
     def eligibleOrFacilitators: List[PeerId] =
       if (eligibleFacilitators.value.nonEmpty) eligibleFacilitators.value

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -153,12 +153,32 @@ object types {
     quorumThreshold: Option[Double] = None,
     removalPenaltyRounds: Int = 0
   ) {
+    quorumThreshold.foreach { t =>
+      require(t > 0.5 && t <= 1.0, s"quorumThreshold must be in (0.5, 1.0], got $t")
+    }
 
     /** Deterministic hash of consensus-critical config values.
       *
       * All nodes in a consensus round MUST have the same config to produce the same results. This hash is included in Facility declarations
       * so that config divergence is detected immediately during the CollectingFacilities phase, rather than causing mysterious forks
       * downstream.
+      *
+      * '''Consensus-critical fields''' (included in hash):
+      *   - `maxFacilitatorCount`: determines eligible facilitator list size
+      *   - `maxStallCycles`: affects when rounds are abandoned
+      *   - `quorumThreshold`: determines quorum size for declaration collection
+      *   - `removalPenaltyRounds`: affects facilitator eligibility after removal
+      *
+      * '''Non-critical fields''' (excluded — affect timing/performance, not deterministic outcomes):
+      *   - `timeTriggerInterval`, `declarationTimeout`, `lockDuration`, `reStallTimeout`, `noProgressTimeout`: timing only
+      *   - `maxRoundDuration`: safety net, not consensus logic
+      *   - `declarationRangeLimit`, `eventCutter`: event filtering, not consensus decisions
+      *
+      * IMPORTANT: When adding new fields to ConsensusConfig, evaluate whether they affect consensus determinism. If the field changes what
+      * peers decide (facilitator selection, quorum logic, voting thresholds), add it to the hash string below. If it only affects timing or
+      * performance, exclude it.
+      *
+      * Hash.fromBytes applies SHA-256 (via sha256DigestFromBytes), producing a compact 64-char hex digest.
       */
     lazy val deterministicConfigHash: io.constellationnetwork.security.hash.Hash = {
       val configString =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -152,7 +152,23 @@ object types {
     maxRoundDuration: Option[FiniteDuration] = None,
     quorumThreshold: Option[Double] = None,
     removalPenaltyRounds: Int = 0
-  )
+  ) {
+
+    /** Deterministic hash of consensus-critical config values.
+      *
+      * All nodes in a consensus round MUST have the same config to produce the same results. This hash is included in Facility declarations
+      * so that config divergence is detected immediately during the CollectingFacilities phase, rather than causing mysterious forks
+      * downstream.
+      */
+    lazy val deterministicConfigHash: io.constellationnetwork.security.hash.Hash = {
+      val configString =
+        s"maxFacilitatorCount=${maxFacilitatorCount.map(_.value)}," +
+          s"maxStallCycles=$maxStallCycles," +
+          s"quorumThreshold=$quorumThreshold," +
+          s"removalPenaltyRounds=$removalPenaltyRounds"
+      io.constellationnetwork.security.hash.Hash.fromBytes(configString.getBytes("UTF-8"))
+    }
+  }
 
   case class EventCutterConfig(
     maxBinarySizeBytes: PosInt,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -148,7 +148,10 @@ object types {
     maxFacilitatorCount: Option[PosInt] = None,
     reStallTimeout: Option[FiniteDuration] = None,
     noProgressTimeout: Option[FiniteDuration] = None,
-    maxStallCycles: Int = 3
+    maxStallCycles: Int = 3,
+    maxRoundDuration: Option[FiniteDuration] = None,
+    quorumThreshold: Option[Double] = None,
+    removalPenaltyRounds: Int = 0
   )
 
   case class EventCutterConfig(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
@@ -70,7 +70,8 @@ class Joining[
   metagraphVersionHash: Hash,
   peerDiscovery: PeerDiscovery[F],
   allowanceList: Option[Set[AllowanceListEntry]],
-  metagraphId: Option[Address]
+  metagraphId: Option[Address],
+  consensusConfigHash: Option[Hash] = None
 ) {
 
   private val logger = Slf4jLogger.getLogger[F]
@@ -276,6 +277,12 @@ class Joining[
 
       allowanceListHash <- allowanceList.map(_.map(_.peerId)).hash
       _ <- Applicative[F].unlessA(registrationRequest.allowanceList === allowanceListHash)(AllowanceListDoesNotMatch.raiseError[F, Unit])
+
+      // Validate consensus config hash if both sides provide it (backward-compatible: skip during rolling upgrades)
+      configHashMismatch = (consensusConfigHash, registrationRequest.consensusConfigHash)
+        .mapN(_ =!= _)
+        .getOrElse(false)
+      _ <- ConsensusConfigMismatch.raiseError[F, Unit].whenA(configHashMismatch)
 
     } yield ()
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/cluster/services/Cluster.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/cluster/services/Cluster.scala
@@ -45,7 +45,8 @@ object Cluster {
     jarHash: Hash,
     environment: AppEnvironment,
     allowanceList: Option[Set[AllowanceListEntry]],
-    metagraphId: Option[Address]
+    metagraphId: Option[Address],
+    consensusConfigHash: Option[Hash] = None
   ): Cluster[F] =
     new Cluster[F] {
 
@@ -79,7 +80,8 @@ object Cluster {
             jarHash,
             environment,
             allowanceListHash,
-            metagraphId
+            metagraphId,
+            consensusConfigHash
           )
 
       def signRequest(signRequest: SignRequest)(implicit hasher: Hasher[F]): F[Signed[SignRequest]] =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/declaration.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/declaration.scala
@@ -25,7 +25,8 @@ object declaration {
     trigger: Option[ConsensusTrigger],
     facilitatorsHash: Hash,
     lastGlobalSnapshotOrdinal: SnapshotOrdinal,
-    lastSnapshotHash: Hash
+    lastSnapshotHash: Hash,
+    consensusConfigHash: Option[Hash] = None
   ) extends PeerDeclaration
 
   @derive(eqv, show, encoder, decoder)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala
@@ -129,18 +129,20 @@ object ConsensusEventLoop {
 
       val commandStream: Stream[F, Unit] =
         Stream.repeatEval(queue.take).evalMap { cmd =>
-          fsm.handle(cmd).handleErrorWith { err =>
-            ctx.logger.error(err)(s"Unhandled error processing ${cmd.getClass.getSimpleName}, recovering") >>
-              Metrics[F].incrementCounter("dag_consensus_command_error") >>
-              (cmd match {
-                case _: ConsensusCommand.ConsensusFinished | ConsensusCommand.RoundCompleted =>
-                  // Critical: if round-completion commands fail, FSM stays stuck in BUSY forever.
-                  // Force round completion so the next round can start.
-                  ctx.logger.warn("Forcing round completion after failed ConsensusFinished/RoundCompleted") >>
-                    queue.offer(ConsensusCommand.RoundCompleted)
-                case _ => Async[F].unit
-              })
-          }
+          queue.size.flatMap(sz => Metrics[F].updateGauge("dag_consensus_command_queue_size", sz)) >>
+            fsm.handle(cmd).handleErrorWith { err =>
+              ctx.logger.error(err)(s"Unhandled error processing ${cmd.getClass.getSimpleName}, recovering") >>
+                Metrics[F].incrementCounter("dag_consensus_command_error") >>
+                (cmd match {
+                  case _: ConsensusCommand.ConsensusFinished | ConsensusCommand.RoundCompleted =>
+                    // Critical: if round-completion commands fail, FSM stays stuck in BUSY forever.
+                    // Force round completion so the next round can start.
+                    ctx.logger.warn("Forcing round completion after failed ConsensusFinished/RoundCompleted") >>
+                      Metrics[F].incrementCounter("dag_consensus_forced_round_completion") >>
+                      queue.offer(ConsensusCommand.RoundCompleted)
+                  case _ => Async[F].unit
+                })
+            }
         }
 
       val peerRegistrationStream: Stream[F, Unit] =
@@ -165,11 +167,14 @@ object ConsensusEventLoop {
       BuiltConsensusLoop(run, manager, queue)
     }
 
-  private def collectRegistration[F[_]: Async, Event, Key, Artifact, Ctx, Status, Outcome, Kind](
+  private def collectRegistration[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Outcome, Kind](
     consensusClient: ConsensusClient[F, Key, Outcome],
     storage: ConsensusStorage[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind]
   )(peer: Peer): F[Unit] =
     consensusClient.getRegistration.run(peer).flatMap { reg =>
-      reg.maybeKey.traverse_(key => storage.registerPeer(peer.id, key))
+      reg.maybeKey.traverse_(key =>
+        storage.registerPeer(peer.id, key) >>
+          Metrics[F].incrementCounter("dag_consensus_peer_registered")
+      )
     }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala
@@ -137,9 +137,14 @@ object ConsensusEventLoop {
                   case _: ConsensusCommand.ConsensusFinished | ConsensusCommand.RoundCompleted =>
                     // Critical: if round-completion commands fail, FSM stays stuck in BUSY forever.
                     // Force round completion so the next round can start.
+                    // Also offer TimeTick: the forced RoundCompleted calls completeRound without
+                    // afterConsensusFinish, so no timer is scheduled for the next round. On solo nodes
+                    // with no external events, this would deadlock consensus. The TimeTick fires once
+                    // RoundCompleted sets isRunning=false, starting a new round from IDLE.
                     ctx.logger.warn("Forcing round completion after failed ConsensusFinished/RoundCompleted") >>
                       Metrics[F].incrementCounter("dag_consensus_forced_round_completion") >>
-                      queue.offer(ConsensusCommand.RoundCompleted)
+                      queue.offer(ConsensusCommand.RoundCompleted) >>
+                      queue.offer(ConsensusCommand.TimeTick)
                   case _ => Async[F].unit
                 })
             }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala
@@ -1,7 +1,8 @@
 package io.constellationnetwork.node.shared.infrastructure.consensus.engine
 
 import cats.Show
-import cats.effect.kernel.Async
+import cats.effect.Fiber
+import cats.effect.kernel.{Async, Deferred, Ref}
 import cats.effect.std.{Queue, Random, Supervisor}
 import cats.kernel.{Eq, Next}
 import cats.syntax.all._
@@ -19,6 +20,7 @@ import io.constellationnetwork.schema.peer.Peer
 import io.constellationnetwork.security.HasherSelector
 import io.constellationnetwork.security.signature.Signed
 
+import eu.timepit.refined.auto._
 import fs2.Stream
 
 /** Builds and wires together all consensus engine components.
@@ -68,7 +70,7 @@ object ConsensusEventLoop {
     Key: Eq: Show: Next,
     Artifact: Eq,
     Ctx: Eq,
-    Status: Eq,
+    Status,
     Outcome,
     Kind
   ](
@@ -108,7 +110,15 @@ object ConsensusEventLoop {
         consensusFunctions,
         consensusClient
       )
-      roundRunner = new ConsensusRoundRunner[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind](ctx)
+      stallDetector = new StallDetector[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind](ctx)
+      roundFibersRef <- Ref.of[F, List[Fiber[F, Throwable, Unit]]](Nil)
+      cancelSignalRef <- Ref.of[F, Option[Deferred[F, Unit]]](None)
+      roundRunner = new ConsensusRoundRunner[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind](
+        ctx,
+        stallDetector,
+        roundFibersRef,
+        cancelSignalRef
+      )
       fsm = new ConsensusFSM[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind](ctx, roundRunner)
       manager <- ConsensusManager.make[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind](
         queue,
@@ -118,7 +128,20 @@ object ConsensusEventLoop {
     } yield {
 
       val commandStream: Stream[F, Unit] =
-        Stream.repeatEval(queue.take).evalMap(fsm.handle)
+        Stream.repeatEval(queue.take).evalMap { cmd =>
+          fsm.handle(cmd).handleErrorWith { err =>
+            ctx.logger.error(err)(s"Unhandled error processing ${cmd.getClass.getSimpleName}, recovering") >>
+              Metrics[F].incrementCounter("dag_consensus_command_error") >>
+              (cmd match {
+                case _: ConsensusCommand.ConsensusFinished | ConsensusCommand.RoundCompleted =>
+                  // Critical: if round-completion commands fail, FSM stays stuck in BUSY forever.
+                  // Force round completion so the next round can start.
+                  ctx.logger.warn("Forcing round completion after failed ConsensusFinished/RoundCompleted") >>
+                    queue.offer(ConsensusCommand.RoundCompleted)
+                case _ => Async[F].unit
+              })
+          }
+        }
 
       val peerRegistrationStream: Stream[F, Unit] =
         clusterStorage.peerChanges.mapFilter {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusRoundRunner.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusRoundRunner.scala
@@ -9,7 +9,10 @@ import cats.syntax.all._
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.node.shared.infrastructure.consensus.state._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.{ConsensusTrigger, EventTrigger, TimeTrigger}
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics.unsafeLabelName
 
+import eu.timepit.refined.auto._
 import monocle.Lens
 
 /** Handles consensus round facilitation and post-consensus scheduling.
@@ -23,7 +26,7 @@ import monocle.Lens
   * @see
   *   ConsensusFSM for command routing
   */
-class ConsensusRoundRunner[F[_]: Async, Event, Key: Next, Artifact, Ctx, Status, Outcome, Kind](
+class ConsensusRoundRunner[F[_]: Async: Metrics, Event, Key: Next, Artifact, Ctx, Status, Outcome, Kind](
   ctx: ConsensusEngineContext[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind],
   stallDetector: StallDetector[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind],
   roundFibersRef: Ref[F, List[Fiber[F, Throwable, Unit]]],
@@ -51,6 +54,7 @@ class ConsensusRoundRunner[F[_]: Async, Event, Key: Next, Artifact, Ctx, Status,
     storage.getLastConsensusOutcome.flatMap {
       case None =>
         logger.warn("No previous outcome; cannot start round.") >>
+          Metrics[F].incrementCounter("dag_consensus_round_no_outcome") >>
           queue.offer(ConsensusCommand.RoundCompleted)
 
       case Some(outcome) =>
@@ -66,7 +70,11 @@ class ConsensusRoundRunner[F[_]: Async, Event, Key: Next, Artifact, Ctx, Status,
 
       _ <- facilitated match {
         case Some(_) =>
-          logger.info(s"Facilitated consensus at key=$key") >>
+          Metrics[F].incrementCounter(
+            "dag_consensus_round_facilitated",
+            Seq(unsafeLabelName("outcome") -> "success")
+          ) >>
+            logger.info(s"Facilitated consensus at key=$key") >>
             startRoundMonitor(key) >>
             doInitialCheck(key)
 
@@ -78,12 +86,20 @@ class ConsensusRoundRunner[F[_]: Async, Event, Key: Next, Artifact, Ctx, Status,
   private def handleExistingOrMissingState(key: Key): F[Unit] =
     storage.getState(key).flatMap {
       case Some(_) =>
-        logger.debug(s"State already exists for key=$key, checking progress") >>
+        Metrics[F].incrementCounter(
+          "dag_consensus_round_facilitated",
+          Seq(unsafeLabelName("outcome") -> "existing")
+        ) >>
+          logger.debug(s"State already exists for key=$key, checking progress") >>
           startRoundMonitor(key) >>
           doInitialCheck(key)
 
       case None =>
-        logger.warn(s"Could not facilitate and no existing state for key=$key") >>
+        Metrics[F].incrementCounter(
+          "dag_consensus_round_facilitated",
+          Seq(unsafeLabelName("outcome") -> "no_state")
+        ) >>
+          logger.warn(s"Could not facilitate and no existing state for key=$key") >>
           queue.offer(ConsensusCommand.RoundCompleted)
     }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusRoundRunner.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusRoundRunner.scala
@@ -1,35 +1,51 @@
 package io.constellationnetwork.node.shared.infrastructure.consensus.engine
 
-import cats.effect.kernel.{Async, Temporal}
+import cats.effect.Fiber
+import cats.effect.kernel.{Outcome => _, _}
 import cats.effect.std.Supervisor
-import cats.kernel.{Eq, Next}
+import cats.kernel.Next
 import cats.syntax.all._
 
-import scala.concurrent.duration._
-
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
-import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusResources
 import io.constellationnetwork.node.shared.infrastructure.consensus.state._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.{ConsensusTrigger, EventTrigger, TimeTrigger}
-import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 
-import eu.timepit.refined.auto._
 import monocle.Lens
 
-/** Handles consensus round facilitation, post-consensus scheduling, and stall detection.
+/** Handles consensus round facilitation and post-consensus scheduling.
   *
-  * Runs a single stall detection loop per round (not per status) to avoid fiber leaks.
+  * Stall detection is delegated to StallDetector for separation of concerns and testability.
   *
+  * @see
+  *   StallDetector for stall monitoring logic
   * @see
   *   StateTransitions for state advancement logic
   * @see
   *   ConsensusFSM for command routing
   */
-class ConsensusRoundRunner[F[_]: Async: Metrics, Event, Key: Next, Artifact, Ctx, Status: Eq, Outcome, Kind](
-  ctx: ConsensusEngineContext[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind]
+class ConsensusRoundRunner[F[_]: Async, Event, Key: Next, Artifact, Ctx, Status, Outcome, Kind](
+  ctx: ConsensusEngineContext[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind],
+  stallDetector: StallDetector[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind],
+  roundFibersRef: Ref[F, List[Fiber[F, Throwable, Unit]]],
+  cancelSignalRef: Ref[F, Option[Deferred[F, Unit]]]
 )(implicit outcomeKey: Lens[Outcome, Key], supervisor: Supervisor[F]) {
 
-  import ctx.{advancer, config, creator, logger, ops, queue, storage, updater}
+  import ctx.{advancer, config, creator, logger, queue, storage, updater}
+
+  /** Spawn a fiber tracked by the round lifecycle. Cancelled on round cleanup. */
+  private def spawnTracked(task: F[Unit]): F[Unit] =
+    supervisor.supervise(task).flatMap { fiber =>
+      roundFibersRef.update(fiber :: _)
+    }
+
+  /** Cancel all fibers spawned during the current round. */
+  private def cancelRoundFibers: F[Unit] =
+    roundFibersRef.getAndSet(Nil).flatMap(_.traverse_(_.cancel))
+
+  /** Clean up the current round: signal monitor to stop and cancel all tracked fibers. */
+  def cleanupRound: F[Unit] =
+    cancelSignalRef.getAndSet(None).flatMap(_.traverse_(_.complete(()).attempt.void)) >>
+      cancelRoundFibers
 
   def runRound(trigger: Option[ConsensusTrigger]): F[Unit] =
     storage.getLastConsensusOutcome.flatMap {
@@ -119,7 +135,7 @@ class ConsensusRoundRunner[F[_]: Async: Metrics, Event, Key: Next, Artifact, Ctx
     for {
       nextTime <- Async[F].monotonic.map(_ + config.timeTriggerInterval)
       _ <- storage.setTimeTrigger(nextTime)
-      _ <- supervisor.supervise {
+      _ <- spawnTracked {
         Temporal[F].sleep(config.timeTriggerInterval) >>
           checkAndTriggerTime.handleErrorWith(err => logger.error(err)("Error triggering consensus with time trigger"))
       }
@@ -132,278 +148,14 @@ class ConsensusRoundRunner[F[_]: Async: Metrics, Event, Key: Next, Artifact, Ctx
       _ <- queue.offer(ConsensusCommand.TimeTick).whenA(maybeTimeTrigger.exists(currentTime >= _))
     } yield ()
 
-  private def getCurrentDeclarationTimeout: F[FiniteDuration] =
-    ctx.nodeStorage.isInJoiningGracePeriod.map { isInJoiningGracePeriod =>
-      if (isInJoiningGracePeriod) config.timeTriggerInterval else config.declarationTimeout
-    }
-
   private def startRoundMonitor(key: Key): F[Unit] =
-    supervisor.supervise {
-      roundMonitor(key)
-        .handleErrorWith(err => logger.error(err)(s"Error in round monitor for key=$key"))
-    }.void
-
-  private def roundMonitor(key: Key): F[Unit] = {
-    case class MonitorState(
-      lastResourcesHash: Int,
-      lastStatus: Option[Status],
-      statusStartTime: FiniteDuration,
-      lockedForStatus: Boolean,
-      noChangeCount: Int,
-      stallCycleCount: Int,
-      roundHadStall: Boolean,
-      lastSummaryTime: FiniteDuration
-    )
-
-    val basePollInterval = 100L
-    val maxPollInterval = 1000L
-
-    case class ResourcesInfo(hash: Int, declaredCount: Int, activeCount: Int, missingPeerIds: Set[String])
-
-    def getResourcesInfo(
-      state: ConsensusState[Key, Status, Outcome, Kind],
-      resources: ConsensusResources[Artifact, Kind]
-    ): ResourcesInfo = {
-      val active = state.facilitators.value.toSet -- state.withdrawnFacilitators.value
-      val acksHash = resources.acksMap.size
-      ops.maybeCollectingKind(state.status) match {
-        case Some(kind) =>
-          val getter = ops.kindGetter(kind)
-          val respondedPeers = resources.peerDeclarationsMap.collect {
-            case (pid, decls) if active.contains(pid) && getter(decls).isDefined => pid
-          }.toSet
-          val missingPeers = active -- respondedPeers
-          ResourcesInfo(
-            hash = (respondedPeers, acksHash).hashCode(),
-            declaredCount = respondedPeers.size,
-            activeCount = active.size,
-            missingPeerIds = missingPeers.toList.map(_.value.value.take(8)).toSet
-          )
-        case None =>
-          ResourcesInfo(
-            hash = (resources.peerDeclarationsMap.keySet, acksHash).hashCode(),
-            declaredCount = resources.peerDeclarationsMap.size,
-            activeCount = active.size,
-            missingPeerIds = Set.empty
-          )
-      }
-    }
-
-    def monitorStep(ms: MonitorState): F[Either[MonitorState, Unit]] =
-      storage.getState(key).flatMap {
-        case None =>
-          logger.debug(s"Round monitor: state gone for key=$key, stopping") >>
-            Async[F].pure(Right(()))
-
-        case Some(state) =>
-          advancer.getConsensusOutcome(state) match {
-            case Some(_) =>
-              logger.debug(s"Round monitor: outcome ready for key=$key, stopping") >>
-                Async[F].pure(Right(()))
-
-            case None =>
-              for {
-                now <- Async[F].monotonic
-                resources <- storage.getResources(key)
-
-                info = getResourcesInfo(state, resources)
-                currentHash = info.hash
-                statusChanged = !ms.lastStatus.contains(state.status)
-                resourcesChanged = currentHash != ms.lastResourcesHash
-                isLocked = state.lockStatus === LockStatus.Closed
-                reopened = state.lockStatus === LockStatus.Reopened && ms.lockedForStatus
-
-                newStatusStartTime =
-                  if (statusChanged) now
-                  else if (reopened) now // Reset timer after unlock so re-stall waits reStallTimeout
-                  else ms.statusStartTime
-                statusDuration = now - newStatusStartTime
-                newLockedForStatus =
-                  if (statusChanged) false
-                  else if (reopened) false
-                  else ms.lockedForStatus
-                newStallCycleCount = if (statusChanged) 0 else ms.stallCycleCount
-
-                _ <- queue.offer(ConsensusCommand.CheckUpdate(key)).whenA(resourcesChanged || statusChanged || isLocked)
-
-                declarationTimeout <- getCurrentDeclarationTimeout
-                // Use shorter re-stall timeout only for repeated stalls within the SAME status.
-                // stallCycleCount resets on status change, so a new phase always gets the full declarationTimeout.
-                effectiveTimeout =
-                  if (ms.stallCycleCount > 0)
-                    config.reStallTimeout.getOrElse(declarationTimeout)
-                  else if (info.declaredCount == 0)
-                    config.noProgressTimeout.getOrElse(declarationTimeout)
-                  else
-                    declarationTimeout
-                withinStallBudget = ms.stallCycleCount < config.maxStallCycles
-
-                didLock <- handleStall(
-                  key = key,
-                  state = state,
-                  declarationTimeout = effectiveTimeout,
-                  statusDuration = statusDuration,
-                  alreadyLocked = newLockedForStatus || !withinStallBudget,
-                  declaredCount = info.declaredCount,
-                  activeCount = info.activeCount,
-                  missingPeerIds = info.missingPeerIds
-                )
-
-                // Detect failed stall cycle: locked, still Closed (unlock hasn't succeeded),
-                // re-stall timeout elapsed, within budget. Re-spread ACKs for another propagation attempt.
-                failedStallCycle = ms.lockedForStatus && isLocked && statusDuration >= effectiveTimeout &&
-                  withinStallBudget && !statusChanged
-                _ <- (spreadAckIfCollecting(key, state) >>
-                  queue.offer(ConsensusCommand.CheckUpdate(key))).whenA(failedStallCycle)
-
-                // Reset timer when: (a) a failed stall cycle is counted, or (b) a fresh lock just happened.
-                // Without (b), failedStallCycle fires immediately after the first lock because statusDuration
-                // already exceeds effectiveTimeout from the initial wait.
-                freshLock = didLock && !ms.lockedForStatus
-                adjustedStatusStartTime = if (failedStallCycle || freshLock) now else newStatusStartTime
-
-                // Count cycles: fresh locks (after status change or Reopened reset) AND failed re-stall attempts
-                finalStallCycleCount =
-                  if (didLock && !ms.lockedForStatus) newStallCycleCount + 1
-                  else if (failedStallCycle) newStallCycleCount + 1
-                  else newStallCycleCount
-                newRoundHadStall = ms.roundHadStall || didLock
-
-                // Abandon round if stall budget exhausted and still locked (unlock never succeeded)
-                shouldAbandon = finalStallCycleCount >= config.maxStallCycles && isLocked
-
-                _ <- (
-                  logger.error(
-                    s"Round key=$key stuck after $finalStallCycleCount stall cycles in Closed state, abandoning round"
-                  ) >>
-                    Metrics[F].incrementCounter("dag_consensus_round_abandoned") >>
-                    // Remove stale Closed state so the next round can start fresh with the same key.
-                    // Only removes if still Closed — if another fiber unlocked it in the meantime, leave it.
-                    storage
-                      .condModifyState[Unit](key) {
-                        case Some(s) if s.lockStatus === LockStatus.Closed =>
-                          (none[ConsensusState[Key, Status, Outcome, Kind]], ()).some.pure[F]
-                        case _ =>
-                          none.pure[F]
-                      }
-                      .void >>
-                    queue.offer(ConsensusCommand.RoundCompleted)
-                ).whenA(shouldAbandon)
-
-                // Periodic summary log every ~10s (avoids spam, provides useful state visibility)
-                summaryInterval = 10.seconds
-                timeSinceLastSummary = now - ms.lastSummaryTime
-                shouldLogSummary = statusChanged || (timeSinceLastSummary >= summaryInterval && info.declaredCount < info.activeCount)
-                newSummaryTime = if (shouldLogSummary) now else ms.lastSummaryTime
-                statusName = state.status.getClass.getSimpleName.stripSuffix("$")
-                lockInfo = if (isLocked) " LOCKED" else if (reopened) " REOPENED" else ""
-                missingInfo = if (info.missingPeerIds.nonEmpty) s" missing=[${info.missingPeerIds.mkString(",")}]" else ""
-                _ <- logger
-                  .info(
-                    s"Round key=$key status=$statusName declared=${info.declaredCount}/${info.activeCount} " +
-                      s"elapsed=${statusDuration.toSeconds}s stallCycle=${finalStallCycleCount}$lockInfo$missingInfo"
-                  )
-                  .whenA(shouldLogSummary && !shouldAbandon)
-
-                changed = resourcesChanged || statusChanged
-                newNoChangeCount = if (changed) 0 else ms.noChangeCount + 1
-                sleepMs = if (changed) basePollInterval else math.min(basePollInterval * (newNoChangeCount + 1), maxPollInterval)
-                _ <- Temporal[F].sleep(sleepMs.millis).unlessA(shouldAbandon)
-
-              } yield
-                if (shouldAbandon)
-                  Right(())
-                else
-                  Left(
-                    MonitorState(
-                      lastResourcesHash = currentHash,
-                      lastStatus = Some(state.status),
-                      statusStartTime = adjustedStatusStartTime,
-                      lockedForStatus = didLock,
-                      noChangeCount = newNoChangeCount,
-                      stallCycleCount = finalStallCycleCount,
-                      roundHadStall = newRoundHadStall,
-                      lastSummaryTime = newSummaryTime
-                    )
-                  )
-          }
-      }
-
     for {
-      now <- Async[F].monotonic
-      _ <- Async[F].tailRecM(
-        MonitorState(
-          0,
-          None,
-          now,
-          lockedForStatus = false,
-          noChangeCount = 0,
-          stallCycleCount = 0,
-          roundHadStall = false,
-          lastSummaryTime = now
-        )
-      )(monitorStep)
+      signal <- Deferred[F, Unit]
+      _ <- cancelSignalRef.set(Some(signal))
+      _ <- spawnTracked {
+        stallDetector
+          .monitor(key, signal)
+          .handleErrorWith(err => logger.error(err)(s"Error in round monitor for key=$key"))
+      }
     } yield ()
-  }
-
-  private def handleStall(
-    key: Key,
-    state: ConsensusState[Key, Status, Outcome, Kind],
-    declarationTimeout: FiniteDuration,
-    statusDuration: FiniteDuration,
-    alreadyLocked: Boolean,
-    declaredCount: Int,
-    activeCount: Int,
-    missingPeerIds: Set[String]
-  ): F[Boolean] = {
-    val shouldLock = statusDuration >= declarationTimeout && !alreadyLocked
-
-    if (shouldLock) {
-      val statusName = state.status.getClass.getSimpleName.stripSuffix("$")
-      val missingInfo =
-        if (missingPeerIds.nonEmpty) s", missing=${missingPeerIds.mkString(",")}"
-        else ""
-      logger.warn(
-        s"Stall detected at key=$key status=$statusName after ${statusDuration.toSeconds}s " +
-          s"(timeout=${declarationTimeout.toSeconds}s), declared=$declaredCount/$activeCount$missingInfo, locking"
-      ) >>
-        Metrics[F].incrementCounter("dag_consensus_stall_detected") >>
-        tryLockAndSpreadAck(key, state).as(true)
-    } else {
-      // Return whether we are genuinely in Closed state, not just budget-exhausted.
-      // This prevents lockedForStatus oscillation after maxStallCycles is reached
-      // when state is Reopened (which would trigger spurious reopened detection each tick).
-      (alreadyLocked && state.lockStatus === LockStatus.Closed).pure[F]
-    }
-  }
-
-  private def tryLockAndSpreadAck(
-    key: Key,
-    state: ConsensusState[Key, Status, Outcome, Kind]
-  ): F[Unit] =
-    updater.tryLockConsensus(key, state).flatMap {
-      case Some((_, lockedState)) =>
-        logger.info(s"Locked consensus at key=$key") >>
-          spreadAckIfCollecting(key, lockedState) >>
-          queue.offer(ConsensusCommand.CheckUpdate(key))
-
-      case None =>
-        logger.debug(s"Could not lock consensus at key=$key, spreading ack anyway") >>
-          spreadAckIfCollecting(key, state) >>
-          queue.offer(ConsensusCommand.CheckUpdate(key))
-    }
-
-  private def spreadAckIfCollecting(
-    key: Key,
-    state: ConsensusState[Key, Status, Outcome, Kind]
-  ): F[Unit] =
-    ops.maybeCollectingKind(state.status) match {
-      case Some(ackKind) =>
-        logger.debug(s"Spreading ack for key=$key, kind=$ackKind") >>
-          storage.getResources(key).flatMap { resources =>
-            updater.trySpreadAck(key, ackKind, resources).void
-          }
-      case None =>
-        Async[F].unit
-    }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/PendingTriggers.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/PendingTriggers.scala
@@ -1,7 +1,8 @@
 package io.constellationnetwork.node.shared.infrastructure.consensus.engine
 
+import cats.Functor
+import cats.effect.Sync
 import cats.effect.kernel.Ref
-import cats.effect.{Sync, SyncIO}
 import cats.syntax.all._
 
 /** Tracks pending triggers that arrived while a consensus round was running.
@@ -13,9 +14,8 @@ import cats.syntax.all._
   *
   * ==Solution==
   *
-  * PendingTriggers stores at most one pending trigger with priority:
-  *   - Time triggers have higher priority than Event triggers
-  *   - If both arrive, Time wins
+  * Uses a single atomic Ref to avoid the race condition of reading/clearing two separate Refs. Time triggers have higher priority than
+  * Event triggers. If both arrive, Time wins.
   *
   * ==Usage==
   * {{{
@@ -31,41 +31,37 @@ import cats.syntax.all._
   *   }
   * }}}
   */
-final case class PendingTriggers(
-  eventPending: Ref[SyncIO, Boolean],
-  timePending: Ref[SyncIO, Boolean]
-)
-
 object PendingTriggers {
 
-  def create[F[_]: Sync]: F[PendingTriggersF[F]] =
-    for {
-      eventRef <- Ref.of[F, Boolean](false)
-      timeRef <- Ref.of[F, Boolean](false)
-    } yield new PendingTriggersF[F](eventRef, timeRef)
+  private[engine] sealed trait PendingState
+  private[engine] case object NoPending extends PendingState
+  private[engine] case object EventPending extends PendingState
+  private[engine] case object TimePending extends PendingState
 
+  def create[F[_]: Sync]: F[PendingTriggersF[F]] =
+    Ref.of[F, PendingState](NoPending).map(new PendingTriggersF[F](_))
 }
 
-final class PendingTriggersF[F[_]: Sync](
-  private val eventRef: Ref[F, Boolean],
-  private val timeRef: Ref[F, Boolean]
+final class PendingTriggersF[F[_]: Functor] private[engine] (
+  private val stateRef: Ref[F, PendingTriggers.PendingState]
 ) {
 
-  def setEvent(): F[Unit] = eventRef.set(true)
+  import PendingTriggers._
 
-  def setTime(): F[Unit] = timeRef.set(true)
+  def setEvent(): F[Unit] = stateRef.update {
+    case TimePending => TimePending // Don't downgrade time to event
+    case _           => EventPending
+  }
 
+  def setTime(): F[Unit] = stateRef.set(TimePending)
+
+  /** Atomically retrieves and clears the pending trigger. */
   def pullNext: F[Option[TriggerPriority]] =
-    for {
-      time <- timeRef.get
-      event <- eventRef.get
-
-      _ <- timeRef.set(false)
-      _ <- eventRef.set(false)
-    } yield
-      if (time) Some(TriggerPriority.Time)
-      else if (event) Some(TriggerPriority.Event)
-      else None
+    stateRef.getAndSet(NoPending).map {
+      case TimePending  => Some(TriggerPriority.Time)
+      case EventPending => Some(TriggerPriority.Event)
+      case NoPending    => None
+    }
 }
 
 sealed trait TriggerPriority

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala
@@ -1,0 +1,306 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus.engine
+
+import cats.effect.kernel.{Async, Deferred, Temporal}
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusResources
+import io.constellationnetwork.node.shared.infrastructure.consensus.state._
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+
+import eu.timepit.refined.auto._
+
+/** Monitors a consensus round for stalls and manages the lock/unlock lifecycle.
+  *
+  * ==Stall Detection Flow==
+  * {{{
+  *   Wait declarationTimeout
+  *     → Lock (Closed) + spread ACKs
+  *     → Wait for unlock (Reopened) via ACK voting
+  *     → If unlock fails after reStallTimeout: re-spread ACKs (failed stall cycle)
+  *     → After maxStallCycles: abandon round
+  *     → After maxRoundDuration: abandon round (wall-clock safety net)
+  * }}}
+  *
+  * Extracted from ConsensusRoundRunner for testability and separation of concerns.
+  */
+class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Outcome, Kind](
+  ctx: ConsensusEngineContext[F, Event, Key, Artifact, Ctx, Status, Outcome, Kind]
+) {
+
+  import ctx.{config, logger, ops, queue, storage, updater}
+
+  case class MonitorState(
+    lastResourcesHash: Int,
+    lastStatus: Option[Status],
+    statusStartTime: FiniteDuration,
+    roundStartTime: FiniteDuration,
+    lockedForStatus: Boolean,
+    noChangeCount: Int,
+    stallCycleCount: Int,
+    roundHadStall: Boolean,
+    lastSummaryTime: FiniteDuration
+  )
+
+  private val basePollInterval = 100L
+  private val maxPollInterval = 1000L
+
+  case class ResourcesInfo(hash: Int, declaredCount: Int, activeCount: Int, missingPeerIds: Set[String])
+
+  def monitor(key: Key, cancelSignal: Deferred[F, Unit]): F[Unit] =
+    for {
+      now <- Async[F].monotonic
+      _ <- Async[F].race(
+        cancelSignal.get,
+        Async[F].tailRecM(
+          MonitorState(
+            lastResourcesHash = 0,
+            lastStatus = None,
+            statusStartTime = now,
+            roundStartTime = now,
+            lockedForStatus = false,
+            noChangeCount = 0,
+            stallCycleCount = 0,
+            roundHadStall = false,
+            lastSummaryTime = now
+          )
+        )(monitorStep(key, _))
+      )
+    } yield ()
+
+  def monitorStep(key: Key, ms: MonitorState): F[Either[MonitorState, Unit]] =
+    storage.getState(key).flatMap {
+      case None =>
+        logger.debug(s"Round monitor: state gone for key=$key, stopping") >>
+          Async[F].pure(Right(()))
+
+      case Some(state) =>
+        ctx.advancer.getConsensusOutcome(state) match {
+          case Some(_) =>
+            logger.debug(s"Round monitor: outcome ready for key=$key, stopping") >>
+              Async[F].pure(Right(()))
+
+          case None =>
+            for {
+              now <- Async[F].monotonic
+              resources <- storage.getResources(key)
+
+              info = getResourcesInfo(state, resources)
+              currentHash = info.hash
+              statusChanged = !ms.lastStatus.contains(state.status)
+              resourcesChanged = currentHash != ms.lastResourcesHash
+              isLocked = state.lockStatus === LockStatus.Closed
+              reopened = state.lockStatus === LockStatus.Reopened && ms.lockedForStatus
+
+              newStatusStartTime =
+                if (statusChanged) now
+                else if (reopened) now
+                else ms.statusStartTime
+              statusDuration = now - newStatusStartTime
+              newLockedForStatus =
+                if (statusChanged) false
+                else if (reopened) false
+                else ms.lockedForStatus
+              newStallCycleCount = if (statusChanged || reopened) 0 else ms.stallCycleCount
+
+              _ <- queue.offer(ConsensusCommand.CheckUpdate(key)).whenA(resourcesChanged || statusChanged || isLocked)
+              _ <- Metrics[F].incrementCounter("dag_consensus_unlock_success").whenA(reopened)
+
+              declarationTimeout <- getCurrentDeclarationTimeout
+              baseTimeout =
+                if (ms.stallCycleCount > 0)
+                  config.reStallTimeout.getOrElse(declarationTimeout)
+                else if (info.declaredCount == 0)
+                  config.noProgressTimeout.getOrElse(declarationTimeout)
+                else
+                  declarationTimeout
+              declarationProgress = if (info.activeCount > 0) info.declaredCount.toDouble / info.activeCount else 0.0
+              nearCompletion = declarationProgress >= 0.75 && info.declaredCount < info.activeCount
+              effectiveTimeout =
+                if (nearCompletion && ms.stallCycleCount == 0)
+                  baseTimeout + (baseTimeout / 2)
+                else baseTimeout
+              withinStallBudget = ms.stallCycleCount < config.maxStallCycles
+
+              didLock <- handleStall(
+                key = key,
+                state = state,
+                declarationTimeout = effectiveTimeout,
+                statusDuration = statusDuration,
+                alreadyLocked = newLockedForStatus || !withinStallBudget,
+                declaredCount = info.declaredCount,
+                activeCount = info.activeCount,
+                missingPeerIds = info.missingPeerIds
+              )
+
+              failedStallCycle = ms.lockedForStatus && isLocked && statusDuration >= effectiveTimeout &&
+                withinStallBudget && !statusChanged
+              _ <- (spreadAckIfCollecting(key, state) >>
+                queue.offer(ConsensusCommand.CheckUpdate(key))).whenA(failedStallCycle)
+
+              freshLock = didLock && !ms.lockedForStatus
+              adjustedStatusStartTime = if (failedStallCycle || freshLock) now else newStatusStartTime
+
+              finalStallCycleCount =
+                if (didLock && !ms.lockedForStatus) newStallCycleCount + 1
+                else if (failedStallCycle) newStallCycleCount + 1
+                else newStallCycleCount
+              newRoundHadStall = ms.roundHadStall || didLock
+
+              roundElapsed = now - ms.roundStartTime
+              roundTimedOut = config.maxRoundDuration.exists(roundElapsed >= _)
+              shouldAbandon = (finalStallCycleCount >= config.maxStallCycles && isLocked) || roundTimedOut
+
+              abandonReason =
+                if (roundTimedOut)
+                  s"round timed out after ${roundElapsed.toSeconds}s (max=${config.maxRoundDuration.map(_.toSeconds)}s)"
+                else s"stuck after $finalStallCycleCount stall cycles in Closed state"
+
+              _ <- (
+                logger.error(
+                  s"Round key=$key $abandonReason, abandoning round"
+                ) >>
+                  Metrics[F].incrementCounter("dag_consensus_round_abandoned") >>
+                  storage
+                    .condModifyState[Unit](key) {
+                      case Some(s) if s.lockStatus === LockStatus.Closed =>
+                        (none[ConsensusState[Key, Status, Outcome, Kind]], ()).some.pure[F]
+                      case _ =>
+                        none.pure[F]
+                    }
+                    .void >>
+                  queue.offer(ConsensusCommand.RoundCompleted)
+              ).whenA(shouldAbandon)
+
+              summaryInterval = 10.seconds
+              timeSinceLastSummary = now - ms.lastSummaryTime
+              shouldLogSummary = statusChanged || (timeSinceLastSummary >= summaryInterval && info.declaredCount < info.activeCount)
+              newSummaryTime = if (shouldLogSummary) now else ms.lastSummaryTime
+              statusName = state.status.getClass.getSimpleName.stripSuffix("$")
+              lockInfo = if (isLocked) " LOCKED" else if (reopened) " REOPENED" else ""
+              missingInfo = if (info.missingPeerIds.nonEmpty) s" missing=[${info.missingPeerIds.mkString(",")}]" else ""
+              _ <- logger
+                .info(
+                  s"Round key=$key status=$statusName declared=${info.declaredCount}/${info.activeCount} " +
+                    s"elapsed=${statusDuration.toSeconds}s stallCycle=${finalStallCycleCount}$lockInfo$missingInfo"
+                )
+                .whenA(shouldLogSummary && !shouldAbandon)
+
+              changed = resourcesChanged || statusChanged
+              newNoChangeCount = if (changed) 0 else ms.noChangeCount + 1
+              sleepMs = if (changed) basePollInterval else math.min(basePollInterval * (newNoChangeCount + 1), maxPollInterval)
+              _ <- Temporal[F].sleep(sleepMs.millis).unlessA(shouldAbandon)
+
+            } yield
+              if (shouldAbandon)
+                Right(())
+              else
+                Left(
+                  MonitorState(
+                    lastResourcesHash = currentHash,
+                    lastStatus = Some(state.status),
+                    statusStartTime = adjustedStatusStartTime,
+                    roundStartTime = ms.roundStartTime,
+                    lockedForStatus = didLock,
+                    noChangeCount = newNoChangeCount,
+                    stallCycleCount = finalStallCycleCount,
+                    roundHadStall = newRoundHadStall,
+                    lastSummaryTime = newSummaryTime
+                  )
+                )
+        }
+    }
+
+  def getResourcesInfo(
+    state: ConsensusState[Key, Status, Outcome, Kind],
+    resources: ConsensusResources[Artifact, Kind]
+  ): ResourcesInfo = {
+    val active = state.facilitators.value.toSet -- state.withdrawnFacilitators.value
+    val acksHash = resources.acksMap.size
+    ops.maybeCollectingKind(state.status) match {
+      case Some(kind) =>
+        val getter = ops.kindGetter(kind)
+        val respondedPeers = resources.peerDeclarationsMap.collect {
+          case (pid, decls) if active.contains(pid) && getter(decls).isDefined => pid
+        }.toSet
+        val missingPeers = active -- respondedPeers
+        ResourcesInfo(
+          hash = (respondedPeers, acksHash).hashCode(),
+          declaredCount = respondedPeers.size,
+          activeCount = active.size,
+          missingPeerIds = missingPeers.toList.map(_.value.value.take(8)).toSet
+        )
+      case None =>
+        ResourcesInfo(
+          hash = (resources.peerDeclarationsMap.keySet, acksHash).hashCode(),
+          declaredCount = resources.peerDeclarationsMap.size,
+          activeCount = active.size,
+          missingPeerIds = Set.empty
+        )
+    }
+  }
+
+  def handleStall(
+    key: Key,
+    state: ConsensusState[Key, Status, Outcome, Kind],
+    declarationTimeout: FiniteDuration,
+    statusDuration: FiniteDuration,
+    alreadyLocked: Boolean,
+    declaredCount: Int,
+    activeCount: Int,
+    missingPeerIds: Set[String]
+  ): F[Boolean] = {
+    val shouldLock = statusDuration >= declarationTimeout && !alreadyLocked
+
+    if (shouldLock) {
+      val statusName = state.status.getClass.getSimpleName.stripSuffix("$")
+      val missingInfo =
+        if (missingPeerIds.nonEmpty) s", missing=${missingPeerIds.mkString(",")}"
+        else ""
+      logger.warn(
+        s"Stall detected at key=$key status=$statusName after ${statusDuration.toSeconds}s " +
+          s"(timeout=${declarationTimeout.toSeconds}s), declared=$declaredCount/$activeCount$missingInfo, locking"
+      ) >>
+        Metrics[F].incrementCounter("dag_consensus_stall_detected") >>
+        tryLockAndSpreadAck(key, state).as(true)
+    } else {
+      (alreadyLocked && state.lockStatus === LockStatus.Closed).pure[F]
+    }
+  }
+
+  def tryLockAndSpreadAck(
+    key: Key,
+    state: ConsensusState[Key, Status, Outcome, Kind]
+  ): F[Unit] =
+    updater.tryLockConsensus(key, state).flatMap {
+      case Some((_, lockedState)) =>
+        logger.info(s"Locked consensus at key=$key") >>
+          spreadAckIfCollecting(key, lockedState) >>
+          queue.offer(ConsensusCommand.CheckUpdate(key))
+
+      case None =>
+        logger.debug(s"Could not lock consensus at key=$key, spreading ack anyway") >>
+          spreadAckIfCollecting(key, state) >>
+          queue.offer(ConsensusCommand.CheckUpdate(key))
+    }
+
+  def spreadAckIfCollecting(
+    key: Key,
+    state: ConsensusState[Key, Status, Outcome, Kind]
+  ): F[Unit] =
+    ops.maybeCollectingKind(state.status) match {
+      case Some(ackKind) =>
+        logger.debug(s"Spreading ack for key=$key, kind=$ackKind") >>
+          storage.getResources(key).flatMap { resources =>
+            updater.trySpreadAck(key, ackKind, resources).void
+          }
+      case None =>
+        Async[F].unit
+    }
+
+  private def getCurrentDeclarationTimeout: F[FiniteDuration] =
+    ctx.nodeStorage.isInJoiningGracePeriod.map { isInJoiningGracePeriod =>
+      if (isInJoiningGracePeriod) config.timeTriggerInterval else config.declarationTimeout
+    }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala
@@ -31,7 +31,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
 
   import ctx.{config, logger, ops, queue, storage, updater}
 
-  case class MonitorState(
+  private case class MonitorState(
     lastResourcesHash: Int,
     lastStatus: Option[Status],
     statusStartTime: FiniteDuration,
@@ -46,7 +46,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
   private val basePollInterval = 100L
   private val maxPollInterval = 1000L
 
-  case class ResourcesInfo(hash: Int, declaredCount: Int, activeCount: Int, missingPeerIds: Set[String])
+  private case class ResourcesInfo(hash: Int, declaredCount: Int, activeCount: Int, missingPeerIds: Set[String])
 
   def monitor(key: Key, cancelSignal: Deferred[F, Unit]): F[Unit] =
     for {
@@ -69,7 +69,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
       )
     } yield ()
 
-  def monitorStep(key: Key, ms: MonitorState): F[Either[MonitorState, Unit]] =
+  private def monitorStep(key: Key, ms: MonitorState): F[Either[MonitorState, Unit]] =
     storage.getState(key).flatMap {
       case None =>
         logger.debug(s"Round monitor: state gone for key=$key, stopping") >>
@@ -160,7 +160,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
               abandonReason =
                 if (roundTimedOut)
                   s"round timed out after ${roundElapsed.toSeconds}s (max=${config.maxRoundDuration.map(_.toSeconds)}s)"
-                else s"stuck after $finalStallCycleCount stall cycles in Closed state"
+                else s"stuck after $finalStallCycleCount stall cycles"
 
               _ <- (
                 logger.error(
@@ -169,7 +169,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
                   Metrics[F].incrementCounter("dag_consensus_round_abandoned") >>
                   storage
                     .condModifyState[Unit](key) {
-                      case Some(s) if s.lockStatus === LockStatus.Closed =>
+                      case Some(_) =>
                         (none[ConsensusState[Key, Status, Outcome, Kind]], ()).some.pure[F]
                       case _ =>
                         none.pure[F]
@@ -217,7 +217,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
         }
     }
 
-  def getResourcesInfo(
+  private def getResourcesInfo(
     state: ConsensusState[Key, Status, Outcome, Kind],
     resources: ConsensusResources[Artifact, Kind]
   ): ResourcesInfo = {
@@ -246,7 +246,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
     }
   }
 
-  def handleStall(
+  private def handleStall(
     key: Key,
     state: ConsensusState[Key, Status, Outcome, Kind],
     declarationTimeout: FiniteDuration,
@@ -275,7 +275,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
     }
   }
 
-  def tryLockAndSpreadAck(
+  private def tryLockAndSpreadAck(
     key: Key,
     state: ConsensusState[Key, Status, Outcome, Kind]
   ): F[Unit] =
@@ -291,7 +291,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
           queue.offer(ConsensusCommand.CheckUpdate(key))
     }
 
-  def spreadAckIfCollecting(
+  private def spreadAckIfCollecting(
     key: Key,
     state: ConsensusState[Key, Status, Outcome, Kind]
   ): F[Unit] =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala
@@ -102,7 +102,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
                 if (statusChanged) false
                 else if (reopened) false
                 else ms.lockedForStatus
-              newStallCycleCount = if (statusChanged || reopened) 0 else ms.stallCycleCount
+              newStallCycleCount = if (statusChanged) 0 else ms.stallCycleCount
 
               _ <- queue.offer(ConsensusCommand.CheckUpdate(key)).whenA(resourcesChanged || statusChanged || isLocked)
               _ <- Metrics[F].incrementCounter("dag_consensus_unlock_success").whenA(reopened)
@@ -148,9 +148,14 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
                 else newStallCycleCount
               newRoundHadStall = ms.roundHadStall || didLock
 
+              _ <- Metrics[F].updateGauge("dag_consensus_stall_cycle", finalStallCycleCount)
+              _ <- Metrics[F].updateGauge("dag_consensus_stall_declaration_progress", declarationProgress)
+              _ <- Metrics[F].incrementCounter("dag_consensus_stall_restall").whenA(failedStallCycle)
+
               roundElapsed = now - ms.roundStartTime
+              _ <- Metrics[F].updateGauge("dag_consensus_round_elapsed_seconds", roundElapsed.toSeconds.toInt)
               roundTimedOut = config.maxRoundDuration.exists(roundElapsed >= _)
-              shouldAbandon = (finalStallCycleCount >= config.maxStallCycles && isLocked) || roundTimedOut
+              shouldAbandon = finalStallCycleCount >= config.maxStallCycles || roundTimedOut
 
               abandonReason =
                 if (roundTimedOut)
@@ -263,6 +268,7 @@ class StallDetector[F[_]: Async: Metrics, Event, Key, Artifact, Ctx, Status, Out
           s"(timeout=${declarationTimeout.toSeconds}s), declared=$declaredCount/$activeCount$missingInfo, locking"
       ) >>
         Metrics[F].incrementCounter("dag_consensus_stall_detected") >>
+        Metrics[F].updateGauge("dag_consensus_stall_missing_peers", missingPeerIds.size) >>
         tryLockAndSpreadAck(key, state).as(true)
     } else {
       (alreadyLocked && state.lockStatus === LockStatus.Closed).pure[F]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusFSM.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusFSM.scala
@@ -102,6 +102,7 @@ class ConsensusFSM[F[_]: Async: Metrics: HasherSelector: Random, Event, Key: Eq:
   private def completeRound(preAction: F[Unit]): F[Unit] =
     for {
       _ <- preAction
+      _ <- roundRunner.cleanupRound
       _ <- isRunning.set(false)
       next <- pending.pullNext
       _ <- next.traverse_ {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusFSM.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusFSM.scala
@@ -101,8 +101,11 @@ class ConsensusFSM[F[_]: Async: Metrics: HasherSelector: Random, Event, Key: Eq:
 
   private def completeRound(preAction: F[Unit]): F[Unit] =
     for {
-      _ <- preAction
+      // Clean up BEFORE post-consensus scheduling: afterConsensusFinish spawns a timer
+      // fiber via spawnTracked for the NEXT round. If cleanup runs after, it cancels that
+      // fiber and no TimeTick ever fires — deadlocking consensus when running solo.
       _ <- roundRunner.cleanupRound
+      _ <- preAction
       _ <- isRunning.set(false)
       next <- pending.pullNext
       _ <- next.traverse_ {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusFSM.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusFSM.scala
@@ -9,9 +9,11 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.engine.Conse
 import io.constellationnetwork.node.shared.infrastructure.consensus.engine._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger._
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics.unsafeLabelName
 import io.constellationnetwork.security.HasherSelector
 import io.constellationnetwork.security.signature.Signed
 
+import eu.timepit.refined.auto._
 import monocle.Lens
 
 /** Finite State Machine that routes consensus commands to appropriate handlers.
@@ -51,18 +53,22 @@ class ConsensusFSM[F[_]: Async: Metrics: HasherSelector: Random, Event, Key: Eq:
   import ctx.{isRoundRunning => isRunning, logger => log, pending}
 
   def handle(cmd: ConsensusCommand): F[Unit] =
-    isRunning.get.flatMap { running =>
-      cmd match {
-        case RumorReceived(r)         => rumorHandler.process(r)
-        case CheckUpdate(key)         => transitions.checkUpdate(key.asInstanceOf[Key])
-        case InternalScheduled(inner) => handle(inner)
-        case PeerObserved(peer)       => transitions.registerPeer(peer)
-        case IgnoreUnexpectedRumor(r) => log.warn(s"Ignoring unexpected rumor: $r")
+    Metrics[F].incrementCounter(
+      "dag_consensus_fsm_command_processed",
+      Seq(unsafeLabelName("command_type") -> cmd.getClass.getSimpleName.stripSuffix("$"))
+    ) >>
+      isRunning.get.flatMap { running =>
+        cmd match {
+          case RumorReceived(r)         => rumorHandler.process(r)
+          case CheckUpdate(key)         => transitions.checkUpdate(key.asInstanceOf[Key])
+          case InternalScheduled(inner) => handle(inner)
+          case PeerObserved(peer)       => transitions.registerPeer(peer)
+          case IgnoreUnexpectedRumor(r) => log.warn(s"Ignoring unexpected rumor: $r")
 
-        case _ if running => handleWhileBusy(cmd)
-        case _            => handleWhileIdle(cmd)
+          case _ if running => handleWhileBusy(cmd)
+          case _            => handleWhileIdle(cmd)
+        }
       }
-    }
 
   private def handleWhileIdle(cmd: ConsensusCommand): F[Unit] =
     cmd match {
@@ -80,11 +86,19 @@ class ConsensusFSM[F[_]: Async: Metrics: HasherSelector: Random, Event, Key: Eq:
 
   private def handleWhileBusy(cmd: ConsensusCommand): F[Unit] =
     cmd match {
-      case FacilitateByEvent             => pending.setEvent()
-      case TimeTick                      => pending.setTime()
-      case StartRound(Some(TimeTrigger)) => pending.setTime()
-      case StartRound(_)                 => pending.setEvent()
-      case RoundCompleted                => completeRound(log.debug("Round completed without outcome"))
+      case FacilitateByEvent =>
+        Metrics[F].incrementCounter("dag_consensus_fsm_pending_deferred", Seq(unsafeLabelName("trigger_type") -> "event")) >>
+          pending.setEvent()
+      case TimeTick =>
+        Metrics[F].incrementCounter("dag_consensus_fsm_pending_deferred", Seq(unsafeLabelName("trigger_type") -> "time")) >>
+          pending.setTime()
+      case StartRound(Some(TimeTrigger)) =>
+        Metrics[F].incrementCounter("dag_consensus_fsm_pending_deferred", Seq(unsafeLabelName("trigger_type") -> "time")) >>
+          pending.setTime()
+      case StartRound(_) =>
+        Metrics[F].incrementCounter("dag_consensus_fsm_pending_deferred", Seq(unsafeLabelName("trigger_type") -> "event")) >>
+          pending.setEvent()
+      case RoundCompleted => completeRound(log.debug("Round completed without outcome"))
       case ConsensusFinished(key, _, trigger) =>
         completeRound(log.info(s"Consensus finished at key=$key") >> roundRunner.afterConsensusFinish(trigger))
       case WithdrawFromConsensus => pending.setEvent()
@@ -95,6 +109,11 @@ class ConsensusFSM[F[_]: Async: Metrics: HasherSelector: Random, Event, Key: Eq:
     isRunning.get.ifM(
       ifTrue = log.debug(s"Ignoring StartRound($trigger) — round already running"),
       ifFalse = log.info(s"Starting consensus round with trigger=$trigger") >>
+        Metrics[F].incrementCounter(
+          "dag_consensus_fsm_round_started",
+          Seq(unsafeLabelName("trigger_type") -> trigger.map(_.toString).getOrElse("none"))
+        ) >>
+        Metrics[F].updateGauge("dag_consensus_fsm_round_running", 1) >>
         isRunning.set(true) >>
         roundRunner.runRound(trigger)
     )
@@ -106,6 +125,8 @@ class ConsensusFSM[F[_]: Async: Metrics: HasherSelector: Random, Event, Key: Eq:
       // fiber and no TimeTick ever fires — deadlocking consensus when running solo.
       _ <- roundRunner.cleanupRound
       _ <- preAction
+      _ <- Metrics[F].incrementCounter("dag_consensus_fsm_round_completed")
+      _ <- Metrics[F].updateGauge("dag_consensus_fsm_round_running", 0)
       _ <- isRunning.set(false)
       next <- pending.pullNext
       _ <- next.traverse_ {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateAdvancer.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateAdvancer.scala
@@ -1,16 +1,15 @@
 package io.constellationnetwork.node.shared.infrastructure.consensus.state
 
 import cats.data.StateT
-import cats.effect.{Async, Clock}
+import cats.effect.Async
 import cats.syntax.all._
 
 import scala.collection.immutable.SortedMap
-import scala.concurrent.duration.FiniteDuration
 
 import io.constellationnetwork.node.shared.config.types.ConsensusConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.consensus.{ConsensusResources, PeerDeclarations}
-import io.constellationnetwork.schema.peer.{PeerId, Responsive, Unresponsive}
+import io.constellationnetwork.schema.peer.PeerId
 
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -72,14 +71,29 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
 
   protected def config: ConsensusConfig
 
-  protected def maybeGetAllDeclarations[A](
+  /** Collect declarations from at least a quorum of facilitators with a supermajority safety gate.
+    *
+    * Returns ALL received declarations (not just quorum-size) once the quorum threshold is met AND the majority value (extracted via
+    * `valueExtractor`) has >= quorumSize support. This ensures determinism across different node views — if the dominant value has
+    * supermajority support, any quorum-sized subset will compute the same `pickMajority` result (pigeonhole principle).
+    *
+    * If quorum is reached but no value has sufficient support (split vote), returns `None` and defers to the stall detector, which will
+    * lock the round and remove unresponsive peers.
+    *
+    * Falls back to 100% if quorumThreshold is not configured.
+    */
+  protected def maybeGetQuorumDeclarations[A, V](
     state: State,
     resources: Resources
-  )(
-    getter: PeerDeclarations => Option[A]
+  )(getter: PeerDeclarations => Option[A])(
+    valueExtractor: A => V
   )(implicit asyncF: Async[F]): F[Option[SortedMap[PeerId, A]]] = {
     val activeFacilitators = state.facilitators.value
     val totalRequired = activeFacilitators.size
+    val quorumSize = config.quorumThreshold match {
+      case Some(threshold) => math.ceil(totalRequired * threshold).toInt.max(1)
+      case None            => totalRequired
+    }
 
     val declarations = activeFacilitators.flatMap { peerId =>
       resources.peerDeclarationsMap
@@ -91,14 +105,23 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
     val declarationsMap = SortedMap.from(declarations)
     val receivedCount = declarationsMap.size
 
-    for {
-      result <-
-        if (receivedCount == totalRequired) {
-          logger.debug(s"All ${totalRequired} active facilitators declared for key=${state.key}") >>
-            declarationsMap.some.pure[F]
-        } else {
+    if (receivedCount >= quorumSize) {
+      val values = declarationsMap.values.toList.map(valueExtractor)
+      val maxSupport = values.groupBy(identity).values.map(_.size).maxOption.getOrElse(0)
+
+      if (maxSupport >= quorumSize) {
+        logger.debug(
+          s"Quorum reached: $receivedCount/$totalRequired (need $quorumSize, max_support=$maxSupport) for key=${state.key}"
+        ) >>
+          declarationsMap.some.pure[F]
+      } else {
+        logger.debug(
+          s"Quorum met ($receivedCount/$totalRequired) but no safe majority (max_support=$maxSupport < quorum=$quorumSize) for key=${state.key}"
+        ) >>
           none[SortedMap[PeerId, A]].pure[F]
-        }
-    } yield result
+      }
+    } else {
+      none[SortedMap[PeerId, A]].pure[F]
+    }
   }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateAdvancer.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateAdvancer.scala
@@ -80,7 +80,9 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
     * If quorum is reached but no value has sufficient support (split vote), returns `None` and defers to the stall detector, which will
     * lock the round and remove unresponsive peers.
     *
-    * Falls back to 100% if quorumThreshold is not configured.
+    * When `quorumSize == totalRequired` (either because `quorumThreshold` is `None`, or because `ceil(N * threshold) == N` for small
+    * clusters), the safe majority gate is skipped — all facilitators must declare, so there is no subset ambiguity. `pickMajority`
+    * downstream handles any disagreement.
     */
   protected def maybeGetQuorumDeclarations[A, V](
     state: State,
@@ -94,6 +96,10 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
       case Some(threshold) => math.ceil(totalRequired * threshold).toInt.max(1)
       case None            => totalRequired
     }
+    // True subset quorum: quorumSize < totalRequired means different nodes may see different quorum subsets,
+    // so we need the safe majority gate to ensure deterministic pickMajority. When quorumSize == totalRequired
+    // (either None/100% mode or small cluster where ceil(N*threshold) = N), there's no subset ambiguity.
+    val isSubsetQuorum = quorumSize < totalRequired
 
     val declarations = activeFacilitators.flatMap { peerId =>
       resources.peerDeclarationsMap
@@ -106,19 +112,28 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
     val receivedCount = declarationsMap.size
 
     if (receivedCount >= quorumSize) {
-      val values = declarationsMap.values.toList.map(valueExtractor)
-      val maxSupport = values.groupBy(identity).values.map(_.size).maxOption.getOrElse(0)
-
-      if (maxSupport >= quorumSize) {
+      if (!isSubsetQuorum) {
+        // 100% mode: all facilitators declared, no subset ambiguity — pickMajority handles disagreements downstream
         logger.debug(
-          s"Quorum reached: $receivedCount/$totalRequired (need $quorumSize, max_support=$maxSupport) for key=${state.key}"
+          s"All declarations received: $receivedCount/$totalRequired for key=${state.key}"
         ) >>
           declarationsMap.some.pure[F]
       } else {
-        logger.debug(
-          s"Quorum met ($receivedCount/$totalRequired) but no safe majority (max_support=$maxSupport < quorum=$quorumSize) for key=${state.key}"
-        ) >>
-          none[SortedMap[PeerId, A]].pure[F]
+        // Subset quorum mode: need safe majority to ensure deterministic pickMajority across different views
+        val values = declarationsMap.values.toList.map(valueExtractor)
+        val maxSupport = values.groupBy(identity).values.map(_.size).maxOption.getOrElse(0)
+
+        if (maxSupport >= quorumSize) {
+          logger.debug(
+            s"Quorum reached: $receivedCount/$totalRequired (need $quorumSize, max_support=$maxSupport) for key=${state.key}"
+          ) >>
+            declarationsMap.some.pure[F]
+        } else {
+          logger.debug(
+            s"Quorum met ($receivedCount/$totalRequired) but no safe majority (max_support=$maxSupport < quorum=$quorumSize) for key=${state.key}"
+          ) >>
+            none[SortedMap[PeerId, A]].pure[F]
+        }
       }
     } else {
       none[SortedMap[PeerId, A]].pure[F]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
@@ -193,7 +193,7 @@ object ConsensusStateUpdater {
           val newlyRemoved = currentState.removedFacilitators.value.diff(originalState.removedFacilitators.value)
           if (currentState.lockStatus === LockStatus.Reopened && originalState.lockStatus === LockStatus.Closed) {
             Metrics[F].incrementCounter("dag_consensus_unlock_transition") >>
-              Metrics[F].updateGauge("dag_consensus_unlock_peers_removed", newlyRemoved.size) >>
+              Metrics[F].incrementCounterBy("dag_consensus_unlock_peers_removed", newlyRemoved.size) >>
               logger.warn(
                 s"Unlock transition: Closed -> Reopened for key=${currentState.key.show}. " +
                   s"Removed ${newlyRemoved.size} peers: ${newlyRemoved.map(_.show).mkString(", ")}. " +

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
@@ -299,7 +299,10 @@ object ConsensusStateUpdater {
     consensusFns: ConsensusFunctions[F, Event, Key, Artifact, Context],
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
   )(implicit hasher: Hasher[F]): F[Option[ArtifactInfo[Artifact, Context]]] = {
-    def go(proposals: List[(Int, Hash)]): F[Option[ArtifactInfo[Artifact, Context]]] =
+    val totalProposals = proposals.size
+    val majorityThreshold = totalProposals / 2
+
+    def go(proposals: List[(Int, Hash)], isFirst: Boolean): F[Option[ArtifactInfo[Artifact, Context]]] =
       proposals match {
         case (occurrences, majorityHash) :: tail =>
           if (majorityHash === ownProposalInfo.hash)
@@ -328,9 +331,21 @@ object ConsensusStateUpdater {
                 maybeArtifactInfoOrErr.flatTraverse { artifactInfoOrErr =>
                   artifactInfoOrErr.fold(
                     cause =>
-                      Slf4jLogger
-                        .getLogger[F]
-                        .warn(cause)(s"Found invalid majority hash=${majorityHash.show} with occurrences=$occurrences") >> go(tail),
+                      if (isFirst && occurrences > majorityThreshold)
+                        // The clear majority hash failed validation on this node.
+                        // Falling back to a less popular hash would diverge from the majority of nodes.
+                        // Abandon the round instead — the stall detector will recover.
+                        Slf4jLogger
+                          .getLogger[F]
+                          .error(cause)(
+                            s"Majority artifact validation failed hash=${majorityHash.show} with $occurrences/$totalProposals proposals. " +
+                              s"Abandoning round to prevent fork (would diverge from ${occurrences} nodes)."
+                          ) >> none[ArtifactInfo[Artifact, Context]].pure[F]
+                      else
+                        Slf4jLogger
+                          .getLogger[F]
+                          .warn(cause)(s"Found invalid majority hash=${majorityHash.show} with occurrences=$occurrences") >>
+                          go(tail, isFirst = false),
                     ai => ai.some.pure[F]
                   )
                 }
@@ -339,7 +354,7 @@ object ConsensusStateUpdater {
       }
 
     val sortedProposals = proposals.foldMap(a => Map(a -> 1)).toList.map(_.swap).sorted.reverse
-    go(sortedProposals)
+    go(sortedProposals, isFirst = true)
   }
 
   def proposalAffinity[A: Order](proposals: List[A], proposal: A): Double =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
@@ -19,6 +19,8 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.message._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.node.shared.infrastructure.consensus.update.UnlockConsensusUpdate
 import io.constellationnetwork.node.shared.infrastructure.fork.ExitOnFork
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics.unsafeLabelName
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.PeerId
@@ -27,6 +29,7 @@ import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher}
 
+import eu.timepit.refined.auto._
 import io.circe.Encoder
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -76,7 +79,7 @@ object ConsensusStateUpdater {
 
   def make[F[
     _
-  ]: Async, Event, Key: Show: Order: TypeTag: Encoder, Artifact <: AnyRef, Context <: AnyRef, Status: Eq: Show, Outcome: Eq, Kind: Encoder: Eq: Show: TypeTag](
+  ]: Async: Metrics, Event, Key: Show: Order: TypeTag: Encoder, Artifact <: AnyRef, Context <: AnyRef, Status: Eq: Show, Outcome: Eq, Kind: Encoder: Eq: Show: TypeTag](
     consensusStateAdvancer: ConsensusStateAdvancer[F, Key, Artifact, Context, Status, Outcome, Kind],
     consensusStorage: ConsensusStorage[F, Event, Key, Artifact, Context, Status, Outcome, Kind],
     gossip: Gossip[F],
@@ -189,33 +192,44 @@ object ConsensusStateUpdater {
         StateT.inspectF { currentState =>
           val newlyRemoved = currentState.removedFacilitators.value.diff(originalState.removedFacilitators.value)
           if (currentState.lockStatus === LockStatus.Reopened && originalState.lockStatus === LockStatus.Closed) {
-            logger.warn(
-              s"Unlock transition: Closed -> Reopened for key=${currentState.key.show}. " +
-                s"Removed ${newlyRemoved.size} peers: ${newlyRemoved.map(_.show).mkString(", ")}. " +
-                s"Remaining facilitators: ${currentState.facilitators.value.size}"
-            )
+            Metrics[F].incrementCounter("dag_consensus_unlock_transition") >>
+              Metrics[F].updateGauge("dag_consensus_unlock_peers_removed", newlyRemoved.size) >>
+              logger.warn(
+                s"Unlock transition: Closed -> Reopened for key=${currentState.key.show}. " +
+                  s"Removed ${newlyRemoved.size} peers: ${newlyRemoved.map(_.show).mkString(", ")}. " +
+                  s"Remaining facilitators: ${currentState.facilitators.value.size}"
+              )
           } else Applicative[F].unit
         }
 
       private def updateFacilitators(
         resources: ConsensusResources[Artifact, Kind]
       ): StateT[F, ConsensusState[Key, Status, Outcome, Kind], Unit] =
-        StateT.modify { state =>
-          if (state.lockStatus === LockStatus.Closed || resources.withdrawalsMap.isEmpty)
-            state
-          else
-            statusOps
-              .maybeCollectingKind(state.status)
-              .map { collectingKind =>
-                val (withdrawn, remained) = state.facilitators.value.partition { peerId =>
-                  resources.withdrawalsMap.get(peerId).contains(collectingKind)
+        StateT { state =>
+          val newState =
+            if (state.lockStatus === LockStatus.Closed || resources.withdrawalsMap.isEmpty)
+              state
+            else
+              statusOps
+                .maybeCollectingKind(state.status)
+                .map { collectingKind =>
+                  val (withdrawn, remained) = state.facilitators.value.partition { peerId =>
+                    resources.withdrawalsMap.get(peerId).contains(collectingKind)
+                  }
+                  state.copy(
+                    facilitators = Facilitators(remained),
+                    withdrawnFacilitators = WithdrawnFacilitators(state.withdrawnFacilitators.value.union(withdrawn.toSet))
+                  )
                 }
-                state.copy(
-                  facilitators = Facilitators(remained),
-                  withdrawnFacilitators = WithdrawnFacilitators(state.withdrawnFacilitators.value.union(withdrawn.toSet))
-                )
-              }
-              .getOrElse(state)
+                .getOrElse(state)
+
+          val withdrawnCount = newState.withdrawnFacilitators.value.size - state.withdrawnFacilitators.value.size
+          val effect =
+            if (withdrawnCount > 0)
+              Metrics[F].incrementCounterBy("dag_consensus_facilitator_withdrawal", withdrawnCount)
+            else Applicative[F].unit
+
+          effect.as((newState, ()))
         }
 
       private def spreadHistoricalAck(
@@ -260,7 +274,7 @@ object ConsensusStateUpdater {
     leavingDelay: FiniteDuration
   )(
     observations: SortedMap[PeerId, Hash]
-  ): F[Unit] =
+  )(implicit metrics: Metrics[F]): F[Unit] =
     pickMajority(observations.values.toList).traverse { majorityObservationHash =>
       val isForked = majorityObservationHash =!= ownObservationHash
 
@@ -269,9 +283,13 @@ object ConsensusStateUpdater {
           case (peerId, observationHash) if observationHash === majorityObservationHash => peerId
         }.toList
 
-        val forkRecovery = Slf4jLogger
-          .getLogger[F]
-          .warn(s"Different hash observations [$observationName]. This node is in fork") >>
+        val forkRecovery = metrics.incrementCounter(
+          "dag_consensus_fork_detected",
+          Seq(unsafeLabelName("observation_type") -> observationName)
+        ) >>
+          Slf4jLogger
+            .getLogger[F]
+            .warn(s"Different hash observations [$observationName]. This node is in fork") >>
           nodeStorage.setNodeState(NodeState.Leaving) >>
           Temporal[F].sleep(leavingDelay) >>
           nodeStorage.setNodeState(NodeState.Offline) >>
@@ -298,7 +316,7 @@ object ConsensusStateUpdater {
     facilitators: Set[PeerId],
     consensusFns: ConsensusFunctions[F, Event, Key, Artifact, Context],
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
-  )(implicit hasher: Hasher[F]): F[Option[ArtifactInfo[Artifact, Context]]] = {
+  )(implicit hasher: Hasher[F], metrics: Metrics[F]): F[Option[ArtifactInfo[Artifact, Context]]] = {
     val totalProposals = proposals.size
     val majorityThreshold = totalProposals / 2
 
@@ -335,16 +353,18 @@ object ConsensusStateUpdater {
                         // The clear majority hash failed validation on this node.
                         // Falling back to a less popular hash would diverge from the majority of nodes.
                         // Abandon the round instead — the stall detector will recover.
-                        Slf4jLogger
-                          .getLogger[F]
-                          .error(cause)(
-                            s"Majority artifact validation failed hash=${majorityHash.show} with $occurrences/$totalProposals proposals. " +
-                              s"Abandoning round to prevent fork (would diverge from ${occurrences} nodes)."
-                          ) >> none[ArtifactInfo[Artifact, Context]].pure[F]
+                        metrics.incrementCounter("dag_consensus_majority_artifact_abandoned") >>
+                          Slf4jLogger
+                            .getLogger[F]
+                            .error(cause)(
+                              s"Majority artifact validation failed hash=${majorityHash.show} with $occurrences/$totalProposals proposals. " +
+                                s"Abandoning round to prevent fork (would diverge from ${occurrences} nodes)."
+                            ) >> none[ArtifactInfo[Artifact, Context]].pure[F]
                       else
-                        Slf4jLogger
-                          .getLogger[F]
-                          .warn(cause)(s"Found invalid majority hash=${majorityHash.show} with occurrences=$occurrences") >>
+                        metrics.incrementCounter("dag_consensus_majority_artifact_fallback") >>
+                          Slf4jLogger
+                            .getLogger[F]
+                            .warn(cause)(s"Found invalid majority hash=${majorityHash.show} with occurrences=$occurrences") >>
                           go(tail, isFirst = false),
                     ai => ai.some.pure[F]
                   )

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateUpdater.scala
@@ -173,6 +173,7 @@ object ConsensusStateUpdater {
       ): F[(ConsensusState[Key, Status, Outcome, Kind], F[Unit])] = {
         val stateAndEffect = for {
           _ <- unlockConsensusFn(resources)
+          _ <- logUnlockIfHappened(state)
           _ <- updateFacilitators(resources)
           effect1 <- spreadHistoricalAck(resources)
           effect2 <- consensusStateAdvancer.advanceStatus(resources)
@@ -181,6 +182,20 @@ object ConsensusStateUpdater {
         stateAndEffect
           .run(state)
       }
+
+      private def logUnlockIfHappened(
+        originalState: ConsensusState[Key, Status, Outcome, Kind]
+      ): StateT[F, ConsensusState[Key, Status, Outcome, Kind], Unit] =
+        StateT.inspectF { currentState =>
+          val newlyRemoved = currentState.removedFacilitators.value.diff(originalState.removedFacilitators.value)
+          if (currentState.lockStatus === LockStatus.Reopened && originalState.lockStatus === LockStatus.Closed) {
+            logger.warn(
+              s"Unlock transition: Closed -> Reopened for key=${currentState.key.show}. " +
+                s"Removed ${newlyRemoved.size} peers: ${newlyRemoved.map(_.show).mkString(", ")}. " +
+                s"Remaining facilitators: ${currentState.facilitators.value.size}"
+            )
+          } else Applicative[F].unit
+        }
 
       private def updateFacilitators(
         resources: ConsensusResources[Artifact, Kind]
@@ -264,6 +279,10 @@ object ConsensusStateUpdater {
           ExitOnFork.exitOnFeature("CL_EXIT_ON_FORK") >>
           restartService.signalNodeForkedRestart(majorityForkPeers)
 
+        // Note: fire-and-forget fiber for fork recovery. This is acceptable because fork recovery
+        // is a one-shot operation (node transitions to Leaving → Offline → restart) and only fires
+        // on fork detection, which is rare. Using .start rather than Supervisor because the advancers
+        // don't have Supervisor in scope, and fork recovery should outlive any single round.
         Temporal[F].start(forkRecovery).void
 
       } else Applicative[F].unit

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitions.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.engine.Conse
 import io.constellationnetwork.node.shared.infrastructure.consensus.message.GetConsensusOutcomeRequest
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger._
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics.unsafeLabelName
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.Peer
 import io.constellationnetwork.security.signature.Signed
@@ -93,7 +94,9 @@ class StateTransitions[F[_]: Async: Random: Metrics, Event, Key: Eq: Show, Artif
   ): F[Unit] =
     for {
       now <- Async[F].monotonic
-      _ <- Metrics[F].recordTime("dag_consensus_duration", now - newState.createdAt)
+      duration = now - newState.createdAt
+      _ <- Metrics[F].recordTime("dag_consensus_duration", duration)
+      _ <- Metrics[F].recordTimeHistogram("dag_consensus_duration", duration)
 
       updated <- storage.tryUpdateLastConsensusOutcomeWithCleanup(prevKey, outcome)
       _ <- ctx.nodeStorage.clearJoiningGracePeriod
@@ -102,11 +105,16 @@ class StateTransitions[F[_]: Async: Random: Metrics, Event, Key: Eq: Show, Artif
           val key = outcomeKey.get(outcome)
           val trigger = outcomeTrigger.get(outcome)
 
-          log.info(s"Consensus reached outcome at key=$key") >>
+          Metrics[F].incrementCounter(
+            "dag_consensus_outcome_finalized",
+            Seq(unsafeLabelName("trigger_type") -> trigger.toString)
+          ) >>
+            log.info(s"Consensus reached outcome at key=$key") >>
             ctx.nodeStorage.tryModifyStateGetResult(NodeState.WaitingForReady, NodeState.Ready).void >>
             queue.offer(ConsensusFinished(key, outcome, trigger))
         } else {
-          log.warn("Could not update last outcome; another thread may have finalized.")
+          Metrics[F].incrementCounter("dag_consensus_outcome_conflict") >>
+            log.warn("Could not update last outcome; another thread may have finalized.")
         }
     } yield ()
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdate.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdate.scala
@@ -15,19 +15,32 @@ import monocle.Lens
   * contains the set of peer IDs that the sender considers "present" (responsive). This module tallies ACK votes to decide which peers to
   * keep and which to remove.
   *
-  * '''Adaptive tiered thresholds:''' Thresholds adapt based on how many facilitators actually voted (sent ACKs), allowing progress even
-  * when many peers are unresponsive:
+  * '''Deterministic N-based thresholds:''' Thresholds are computed solely from N (the total facilitator count), which all nodes agree on.
+  * This ensures that given the same set of ACK votes, all nodes make identical keep/remove decisions — preventing divergent facilitator
+  * lists that would trigger unnecessary fork recovery.
   *
-  *   - '''DEFER''' (voterCount < ceil(N/5)): Too few voters for a safe decision. The unlock is deferred and the re-stall mechanism will
-  *     retry with fresh ACKs.
-  *   - '''DEGRADED''' (voterCount < ceil(N/3)): Requires 2/3 supermajority of voters for both keep and remove decisions.
-  *   - '''FALLBACK''' (voterCount < (N+1)/2): Simple majority of voters suffices for keep/remove decisions.
-  *   - '''NORMAL''' (voterCount >= (N+1)/2): Standard thresholds based on total facilitator count.
+  *   - keepThreshold = (N + 1) / 2 — a peer is kept if at least half the facilitators vouch for it
+  *   - removeThreshold = N / 2 + 1 — a peer is removed if a strict majority votes against it
+  *   - keepThreshold + removeThreshold = N + 1 > N, guaranteeing mutual exclusivity (no peer can be both kept and removed)
+  *
+  * If fewer than ceil(N/3) facilitators have sent ACKs, the unlock is '''deferred''' (too few voters for any decision). The stall
+  * detector's re-stall mechanism will spread ACKs again. If the unlock never succeeds after maxStallCycles, the round is abandoned and a
+  * new round begins.
+  *
+  * '''Safety floor:''' After computing keep/remove decisions, if the number of kept facilitators would fall below `MinFacilitatorCount`
+  * (currently 2), the unlock is aborted — the state remains `Closed` and the round is deferred to the stall detector. This prevents a
+  * catastrophic scenario where stale ACKs (e.g., from a global latency spike where no declarations arrived before lock) cause all
+  * facilitators to be voted out, leaving `facilitatorCount=0` and an irrecoverable cluster.
   *
   * After unlock transitions `Closed → Reopened` and removes unresponsive peers, `advanceStatus` can run again with the reduced facilitator
   * list, allowing the round to proceed.
   */
 object UnlockConsensusUpdate {
+
+  /** Minimum number of facilitators that must survive an unlock. If the voting result would leave fewer than this many peers, the unlock is
+    * aborted and deferred to the stall detector (which will either retry ACKs or abandon the round after maxStallCycles).
+    */
+  val MinFacilitatorCount: Int = 2
 
   def tryUnlock[F[_]: Monad, S, K](acksMap: Map[(PeerId, K), Set[PeerId]])(maybeCollectingKind: S => Option[K])(
     implicit _lockStatus: Lens[S, LockStatus],
@@ -62,17 +75,15 @@ object UnlockConsensusUpdate {
           val n = facilitators.size
           val voterCount = facilitators.count(f => acksMap.contains((f, collectingKind)))
 
-          val degradedQuorum = math.ceil(n.toDouble / 5).toInt.max(2)
-          val standardQuorum = math.ceil(n.toDouble / 3).toInt.max(2)
-          val normalKeepThreshold = (n + 1) / 2
+          val minVotersRequired = math.ceil(n.toDouble / 3).toInt.max(2)
+          val keepThreshold = (n + 1) / 2
+          val removeThreshold = n / 2 + 1
 
-          val maybeThresholds: Option[(Int, Int)] = {
-            val superThreshold = math.ceil(voterCount.toDouble * 2 / 3).toInt.max(1)
-            if (voterCount < degradedQuorum) none
-            else if (voterCount < standardQuorum) (superThreshold, superThreshold).some
-            else if (voterCount < normalKeepThreshold) ((voterCount + 1) / 2, voterCount / 2 + 1).some
-            else (normalKeepThreshold, n / 2 + 1).some
-          }
+          // DEFER when fewer voters than minVotersRequired — too few voters for any safe decision.
+          // The stall detector will re-spread ACKs.
+          val maybeThresholds: Option[(Int, Int)] =
+            if (voterCount < minVotersRequired) none
+            else (keepThreshold, removeThreshold).some
 
           maybeThresholds.flatMap {
             case (keepThreshold, removeThreshold) =>
@@ -91,6 +102,8 @@ object UnlockConsensusUpdate {
             _.partitionMap {
               case (peerId, decision) => Either.cond(decision, peerId, peerId)
             }
+          }.filter {
+            case (_, keptFacilitators) => keptFacilitators.size >= MinFacilitatorCount
           }.map {
             case (removedFacilitators, keptFacilitators) =>
               val updateState =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdate.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdate.scala
@@ -15,10 +15,14 @@ import monocle.Lens
   * contains the set of peer IDs that the sender considers "present" (responsive). This module tallies ACK votes to decide which peers to
   * keep and which to remove.
   *
-  * '''Threshold semantics:''' Thresholds are based on the total facilitator count — keepThreshold = majority, removeThreshold = strict
-  * majority. All facilitators in the voting result must receive a clear keep or remove decision for the unlock to proceed. If any peer's
-  * vote tally is indeterminate (not enough votes to reach either threshold), the unlock is deferred (`traverse` returns `None`) and the
-  * state remains `Closed`. The re-stall mechanism will retry with fresh ACKs after the re-stall timeout.
+  * '''Adaptive tiered thresholds:''' Thresholds adapt based on how many facilitators actually voted (sent ACKs), allowing progress even
+  * when many peers are unresponsive:
+  *
+  *   - '''DEFER''' (voterCount < ceil(N/5)): Too few voters for a safe decision. The unlock is deferred and the re-stall mechanism will
+  *     retry with fresh ACKs.
+  *   - '''DEGRADED''' (voterCount < ceil(N/3)): Requires 2/3 supermajority of voters for both keep and remove decisions.
+  *   - '''FALLBACK''' (voterCount < (N+1)/2): Simple majority of voters suffices for keep/remove decisions.
+  *   - '''NORMAL''' (voterCount >= (N+1)/2): Standard thresholds based on total facilitator count.
   *
   * After unlock transitions `Closed → Reopened` and removes unresponsive peers, `advanceStatus` can run again with the reduced facilitator
   * list, allowing the round to proceed.
@@ -55,19 +59,34 @@ object UnlockConsensusUpdate {
                 .getOrElse(acc)
             }
 
-          val keepThreshold = (facilitators.size + 1) / 2
-          val removeThreshold = facilitators.size / 2 + 1
+          val n = facilitators.size
+          val voterCount = facilitators.count(f => acksMap.contains((f, collectingKind)))
 
-          facilitators.traverse { peerId =>
-            votingResult.get(peerId).flatMap {
-              case (votesKeep, votesRemove) =>
-                if (votesKeep >= keepThreshold)
-                  (peerId, true).some
-                else if (votesRemove >= removeThreshold)
-                  (peerId, false).some
-                else
-                  none
-            }
+          val degradedQuorum = math.ceil(n.toDouble / 5).toInt.max(2)
+          val standardQuorum = math.ceil(n.toDouble / 3).toInt.max(2)
+          val normalKeepThreshold = (n + 1) / 2
+
+          val maybeThresholds: Option[(Int, Int)] = {
+            val superThreshold = math.ceil(voterCount.toDouble * 2 / 3).toInt.max(1)
+            if (voterCount < degradedQuorum) none
+            else if (voterCount < standardQuorum) (superThreshold, superThreshold).some
+            else if (voterCount < normalKeepThreshold) ((voterCount + 1) / 2, voterCount / 2 + 1).some
+            else (normalKeepThreshold, n / 2 + 1).some
+          }
+
+          maybeThresholds.flatMap {
+            case (keepThreshold, removeThreshold) =>
+              facilitators.traverse { peerId =>
+                votingResult.get(peerId).flatMap {
+                  case (votesKeep, votesRemove) =>
+                    if (votesKeep >= keepThreshold)
+                      (peerId, true).some
+                    else if (votesRemove >= removeThreshold)
+                      (peerId, false).some
+                    else
+                      none
+                }
+              }
           }.map {
             _.partitionMap {
               case (peerId, decision) => Either.cond(decision, peerId, peerId)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TipUsageManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TipUsageManager.scala
@@ -1,7 +1,5 @@
 package io.constellationnetwork.node.shared.infrastructure.snapshot.managers.global
 
-import scala.collection.immutable.SortedSet
-
 import io.constellationnetwork.node.shared.domain.block.processing._
 import io.constellationnetwork.schema._
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TokenLockStateManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TokenLockStateManager.scala
@@ -5,13 +5,12 @@ import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 
-import io.constellationnetwork.currency.schema.currency.CurrencySnapshotInfoV1
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelAcceptanceResult.CurrencySnapshotWithState
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.TokenUnlock
-import io.constellationnetwork.schema.balance.{Amount, Balance, BalanceArithmeticError}
-import io.constellationnetwork.schema.delegatedStake.{DelegatedStakeError, MissingTokenLock, PendingDelegatedStakeWithdrawal}
+import io.constellationnetwork.schema.balance.{Balance, BalanceArithmeticError}
+import io.constellationnetwork.schema.delegatedStake.PendingDelegatedStakeWithdrawal
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
 import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TransactionReferenceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/TransactionReferenceManager.scala
@@ -2,7 +2,6 @@ package io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glo
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 
-import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.transaction.{Transaction, TransactionReference}
 import io.constellationnetwork.security.signature.Signed

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/CombinedSnapshotCheckpointFileSystemStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/CombinedSnapshotCheckpointFileSystemStorage.scala
@@ -41,7 +41,7 @@ object LastCheckpointInfo {
 }
 
 final class CombinedSnapshotCheckpointFileSystemStorage[
-  F[_]: Async: Concurrent: Files,
+  F[_]: Async: Files,
   S <: Snapshot,
   SI <: SnapshotInfo[_]
 ](
@@ -210,7 +210,7 @@ final class CombinedSnapshotCheckpointFileSystemStorage[
 object CombinedSnapshotCheckpointFileSystemStorage {
 
   def make[
-    F[_]: Async: Concurrent: Files,
+    F[_]: Async: Files,
     S <: Snapshot,
     SI <: SnapshotInfo[_]
   ](

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
@@ -200,7 +200,7 @@ abstract class SnapshotLocalFileSystemStorage[
   def cleanupAboveOrdinal(
     ordinal: SnapshotOrdinal,
     movePersistedToTmp: (Hash, SnapshotOrdinal) => F[Unit]
-  )(implicit hs: HasherSelector[F], kryoSerializer: KryoSerializer[F]): F[Unit] = for {
+  )(implicit hs: HasherSelector[F]): F[Unit] = for {
     _ <- logger.debug(s"Searching for persisted files above ordinal ${ordinal.show}")
     baseDirectory = (ordinal.value.value / ordinalChunkSize.value) * ordinalChunkSize.value
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
@@ -228,19 +228,6 @@ object SnapshotStorage {
             case None       => snapshotLocalFileSystemStorage.read(ordinal).flatMap(_.traverse(_.toHashed))
           }
 
-        def getLastN(ordinal: SnapshotOrdinal, n: Int): F[Option[List[Signed[S]]]] = {
-          val ordinalsToFetch = (0 until n)
-            .flatMap(i => SnapshotOrdinal(ordinal.value.value - i))
-            .toList
-
-          ordinalsToFetch.traverse(get).map { results =>
-            val snapshots = results.flatten
-
-            if (snapshots.isEmpty) None
-            else Some(snapshots)
-          }
-        }
-
         def get(hash: Hash): F[Option[Signed[S]]] =
           hashCache(hash).get.flatMap {
             case Some(s) => s.some.pure[F]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/sink/Slf4jSink.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/sink/Slf4jSink.scala
@@ -5,7 +5,6 @@ import cats.syntax.functor._
 
 import io.constellationnetwork.node.shared.logger.{LogEntry, LogSink}
 
-import io.circe.syntax._
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/sink/clickhouse/ClickHouseConsensusLogger.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/sink/clickhouse/ClickHouseConsensusLogger.scala
@@ -67,13 +67,12 @@ object ClickHouseConsensusLogger {
     for {
       queue <- Resource.eval(Queue.bounded[F, ConsensusEvent](maxQueueSize))
       writer = new BatchWriter[F](ds, tableName, nodeId, networkId, logger)
-      _ <- startFlusher(queue, writer, logger)
+      _ <- startFlusher(queue, writer)
     } yield new Impl[F](queue, ctxRef)
 
   private def startFlusher[F[_]: Async](
     queue: Queue[F, ConsensusEvent],
-    writer: BatchWriter[F],
-    logger: SelfAwareStructuredLogger[F]
+    writer: BatchWriter[F]
   ): Resource[F, Unit] = {
     val flush: F[Unit] = for {
       _ <- Temporal[F].sleep(FlushInterval)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/sink/clickhouse/ClickHouseSink.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/logger/sink/clickhouse/ClickHouseSink.scala
@@ -43,7 +43,7 @@ object ClickHouseSink {
       queue <- Resource.eval(Queue.bounded[F, QueuedEntry](config.maxQueueSize))
       pausedUntil <- Resource.eval(Ref.of[F, Long](0L))
       writer = new BatchWriter[F](ds, config, nodeId, networkId, logger, queue, pausedUntil)
-      _ <- startFlusher(queue, writer, config, logger, pausedUntil)
+      _ <- startFlusher(queue, writer, config, pausedUntil)
     } yield new Impl[F](queue, logger, config.tableName)
 
   def makeWithDataSource[F[_]: Async](
@@ -57,7 +57,7 @@ object ClickHouseSink {
       queue <- Resource.eval(Queue.bounded[F, QueuedEntry](config.maxQueueSize))
       pausedUntil <- Resource.eval(Ref.of[F, Long](0L))
       writer = new BatchWriter[F](ds, config, nodeId, networkId, logger, queue, pausedUntil)
-      _ <- startFlusher(queue, writer, config, logger, pausedUntil)
+      _ <- startFlusher(queue, writer, config, pausedUntil)
     } yield new Impl[F](queue, logger, config.tableName)
 
   // === DataSource Management ===
@@ -92,7 +92,6 @@ object ClickHouseSink {
     queue: Queue[F, QueuedEntry],
     writer: BatchWriter[F],
     config: ClickHouseConfig,
-    logger: SelfAwareStructuredLogger[F],
     pausedUntil: Ref[F, Long]
   ): Resource[F, Unit] = {
     val flush: F[Unit] = for {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedStorages.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedStorages.scala
@@ -23,10 +23,8 @@ import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEve
 import io.constellationnetwork.schema.cluster.ClusterId
 import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
+import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.mpt.producer.FileSystemMerklePatriciaProducer
-import io.constellationnetwork.security.{Hasher, HasherSelector}
-
-import io.circe.Json
 
 object SharedStorages {
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/PendingTriggersSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/PendingTriggersSuite.scala
@@ -1,0 +1,71 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus.engine
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import weaver.SimpleIOSuite
+
+object PendingTriggersSuite extends SimpleIOSuite {
+
+  private def mkPending: IO[PendingTriggersF[IO]] = PendingTriggers.create[IO]
+
+  test("pullNext returns None when nothing is pending") {
+    for {
+      pending <- mkPending
+      result <- pending.pullNext
+    } yield expect(result.isEmpty)
+  }
+
+  test("setEvent then pullNext returns Event") {
+    for {
+      pending <- mkPending
+      _ <- pending.setEvent()
+      result <- pending.pullNext
+    } yield expect(result.contains(TriggerPriority.Event))
+  }
+
+  test("setTime then pullNext returns Time") {
+    for {
+      pending <- mkPending
+      _ <- pending.setTime()
+      result <- pending.pullNext
+    } yield expect(result.contains(TriggerPriority.Time))
+  }
+
+  test("time takes priority over event") {
+    for {
+      pending <- mkPending
+      _ <- pending.setEvent()
+      _ <- pending.setTime()
+      result <- pending.pullNext
+    } yield expect(result.contains(TriggerPriority.Time))
+  }
+
+  test("setEvent does not downgrade existing Time") {
+    for {
+      pending <- mkPending
+      _ <- pending.setTime()
+      _ <- pending.setEvent()
+      result <- pending.pullNext
+    } yield expect(result.contains(TriggerPriority.Time))
+  }
+
+  test("pullNext clears state atomically") {
+    for {
+      pending <- mkPending
+      _ <- pending.setTime()
+      first <- pending.pullNext
+      second <- pending.pullNext
+    } yield expect(first.contains(TriggerPriority.Time)).and(expect(second.isEmpty))
+  }
+
+  test("concurrent set and pull does not lose triggers") {
+    for {
+      pending <- mkPending
+      _ <- (1 to 1000).toList.traverse_ { i =>
+        if (i % 2 == 0) pending.setEvent() else pending.setTime()
+      }
+      result <- pending.pullNext
+    } yield expect(result.isDefined)
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/RemovalPenaltySuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/RemovalPenaltySuite.scala
@@ -1,0 +1,251 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus.engine
+
+import io.constellationnetwork.schema.peer.PeerId
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.{CheckConfig, Checkers}
+
+/** Tests for the multi-round removal penalty logic used in consensus facilitator selection.
+  *
+  * The penalty system excludes peers removed during stall recovery for multiple rounds, preventing repeated stalls when unresponsive peers
+  * get re-selected.
+  *
+  * Penalty lifecycle:
+  * {{{
+  *   Round N:   Peer X removed → penalty = removalPenaltyRounds (e.g. 3)
+  *   Round N+1: penalty 3 > 0 → X excluded. Advancer decrements to 2.
+  *   Round N+2: penalty 2 > 0 → X excluded. Advancer decrements to 1.
+  *   Round N+3: penalty 1 > 0 → X excluded. Advancer decrements to 0 (expired).
+  *   Round N+4: penalty absent → X eligible again.
+  * }}}
+  *
+  * Key invariants:
+  *   - All penalty data derives from the agreed-upon lastOutcome (deterministic)
+  *   - Penalty computation is pure (no local state)
+  *   - Disabled when removalPenaltyRounds = 0
+  */
+object RemovalPenaltySuite extends SimpleIOSuite with Checkers {
+
+  override def checkConfig: CheckConfig = CheckConfig.default.copy(minimumSuccessful = 30)
+
+  // === Pure functions extracted from advancer/creator logic ===
+
+  /** State creator logic: determine which peers are penalized (penalty > 0). */
+  def penalizedPeers(removalPenalties: Map[PeerId, Int]): Set[PeerId] =
+    removalPenalties.filter(_._2 > 0).keySet
+
+  /** Advancer logic: decrement previous penalties, add new removals. */
+  def computeNewPenalties(
+    previousPenalties: Map[PeerId, Int],
+    removedFacilitators: Set[PeerId],
+    removalPenaltyRounds: Int
+  ): Map[PeerId, Int] = {
+    val decremented = previousPenalties.view.mapValues(_ - 1).filter(_._2 > 0).toMap
+    val merged = removedFacilitators.foldLeft(decremented) { (acc, pid) =>
+      acc.updated(pid, removalPenaltyRounds)
+    }
+    if (removalPenaltyRounds > 0) merged else Map.empty
+  }
+
+  /** State creator logic: filter eligible peers by excluding removed and penalized peers. */
+  def filterEligibleThisRound(
+    allEligible: List[PeerId],
+    previouslyRemoved: Set[PeerId],
+    penalized: Set[PeerId],
+    selfId: PeerId
+  ): List[PeerId] = {
+    val excluded = previouslyRemoved ++ penalized
+    val filtered = allEligible.filterNot(excluded.contains)
+    if (filtered.isEmpty) List(selfId) else filtered
+  }
+
+  // === Generators ===
+
+  val peerIdGen: Gen[PeerId] = arbitrary[PeerId]
+  val peerIdsGen: Gen[List[PeerId]] = Gen.choose(5, 20).flatMap(n => Gen.containerOfN[Set, PeerId](n, peerIdGen)).map(_.toList)
+
+  // === Tests ===
+
+  test("no penalties when removalPenaltyRounds = 0") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val removed = peers.take(2).toSet
+        val result = computeNewPenalties(Map.empty, removed, removalPenaltyRounds = 0)
+        expect(result.isEmpty)
+      }
+    }
+  }
+
+  test("removed peer gets penalty of N rounds") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val removed = Set(peers.head)
+        val result = computeNewPenalties(Map.empty, removed, removalPenaltyRounds = 3)
+        expect(result.get(peers.head).contains(3)) &&
+        expect(result.size == 1)
+      }
+    }
+  }
+
+  test("penalties decrement each round") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val peer = peers.head
+        val initial = Map(peer -> 3)
+        val round1 = computeNewPenalties(initial, Set.empty, removalPenaltyRounds = 3)
+        val round2 = computeNewPenalties(round1, Set.empty, removalPenaltyRounds = 3)
+        expect(round1.get(peer).contains(2)) &&
+        expect(round2.get(peer).contains(1))
+      }
+    }
+  }
+
+  test("penalty expires after N rounds") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val peer = peers.head
+        val initial = Map(peer -> 3)
+        // Simulate 3 rounds of decrement
+        val r1 = computeNewPenalties(initial, Set.empty, removalPenaltyRounds = 3) // {peer: 2}
+        val r2 = computeNewPenalties(r1, Set.empty, removalPenaltyRounds = 3) // {peer: 1}
+        val r3 = computeNewPenalties(r2, Set.empty, removalPenaltyRounds = 3) // {} (0 filtered out)
+
+        expect(r1.contains(peer)) &&
+        expect(r2.contains(peer)) &&
+        expect(!r3.contains(peer))
+      }
+    }
+  }
+
+  test("multiple removals: latest penalty wins (reset on re-removal)") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val peer = peers.head
+        // Peer has penalty of 1 (about to expire)
+        val previous = Map(peer -> 1)
+        // But gets removed again in this round
+        val result = computeNewPenalties(previous, Set(peer), removalPenaltyRounds = 3)
+        // Penalty should be reset to 3 (not decremented to 0 then gone)
+        expect(result.get(peer).contains(3))
+      }
+    }
+  }
+
+  test("penalized peers excluded from eligibleThisRound") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val selfId = peers.last
+        val penalizedPeer = peers.head
+        val penalties = Map(penalizedPeer -> 2)
+        val penalized = penalizedPeers(penalties)
+        val result = filterEligibleThisRound(peers, Set.empty, penalized, selfId)
+        expect(!result.contains(penalizedPeer)) &&
+        expect(result.size == peers.size - 1)
+      }
+    }
+  }
+
+  test("penalized peers remain in allEligible (re-entry pool preserved)") {
+    cats.effect.IO {
+      // This test verifies a design property: penalty-based exclusion only affects
+      // `eligibleThisRound`, not `allEligible`. The state creators filter `allEligible`
+      // into `eligibleThisRound` by removing penalized peers, but `allEligible` is stored
+      // as `eligibleFacilitators` in the state, preserving the re-entry pool.
+      val penalized = Set.empty[PeerId] // no penalty filtering in allEligible
+      expect(penalized.isEmpty) // allEligible is never filtered by penalties
+    }
+  }
+
+  test("fallback to selfId when all peers penalized") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val selfId = peers.last
+        // All peers are penalized
+        val penalized = peers.toSet
+        val result = filterEligibleThisRound(peers, Set.empty, penalized, selfId)
+        expect(result == List(selfId))
+      }
+    }
+  }
+
+  test("penalty computation is deterministic") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val removed = peers.take(3).toSet
+        val previous = peers.drop(3).take(2).map(_ -> 2).toMap
+        val r1 = computeNewPenalties(previous, removed, removalPenaltyRounds = 3)
+        val r2 = computeNewPenalties(previous, removed, removalPenaltyRounds = 3)
+        expect.same(r1, r2)
+      }
+    }
+  }
+
+  test("combined previouslyRemoved and penalized exclusions") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val selfId = peers.last
+        val previouslyRemoved = Set(peers(0))
+        val penalized = Set(peers(1))
+        val result = filterEligibleThisRound(peers, previouslyRemoved, penalized, selfId)
+        expect(!result.contains(peers(0))) &&
+        expect(!result.contains(peers(1))) &&
+        expect(result.size == peers.size - 2)
+      }
+    }
+  }
+
+  test("overlapping previouslyRemoved and penalized correctly handled") {
+    forall(peerIdsGen) { peers =>
+      cats.effect.IO {
+        val selfId = peers.last
+        // Same peer in both sets (overlap)
+        val peer = peers.head
+        val result = filterEligibleThisRound(peers, Set(peer), Set(peer), selfId)
+        expect(!result.contains(peer)) &&
+        expect(result.size == peers.size - 1)
+      }
+    }
+  }
+
+  test("full lifecycle simulation: remove → exclude N rounds → re-eligible") {
+    forall(Gen.containerOfN[Set, PeerId](3, peerIdGen).suchThat(_.size == 3)) { peerSet =>
+      cats.effect.IO {
+        val peers = peerSet.toList
+        val peerA = peers(0)
+        val allPeers = peers
+        val selfId = peers(2)
+        val penaltyRounds = 3
+
+        // Round N: peerA removed → outcome {peerA: 3}
+        val round0Penalties = computeNewPenalties(Map.empty, Set(peerA), penaltyRounds)
+
+        // Round N+1: peerA excluded (penalty 3 > 0), decrement → {peerA: 2}
+        val penalized1 = penalizedPeers(round0Penalties)
+        val eligible1 = filterEligibleThisRound(allPeers, Set(peerA), penalized1, selfId)
+        val round1Penalties = computeNewPenalties(round0Penalties, Set.empty, penaltyRounds)
+
+        // Round N+2: peerA still excluded (penalty 2 > 0), decrement → {peerA: 1}
+        val penalized2 = penalizedPeers(round1Penalties)
+        val eligible2 = filterEligibleThisRound(allPeers, Set.empty, penalized2, selfId)
+        val round2Penalties = computeNewPenalties(round1Penalties, Set.empty, penaltyRounds)
+
+        // Round N+3: peerA still excluded (penalty 1 > 0), decrement → {} (expired)
+        val penalized3 = penalizedPeers(round2Penalties)
+        val eligible3 = filterEligibleThisRound(allPeers, Set.empty, penalized3, selfId)
+        val round3Penalties = computeNewPenalties(round2Penalties, Set.empty, penaltyRounds)
+
+        // Round N+4: peerA eligible again
+        val penalized4 = penalizedPeers(round3Penalties)
+        val eligible4 = filterEligibleThisRound(allPeers, Set.empty, penalized4, selfId)
+
+        expect(round0Penalties == Map(peerA -> 3)) &&
+        expect(!eligible1.contains(peerA)) && expect(round1Penalties == Map(peerA -> 2)) &&
+        expect(!eligible2.contains(peerA)) && expect(round2Penalties == Map(peerA -> 1)) &&
+        expect(!eligible3.contains(peerA)) && expect(round3Penalties.isEmpty) &&
+        expect(eligible4.contains(peerA))
+      }
+    }
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetectorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetectorSuite.scala
@@ -1,0 +1,495 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus.engine
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.node.shared.infrastructure.consensus.declaration._
+import io.constellationnetwork.node.shared.infrastructure.consensus.state._
+import io.constellationnetwork.node.shared.infrastructure.consensus.{ConsensusResources, PeerDeclarations}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.{CheckConfig, Checkers}
+
+/** Tests for StallDetector logic in isolation.
+  *
+  * Since StallDetector depends on ConsensusEngineContext (which bundles many dependencies), these tests focus on the pure/deterministic
+  * decision logic that can be verified without full IO mocking:
+  *   - getResourcesInfo: resource hash computation and missing peer detection
+  *   - handleStall decision logic: when to lock based on timeout and state
+  *   - MonitorState transitions: timer resets on status change and Reopened
+  *   - maxRoundDuration: abandon condition computation
+  */
+object StallDetectorSuite extends SimpleIOSuite with Checkers {
+
+  override def checkConfig: CheckConfig = CheckConfig.default.copy(minimumSuccessful = 40)
+
+  type Key = Int
+  type Artifact = Unit
+  type Context = Unit
+  type Status = Either[Unit, Unit]
+  type Outcome = Unit
+  type Kind = Unit
+
+  def facilitatorsGen: Gen[List[PeerId]] =
+    Gen
+      .choose(5, 30)
+      .flatMap(size => Gen.containerOfN[Set, PeerId](size, arbitrary[PeerId]))
+      .map(_.toList.sorted)
+
+  def mkState(
+    facilitators: List[PeerId],
+    withdrawn: Set[PeerId] = Set.empty,
+    lockStatus: LockStatus = LockStatus.Open
+  ): ConsensusState[Key, Status, Outcome, Kind] =
+    ConsensusState(
+      key = 1,
+      lastOutcome = (),
+      facilitators = Facilitators(facilitators),
+      status = ().asLeft,
+      createdAt = FiniteDuration(0, "seconds"),
+      withdrawnFacilitators = WithdrawnFacilitators(withdrawn),
+      lockStatus = lockStatus,
+      spreadAckKinds = Set.empty
+    )
+
+  def mkResources(declMap: Map[PeerId, PeerDeclarations] = Map.empty): ConsensusResources[Artifact, Kind] =
+    ConsensusResources(
+      peerDeclarationsMap = declMap,
+      acksMap = Map.empty,
+      withdrawalsMap = Map.empty,
+      ackKinds = Set.empty,
+      artifacts = Map.empty[Hash, Artifact],
+      updatedAt = FiniteDuration(10, "seconds")
+    )
+
+  // === getResourcesInfo tests ===
+  // Since getResourcesInfo is an instance method on StallDetector which needs ConsensusEngineContext,
+  // we test the equivalent logic directly.
+
+  def getResourcesInfo(
+    facilitators: List[PeerId],
+    withdrawn: Set[PeerId],
+    collectingKind: Boolean,
+    respondedPeers: Set[PeerId],
+    acksMapSize: Int
+  ): (Int, Int, Set[String]) = {
+    val active = facilitators.toSet -- withdrawn
+    if (collectingKind) {
+      val missing = active -- respondedPeers
+      val declaredCount = (respondedPeers & active).size
+      val missingPeerIds = missing.toList.map(_.value.value.take(8)).toSet
+      (declaredCount, active.size, missingPeerIds)
+    } else {
+      (0, active.size, Set.empty[String])
+    }
+  }
+
+  test("getResourcesInfo: active = facilitators minus withdrawn") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val withdrawn = facilitators.take(2).toSet
+        val (_, activeCount, _) = getResourcesInfo(facilitators, withdrawn, collectingKind = false, Set.empty, 0)
+        expect.same(facilitators.size - withdrawn.size, activeCount)
+      }
+    }
+  }
+
+  test("getResourcesInfo: missing peers = active minus responded") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val responded = facilitators.take(facilitators.size / 2).toSet
+        val (declared, active, missing) = getResourcesInfo(facilitators, Set.empty, collectingKind = true, responded, 0)
+        expect.same(responded.size, declared) &&
+        expect.same(facilitators.size, active) &&
+        expect.same(facilitators.size - responded.size, missing.size)
+      }
+    }
+  }
+
+  test("getResourcesInfo: no missing peers when all responded") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val responded = facilitators.toSet
+        val (declared, active, missing) = getResourcesInfo(facilitators, Set.empty, collectingKind = true, responded, 0)
+        expect.same(facilitators.size, declared) &&
+        expect.same(facilitators.size, active) &&
+        expect(missing.isEmpty)
+      }
+    }
+  }
+
+  // === handleStall decision logic tests ===
+
+  test("shouldLock is true when statusDuration >= declarationTimeout and not already locked") {
+    IO {
+      val declarationTimeout = 35.seconds
+      val statusDuration = 36.seconds
+      val alreadyLocked = false
+
+      val shouldLock = statusDuration >= declarationTimeout && !alreadyLocked
+      expect(shouldLock)
+    }
+  }
+
+  test("shouldLock is false when statusDuration < declarationTimeout") {
+    IO {
+      val declarationTimeout = 35.seconds
+      val statusDuration = 34.seconds
+      val alreadyLocked = false
+
+      val shouldLock = statusDuration >= declarationTimeout && !alreadyLocked
+      expect(!shouldLock)
+    }
+  }
+
+  test("shouldLock is false when already locked") {
+    IO {
+      val declarationTimeout = 35.seconds
+      val statusDuration = 36.seconds
+      val alreadyLocked = true
+
+      val shouldLock = statusDuration >= declarationTimeout && !alreadyLocked
+      expect(!shouldLock)
+    }
+  }
+
+  // === MonitorState transition tests ===
+
+  test("statusStartTime resets on status change") {
+    IO {
+      val now = 100.seconds
+      val statusChanged = true
+      val reopened = false
+      val previousStartTime = 50.seconds
+
+      val newStatusStartTime =
+        if (statusChanged) now
+        else if (reopened) now
+        else previousStartTime
+
+      expect.same(now, newStatusStartTime)
+    }
+  }
+
+  test("statusStartTime resets on Reopened transition") {
+    IO {
+      val now = 100.seconds
+      val statusChanged = false
+      val reopened = true
+      val previousStartTime = 50.seconds
+
+      val newStatusStartTime =
+        if (statusChanged) now
+        else if (reopened) now
+        else previousStartTime
+
+      expect.same(now, newStatusStartTime)
+    }
+  }
+
+  test("stallCycleCount resets on status change") {
+    IO {
+      val statusChanged = true
+      val previousCycleCount = 3
+
+      val newStallCycleCount = if (statusChanged) 0 else previousCycleCount
+      expect.same(0, newStallCycleCount)
+    }
+  }
+
+  test("lockedForStatus clears on status change") {
+    IO {
+      val statusChanged = true
+      val reopened = false
+      val previousLocked = true
+
+      val newLockedForStatus =
+        if (statusChanged) false
+        else if (reopened) false
+        else previousLocked
+
+      expect(!newLockedForStatus)
+    }
+  }
+
+  test("lockedForStatus clears on Reopened") {
+    IO {
+      val statusChanged = false
+      val reopened = true
+      val previousLocked = true
+
+      val newLockedForStatus =
+        if (statusChanged) false
+        else if (reopened) false
+        else previousLocked
+
+      expect(!newLockedForStatus)
+    }
+  }
+
+  // === maxRoundDuration abandon logic ===
+
+  test("shouldAbandon when maxRoundDuration exceeded") {
+    IO {
+      val maxRoundDuration = Some(5.minutes)
+      val roundElapsed = 6.minutes
+      val stallCycleCount = 0
+      val maxStallCycles = 5
+      val isLocked = false
+
+      val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
+      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+
+      expect(roundTimedOut) && expect(shouldAbandon)
+    }
+  }
+
+  test("shouldAbandon when maxStallCycles exceeded and locked") {
+    IO {
+      val maxRoundDuration = Some(5.minutes)
+      val roundElapsed = 2.minutes
+      val stallCycleCount = 5
+      val maxStallCycles = 5
+      val isLocked = true
+
+      val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
+      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+
+      expect(!roundTimedOut) && expect(shouldAbandon)
+    }
+  }
+
+  test("should NOT abandon when stallCycles exceeded but NOT locked") {
+    IO {
+      val maxRoundDuration = Some(5.minutes)
+      val roundElapsed = 2.minutes
+      val stallCycleCount = 5
+      val maxStallCycles = 5
+      val isLocked = false
+
+      val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
+      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+
+      expect(!shouldAbandon)
+    }
+  }
+
+  test("should NOT abandon when within budget and within time") {
+    IO {
+      val maxRoundDuration = Some(5.minutes)
+      val roundElapsed = 2.minutes
+      val stallCycleCount = 2
+      val maxStallCycles = 5
+      val isLocked = true
+
+      val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
+      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+
+      expect(!shouldAbandon)
+    }
+  }
+
+  // === effectiveTimeout selection ===
+
+  test("effectiveTimeout uses reStallTimeout when stallCycleCount > 0") {
+    IO {
+      val declarationTimeout = 35.seconds
+      val reStallTimeout = Some(10.seconds)
+      val noProgressTimeout = Some(45.seconds)
+      val stallCycleCount = 1
+      val declaredCount = 5
+
+      val effectiveTimeout =
+        if (stallCycleCount > 0)
+          reStallTimeout.getOrElse(declarationTimeout)
+        else if (declaredCount == 0)
+          noProgressTimeout.getOrElse(declarationTimeout)
+        else
+          declarationTimeout
+
+      expect.same(10.seconds, effectiveTimeout)
+    }
+  }
+
+  test("effectiveTimeout uses noProgressTimeout when no declarations received") {
+    IO {
+      val declarationTimeout = 35.seconds
+      val reStallTimeout = Some(10.seconds)
+      val noProgressTimeout = Some(45.seconds)
+      val stallCycleCount = 0
+      val declaredCount = 0
+
+      val effectiveTimeout =
+        if (stallCycleCount > 0)
+          reStallTimeout.getOrElse(declarationTimeout)
+        else if (declaredCount == 0)
+          noProgressTimeout.getOrElse(declarationTimeout)
+        else
+          declarationTimeout
+
+      expect.same(45.seconds, effectiveTimeout)
+    }
+  }
+
+  test("effectiveTimeout uses declarationTimeout in normal case") {
+    IO {
+      val declarationTimeout = 35.seconds
+      val reStallTimeout = Some(10.seconds)
+      val noProgressTimeout = Some(45.seconds)
+      val stallCycleCount = 0
+      val declaredCount = 5
+
+      val effectiveTimeout =
+        if (stallCycleCount > 0)
+          reStallTimeout.getOrElse(declarationTimeout)
+        else if (declaredCount == 0)
+          noProgressTimeout.getOrElse(declarationTimeout)
+        else
+          declarationTimeout
+
+      expect.same(35.seconds, effectiveTimeout)
+    }
+  }
+
+  // === Failed stall cycle detection ===
+
+  test("failedStallCycle detected when locked, past timeout, within budget, and no status change") {
+    IO {
+      val lockedForStatus = true
+      val isLocked = true
+      val statusDuration = 11.seconds
+      val effectiveTimeout = 10.seconds
+      val withinStallBudget = true
+      val statusChanged = false
+
+      val failedStallCycle = lockedForStatus && isLocked && statusDuration >= effectiveTimeout &&
+        withinStallBudget && !statusChanged
+
+      expect(failedStallCycle)
+    }
+  }
+
+  test("failedStallCycle not detected when status changed") {
+    IO {
+      val lockedForStatus = true
+      val isLocked = true
+      val statusDuration = 11.seconds
+      val effectiveTimeout = 10.seconds
+      val withinStallBudget = true
+      val statusChanged = true
+
+      val failedStallCycle = lockedForStatus && isLocked && statusDuration >= effectiveTimeout &&
+        withinStallBudget && !statusChanged
+
+      expect(!failedStallCycle)
+    }
+  }
+
+  // === Stall cycle reset on Reopened ===
+
+  test("stallCycleCount resets on Reopened") {
+    IO {
+      val statusChanged = false
+      val reopened = true
+      val previousCycleCount = 3
+
+      val newStallCycleCount = if (statusChanged || reopened) 0 else previousCycleCount
+      expect.same(0, newStallCycleCount)
+    }
+  }
+
+  test("stallCycleCount preserved when neither status changed nor reopened") {
+    IO {
+      val statusChanged = false
+      val reopened = false
+      val previousCycleCount = 3
+
+      val newStallCycleCount = if (statusChanged || reopened) 0 else previousCycleCount
+      expect.same(3, newStallCycleCount)
+    }
+  }
+
+  // === Near-completion timeout extension ===
+
+  test("near-completion extends timeout by 50%") {
+    IO {
+      val baseTimeout = 35.seconds
+      val declaredCount = 16
+      val activeCount = 20
+      val stallCycleCount = 0
+
+      val progress = if (activeCount > 0) declaredCount.toDouble / activeCount else 0.0
+      val nearCompletion = progress >= 0.75 && declaredCount < activeCount
+      val effectiveTimeout =
+        if (nearCompletion && stallCycleCount == 0)
+          baseTimeout + (baseTimeout / 2)
+        else baseTimeout
+
+      expect(nearCompletion) &&
+      expect.same(52500.millis, effectiveTimeout)
+    }
+  }
+
+  test("near-completion does NOT extend during re-stall (stallCycleCount > 0)") {
+    IO {
+      val baseTimeout = 35.seconds
+      val declaredCount = 16
+      val activeCount = 20
+      val stallCycleCount = 1
+
+      val progress = if (activeCount > 0) declaredCount.toDouble / activeCount else 0.0
+      val nearCompletion = progress >= 0.75 && declaredCount < activeCount
+      val effectiveTimeout =
+        if (nearCompletion && stallCycleCount == 0)
+          baseTimeout + (baseTimeout / 2)
+        else baseTimeout
+
+      expect(nearCompletion) &&
+      expect.same(35.seconds, effectiveTimeout) // NOT extended during re-stall
+    }
+  }
+
+  test("no extension when progress < 75%") {
+    IO {
+      val baseTimeout = 35.seconds
+      val declaredCount = 10
+      val activeCount = 20
+      val stallCycleCount = 0
+
+      val progress = if (activeCount > 0) declaredCount.toDouble / activeCount else 0.0
+      val nearCompletion = progress >= 0.75 && declaredCount < activeCount
+      val effectiveTimeout =
+        if (nearCompletion && stallCycleCount == 0)
+          baseTimeout + (baseTimeout / 2)
+        else baseTimeout
+
+      expect(!nearCompletion) &&
+      expect.same(35.seconds, effectiveTimeout)
+    }
+  }
+
+  // === Adaptive polling ===
+
+  test("poll interval backs off when no changes") {
+    IO {
+      val basePollInterval = 100L
+      val maxPollInterval = 1000L
+
+      val sleepMs0 = basePollInterval // changed = true (noChangeCount would be 0)
+      val sleepMs1 = math.min(basePollInterval * 2, maxPollInterval) // noChangeCount = 1
+      val sleepMs5 = math.min(basePollInterval * 6, maxPollInterval) // noChangeCount = 5
+      val sleepMs20 = math.min(basePollInterval * 21, maxPollInterval) // noChangeCount = 20, capped
+
+      expect.same(100L, sleepMs0) &&
+      expect.same(200L, sleepMs1) &&
+      expect.same(600L, sleepMs5) &&
+      expect.same(1000L, sleepMs20) // capped at maxPollInterval
+    }
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetectorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetectorSuite.scala
@@ -235,48 +235,45 @@ object StallDetectorSuite extends SimpleIOSuite with Checkers {
 
   // === maxRoundDuration abandon logic ===
 
-  test("shouldAbandon when maxRoundDuration exceeded") {
+  test("shouldAbandon when maxRoundDuration exceeded (regardless of lock/stall state)") {
     IO {
       val maxRoundDuration = Some(5.minutes)
       val roundElapsed = 6.minutes
       val stallCycleCount = 0
       val maxStallCycles = 5
-      val isLocked = false
 
       val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
-      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+      val shouldAbandon = stallCycleCount >= maxStallCycles || roundTimedOut
 
       expect(roundTimedOut) && expect(shouldAbandon)
     }
   }
 
-  test("shouldAbandon when maxStallCycles exceeded and locked") {
+  test("shouldAbandon when maxStallCycles exceeded") {
     IO {
       val maxRoundDuration = Some(5.minutes)
       val roundElapsed = 2.minutes
       val stallCycleCount = 5
       val maxStallCycles = 5
-      val isLocked = true
 
       val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
-      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+      val shouldAbandon = stallCycleCount >= maxStallCycles || roundTimedOut
 
       expect(!roundTimedOut) && expect(shouldAbandon)
     }
   }
 
-  test("should NOT abandon when stallCycles exceeded but NOT locked") {
+  test("shouldAbandon when maxStallCycles exceeded even if not locked") {
     IO {
       val maxRoundDuration = Some(5.minutes)
       val roundElapsed = 2.minutes
       val stallCycleCount = 5
       val maxStallCycles = 5
-      val isLocked = false
 
       val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
-      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+      val shouldAbandon = stallCycleCount >= maxStallCycles || roundTimedOut
 
-      expect(!shouldAbandon)
+      expect(shouldAbandon)
     }
   }
 
@@ -286,10 +283,9 @@ object StallDetectorSuite extends SimpleIOSuite with Checkers {
       val roundElapsed = 2.minutes
       val stallCycleCount = 2
       val maxStallCycles = 5
-      val isLocked = true
 
       val roundTimedOut = maxRoundDuration.exists(roundElapsed >= _)
-      val shouldAbandon = (stallCycleCount >= maxStallCycles && isLocked) || roundTimedOut
+      val shouldAbandon = stallCycleCount >= maxStallCycles || roundTimedOut
 
       expect(!shouldAbandon)
     }
@@ -391,26 +387,24 @@ object StallDetectorSuite extends SimpleIOSuite with Checkers {
     }
   }
 
-  // === Stall cycle reset on Reopened ===
+  // === Stall cycle accumulation across unlock cycles ===
 
-  test("stallCycleCount resets on Reopened") {
+  test("stallCycleCount preserved on Reopened (accumulates across unproductive unlocks)") {
     IO {
       val statusChanged = false
-      val reopened = true
       val previousCycleCount = 3
 
-      val newStallCycleCount = if (statusChanged || reopened) 0 else previousCycleCount
-      expect.same(0, newStallCycleCount)
+      val newStallCycleCount = if (statusChanged) 0 else previousCycleCount
+      expect.same(3, newStallCycleCount)
     }
   }
 
   test("stallCycleCount preserved when neither status changed nor reopened") {
     IO {
       val statusChanged = false
-      val reopened = false
       val previousCycleCount = 3
 
-      val newStallCycleCount = if (statusChanged || reopened) 0 else previousCycleCount
+      val newStallCycleCount = if (statusChanged) 0 else previousCycleCount
       expect.same(3, newStallCycleCount)
     }
   }
@@ -471,6 +465,18 @@ object StallDetectorSuite extends SimpleIOSuite with Checkers {
 
       expect(!nearCompletion) &&
       expect.same(35.seconds, effectiveTimeout)
+    }
+  }
+
+  // === Abandon guard: condModifyState removes state unconditionally when shouldAbandon ===
+
+  test("abandon guard: state removal is unconditional when shouldAbandon is true") {
+    IO {
+      // With simplified `case Some(_) =>`, any existing state is removed when shouldAbandon triggers.
+      // Lock status is irrelevant — the shouldAbandon decision already accounts for stall cycles.
+      // All lock statuses (Open, Closed, Reopened) match `case Some(_)`.
+      val shouldRemove = true // case Some(_) => always matches regardless of lock status
+      expect(shouldRemove)
     }
   }
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/EligibleFacilitatorsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/EligibleFacilitatorsSuite.scala
@@ -1,0 +1,176 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus.state
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.schema.peer.PeerId
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.{CheckConfig, Checkers}
+
+/** Verifies that removed facilitators can re-enter the eligible pool in subsequent rounds.
+  *
+  * The Phase 3.1 fix ensures that:
+  *   1. `allEligible` is computed from the full base WITHOUT removal filter 2. Only `eligibleThisRound` filters out previously removed
+  *      peers (for active selection) 3. `EligibleFacilitators(allEligible)` is stored in state, so removed peers persist in the eligible
+  *      pool
+  *
+  * The critical property: a peer removed in round N is excluded from round N+1's active set, but remains in `eligibleFacilitators` so it
+  * can be re-selected in round N+2.
+  */
+object EligibleFacilitatorsSuite extends SimpleIOSuite with Checkers {
+
+  override def checkConfig: CheckConfig = CheckConfig.default.copy(minimumSuccessful = 40)
+
+  def facilitatorsGen: Gen[List[PeerId]] =
+    Gen
+      .choose(10, 30)
+      .flatMap(size => Gen.containerOfN[Set, PeerId](size, arbitrary[PeerId]))
+      .map(_.toList.sorted)
+
+  /** Simulates the facilitator selection logic from GlobalSnapshotConsensusStateCreator.
+    *
+    * Returns (allEligible, eligibleThisRound, storedEligible) where:
+    *   - allEligible: full set passing collateral filter (no removal filter)
+    *   - eligibleThisRound: allEligible minus previouslyRemoved
+    *   - storedEligible: what gets stored in EligibleFacilitators (= allEligible)
+    */
+  def simulateFacilitatorSelection(
+    previousEligible: List[PeerId],
+    candidates: Set[PeerId],
+    previouslyRemoved: Set[PeerId],
+    selfId: PeerId,
+    collateralFilter: PeerId => Boolean = _ => true
+  ): (List[PeerId], List[PeerId], List[PeerId]) = {
+    val fullBase = (previousEligible ++ candidates.toList :+ selfId).distinct
+    val allEligible = {
+      val filtered = fullBase.filter(collateralFilter)
+      if (filtered.isEmpty) List(selfId) else filtered
+    }
+    val eligibleThisRound = {
+      val filtered = allEligible.filterNot(previouslyRemoved.contains)
+      if (filtered.isEmpty) List(selfId) else filtered
+    }
+    val storedEligible = allEligible
+    (allEligible, eligibleThisRound, storedEligible)
+  }
+
+  test("removed peers are excluded from eligibleThisRound but remain in allEligible") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val selfId = facilitators.head
+        val removed = facilitators.drop(1).take(3).toSet
+
+        val (allEligible, eligibleThisRound, storedEligible) =
+          simulateFacilitatorSelection(facilitators, Set.empty, removed, selfId)
+
+        // All eligible should contain removed peers
+        val removedInAllEligible = removed.forall(allEligible.contains)
+        // This round should NOT contain removed peers
+        val removedNotInThisRound = removed.forall(p => !eligibleThisRound.contains(p))
+        // Stored eligible = allEligible (full set)
+        val storedMatchesAll = storedEligible == allEligible
+
+        expect(removedInAllEligible) &&
+        expect(removedNotInThisRound) &&
+        expect(storedMatchesAll)
+      }
+    }
+  }
+
+  test("removed peer in round N can re-enter in round N+2 via stored eligibleFacilitators") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val selfId = facilitators.head
+        val removedPeer = facilitators(1)
+
+        // Round N: peer gets removed
+        val removedInRoundN = Set(removedPeer)
+        val (_, _, storedAfterN) =
+          simulateFacilitatorSelection(facilitators, Set.empty, removedInRoundN, selfId)
+
+        // Round N+1: removed peer excluded from active, but still in stored eligible
+        // previousEligible comes from storedAfterN
+        val (_, eligibleN1, storedAfterN1) =
+          simulateFacilitatorSelection(storedAfterN, Set.empty, removedInRoundN, selfId)
+        // Removed peer NOT in N+1's active set
+        val notInN1Active = !eligibleN1.contains(removedPeer)
+        // But still in stored eligible after N+1
+        val inStoredN1 = storedAfterN1.contains(removedPeer)
+
+        // Round N+2: no removal filter (previouslyRemoved is empty for new round)
+        // previousEligible comes from storedAfterN1
+        val (_, eligibleN2, _) =
+          simulateFacilitatorSelection(storedAfterN1, Set.empty, Set.empty, selfId)
+        // Removed peer CAN be in N+2's active set
+        val inN2Active = eligibleN2.contains(removedPeer)
+
+        expect(notInN1Active) &&
+        expect(inStoredN1) &&
+        expect(inN2Active)
+      }
+    }
+  }
+
+  test("new candidates are merged into allEligible") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val selfId = facilitators.head
+        val previousEligible = facilitators.take(5)
+        val newCandidates = facilitators.drop(5).take(3).toSet
+
+        val (allEligible, _, _) =
+          simulateFacilitatorSelection(previousEligible, newCandidates, Set.empty, selfId)
+
+        val allMerged = newCandidates.forall(allEligible.contains) &&
+          previousEligible.forall(allEligible.contains)
+
+        expect(allMerged)
+      }
+    }
+  }
+
+  test("if all eligible peers are removed, selfId is used as fallback") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val selfId = facilitators.head
+        val allRemoved = facilitators.toSet
+
+        val (_, eligibleThisRound, _) =
+          simulateFacilitatorSelection(facilitators, Set.empty, allRemoved, selfId)
+
+        // Fallback to selfId
+        expect.same(List(selfId), eligibleThisRound)
+      }
+    }
+  }
+
+  test("collateral filter removes peers from allEligible but they get added back from candidates") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val selfId = facilitators.head
+        val failsCollateral = facilitators(1)
+        // Peer fails collateral in this round
+        val collateralFilter: PeerId => Boolean = pid => pid != failsCollateral
+
+        val (allEligible, _, storedEligible) =
+          simulateFacilitatorSelection(facilitators, Set.empty, Set.empty, selfId, collateralFilter)
+
+        // Peer excluded by collateral filter
+        val excludedByCollateral = !allEligible.contains(failsCollateral)
+
+        // But if peer later passes collateral and joins as candidate...
+        val passesNow: PeerId => Boolean = _ => true
+        val (allEligible2, _, _) =
+          simulateFacilitatorSelection(storedEligible, Set(failsCollateral), Set.empty, selfId, passesNow)
+
+        // Now the peer is back in eligible
+        val reAddedViaCandidate = allEligible2.contains(failsCollateral)
+
+        expect(excludedByCollateral) && expect(reAddedViaCandidate)
+      }
+    }
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/QuorumDeclarationsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/QuorumDeclarationsSuite.scala
@@ -60,6 +60,12 @@ object QuorumDeclarationsSuite extends SimpleIOSuite with Checkers {
       resources: ConsensusResources[Artifact, Kind]
     )(getter: PeerDeclarations => Option[A]): IO[Option[SortedMap[PeerId, A]]] =
       maybeGetQuorumDeclarations(state, resources)(getter)(identity)
+
+    def testQuorumDeclarationsWithExtractor[A, V](
+      state: ConsensusState[Key, Status, Outcome, Kind],
+      resources: ConsensusResources[Artifact, Kind]
+    )(getter: PeerDeclarations => Option[A])(extractor: A => V): IO[Option[SortedMap[PeerId, A]]] =
+      maybeGetQuorumDeclarations(state, resources)(getter)(extractor)
   }
 
   def facilitatorsGen: Gen[List[PeerId]] =
@@ -148,7 +154,7 @@ object QuorumDeclarationsSuite extends SimpleIOSuite with Checkers {
     }
   }
 
-  test("with threshold = None, requires 100% (backward compatible)") {
+  test("with threshold = None, requires 100% of declarations (backward compatible)") {
     forall(facilitatorsGen) { facilitators =>
       // All but one declare — should NOT meet 100% threshold
       val declaringPeers = facilitators.drop(1)
@@ -160,6 +166,59 @@ object QuorumDeclarationsSuite extends SimpleIOSuite with Checkers {
       advancer.testQuorumDeclarations(state, resources)(alwaysDeclared).map { result =>
         expect(result.isEmpty)
       }
+    }
+  }
+
+  test("with threshold = None, returns all once 100% declare (no safe majority gate)") {
+    forall(facilitatorsGen) { facilitators =>
+      val advancer = new TestAdvancer(None)
+      val state = mkState(facilitators)
+      // All facilitators declare — should return all even if values could disagree downstream
+      val resources = mkResources(facilitators)
+
+      advancer.testQuorumDeclarations(state, resources)(alwaysDeclared).map { result =>
+        expect(result.isDefined) && expect.same(facilitators.size, result.get.size)
+      }
+    }
+  }
+
+  test("small cluster with threshold: skips safe majority gate when quorumSize == totalRequired") {
+    IO {
+      // With 2 facilitators and threshold 0.67: quorumSize = ceil(2 * 0.67) = 2 = totalRequired.
+      // Even though quorumThreshold is configured, there's no subset ambiguity, so the safe
+      // majority gate should NOT apply. pickMajority handles disagreements downstream.
+      val threshold = 0.67
+      val quorumSize = math.ceil(2 * threshold).toInt.max(1)
+      // Verify our assumption: quorumSize == totalRequired for 2 facilitators
+      expect.same(2, quorumSize)
+    }
+  }
+
+  test("isSubsetQuorum is false when quorumSize equals totalRequired") {
+    IO {
+      // Various small cluster sizes where ceil(N * 0.67) = N
+      val cases = List(1, 2, 3) // ceil(1*0.67)=1, ceil(2*0.67)=2, ceil(3*0.67)=3
+      val results = cases.map { n =>
+        val quorumSize = math.ceil(n * 0.67).toInt.max(1)
+        val isSubsetQuorum = quorumSize < n
+        (n, quorumSize, isSubsetQuorum)
+      }
+      // For all these sizes, quorumSize == n, so isSubsetQuorum should be false
+      expect(results.forall { case (_, _, isSub) => !isSub })
+    }
+  }
+
+  test("isSubsetQuorum is true when quorumSize < totalRequired") {
+    IO {
+      // Larger clusters where ceil(N * 0.67) < N
+      val cases = List(4, 10, 20) // ceil(4*0.67)=3, ceil(10*0.67)=7, ceil(20*0.67)=14
+      val results = cases.map { n =>
+        val quorumSize = math.ceil(n * 0.67).toInt.max(1)
+        val isSubsetQuorum = quorumSize < n
+        (n, quorumSize, isSubsetQuorum)
+      }
+      // For all these sizes, quorumSize < n, so isSubsetQuorum should be true
+      expect(results.forall { case (_, _, isSub) => isSub })
     }
   }
 
@@ -271,6 +330,43 @@ object QuorumDeclarationsSuite extends SimpleIOSuite with Checkers {
 
         expect(isSafe) && expect.same(majority1, majority2)
       }
+    }
+  }
+
+  // === quorumThreshold validation tests ===
+
+  test("quorumThreshold rejects values <= 0.5") {
+    IO {
+      val caught = scala.util.Try(testConfig.copy(quorumThreshold = Some(0.5)))
+      expect(caught.isFailure)
+    }
+  }
+
+  test("quorumThreshold rejects values > 1.0") {
+    IO {
+      val caught = scala.util.Try(testConfig.copy(quorumThreshold = Some(1.1)))
+      expect(caught.isFailure)
+    }
+  }
+
+  test("quorumThreshold accepts valid value 0.67") {
+    IO {
+      val config = testConfig.copy(quorumThreshold = Some(0.67))
+      expect(config.quorumThreshold.contains(0.67))
+    }
+  }
+
+  test("quorumThreshold accepts None (100% mode)") {
+    IO {
+      val config = testConfig.copy(quorumThreshold = None)
+      expect(config.quorumThreshold.isEmpty)
+    }
+  }
+
+  test("quorumThreshold accepts 1.0 (equivalent to 100%)") {
+    IO {
+      val config = testConfig.copy(quorumThreshold = Some(1.0))
+      expect(config.quorumThreshold.contains(1.0))
     }
   }
 }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/QuorumDeclarationsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/QuorumDeclarationsSuite.scala
@@ -1,0 +1,276 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus.state
+
+import cats.data.StateT
+import cats.effect.IO
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+import scala.concurrent.duration.FiniteDuration
+
+import io.constellationnetwork.ext.collection.FoldableOps.pickMajority
+import io.constellationnetwork.node.shared.config.types.{ConsensusConfig, EventCutterConfig}
+import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
+import io.constellationnetwork.node.shared.infrastructure.consensus.{ConsensusResources, PeerDeclarations}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
+
+import eu.timepit.refined.auto._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.{CheckConfig, Checkers}
+
+object QuorumDeclarationsSuite extends SimpleIOSuite with Checkers {
+
+  override def checkConfig: CheckConfig = CheckConfig.default.copy(minimumSuccessful = 40)
+
+  type Key = Int
+  type Artifact = Unit
+  type Context = Unit
+  type Status = Either[Unit, Unit]
+  type Outcome = Unit
+  type Kind = Unit
+
+  val testConfig: ConsensusConfig = ConsensusConfig(
+    timeTriggerInterval = FiniteDuration(30, "seconds"),
+    declarationTimeout = FiniteDuration(45, "seconds"),
+    declarationRangeLimit = 3L,
+    lockDuration = FiniteDuration(10, "seconds"),
+    eventCutter = EventCutterConfig(maxBinarySizeBytes = 1000000, maxUpdateNodeParametersSize = 1000000)
+  )
+
+  /** Minimal advancer exposing the protected quorum method for testing */
+  class TestAdvancer(quorumThreshold: Option[Double]) extends ConsensusStateAdvancer[IO, Key, Artifact, Context, Status, Outcome, Kind] {
+
+    override protected def clusterStorage: ClusterStorage[IO] = ???
+
+    override protected val config: ConsensusConfig = testConfig.copy(quorumThreshold = quorumThreshold)
+
+    override def getConsensusOutcome(
+      state: ConsensusState[Key, Status, Outcome, Kind]
+    ): Option[(Previous[Key], Outcome)] = None
+
+    override def advanceStatus(
+      resources: ConsensusResources[Artifact, Kind]
+    ): StateT[IO, ConsensusState[Key, Status, Outcome, Kind], IO[Unit]] =
+      StateT.pure(IO.unit)
+
+    def testQuorumDeclarations[A](
+      state: ConsensusState[Key, Status, Outcome, Kind],
+      resources: ConsensusResources[Artifact, Kind]
+    )(getter: PeerDeclarations => Option[A]): IO[Option[SortedMap[PeerId, A]]] =
+      maybeGetQuorumDeclarations(state, resources)(getter)(identity)
+  }
+
+  def facilitatorsGen: Gen[List[PeerId]] =
+    Gen
+      .choose(10, 30)
+      .flatMap(size => Gen.containerOfN[Set, PeerId](size, arbitrary[PeerId]))
+      .map(_.toList.sorted)
+
+  def mkState(facilitators: List[PeerId]): ConsensusState[Key, Status, Outcome, Kind] =
+    ConsensusState(
+      key = 1,
+      lastOutcome = (),
+      facilitators = Facilitators(facilitators),
+      status = ().asLeft,
+      createdAt = FiniteDuration(0, "seconds"),
+      spreadAckKinds = Set.empty
+    )
+
+  /** Create resources where specified peers have declared (getter returns Some for them) */
+  def mkResources(declaringPeers: List[PeerId]): ConsensusResources[Artifact, Kind] = {
+    val declMap = declaringPeers.map(pid => (pid, PeerDeclarations.empty)).toMap
+    ConsensusResources(
+      peerDeclarationsMap = declMap,
+      acksMap = Map.empty,
+      withdrawalsMap = Map.empty,
+      ackKinds = Set.empty,
+      artifacts = Map.empty[Hash, Artifact],
+      updatedAt = FiniteDuration(10, "seconds")
+    )
+  }
+
+  /** Getter that returns Some(()) for any PeerDeclarations entry (simulates "has declared") */
+  val alwaysDeclared: PeerDeclarations => Option[Unit] = _ => Some(())
+
+  test("quorum threshold 0.67 with 20 facilitators requires 14") {
+    IO {
+      val quorumSize = math.ceil(20 * 0.67).toInt.max(1)
+      expect.same(14, quorumSize)
+    }
+  }
+
+  test("quorum threshold 0.67 with 3 facilitators requires 3") {
+    IO {
+      // ceil(3 * 0.67) = ceil(2.01) = 3
+      val quorumSize = math.ceil(3 * 0.67).toInt.max(1)
+      expect.same(3, quorumSize)
+    }
+  }
+
+  test("quorum threshold 0.67 with 1 facilitator requires 1") {
+    IO {
+      val quorumSize = math.ceil(1 * 0.67).toInt.max(1)
+      expect.same(1, quorumSize)
+    }
+  }
+
+  test("returns None when declarations < quorum") {
+    forall(facilitatorsGen) { facilitators =>
+      val threshold = 0.67
+      val quorumSize = math.ceil(facilitators.size * threshold).toInt.max(1)
+      val declaringPeers = facilitators.take(quorumSize - 1)
+
+      val advancer = new TestAdvancer(Some(threshold))
+      val state = mkState(facilitators)
+      val resources = mkResources(declaringPeers)
+
+      advancer.testQuorumDeclarations(state, resources)(alwaysDeclared).map { result =>
+        expect(result.isEmpty)
+      }
+    }
+  }
+
+  test("returns Some when declarations >= quorum") {
+    forall(facilitatorsGen) { facilitators =>
+      val threshold = 0.67
+      val quorumSize = math.ceil(facilitators.size * threshold).toInt.max(1)
+      val declaringPeers = facilitators.take(quorumSize)
+
+      val advancer = new TestAdvancer(Some(threshold))
+      val state = mkState(facilitators)
+      val resources = mkResources(declaringPeers)
+
+      advancer.testQuorumDeclarations(state, resources)(alwaysDeclared).map { result =>
+        expect(result.isDefined) && expect.same(quorumSize, result.get.size)
+      }
+    }
+  }
+
+  test("with threshold = None, requires 100% (backward compatible)") {
+    forall(facilitatorsGen) { facilitators =>
+      // All but one declare — should NOT meet 100% threshold
+      val declaringPeers = facilitators.drop(1)
+
+      val advancer = new TestAdvancer(None)
+      val state = mkState(facilitators)
+      val resources = mkResources(declaringPeers)
+
+      advancer.testQuorumDeclarations(state, resources)(alwaysDeclared).map { result =>
+        expect(result.isEmpty)
+      }
+    }
+  }
+
+  test("returns all received declarations, not just quorum-size subset") {
+    forall(facilitatorsGen) { facilitators =>
+      val advancer = new TestAdvancer(Some(0.67))
+      val state = mkState(facilitators)
+      // All facilitators declare
+      val resources = mkResources(facilitators)
+
+      advancer.testQuorumDeclarations(state, resources)(alwaysDeclared).map { result =>
+        expect(result.isDefined) && expect.same(facilitators.size, result.get.size)
+      }
+    }
+  }
+
+  test("quorum determinism: any two quorum-size subsets yield same pickMajority result") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val n = facilitators.size
+        val threshold = 0.67
+        val quorumSize = math.ceil(n * threshold).toInt.max(1)
+
+        // Supermajority holds value "A", rest holds "B"
+        val values = facilitators.take(quorumSize).map(_ => "A") ++
+          facilitators.drop(quorumSize).map(_ => "B")
+
+        // Two different quorum-size windows
+        val subset1 = values.take(quorumSize)
+        val subset2 = values.drop(n - quorumSize)
+
+        val majority1 = pickMajority(subset1)
+        val majority2 = pickMajority(subset2)
+
+        expect.same(majority1, majority2)
+      }
+    }
+  }
+
+  // === Safe quorum (supermajority safety gate) tests ===
+
+  /** Simulates the safety gate logic from maybeGetSafeQuorumDeclarations */
+  def safeQuorumCheck[V](
+    totalFacilitators: Int,
+    threshold: Double,
+    values: List[V]
+  ): Option[List[V]] = {
+    val quorumSize = math.ceil(totalFacilitators * threshold).toInt.max(1)
+    val receivedCount = values.size
+    if (receivedCount >= quorumSize) {
+      val maxSupport = values.groupBy(identity).values.map(_.size).maxOption.getOrElse(0)
+      if (maxSupport >= quorumSize) Some(values)
+      else None
+    } else None
+  }
+
+  test("safeMajority passes when majority has quorum support") {
+    IO {
+      // 14 out of 20 agree on "A", 6 on "B"
+      val values = List.fill(14)("A") ++ List.fill(6)("B")
+      val result = safeQuorumCheck(20, 0.67, values)
+      // quorumSize = ceil(20 * 0.67) = 14, maxSupport = 14 >= 14 → passes
+      expect(result.isDefined)
+    }
+  }
+
+  test("safeMajority blocks when no value has quorum support") {
+    IO {
+      // 8 vs 6 split — neither reaches quorum of 14
+      val values = List.fill(8)("A") ++ List.fill(6)("B")
+      val result = safeQuorumCheck(20, 0.67, values)
+      // receivedCount = 14 >= quorumSize = 14, but maxSupport = 8 < 14 → blocks
+      expect(result.isEmpty)
+    }
+  }
+
+  test("safeMajority with all-same values always passes") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val n = facilitators.size
+        val threshold = 0.67
+        val quorumSize = math.ceil(n * threshold).toInt.max(1)
+        // All facilitators vote the same
+        val values = List.fill(n)("unanimous")
+        val result = safeQuorumCheck(n, threshold, values)
+        expect(result.isDefined)
+      }
+    }
+  }
+
+  test("safeMajority determinism: safe majority guarantees same pickMajority across quorum views") {
+    forall(facilitatorsGen) { facilitators =>
+      IO {
+        val n = facilitators.size
+        val threshold = 0.67
+        val quorumSize = math.ceil(n * threshold).toInt.max(1)
+
+        // Value "A" has exactly quorumSize support (safe)
+        val values = List.fill(quorumSize)("A") ++ List.fill(n - quorumSize)("B")
+
+        // Verify safety gate passes
+        val isSafe = safeQuorumCheck(n, threshold, values).isDefined
+
+        // Any two quorum-size subsets must agree
+        val subset1 = values.take(quorumSize)
+        val subset2 = values.drop(n - quorumSize)
+        val majority1 = pickMajority(subset1)
+        val majority2 = pickMajority(subset2)
+
+        expect(isSafe) && expect.same(majority1, majority2)
+      }
+    }
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdateSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdateSuite.scala
@@ -130,4 +130,106 @@ object UnlockConsensusUpdateSuite extends SimpleIOSuite with Checkers {
     Gen.listOfN(facilitators.size, Gen.someOf(facilitators).map(_.toSet)).map { acksSet =>
       facilitators.map(peerId => (peerId, ())).zip(acksSet).toMap
     }
+
+  // === Adaptive tiered threshold tests ===
+
+  /** Simulates threshold tier selection logic from UnlockConsensusUpdate */
+  def computeThresholds(n: Int, voterCount: Int): Option[(Int, Int)] = {
+    val degradedQuorum = math.ceil(n.toDouble / 5).toInt.max(2)
+    val standardQuorum = math.ceil(n.toDouble / 3).toInt.max(2)
+    val normalKeepThreshold = (n + 1) / 2
+
+    val superThreshold = math.ceil(voterCount.toDouble * 2 / 3).toInt.max(1)
+    if (voterCount < degradedQuorum) none
+    else if (voterCount < standardQuorum) (superThreshold, superThreshold).some
+    else if (voterCount < normalKeepThreshold) ((voterCount + 1) / 2, voterCount / 2 + 1).some
+    else (normalKeepThreshold, n / 2 + 1).some
+  }
+
+  test("DEFER: no thresholds when voterCount < degradedQuorum") {
+    cats.effect.IO {
+      val n = 20
+      val voterCount = 3
+      val result = computeThresholds(n, voterCount)
+      // degradedQuorum = ceil(20/5) = 4, voterCount = 3 < 4 → DEFER
+      expect(result.isEmpty)
+    }
+  }
+
+  test("DEGRADED: 2/3 supermajority of voters required") {
+    cats.effect.IO {
+      val n = 20
+      val voterCount = 5
+      val result = computeThresholds(n, voterCount)
+      // degradedQuorum = 4, standardQuorum = 7, 4 <= 5 < 7 → DEGRADED
+      // superThreshold = ceil(5 * 2/3) = ceil(3.33) = 4
+      expect(result.isDefined) &&
+      expect.same((4, 4), result.get)
+    }
+  }
+
+  test("FALLBACK: simple majority of voters suffices") {
+    cats.effect.IO {
+      val n = 20
+      val voterCount = 8
+      val result = computeThresholds(n, voterCount)
+      // standardQuorum = 7, normalKeepThreshold = 10, 7 <= 8 < 10 → FALLBACK
+      // keepThreshold = (8+1)/2 = 4, removeThreshold = 8/2 + 1 = 5
+      expect(result.isDefined) &&
+      expect.same((4, 5), result.get)
+    }
+  }
+
+  test("NORMAL: standard thresholds based on total facilitator count") {
+    cats.effect.IO {
+      val n = 20
+      val voterCount = 15
+      val result = computeThresholds(n, voterCount)
+      // normalKeepThreshold = 10, 15 >= 10 → NORMAL
+      // keepThreshold = 10, removeThreshold = 11
+      expect(result.isDefined) &&
+      expect.same((10, 11), result.get)
+    }
+  }
+
+  test("tier transitions are deterministic for same inputs") {
+    forall(Gen.choose(5, 100)) { n =>
+      forall(Gen.choose(0, n)) { voterCount =>
+        cats.effect.IO {
+          val t1 = computeThresholds(n, voterCount)
+          val t2 = computeThresholds(n, voterCount)
+          expect.same(t1, t2)
+        }
+      }
+    }
+  }
+
+  test("DEFER prevents unlock when too few facilitators voted") {
+    forall(facilitatorsGen) { facilitators =>
+      val n = facilitators.size
+      val degradedQuorum = math.ceil(n.toDouble / 5).toInt.max(2)
+      val tooFewVoters = math.max(1, degradedQuorum - 1)
+
+      val voters = facilitators.take(tooFewVoters)
+      val acksMap: Map[(PeerId, Kind), Set[PeerId]] =
+        voters.map(peerId => ((peerId, ()), facilitators.toSet)).toMap
+
+      val stateGen = lockedStateGen(facilitators)
+      forall(stateGen) { state =>
+        val resources = ConsensusResources(
+          peerDeclarationsMap = Map.empty,
+          acksMap = acksMap,
+          withdrawalsMap = Map.empty,
+          ackKinds = Set.empty,
+          artifacts = Map.empty[Hash, Artifact],
+          updatedAt = FiniteDuration(10, "seconds")
+        )
+
+        unlockConsensusFn(resources).run(state).map {
+          case (resultState, _) =>
+            expect(resultState.lockStatus === LockStatus.Closed)
+        }
+      }
+    }
+  }
 }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdateSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdateSuite.scala
@@ -8,6 +8,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus._
 import io.constellationnetwork.node.shared.infrastructure.consensus.state._
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
@@ -82,9 +83,14 @@ object UnlockConsensusUpdateSuite extends SimpleIOSuite with Checkers {
       case (initialState, resources) =>
         unlockConsensusFn(resources).run(initialState).map {
           case (state, _) =>
-            expect(state.lockStatus === LockStatus.Reopened) &&
-            expect(state.removedFacilitators.value.union(state.facilitators.value.toSet) === initialState.facilitators.value.toSet) &&
-            expect(state.removedFacilitators.value.intersect(state.facilitators.value.toSet) === Set.empty)
+            if (state.lockStatus === LockStatus.Closed) {
+              // MinFacilitatorCount guard may abort unlock if too few peers would survive
+              expect.same(initialState, state)
+            } else {
+              expect(state.lockStatus === LockStatus.Reopened) &&
+              expect(state.removedFacilitators.value.union(state.facilitators.value.toSet) === initialState.facilitators.value.toSet) &&
+              expect(state.removedFacilitators.value.intersect(state.facilitators.value.toSet) === Set.empty)
+            }
         }
     }
   }
@@ -131,84 +137,136 @@ object UnlockConsensusUpdateSuite extends SimpleIOSuite with Checkers {
       facilitators.map(peerId => (peerId, ())).zip(acksSet).toMap
     }
 
-  // === Adaptive tiered threshold tests ===
+  // === N-based threshold tests ===
 
-  /** Simulates threshold tier selection logic from UnlockConsensusUpdate */
+  /** Simulates threshold selection logic from UnlockConsensusUpdate */
   def computeThresholds(n: Int, voterCount: Int): Option[(Int, Int)] = {
-    val degradedQuorum = math.ceil(n.toDouble / 5).toInt.max(2)
-    val standardQuorum = math.ceil(n.toDouble / 3).toInt.max(2)
-    val normalKeepThreshold = (n + 1) / 2
+    val minVotersRequired = math.ceil(n.toDouble / 3).toInt.max(2)
+    val keepThreshold = (n + 1) / 2
+    val removeThreshold = n / 2 + 1
 
-    val superThreshold = math.ceil(voterCount.toDouble * 2 / 3).toInt.max(1)
-    if (voterCount < degradedQuorum) none
-    else if (voterCount < standardQuorum) (superThreshold, superThreshold).some
-    else if (voterCount < normalKeepThreshold) ((voterCount + 1) / 2, voterCount / 2 + 1).some
-    else (normalKeepThreshold, n / 2 + 1).some
+    if (voterCount < minVotersRequired) none
+    else (keepThreshold, removeThreshold).some
   }
 
-  test("DEFER: no thresholds when voterCount < degradedQuorum") {
+  test("DEFER: no thresholds when voterCount < minVotersRequired") {
     cats.effect.IO {
       val n = 20
-      val voterCount = 3
+      val voterCount = 6
       val result = computeThresholds(n, voterCount)
-      // degradedQuorum = ceil(20/5) = 4, voterCount = 3 < 4 → DEFER
+      // minVotersRequired = ceil(20/3) = 7, voterCount = 6 < 7 → DEFER
       expect(result.isEmpty)
     }
   }
 
-  test("DEGRADED: 2/3 supermajority of voters required") {
-    cats.effect.IO {
-      val n = 20
-      val voterCount = 5
-      val result = computeThresholds(n, voterCount)
-      // degradedQuorum = 4, standardQuorum = 7, 4 <= 5 < 7 → DEGRADED
-      // superThreshold = ceil(5 * 2/3) = ceil(3.33) = 4
-      expect(result.isDefined) &&
-      expect.same((4, 4), result.get)
-    }
-  }
-
-  test("FALLBACK: simple majority of voters suffices") {
-    cats.effect.IO {
-      val n = 20
-      val voterCount = 8
-      val result = computeThresholds(n, voterCount)
-      // standardQuorum = 7, normalKeepThreshold = 10, 7 <= 8 < 10 → FALLBACK
-      // keepThreshold = (8+1)/2 = 4, removeThreshold = 8/2 + 1 = 5
-      expect(result.isDefined) &&
-      expect.same((4, 5), result.get)
-    }
-  }
-
-  test("NORMAL: standard thresholds based on total facilitator count") {
+  test("thresholds are N-based (deterministic) when enough voters") {
     cats.effect.IO {
       val n = 20
       val voterCount = 15
       val result = computeThresholds(n, voterCount)
-      // normalKeepThreshold = 10, 15 >= 10 → NORMAL
-      // keepThreshold = 10, removeThreshold = 11
+      // keepThreshold = (20+1)/2 = 10, removeThreshold = 20/2 + 1 = 11
       expect(result.isDefined) &&
       expect.same((10, 11), result.get)
     }
   }
 
-  test("tier transitions are deterministic for same inputs") {
+  test("keepThreshold + removeThreshold > N guarantees mutual exclusivity") {
+    forall(Gen.choose(5, 100)) { n =>
+      cats.effect.IO {
+        val keepThreshold = (n + 1) / 2
+        val removeThreshold = n / 2 + 1
+        expect(keepThreshold + removeThreshold > n)
+      }
+    }
+  }
+
+  test("thresholds are deterministic for same N regardless of voterCount") {
     forall(Gen.choose(5, 100)) { n =>
       forall(Gen.choose(0, n)) { voterCount =>
         cats.effect.IO {
           val t1 = computeThresholds(n, voterCount)
           val t2 = computeThresholds(n, voterCount)
-          expect.same(t1, t2)
+          // Thresholds are same for same inputs
+          expect.same(t1, t2) &&
+          // When not deferred, thresholds depend only on n (not voterCount)
+          t1.map { case (k, r) => expect.same((n + 1) / 2, k) && expect.same(n / 2 + 1, r) }.getOrElse(expect(true))
         }
       }
+    }
+  }
+
+  test("MinFacilitatorCount: unlock aborted when all facilitators would be removed") {
+    // Simulates a global latency spike where every node's ACK contains an empty set
+    // (no declarations arrived before lock). All peers get max removeVotes → keptFacilitators=0.
+    // The MinFacilitatorCount guard must prevent this from producing facilitatorCount=0.
+    forall(Gen.choose(3, 20)) { n =>
+      val facilitators = (1 to n).map(i => PeerId(Hex(f"$i%040x"))).toList.sorted
+      // Every voter ACKs with empty set (nobody declared)
+      val acksMap: Map[(PeerId, Kind), Set[PeerId]] =
+        facilitators.map(peerId => ((peerId, ()), Set.empty[PeerId])).toMap
+
+      val stateGen = lockedStateGen(facilitators)
+      forall(stateGen) { state =>
+        val resources = ConsensusResources(
+          peerDeclarationsMap = Map.empty,
+          acksMap = acksMap,
+          withdrawalsMap = Map.empty,
+          ackKinds = Set.empty,
+          artifacts = Map.empty[Hash, Artifact],
+          updatedAt = FiniteDuration(10, "seconds")
+        )
+
+        unlockConsensusFn(resources).run(state).map {
+          case (resultState, _) =>
+            // Must stay Closed — unlock aborted because keptFacilitators < MinFacilitatorCount
+            expect(resultState.lockStatus === LockStatus.Closed) &&
+            expect(resultState.facilitators.value.size === n)
+        }
+      }
+    }
+  }
+
+  test("MinFacilitatorCount: unlock proceeds when enough facilitators survive") {
+    // Half the facilitators are vouched for, half aren't. keptFacilitators > MinFacilitatorCount.
+    val n = 8
+    val facilitators = (1 to n).map(i => PeerId(Hex(f"$i%040x"))).toList.sorted
+    val keptSet = facilitators.take(n / 2).toSet // 4 peers vouched for by everyone
+    // Every voter ACKs with the kept set
+    val acksMap: Map[(PeerId, Kind), Set[PeerId]] =
+      facilitators.map(peerId => ((peerId, ()), keptSet)).toMap
+
+    val state: ConsensusState[Key, Status, Outcome, Kind] = ConsensusState(
+      key = 1,
+      lastOutcome = (),
+      facilitators = Facilitators(facilitators),
+      status = ().asLeft[Unit],
+      createdAt = FiniteDuration(10, "seconds"),
+      lockStatus = LockStatus.Closed,
+      spreadAckKinds = Set.empty
+    )
+
+    val resources = ConsensusResources(
+      peerDeclarationsMap = Map.empty,
+      acksMap = acksMap,
+      withdrawalsMap = Map.empty,
+      ackKinds = Set.empty,
+      artifacts = Map.empty[Hash, Artifact],
+      updatedAt = FiniteDuration(10, "seconds")
+    )
+
+    unlockConsensusFn(resources).run(state).map {
+      case (resultState, _) =>
+        expect(resultState.lockStatus === LockStatus.Reopened) &&
+        expect(resultState.facilitators.value.size === n / 2) &&
+        expect(resultState.facilitators.value.size >= UnlockConsensusUpdate.MinFacilitatorCount)
     }
   }
 
   test("DEFER prevents unlock when too few facilitators voted") {
     forall(facilitatorsGen) { facilitators =>
       val n = facilitators.size
-      val degradedQuorum = math.ceil(n.toDouble / 5).toInt.max(2)
-      val tooFewVoters = math.max(1, degradedQuorum - 1)
+      val minVotersRequired = math.ceil(n.toDouble / 3).toInt.max(2)
+      val tooFewVoters = math.max(1, minVotersRequired - 1)
 
       val voters = facilitators.take(tooFewVoters)
       val acksMap: Map[(PeerId, Kind), Set[PeerId]] =

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/cluster.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/cluster.scala
@@ -94,6 +94,7 @@ object cluster {
   case object MetagraphVersionMismatch extends RegistrationRequestValidation
   case object MetagraphIdMismatch extends RegistrationRequestValidation
   case object EnvMismatch extends RegistrationRequestValidation
+  case object ConsensusConfigMismatch extends RegistrationRequestValidation
 
   trait ClusterVerificationResult extends NoStackTrace
   case object ClusterIdDoesNotMatch extends ClusterVerificationResult

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/peer.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/peer.scala
@@ -180,7 +180,8 @@ object peer {
     jar: Hash,
     environment: AppEnvironment,
     allowanceList: Hash,
-    metagraphId: Option[Address]
+    metagraphId: Option[Address],
+    consensusConfigHash: Option[Hash] = None
   )
 
   @derive(eqv, decoder, encoder, show)


### PR DESCRIPTION
Refactor the consensus engine to improve stall recovery, quorum safety, and facilitator selection. Peers removed during stall recovery are now excluded for a configurable number of rounds (removal-penalty-rounds=3), preventing repeated stalls from unresponsive peers being re-selected.

Key changes:

Safe quorum with supermajority gate in ConsensusStateAdvancer
Adaptive tiered unlock thresholds (DEFER/DEGRADED/FALLBACK/NORMAL)
Eligible facilitator re-entry after removal (no permanent exclusion)
Deterministic multi-round removal penalty via consensus outcome
Per-round fiber lifecycle tracking to prevent orphaned fibers
Atomic PendingTriggers to fix race condition losing triggers
