### PR TITLE
fix: enforce removal of processed delegated stake withdrawals

### DIFF
--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -75,7 +75,18 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
 
           currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager
             .make(
-              FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+              FieldsAddedOrdinals(
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty,
+                Map.empty
+              ),
               Dev,
               LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(50)),
               BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -324,7 +324,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     val snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[IO] =
       GlobalSnapshotAcceptanceManager
         .make[IO](
-          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
           MetagraphsSyncConfig(PosInt(100)),
           Dev,
           bam,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -111,7 +111,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
 
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
-        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
         Dev,
         LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -322,7 +322,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
 
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
-        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
         Dev,
         LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
@@ -371,7 +371,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
-          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
           MetagraphsSyncConfig(PosInt(100)),
           Dev,
           blockAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -159,7 +159,18 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
               currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager
                 .make(
-                  FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+                  FieldsAddedOrdinals(
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty,
+                    Map.empty
+                  ),
                   Dev,
                   LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
                   BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
@@ -200,7 +211,18 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               priceStateUpdater = PriceStateUpdater.make(Dev, DefaultDelegatedRewardsConfigProvider)
 
               globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
-                FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+                FieldsAddedOrdinals(
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty,
+                  Map.empty
+                ),
                 MetagraphsSyncConfig(PosInt(100)),
                 Dev,
                 BlockAcceptanceManager.make[IO](validators.blockValidator, Hasher.forKryo[IO]),

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -191,6 +191,12 @@ fields-added-ordinals {
     integrationnet: 9999999,
     dev: 0
   }
+  removing-processed-delegated-stake-withdrawals {
+    mainnet: 6176655,
+    testnet: 9999999,
+    integrationnet: 9999999,
+    dev: 0
+  }
 }
 
 validation-error-storage {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -35,7 +35,8 @@ object types {
     updatedLastSyncGlobalFromPeersInConsensus: Map[AppEnvironment, SnapshotOrdinal],
     updatingCombineFunctionSpendActions: Map[AppEnvironment, SnapshotOrdinal],
     fixingAllowSpendExpiration: Map[AppEnvironment, SnapshotOrdinal],
-    fixingAllowSpendAndTokenLockValidation: Map[AppEnvironment, SnapshotOrdinal]
+    fixingAllowSpendAndTokenLockValidation: Map[AppEnvironment, SnapshotOrdinal],
+    removingProcessedDelegatedStakeWithdrawals: Map[AppEnvironment, SnapshotOrdinal]
   )
 
   case class MetagraphsSyncConfig(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
@@ -175,6 +175,9 @@ object GlobalSnapshotAcceptanceManager {
       val fixingAllowSpendAndTokenLockValidation = fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation
         .getOrElse(environment, SnapshotOrdinal.MinValue)
 
+      val removingProcessedDelegatedStakeWithdrawalsOrdinal = fieldsAddedOrdinals.removingProcessedDelegatedStakeWithdrawals
+        .getOrElse(environment, SnapshotOrdinal.MinValue)
+
       for {
         acceptanceResult <- acceptBlocks(blocksForAcceptance, lastSnapshotContext, lastActiveTips, lastDeprecatedTips, ordinal)
         delegatedStakeAcceptanceResult <- updateDelegatedStakeAcceptanceManager.accept(
@@ -417,12 +420,51 @@ object GlobalSnapshotAcceptanceManager {
           lastSnapshotContext
         )
 
-        generatedTokenUnlocks = generateTokenUnlocks(
-          expiredWithdrawalsDelegatedStaking,
+        expiredWithdrawalsForUnlock =
+          if (ordinal >= removingProcessedDelegatedStakeWithdrawalsOrdinal) {
+            expiredWithdrawalsDelegatedStaking.map {
+              case (address, withdrawals) =>
+                address -> withdrawals.filter(w => globalActiveTokenLocksByRef.contains(w.event.value.tokenLockRef))
+            }.filter { case (_, withdrawals) => withdrawals.nonEmpty }
+          } else expiredWithdrawalsDelegatedStaking
+
+        _ <-
+          if (ordinal >= removingProcessedDelegatedStakeWithdrawalsOrdinal) {
+            val orphans = expiredWithdrawalsDelegatedStaking.flatMap {
+              case (address, withdrawals) =>
+                withdrawals.toList.collect {
+                  case w if !globalActiveTokenLocksByRef.contains(w.event.value.tokenLockRef) =>
+                    (address, w.event.value.tokenLockRef)
+                }
+            }
+            if (orphans.nonEmpty)
+              logger.warn(
+                s"[ORDINAL=$ordinal] Skipping token unlock generation for orphan delegated stake withdrawals " +
+                  s"(token lock already removed in a prior snapshot). Pairs: ${orphans.toList}"
+              )
+            else Async[F].unit
+          } else Async[F].unit
+
+        generatedTokenUnlocks <- generateTokenUnlocks(
+          expiredWithdrawalsForUnlock,
           globalActiveTokenLocksByRef
         ) match {
-          case Right(tokenUnlocks) => tokenUnlocks
-          case Left(error)         => throw new RuntimeException(s"Error when generating token unlocks: $error")
+          case Right(tokenUnlocks) => tokenUnlocks.pure[F]
+          case Left(error) =>
+            val orphans = expiredWithdrawalsForUnlock.flatMap {
+              case (address, withdrawals) =>
+                withdrawals.toList.collect {
+                  case w if !globalActiveTokenLocksByRef.contains(w.event.value.tokenLockRef) =>
+                    (address, w.event.value.tokenLockRef)
+                }
+            }
+            logger.error(
+              s"[ORDINAL=$ordinal] Error when generating token unlocks: $error. " +
+                s"Orphan (address -> missing tokenLockRef) pairs: ${orphans.toList}"
+            ) >>
+              MonadThrow[F].raiseError[Map[Address, List[TokenUnlock]]](
+                new RuntimeException(s"Error when generating token unlocks: $error")
+              )
         }
 
         updatedGlobalTokenLocks <- acceptTokenLocks(
@@ -549,7 +591,17 @@ object GlobalSnapshotAcceptanceManager {
           case (_, createDelegatedStakeRecords) =>
             createDelegatedStakeRecords.nonEmpty
         }
-        updatedWithdrawDelegatedStakesCleaned = updatedWithdrawDelegatedStakes.filter {
+        processedWithdrawalRefsByAddress =
+          if (ordinal >= removingProcessedDelegatedStakeWithdrawalsOrdinal)
+            expiredWithdrawalsDelegatedStaking.view.mapValues(_.toList.map(_.event.value.tokenLockRef).toSet).toMap
+          else Map.empty[Address, Set[Hash]]
+
+        updatedWithdrawDelegatedStakesCleaned = updatedWithdrawDelegatedStakes.map {
+          case (address, withdrawals) =>
+            val processedRefs = processedWithdrawalRefsByAddress.getOrElse(address, Set.empty[Hash])
+            if (processedRefs.isEmpty) address -> withdrawals
+            else address -> withdrawals.filterNot(w => processedRefs.contains(w.event.value.tokenLockRef))
+        }.filter {
           case (_, updatedDelegatedStakeRecords) =>
             updatedDelegatedStakeRecords.nonEmpty
         }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
@@ -97,27 +97,27 @@ object StateChannelAllowanceLists {
               "75d8f472fb2bebfcefbb27a46cb60aeae1a32806c9f3f40a405d4eaf1c44e8041febf5e6eb9e6f525d6142c7df87304b9fe011863c6d8ed121fa6fcae7d5ca66",
               "e47e0ac3ebc393b61e267aa4189f7fdc36c48440b1fc0a6bad375945cabfd41ab3e7800ae1d22d80d2d4a3b0902df6aeb293b803490bf8d777da3894833f42fb"
             ),
-           // Valid Vote
-           Address("DAG55nwjLR1JhY4a2Wri6Cni2GWPL7Vupu5znnJi") ->
-             NonEmptySet.of(
-               "98e2c7ee9e4bd8aed3a22a075becbe5cad252e25724e7e14050beb69f80e9ea409777470914d21e0bca625cb3ec065a001378b62668355f60bddfc1a322292e5",
-               "7f509f5b2e4d70e9bd9852af0c064f30d95e83243896b7a5857be247a8212b121a96d913e00fe19568f18c9674ea871a8162e4d2d5d711c140be051df21d9744",
-               "08a360052a6444b55f91fdea97ecbdf251b640736e3fb61d9828be8c1a3159bcca234864a6693ba9cd57630ae90bddc2127d8ebe191243eec38aee9a00adb149"
-             ),
-            // CNS
-            Address("DAG1YTmwkBqCBrW8JLFquAmadozEqSWSxJ2mKKcT") ->
-              NonEmptySet.of(
-                "ac1243131c0b2821876e88e3a50ee30d3fb28d571cb8e4dd3f454383ea398f8859cb1159f3250c4ab9cd72e179ce681eb6c00626de21464839fae1715ee58d18",
-                "568c76f6cd690c516a1014bf1569e5680781dd72abf9d2424c77c5edfa50cc74bc6e940831eabb4872b18fbbe335a7a29f7a5ee3b71f1aad9d2257626ed7f68e",
-                "4728c6ef84521d181ffc58a602fb68a66e88f93d6c1e1e7ae0dbef6ccbade1916474d167ad8902e9dafb79677de34bcccb0dcd9fa39aa97b83958cfdbceb6668"
-              ),
-             // StarVault
-             Address("DAG2LFocye7MvTN3V2bmt4kiJG7SxhMz6sbCaJdn") ->
-               NonEmptySet.of(
-                 "b090ca464abd2d1dbd219ff6c801ec8913d88ccc1b28cb1f1acacd83e040e41e41d8d57127ee8991339dd055844bbc3659e1001e6498a9e174c6b3917b4378d5",
-                 "67060feccf1c407db4d46b156203e4b6eabc6c3dde196af1e64bb4f53d86a72420e701fc069d86635506e34c0d4cdea6089addb62213512e5b4de7fff41319c0",
-                 "1391276cd637be03331ae5914a5a063c549fbcc6515b140d1ccc0af7c67631804991ba0dae4c1d95b84f77dc812dd71ed2a1817e50c92b722e9b8182683366ed"
-               )
+          // Valid Vote
+          Address("DAG55nwjLR1JhY4a2Wri6Cni2GWPL7Vupu5znnJi") ->
+            NonEmptySet.of(
+              "98e2c7ee9e4bd8aed3a22a075becbe5cad252e25724e7e14050beb69f80e9ea409777470914d21e0bca625cb3ec065a001378b62668355f60bddfc1a322292e5",
+              "7f509f5b2e4d70e9bd9852af0c064f30d95e83243896b7a5857be247a8212b121a96d913e00fe19568f18c9674ea871a8162e4d2d5d711c140be051df21d9744",
+              "08a360052a6444b55f91fdea97ecbdf251b640736e3fb61d9828be8c1a3159bcca234864a6693ba9cd57630ae90bddc2127d8ebe191243eec38aee9a00adb149"
+            ),
+          // CNS
+          Address("DAG1YTmwkBqCBrW8JLFquAmadozEqSWSxJ2mKKcT") ->
+            NonEmptySet.of(
+              "ac1243131c0b2821876e88e3a50ee30d3fb28d571cb8e4dd3f454383ea398f8859cb1159f3250c4ab9cd72e179ce681eb6c00626de21464839fae1715ee58d18",
+              "568c76f6cd690c516a1014bf1569e5680781dd72abf9d2424c77c5edfa50cc74bc6e940831eabb4872b18fbbe335a7a29f7a5ee3b71f1aad9d2257626ed7f68e",
+              "4728c6ef84521d181ffc58a602fb68a66e88f93d6c1e1e7ae0dbef6ccbade1916474d167ad8902e9dafb79677de34bcccb0dcd9fa39aa97b83958cfdbceb6668"
+            ),
+          // StarVault
+          Address("DAG2LFocye7MvTN3V2bmt4kiJG7SxhMz6sbCaJdn") ->
+            NonEmptySet.of(
+              "b090ca464abd2d1dbd219ff6c801ec8913d88ccc1b28cb1f1acacd83e040e41e41d8d57127ee8991339dd055844bbc3659e1001e6498a9e174c6b3917b4378d5",
+              "67060feccf1c407db4d46b156203e4b6eabc6c3dde196af1e64bb4f53d86a72420e701fc069d86635506e34c0d4cdea6089addb62213512e5b4de7fff41319c0",
+              "1391276cd637be03331ae5914a5a063c549fbcc6515b140d1ccc0af7c67631804991ba0dae4c1d95b84f77dc812dd71ed2a1817e50c92b722e9b8182683366ed"
+            )
         ).some
     }
 


### PR DESCRIPTION
## Summary
- Unblocks mainnet consensus, currently halted at ordinal **6176655** by a `MissingTokenLock` error in `GlobalSnapshotAcceptanceManager.generateTokenUnlocks`
- An orphan `PendingDelegatedStakeWithdrawal` for `DAG15hycLmg7AJbksHUcS6Zbs3oiWjFtyk6Zc28k` (tokenLockRef `bdbdb766…`) survived ordinal 6176654 in `GlobalSnapshotInfo.delegatedStakesWithdrawals` even though its token lock was unlocked in that ordinal. At 6176655 it is partitioned as expired again, but the lock is gone, so unlock generation fails and consensus stalls.
- Enforces the invariant **\"once we generate an unlock for a tokenLockRef, no `PendingDelegatedStakeWithdrawal` referencing it remains\"**

## Changes
Gated by new field-added ordinal `removingProcessedDelegatedStakeWithdrawals` (mainnet=`6176655`, testnet/integrationnet=`9999999`, dev=`0`):

1. **Skip orphans gracefully in `generateTokenUnlocks`** — when a withdrawal's `tokenLockRef` is no longer in `globalActiveTokenLocksByRef`, log a warning and skip it instead of failing the whole snapshot.
2. **Defensively clean `updatedWithdrawDelegatedStakes`** — when building `updatedWithdrawDelegatedStakesCleaned`, subtract every entry whose `tokenLockRef` appeared in `expiredWithdrawalsDelegatedStaking`. Guarantees the invariant regardless of which upstream path computed the value.

Pre-activation behavior is preserved exactly so historical re-validation matches.

## Files
- `modules/node-shared/src/main/resources/application.conf` — new ordinal config
- `modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala` — `FieldsAddedOrdinals` field
- `modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala` — fix logic + diagnostic logs retained for follow-up investigation
- 5 test files — new `Map.empty` for the added field

## Open follow-up (not blocking this PR)
Static analysis still cannot pinpoint *how* the orphan entry survived the prior snapshot — `getUpdatedWithdrawalDelegatedStakes` should have excluded it. Investigation will continue (likely candidates: in-memory `lastOutcome.context` divergence from disk, or a state-rebuild path that bypasses the filter).

## Test plan
- [ ] CI compile + tests
- [ ] Local sbt `nodeShared/test`, `dagL0/test` pass
- [ ] Verify on a staging environment (or one mainnet node first) that consensus resumes past 6176655
- [ ] Confirm warning log appears for `bdbdb766` and the entry is dropped from state at activation ordinal