### PR TITLE
chore: add nftables byte-rate limiting + prometheus exporter for source nodes

### DIFF
--- a/docker/grafana/provisioning/dashboards/tessellation-debug-rest-api-endpoint-sizes.json
+++ b/docker/grafana/provisioning/dashboards/tessellation-debug-rest-api-endpoint-sizes.json
@@ -2219,7 +2219,7 @@
       },
       "id": 1000,
       "panels": [],
-      "title": "nftables Firewall (per source node)",
+      "title": "nftables Firewall (per streaming node)",
       "type": "row"
     },
     {
@@ -2616,114 +2616,6 @@
         }
       ],
       "title": "Public outbound: passed vs dropped (stacked, per node)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "opacity",
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }] },
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 149 },
-      "id": 1008,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "editorMode": "code",
-          "expr": "sum by (key) (rate(nftables_set_element_bytes_total{set=~\"pub_out_dst|p2p_out_dst\", instance=~\"$ip:9437\"}[$__rate_interval]))",
-          "legendFormat": "{{key}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Egress bytes/s by remote IP (pub_out + p2p_out, summed across selected source nodes)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }] },
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 161 },
-      "id": 1009,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "editorMode": "code",
-          "expr": "sum by (instance, key) (rate(nftables_set_element_bytes_total{set=~\"pub_out_dst|p2p_out_dst\", instance=~\"$ip:9437\"}[$__rate_interval]))",
-          "legendFormat": "{{instance}} → {{key}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Egress bytes/s by source-node × remote IP",
       "type": "timeseries"
     }
   ],

--- a/docker/nft-rate-limit/config/etc/firewall/allowlist.conf
+++ b/docker/nft-rate-limit/config/etc/firewall/allowlist.conf
@@ -1,0 +1,18 @@
+# /etc/firewall/allowlist.conf
+# Streaming nodes + monitoring host only. Validators are intentionally
+# NOT here - they are subject to rate limits like any external snapshot
+# consumer. P2P ports remain unconditionally open in steady mode, so
+# consensus/gossip still works regardless of allowlist contents.
+
+# streaming nodes (themselves + each other)
+52.8.132.193/32
+13.57.110.45/32
+54.153.23.79/32
+
+# monitoring (graf testnet Prometheus)
+50.18.64.144/32
+
+# snapshot-streaming consumer (AWS, near 13.57.110.45 streaming node;
+# pulls latest_ordinal + id_hash at high rate - a known infrastructure
+# subscriber, not an external client)
+13.57.169.30/32

