### PR TITLE
fix: support configurable snapshot-streaming repo in E2E build

### DIFF
--- a/.github/workflows/e2e-just-test.yml
+++ b/.github/workflows/e2e-just-test.yml
@@ -16,6 +16,11 @@ on:
         description: 'snapshot-streaming branch to build from'
         required: false
         default: 'release/mainnet'
+      snapshot_streaming_repo:
+        type: string
+        description: 'snapshot-streaming GitHub repo (owner/repo) to clone from'
+        required: false
+        default: 'Constellation-Labs/snapshot-streaming'
       block_explorer_branch:
         type: string
         description: 'block_explorer branch for DB migrations'
@@ -66,7 +71,7 @@ jobs:
           sudo apt-get install -y sbt
 
       - name: Build all JARs
-        run: just build --use-test-metagraph --num-gl0=3 --snapshot-streaming-branch=${{ inputs.snapshot_streaming_branch || 'testing' }} --block-explorer-branch=${{ inputs.block_explorer_branch || 'increase_delegated_stakes' }}
+        run: just build --use-test-metagraph --num-gl0=3 --snapshot-streaming-branch=${{ inputs.snapshot_streaming_branch || 'testing' }} --snapshot-streaming-repo=${{ inputs.snapshot_streaming_repo || 'ottobot-ai/snapshot-streaming' }} --block-explorer-branch=${{ inputs.block_explorer_branch || 'increase_delegated_stakes' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -166,7 +171,7 @@ jobs:
         run: mkdir -p runner-logs
 
       - name: Run E2E tests
-        run: just test --skip-assembly --test=${{ matrix.test-group.tests }} ${{ matrix.test-group.extra-args || '' }} ${{ matrix.test-group.name == 'snapshot-streaming' && format('--snapshot-streaming-branch={0} --block-explorer-branch={1}', inputs.snapshot_streaming_branch || 'testing', inputs.block_explorer_branch || 'increase_delegated_stakes') || '' }}
+        run: just test --skip-assembly --test=${{ matrix.test-group.tests }} ${{ matrix.test-group.extra-args || '' }} ${{ matrix.test-group.name == 'snapshot-streaming' && format('--snapshot-streaming-branch={0} --snapshot-streaming-repo={1} --block-explorer-branch={2}', inputs.snapshot_streaming_branch || 'testing', inputs.snapshot_streaming_repo || 'ottobot-ai/snapshot-streaming', inputs.block_explorer_branch || 'increase_delegated_stakes') || '' }}
 
       - name: Collect Docker container logs
         if: always()

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -16,6 +16,7 @@ export EXTRA_ENV_PATH=${EXTRA_ENV_PATH:-""}
 export EXIT_CODE=${EXIT_CODE:-0}
 export SNAPSHOT_STREAMING_JAR=${SNAPSHOT_STREAMING_JAR:-""}
 export SNAPSHOT_STREAMING_BRANCH=${SNAPSHOT_STREAMING_BRANCH:-"develop"}
+export SNAPSHOT_STREAMING_REPO=${SNAPSHOT_STREAMING_REPO:-"Constellation-Labs/snapshot-streaming"}
 export BLOCK_EXPLORER_BRANCH=${BLOCK_EXPLORER_BRANCH:-"develop"}
 export CL_DOCKER_BIND_INTERFACE=${CL_DOCKER_BIND_INTERFACE:-""}
 export CLEAN_ASSEMBLY=${CLEAN_ASSEMBLY:-false}
@@ -148,6 +149,9 @@ for arg in "$@"; do
       ;;
     --snapshot-streaming-branch=*)
       export SNAPSHOT_STREAMING_BRANCH="${arg#*=}"
+      ;;
+    --snapshot-streaming-repo=*)
+      export SNAPSHOT_STREAMING_REPO="${arg#*=}"
       ;;
     --block-explorer-branch=*)
       export BLOCK_EXPLORER_BRANCH="${arg#*=}"

--- a/docker/snapshot-streaming/build-snapshot-streaming.sh
+++ b/docker/snapshot-streaming/build-snapshot-streaming.sh
@@ -11,7 +11,8 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SS_DIR="$SCRIPT_DIR"
 SS_BRANCH="${SNAPSHOT_STREAMING_BRANCH:-develop}"
-SS_REPO="https://github.com/Constellation-Labs/snapshot-streaming.git"
+_SS_REPO_SLUG="${SNAPSHOT_STREAMING_REPO:-Constellation-Labs/snapshot-streaming}"
+SS_REPO="https://github.com/${_SS_REPO_SLUG}.git"
 
 BE_BRANCH="${BLOCK_EXPLORER_BRANCH:-develop}"
 BE_REPO="https://github.com/Constellation-Labs/block_explorer.git"


### PR DESCRIPTION
## Problem

The E2E workflow in PR #1476 hardcodes `Constellation-Labs/snapshot-streaming` as the clone source. Since snapshot-streaming changes for this PR live in `ottobot-ai/snapshot-streaming:testing` (pending merge via PR #120), the `Build JARs` step fails:

```
error: Remote branch testing not found in upstream origin
```

## Fix

Adds a `SNAPSHOT_STREAMING_REPO` env var (and `--snapshot-streaming-repo` CLI flag) that defaults to `Constellation-Labs/snapshot-streaming`. The E2E workflow now defaults to `ottobot-ai/snapshot-streaming` when building the `testing` branch, allowing CI to pass while PR #120 is pending upstream merge.

Once PR #120 merges to Constellation-Labs, the default can revert to `Constellation-Labs/snapshot-streaming`.

## Changes
- `build-snapshot-streaming.sh`: use `SNAPSHOT_STREAMING_REPO` env var
- `set-env.sh`: export `SNAPSHOT_STREAMING_REPO`; add `--snapshot-streaming-repo=` flag  
- `e2e-just-test.yml`: add `snapshot_streaming_repo` workflow input; default to `ottobot-ai/snapshot-streaming` for the `testing` branch

Fixes E2E Build JARs failure in PR #1476.