### PR TITLE
fix: filter acceptedTokenUnlocks by address in balance calculation

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -1123,8 +1123,9 @@ object CurrencySnapshotAcceptanceManager {
               }
             }
 
+            unlocksForAddress = acceptedTokenUnlocks.filter(_.source == address)
             finalBalance <-
-              acceptedTokenUnlocks.foldLeft[Either[BalanceArithmeticError, Balance]](Right(expiredBalance)) {
+              unlocksForAddress.foldLeft[Either[BalanceArithmeticError, Balance]](Right(expiredBalance)) {
                 case (currentBalanceEither, tokenUnlock) =>
                   for {
                     currentBalance <- currentBalanceEither


### PR DESCRIPTION
## Summary
- Token unlocks in `updateBalancesByTokenLocks` were applied to **every** address in the fold instead of only the address that owns the unlock, inflating balances incorrectly
- Added `acceptedTokenUnlocks.filter(_.source == address)` before the fold, matching the fix already present in v4.0.0+ (`TokenLockOpsManager.scala`)