--- a/docker/nft-rate-limit/config/etc/firewall/bin/firewall-mode
+++ b/docker/nft-rate-limit/config/etc/firewall/bin/firewall-mode
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# /etc/firewall/bin/firewall-mode <steady|emergency|open|reload|status>
+#
+# Atomic mode switching for the inet firewall table on Constellation
+# streaming nodes. Each mode renders its template under
+# /etc/firewall/modes/<mode>.nft, syntax-checks via `nft -c -f`, and
+# applies via `nft -f` (atomic netlink swap). The selected mode is
+# persisted to /etc/firewall/active-mode for boot reapplication.
+
+set -euo pipefail
+
+FW_DIR="${FW_DIR:-/etc/firewall}"
+RUN_DIR="${RUN_DIR:-/run/firewall}"
+
+mkdir -p "$RUN_DIR"
+
+usage() {
+  cat >&2 <<EOF
+usage: $0 <steady|emergency|open|reload|status>
+
+  steady     apply rate-limited mode (1/min per IP, conn cap 2)
+  emergency  drop all non-allowlisted public + P2P traffic
+  open       no limits; counters only
+  reload     re-apply the currently active mode (used by systemd at boot)
+  status     print the active mode (exit 0 if known, 3 if unset)
+EOF
+  exit 2
+}
+
+current_mode() {
+  if [ -r "$FW_DIR/active-mode" ]; then
+    cat "$FW_DIR/active-mode"
+  else
+    echo "unknown"
+  fi
+}
+
+apply_mode() {
+  local mode="$1"
+  local template="$FW_DIR/modes/${mode}.nft"
+  if [ ! -f "$template" ]; then
+    echo "no template for mode '$mode' at $template" >&2
+    exit 1
+  fi
+
+  local rendered="$RUN_DIR/active.nft.new"
+  "$FW_DIR/bin/render-rules.sh" "$mode" > "$rendered"
+
+  if ! nft -c -f "$rendered"; then
+    echo "syntax check failed for $rendered" >&2
+    exit 1
+  fi
+
+  nft -f "$rendered"
+  mv "$rendered" "$RUN_DIR/active.nft"
+
+  echo "$mode" > "$FW_DIR/active-mode.tmp"
+  mv "$FW_DIR/active-mode.tmp" "$FW_DIR/active-mode"
+
+  logger -t firewall-mode "applied mode=$mode"
+}
+
+case "${1:-}" in
+  steady|emergency|open)
+    apply_mode "$1"
+    echo "applied: $1"
+    ;;
+  reload)
+    cur="$(current_mode)"
+    if [ "$cur" = "unknown" ]; then
+      echo "active-mode missing; defaulting to emergency" >&2
+      logger -t firewall-mode "active-mode missing; defaulting to emergency"
+      cur="emergency"
+    fi
+    apply_mode "$cur"
+    echo "reloaded: $cur"
+    ;;
+  status)
+    cur="$(current_mode)"
+    echo "$cur"
+    case "$cur" in
+      steady|emergency|open) exit 0 ;;
+      *) exit 3 ;;
+    esac
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/docker/nft-rate-limit/config/etc/firewall/bin/render-rules.sh
+++ b/docker/nft-rate-limit/config/etc/firewall/bin/render-rules.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# /etc/firewall/bin/render-rules.sh <mode>
+#
+# Reads /etc/firewall/modes/<mode>.nft and substitutes:
+#   @ALLOW@               -> CSV from /etc/firewall/allowlist.conf
+#   @PUBLIC_PORTS@        -> from /etc/firewall/ports.env
+#   @P2P_PORTS@           -> from /etc/firewall/ports.env
+#   @PUBLIC_BYTE_RATE@    -> from /etc/firewall/ports.env
+# Writes the rendered nftables ruleset to stdout.
+
+set -euo pipefail
+
+FW_DIR="${FW_DIR:-/etc/firewall}"
+
+mode="${1:-}"
+[ -n "$mode" ] || { echo "usage: $0 <mode>" >&2; exit 2; }
+
+template="$FW_DIR/modes/${mode}.nft"
+[ -f "$template" ] || { echo "missing template: $template" >&2; exit 1; }
+
+# shellcheck disable=SC1091
+. "$FW_DIR/ports.env"
+[ -n "${PUBLIC_PORTS:-}"     ] || { echo "ports.env missing PUBLIC_PORTS"     >&2; exit 1; }
+[ -n "${P2P_PORTS:-}"        ] || { echo "ports.env missing P2P_PORTS"        >&2; exit 1; }
+[ -n "${PUBLIC_BYTE_RATE:-}" ] || { echo "ports.env missing PUBLIC_BYTE_RATE" >&2; exit 1; }
+
+# Build CSV of CIDRs from allowlist.conf, stripping comments + blank lines.
+ALLOW="$(
+  grep -hvE '^[[:space:]]*(#|$)' "$FW_DIR/allowlist.conf" \
+    | awk '{print $1}' \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$' \
+    | sort -u \
+    | paste -sd, -
+)"
+
+# Refuse to render with an empty allowlist - would render an empty set
+# which nft accepts but is never the intent. Better to fail loudly.
+[ -n "$ALLOW" ] || { echo "allowlist.conf produced no entries" >&2; exit 1; }
+
+sed \
+  -e "s|@ALLOW@|${ALLOW}|g" \
+  -e "s|@PUBLIC_PORTS@|${PUBLIC_PORTS}|g" \
+  -e "s|@P2P_PORTS@|${P2P_PORTS}|g" \
+  -e "s|@PUBLIC_BYTE_RATE@|${PUBLIC_BYTE_RATE}|g" \
+  "$template"

