### PR TITLE
fix: address ryle-ai review feedback on PR #1476 (WaitingForObserving + TOCTOU)

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/ForkRecoveryService.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/ForkRecoveryService.scala
@@ -39,6 +39,7 @@ object ForkRecoveryService {
         nodeStorage.getNodeState.flatMap { currentState =>
           if (
             currentState === NodeState.Observing ||
+            currentState === NodeState.WaitingForObserving ||
             currentState === NodeState.DownloadInProgress ||
             currentState === NodeState.WaitingForDownload
           ) {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/mempool/EventMempool.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/mempool/EventMempool.scala
@@ -184,42 +184,29 @@ object EventMempool {
 
       def add(event: Signed[Event]): F[Either[MempoolRejectionReason, MempoolEntry[Event, Key]]] =
         for {
-          currentSize <- size
-          result <- (currentSize < config.maxSize)
-            .pure[F]
-            .ifM(
-              ifTrue = doAdd(event),
-              ifFalse = (MempoolRejectionReason.MempoolFull: MempoolRejectionReason).asLeft[MempoolEntry[Event, Key]].pure[F]
-            )
-        } yield result
-
-      private def doAdd(event: Signed[Event]): F[Either[MempoolRejectionReason, MempoolEntry[Event, Key]]] =
-        for {
           hashed <- event.toHashed
-          existing <- storage.get.map(_.entries.get(hashed.hash))
+          stateKeys <- keyExtractor.extractKeys(hashed.signed.value)
+          entry <- MempoolEntry(hashed, stateKeys)
+          result <- storage.modify { state =>
+            state.entries.get(hashed.hash) match {
+              case Some(existing) =>
+                // Duplicate: return existing entry without modifying state
+                (state, existing.asRight[MempoolRejectionReason])
 
-          result <- existing match {
-            case Some(entry) =>
-              entry.asRight[MempoolRejectionReason].pure[F]
+              case None if state.entries.size >= config.maxSize =>
+                // Mempool full: reject without modifying state
+                (state, (MempoolRejectionReason.MempoolFull: MempoolRejectionReason).asLeft[MempoolEntry[Event, Key]])
 
-            case None =>
-              processEvent(hashed)
+              case None =>
+                // New event: atomically insert
+                val newState = state.copy(
+                  entries = state.entries + (hashed.hash -> entry),
+                  insertionOrder = state.insertionOrder :+ hashed.hash
+                )
+                (newState, entry.asRight[MempoolRejectionReason])
+            }
           }
         } yield result
-
-      private def processEvent(
-        hashedEvent: Hashed[Event]
-      ): F[Either[MempoolRejectionReason, MempoolEntry[Event, Key]]] =
-        for {
-          stateKeys <- keyExtractor.extractKeys(hashedEvent.signed.value)
-          entry <- MempoolEntry(hashedEvent, stateKeys)
-          _ <- storage.update { state =>
-            state.copy(
-              entries = state.entries + (hashedEvent.hash -> entry),
-              insertionOrder = state.insertionOrder :+ hashedEvent.hash
-            )
-          }
-        } yield entry.asRight[MempoolRejectionReason]
 
       def get(hash: Hash): F[Option[Hashed[Event]]] =
         storage.get.map(_.entries.get(hash).map(_.hashed))


### PR DESCRIPTION
## Fixes for PR #1476 review feedback

Addresses the two correctness issues flagged by @ryle-ai:

### 1. WaitingForObserving missing from fork recovery suppression set

```
modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/ForkRecoveryService.scala
```

During fork recovery, the node passes through `WaitingForObserving` after download completes and before `observeWithLimit` finishes. Without this state in the suppression set:
- The gossip heartbeat hits neither branch, propagating `InvalidNodeStateTransition` through `runHeartbeat`, logging a misleading `Heartbeat iteration failed` error during every normal recovery cycle.
- If the heartbeat fires after `clearRecoveryDownload` at the tail of recovery, `setRecoveryDownload` is called again with no pending `WaitingForDownload` to consume it, leaving a stale `isRecovery=true`.

**Fix:** add `NodeState.WaitingForObserving` to the suppression check.

### 2. TOCTOU race in EventMempool.add

```
modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/mempool/EventMempool.scala
```

The previous read-then-write pattern (read size → read for duplicate → write) allowed concurrent `add` calls to all pass the size check before any insertion completed, exceeding `maxSize`. The duplicate check was also non-atomic.

**Fix:** hoist all effectful operations (hashing, key extraction, entry creation) before the `Ref`, then perform a single `storage.modify` that atomically checks for duplicates, checks capacity, and inserts.

---

@scasplte2 — these can be cherry-picked directly into the PR branch. The changes are minimal and self-contained.