### PR TITLE
fix: MinFacilitatorCount safety floor to prevent facilitatorCount=0 on unlock

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdate.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/update/UnlockConsensusUpdate.scala
@@ -25,6 +25,11 @@ import monocle.Lens
   */
 object UnlockConsensusUpdate {
 
+  /** Minimum number of facilitators that must survive an unlock. If the voting result would leave fewer than this many peers, the unlock is
+    * aborted and deferred to the stall detector (which will either retry ACKs or abandon the round after maxStallCycles).
+    */
+  val MinFacilitatorCount: Int = 2
+
   def tryUnlock[F[_]: Monad, S, K](acksMap: Map[(PeerId, K), Set[PeerId]])(maybeCollectingKind: S => Option[K])(
     implicit _lockStatus: Lens[S, LockStatus],
     _facilitators: Lens[S, Facilitators],
@@ -72,6 +77,8 @@ object UnlockConsensusUpdate {
             _.partitionMap {
               case (peerId, decision) => Either.cond(decision, peerId, peerId)
             }
+          }.filter {
+            case (_, keptFacilitators) => keptFacilitators.size >= MinFacilitatorCount
           }.map {
             case (removedFacilitators, keptFacilitators) =>
               val updateState =


### PR DESCRIPTION
## Minimal fix for facilitatorCount=0 bug

### Problem

Global latency spike → stale ACKs with empty declaration sets → unlock removes ALL facilitators → `facilitatorCount=0` → irrecoverable cluster death.

**Reproducible on current develop** with 20s global latency on an 8-node cluster. This is a mainnet risk.

### Fix

3 lines added to `UnlockConsensusUpdate.scala`:

```scala
val MinFacilitatorCount: Int = 2

.filter {
  case (_, keptFacilitators) => keptFacilitators.size >= MinFacilitatorCount
}
```

If the voting result would leave fewer than 2 facilitators, the unlock is aborted. State stays `Closed`, deferred to stall detector (retry ACKs or abandon after `maxStallCycles`).

### Testing

| Scenario | Before | After |
|----------|--------|-------|
| 20s global latency then clear | fac=0 (100% repro) | fac stays, round deferred |
| Majority partition then restore | fac=0 | fac stays |
| 60s spike on 6/8 then clear | fac=0 | fac stays |

### Scope

- 1 file, 3 lines of logic + ScalaDoc
- No config changes, no protocol changes, backward compatible
- Standalone fix — no dependency on `feat/refactoring-consensus`