--- a/docker/nft-rate-limit/config/etc/firewall/modes/emergency.nft
+++ b/docker/nft-rate-limit/config/etc/firewall/modes/emergency.nft
@@ -1,0 +1,46 @@
+# Atomic replace (see steady.nft).
+flush ruleset
+
+table inet firewall {
+    set allow_v4 {
+        type ipv4_addr
+        flags interval
+        elements = { @ALLOW@ }
+    }
+
+    set pub_out_dst {
+        type ipv4_addr
+        flags dynamic
+        counter
+    }
+    set p2p_out_dst {
+        type ipv4_addr
+        flags dynamic
+        counter
+    }
+
+    counter pub_dropped { }
+    counter p2p_dropped { }
+    counter pub_out     { }
+    counter p2p_out     { }
+
+    chain input {
+        type filter hook input priority 0; policy accept;
+
+        # Allowlist short-circuit (preserves streaming<->streaming + monitoring)
+        ip saddr @allow_v4 accept
+
+        # Drop public + P2P traffic from anyone not allowlisted
+        tcp dport { @PUBLIC_PORTS@ } counter name pub_dropped drop
+        tcp dport { @P2P_PORTS@ }    counter name p2p_dropped drop
+    }
+
+    # Output observation only - drops happen on input.
+    chain output {
+        type filter hook output priority 0; policy accept;
+        tcp sport { @PUBLIC_PORTS@ } update @pub_out_dst { ip daddr } \
+            counter name pub_out accept
+        tcp sport { @P2P_PORTS@ }    update @p2p_out_dst { ip daddr } \
+            counter name p2p_out accept
+    }
+}

--- a/docker/nft-rate-limit/config/etc/firewall/modes/open.nft
+++ b/docker/nft-rate-limit/config/etc/firewall/modes/open.nft
@@ -1,0 +1,36 @@
+# Atomic replace (see steady.nft).
+flush ruleset
+
+table inet firewall {
+    set pub_out_dst {
+        type ipv4_addr
+        flags dynamic
+        counter
+    }
+    set p2p_out_dst {
+        type ipv4_addr
+        flags dynamic
+        counter
+    }
+
+    counter pub_traffic { }
+    counter p2p_traffic { }
+    counter pub_out     { }
+    counter p2p_out     { }
+
+    chain input {
+        type filter hook input priority 0; policy accept;
+        tcp dport { @PUBLIC_PORTS@ } counter name pub_traffic accept
+        tcp dport { @P2P_PORTS@ }    counter name p2p_traffic accept
+    }
+
+    # Output observation only - no filtering, just counters per port group +
+    # per-destination-IP via dynamic counter sets.
+    chain output {
+        type filter hook output priority 0; policy accept;
+        tcp sport { @PUBLIC_PORTS@ } update @pub_out_dst { ip daddr } \
+            counter name pub_out accept
+        tcp sport { @P2P_PORTS@ }    update @p2p_out_dst { ip daddr } \
+            counter name p2p_out accept
+    }
+}

--- a/docker/nft-rate-limit/config/etc/firewall/modes/steady.nft
+++ b/docker/nft-rate-limit/config/etc/firewall/modes/steady.nft
@@ -1,0 +1,61 @@
+# Atomic replace: flush all nftables state, then redefine. The whole
+# nft -f invocation is one netlink transaction.
+flush ruleset
+
+table inet firewall {
+    set allow_v4 {
+        type ipv4_addr
+        flags interval
+        elements = { @ALLOW@ }
+    }
+
+    # Per-destination-IP byte/packet counters for outbound public + P2P.
+    # The exporter scrapes these to break down egress by remote IP.
+    set pub_out_dst {
+        type ipv4_addr
+        flags dynamic
+        counter
+    }
+    set p2p_out_dst {
+        type ipv4_addr
+        flags dynamic
+        counter
+    }
+
+    counter pub_traffic   { }
+    counter p2p_traffic   { }
+    counter bytes_dropped { }
+    counter pub_out       { }
+    counter p2p_out       { }
+
+    # Input chain: observation only, no filtering. Connection-level
+    # limits are intentionally absent — keep-alive makes them ineffective.
+    chain input {
+        type filter hook input priority 0; policy accept;
+        tcp dport { @PUBLIC_PORTS@ } counter name pub_traffic accept
+        tcp dport { @P2P_PORTS@ }    counter name p2p_traffic accept
+    }
+
+    # Output chain: per-destination-IP byte-rate cap on outbound traffic
+    # from public ports. Counts both rate-passed and allowlisted outbound
+    # so total egress is observable.
+    chain output {
+        type filter hook output priority 0; policy accept;
+
+        # Rate cap only applies to non-allowlisted destinations on
+        # public ports. Drops counted in bytes_dropped.
+        tcp sport { @PUBLIC_PORTS@ } ip daddr != @allow_v4 \
+            meter byterate { ip daddr limit rate over @PUBLIC_BYTE_RATE@ } \
+            counter name bytes_dropped drop
+
+        # Count + accept all successfully-egressed public-port traffic
+        # (both allowlisted and rate-passed). Update per-destination set
+        # so the exporter can break down egress by remote IP.
+        tcp sport { @PUBLIC_PORTS@ } update @pub_out_dst { ip daddr } \
+            counter name pub_out accept
+
+        # Count + accept P2P outbound (no rate cap on P2P).
+        tcp sport { @P2P_PORTS@ } update @p2p_out_dst { ip daddr } \
+            counter name p2p_out accept
+    }
+}

