### PR TITLE
feat: expand local cluster cap from 3 to 9 nodes

### DIFF
--- a/docker/bin/cluster-health-check.sh
+++ b/docker/bin/cluster-health-check.sh
@@ -61,7 +61,7 @@ verify_healthy() {
     fi
   else
     # Local docker: check each node using port prefix pattern
-    for i in "0" "1" "2"; do
+    for i in $(seq 0 $((MAX_NODES - 1))); do
         l0_url="${host}:${DAG_L0_PORT_PREFIX}${i}0"
         l1_url="${host}:${DAG_L1_PORT_PREFIX}${i}0"
         ml0_url="${host}:${ML0_PORT_PREFIX}${i}0"

--- a/docker/bin/compose-runner.sh
+++ b/docker/bin/compose-runner.sh
@@ -117,7 +117,7 @@ else
     echo "removed config, $PROJECT_ROOT/nodes"
   fi
 
-  for i in 0 1 2; do
+  for i in $(seq 0 $((MAX_NODES - 1))); do
     mkdir -p ./nodes/$i
   done
 
@@ -142,7 +142,7 @@ else
     tessellation_common
 
   # Phase 1: Setup compose files and start GL0 nodes
-  for i in 0 1 2; do
+  for i in $(seq 0 $((MAX_NODES - 1))); do
     cd ./nodes/$i/
 
     docker compose -f docker-compose.test.yaml \
@@ -196,7 +196,7 @@ else
   fi
 
   # Phase 2: Start GL1 nodes (GL0 is now ready for peer discovery)
-  for i in 0 1 2; do
+  for i in $(seq 0 $((MAX_NODES - 1))); do
     cd ./nodes/$i/
 
     if [ "$i" -lt "$NUM_GL1_NODES" ]; then
@@ -239,7 +239,7 @@ else
     metagraph_args="-f docker-compose.metagraph.yaml -f docker-compose.metagraph-test.yaml"
 
     # Phase 1: Genesis creation, set METAGRAPH_ID, and start ML0
-    for i in 0 1 2; do
+    for i in $(seq 0 $((MAX_NODES - 1))); do
       cd ./nodes/$i/
 
       if [ ! -f "./genesis.snapshot" ] && [ "$i" -eq 0 ]; then
@@ -291,7 +291,7 @@ else
     fi
 
     # Phase 2: Start CL1/DL1 services (ML0 is now ready)
-    for i in 0 1 2; do
+    for i in $(seq 0 $((MAX_NODES - 1))); do
       cd ./nodes/$i/
 
       l1_profile_args=""

--- a/docker/bin/docker-env-setup.sh
+++ b/docker/bin/docker-env-setup.sh
@@ -76,7 +76,7 @@ if env | grep -q "^CL_TEST_"; then
   done
 fi
 
-for i in 0 1 2; do
+for i in $(seq 0 $((MAX_NODES - 1))); do
   cp ./nodes/.env ./nodes/$i/.env
   cp ./nodes/.envrc ./nodes/$i/.envrc
 done
@@ -105,7 +105,7 @@ cd ../../
 
 
 
-for i in 0 1 2; do
+for i in $(seq 0 $((MAX_NODES - 1))); do
   cd ./nodes/$i
 
   # if i != 0:

--- a/docker/bin/node-key-env-setup.sh
+++ b/docker/bin/node-key-env-setup.sh
@@ -19,13 +19,13 @@ export CL_CLI_HTTP_PORT=9000
 EOF
 
 
-for i in 0 1 2; do
+for i in $(seq 0 $((MAX_NODES - 1))); do
   cp ./nodes/.envrc ./nodes/$i/.envrc
 done
 
 generate_keys() {
 
-  for i in 0 1 2; do
+  for i in $(seq 0 $((MAX_NODES - 1))); do
     mkdir -p ./nodes/$i
     cd ./nodes/$i/
 
@@ -59,8 +59,47 @@ generate_keys() {
 
 }
 
+generate_missing_keys() {
+  # Generate keys for any node index that doesn't already have pre-generated keys
+  for i in $(seq 0 $((MAX_NODES - 1))); do
+    if [ ! -f "./docker/config/local-test-keys/$i/key.p12" ]; then
+      echo "Generating keys for node $i (not found in local-test-keys)"
+      mkdir -p ./nodes/$i
+      cd ./nodes/$i/
+      cp ../0/.envrc .envrc 2>/dev/null || cp ../../nodes/.envrc .envrc
+
+      out=$(
+        source .envrc
+        java -jar ../keytool.jar generate
+      )
+
+      ret_addr=$(
+        source .envrc
+        java -jar ../wallet.jar show-address
+      )
+      echo "$ret_addr" > address
+      id=$(
+        source .envrc
+        java -jar ../wallet.jar show-id
+      )
+      export=$(
+        source .envrc
+        java -jar ../keytool.jar export
+      )
+
+      echo "$id" > peer_id
+      mkdir -p ../../docker/config/local-test-keys/$i
+      cp key.p12 ../../docker/config/local-test-keys/$i
+      cp address ../../docker/config/local-test-keys/$i
+      cp peer_id ../../docker/config/local-test-keys/$i
+      cp id_ecdsa.hex ../../docker/config/local-test-keys/$i
+      cd ../../
+    fi
+  done
+}
+
 populate_test_keys() {
-  for i in 0 1 2; do
+  for i in $(seq 0 $((MAX_NODES - 1))); do
     cp ./docker/config/local-test-keys/$i/key.p12 ./nodes/$i/key.p12
     cp ./docker/config/local-test-keys/$i/address ./nodes/$i/address
     cp ./docker/config/local-test-keys/$i/peer_id ./nodes/$i/peer_id
@@ -68,26 +107,22 @@ populate_test_keys() {
   done
   GENESIS_DIR=$PROJECT_ROOT/.github/code/hypergraph/dag-l0/genesis-node
   mkdir -p $GENESIS_DIR
-  VALIDATOR_1_DIR=$PROJECT_ROOT/.github/code/hypergraph/dag-l0/validator-1
-  VALIDATOR_2_DIR=$PROJECT_ROOT/.github/code/hypergraph/dag-l0/validator-2
-  mkdir -p $VALIDATOR_1_DIR
-  mkdir -p $VALIDATOR_2_DIR
   cp ./nodes/0/id_ecdsa.hex $GENESIS_DIR/id_ecdsa.hex
-  cp ./nodes/1/id_ecdsa.hex $VALIDATOR_1_DIR/id_ecdsa.hex
-  cp ./nodes/2/id_ecdsa.hex $VALIDATOR_2_DIR/id_ecdsa.hex
 
-  # Alternative for overriding github checked in keys if needed
-  # DELEGATED_STAKING_KEYS_DIR=$PROJECT_ROOT/.github/action_scripts/delegated_staking/keys
-  # mkdir -p $DELEGATED_STAKING_KEYS_DIR
-  # cp ./nodes/0/id_ecdsa.hex $DELEGATED_STAKING_KEYS_DIR/genesis-node.hex
-  # cp ./nodes/1/id_ecdsa.hex $DELEGATED_STAKING_KEYS_DIR/validator-1-node.hex
-  # cp ./nodes/2/id_ecdsa.hex $DELEGATED_STAKING_KEYS_DIR/validator-2-node.hex
-
+  # Copy validator keys for all non-genesis nodes
+  for i in $(seq 1 $((MAX_NODES - 1))); do
+    VALIDATOR_DIR=$PROJECT_ROOT/.github/code/hypergraph/dag-l0/validator-$i
+    mkdir -p $VALIDATOR_DIR
+    cp ./nodes/$i/id_ecdsa.hex $VALIDATOR_DIR/id_ecdsa.hex
+  done
 }
 
 
 if [ "$REGENERATE_TEST_KEYS" = true ]; then
   generate_keys
 fi
+
+# Generate keys for any nodes beyond the pre-generated set (0-2)
+generate_missing_keys
 
 populate_test_keys

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -376,6 +376,18 @@ if [ -n "$METAGRAPH" ]; then
     fi
 fi
 
+# Compute MAX_NODES as the maximum of all NUM_*_NODES values (capped at 10)
+# This drives how many node directories, keys, and configs are created
+_max_of() { [ "$1" -gt "$2" ] && echo "$1" || echo "$2"; }
+MAX_NODES=$(_max_of ${NUM_GL0_NODES:-0} ${NUM_GL1_NODES:-0})
+MAX_NODES=$(_max_of $MAX_NODES ${NUM_ML0_NODES:-0})
+MAX_NODES=$(_max_of $MAX_NODES ${NUM_CL1_NODES:-0})
+MAX_NODES=$(_max_of $MAX_NODES ${NUM_DL1_NODES:-0})
+# Ensure at least 3 (legacy default) and at most 9 (single-digit IP/port offset limit)
+MAX_NODES=$(_max_of $MAX_NODES 3)
+[ "$MAX_NODES" -gt 9 ] && MAX_NODES=9
+export MAX_NODES
+
 # Layer URLs: explicit overrides take priority, otherwise built from TEST_HOST + port prefix
 # When using a remote host, GL1 defaults to port 9010 instead of 9100
 if [ "$TEST_HOST" != "http://localhost" ]; then

--- a/docker/bin/tessellation-docker-cleanup.sh
+++ b/docker/bin/tessellation-docker-cleanup.sh
@@ -16,7 +16,7 @@ cleanup_container() {
 }
 
 cleanup() {
-    for i in 0 1 2; do
+    for i in $(seq 0 9); do
         cleanup_container gl0-$i gl0-data-$i &
         cleanup_container gl1-$i gl1-data-$i &
         cleanup_container dl1-$i dl1-data-$i &


### PR DESCRIPTION
Replace hardcoded `for i in 0 1 2` loops with dynamic `seq 0 \$((MAX_NODES-1))` across docker scripts. `MAX_NODES` computed from `NUM_*_NODES` values, capped at 9.

### Changes
- `set-env.sh`: compute MAX_NODES
- `node-key-env-setup.sh`: generate keys for nodes beyond 0-2
- `compose-runner.sh`: dynamic iteration for all phases
- `docker-env-setup.sh`: env files for all nodes
- `cluster-health-check.sh`: check all nodes
- `tessellation-docker-cleanup.sh`: cleanup up to 9

### Usage
```bash
bash docker/bin/compose-runner.sh --up --num-gl0=8
```

Docker-only changes, no Scala code.