--- a/docker/nft-rate-limit/config/etc/firewall/ports.env
+++ b/docker/nft-rate-limit/config/etc/firewall/ports.env
@@ -1,0 +1,14 @@
+# /etc/firewall/ports.env
+# Per-host port and limit configuration. Each streaming node runs both an L0
+# and an L1 validator, hence two public + two P2P ports.
+
+PUBLIC_PORTS="9000, 9010"
+P2P_PORTS="9001, 9011"
+
+# Per-destination-IP byte-rate cap on outbound traffic from public ports.
+# Format is nftables `limit rate over <N> <unit>/<time>`. Common units:
+# bytes, kbytes, mbytes; common times: second, minute. Examples:
+#   "2 mbytes/second"   -> 2 MB/s per destination IP (~16 Mbps)
+#   "500 kbytes/second" -> heavy throttle
+#   "5 mbytes/second"   -> light throttle (current peak external is ~3.3 MB/s)
+PUBLIC_BYTE_RATE="2 mbytes/second"

--- a/docker/nft-rate-limit/config/etc/systemd/system/firewall-mode.service
+++ b/docker/nft-rate-limit/config/etc/systemd/system/firewall-mode.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Apply active firewall mode (nftables) at boot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/etc/firewall/bin/firewall-mode reload
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/nft-rate-limit/config/etc/systemd/system/nftables-exporter.service
+++ b/docker/nft-rate-limit/config/etc/systemd/system/nftables-exporter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=nftables Prometheus exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/nftables_exporter.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/nft-rate-limit/config/usr/local/bin/nftables_exporter.py
+++ b/docker/nft-rate-limit/config/usr/local/bin/nftables_exporter.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+nftables_exporter - lightweight Prometheus exporter for nftables counters,
+meters, dynamic counter sets, and the firewall-mode active-mode marker.
+
+Listens on :9437/metrics. Reads `nft -j list ruleset` once per scrape and
+extracts counter, meter, and per-element set state.
+
+Runs as root via systemd unit because `nft list` requires CAP_NET_ADMIN.
+"""
+
+import json
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+LISTEN_HOST = "0.0.0.0"
+LISTEN_PORT = 9437
+ACTIVE_MODE_FILE = "/etc/firewall/active-mode"
+KNOWN_MODES = ("steady", "emergency", "open", "unknown")
+
+
+def nft_json_list(what):
+    try:
+        r = subprocess.run(
+            ["nft", "-j", "list", what],
+            capture_output=True, text=True, timeout=5
+        )
+        if r.returncode != 0:
+            return None
+        return json.loads(r.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return None
+
+
+def collect_counters():
+    data = nft_json_list("counters")
+    if not data:
+        return []
+    out = []
+    for entry in data.get("nftables", []):
+        c = entry.get("counter")
+        if not c:
+            continue
+        out.append((
+            c.get("table", ""),
+            c.get("family", ""),
+            c.get("name", ""),
+            int(c.get("packets", 0)),
+            int(c.get("bytes", 0)),
+        ))
+    return out
+
+
+def collect_meters():
+    data = nft_json_list("meters")
+    if not data:
+        return []
+    out = []
+    for entry in data.get("nftables", []):
+        m = entry.get("meter")
+        if not m:
+            continue
+        elem = m.get("elem", [])
+        out.append((
+            m.get("table", ""),
+            m.get("family", ""),
+            m.get("name", ""),
+            len(elem),
+        ))
+    return out
+
+
+def collect_set_counters():
+    """Yield (table, family, set_name, key_value, packets, bytes) for every
+    element in every dynamic counter set. Used for per-destination-IP
+    breakdowns of egress (pub_out_dst / p2p_out_dst)."""
+    data = nft_json_list("sets")
+    if not data:
+        return []
+    sets_meta = []
+    # First pass: collect set definitions to know which ones are counter sets.
+    for entry in data.get("nftables", []):
+        s = entry.get("set")
+        if not s:
+            continue
+        sets_meta.append(s)
+
+    out = []
+    for s in sets_meta:
+        # `nft list sets` returns set definitions WITHOUT elements. Need
+        # `nft list set <family> <table> <name>` to get elements.
+        family = s.get("family", "")
+        table = s.get("table", "")
+        name = s.get("name", "")
+        if not (family and table and name):
+            continue
+        details = nft_json_list_set(family, table, name)
+        if not details:
+            continue
+        for entry in details.get("nftables", []):
+            sd = entry.get("set")
+            if not sd or sd.get("name") != name:
+                continue
+            for e in sd.get("elem", []) or []:
+                el = e.get("elem", e) if isinstance(e, dict) else None
+                if not isinstance(el, dict):
+                    continue
+                val = el.get("val")
+                ctr = el.get("counter")
+                if val is None or not isinstance(ctr, dict):
+                    continue
+                out.append((
+                    table, family, name, str(val),
+                    int(ctr.get("packets", 0)),
+                    int(ctr.get("bytes", 0)),
+                ))
+    return out
+
+
+def nft_json_list_set(family, table, name):
+    try:
+        r = subprocess.run(
+            ["nft", "-j", "list", "set", family, table, name],
+            capture_output=True, text=True, timeout=5
+        )
+        if r.returncode != 0:
+            return None
+        return json.loads(r.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return None
+
+
+def read_active_mode():
+    try:
+        with open(ACTIVE_MODE_FILE, "r") as f:
+            return f.read().strip() or "unknown"
+    except FileNotFoundError:
+        return "unknown"
+
+
+def render_metrics():
+    counters = collect_counters()
+    meters = collect_meters()
+    mode = read_active_mode()
+    lines = []
+
+    lines.append("# HELP nftables_counter_packets_total Packet count of nftables named counter")
+    lines.append("# TYPE nftables_counter_packets_total counter")
+    for t, f, n, p, _ in counters:
+        lines.append(f'nftables_counter_packets_total{{table="{t}",family="{f}",name="{n}"}} {p}')
+
+    lines.append("# HELP nftables_counter_bytes_total Byte count of nftables named counter")
+    lines.append("# TYPE nftables_counter_bytes_total counter")
+    for t, f, n, _, b in counters:
+        lines.append(f'nftables_counter_bytes_total{{table="{t}",family="{f}",name="{n}"}} {b}')
+
+    lines.append("# HELP nftables_meter_elements Number of elements currently tracked by an nftables meter")
+    lines.append("# TYPE nftables_meter_elements gauge")
+    for t, f, n, c in meters:
+        lines.append(f'nftables_meter_elements{{table="{t}",family="{f}",name="{n}"}} {c}')
+
+    set_counters = collect_set_counters()
+    lines.append("# HELP nftables_set_element_packets_total Packets per dynamic counter-set element")
+    lines.append("# TYPE nftables_set_element_packets_total counter")
+    for t, f, n, k, p, _ in set_counters:
+        lines.append(f'nftables_set_element_packets_total{{table="{t}",family="{f}",set="{n}",key="{k}"}} {p}')
+
+    lines.append("# HELP nftables_set_element_bytes_total Bytes per dynamic counter-set element")
+    lines.append("# TYPE nftables_set_element_bytes_total counter")
+    for t, f, n, k, _, b in set_counters:
+        lines.append(f'nftables_set_element_bytes_total{{table="{t}",family="{f}",set="{n}",key="{k}"}} {b}')
+
+    lines.append("# HELP nftables_active_mode Active firewall-mode marker (1 indicates current mode)")
+    lines.append("# TYPE nftables_active_mode gauge")
+    for m in KNOWN_MODES:
+        lines.append(f'nftables_active_mode{{mode="{m}"}} {1 if mode == m else 0}')
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/metrics":
+            body = render_metrics().encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/":
+            body = b"<html><body><a href='/metrics'>metrics</a></body></html>"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        # Quiet by default; uncomment to see scrape logs
+        pass
+
+
+class ThreadedServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+if __name__ == "__main__":
+    server = ThreadedServer((LISTEN_HOST, LISTEN_PORT), Handler)
+    sys.stderr.write(f"nftables-exporter listening on {LISTEN_HOST}:{LISTEN_PORT}\n")
+    sys.stderr.flush()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
Per-destination-IP byte-rate cap (2 MB/s) on outbound public-port traffic from the three testnet source nodes, enforced via nftables. 

Three modes (steady / emergency / open) atomically swappable via `firewall-mode`.  

Allowlist bypasses source nodes, prometheus, and snapshot-streaming. 

Includes a Prometheus exporter for nftables counters and Grafana  panels for throughput, drops, mode, and per-peer approximate bytes/s. 