### PR TITLE
fix: apt update before openjdk-21 install to avoid stale-index 404

### DIFF
--- a/docker/bin/install_dependencies.sh
+++ b/docker/bin/install_dependencies.sh
@@ -42,6 +42,9 @@ check_java() {
     Linux)
       if command -v apt >/dev/null 2>&1; then
         echo "Installing Java 21 using apt..."
+        # Refresh the package index first: CI runners can have a stale apt cache
+        # pinned to an openjdk-21 patch the mirror has since purged, causing a 404.
+        sudo apt update
         sudo apt install -y openjdk-21-jdk
       elif command -v yum >/dev/null 2>&1; then
         echo "Installing Java 21 using yum..."


### PR DESCRIPTION
Nightly Deploy failed in `just _check_deps` because `apt install -y openjdk-21-jdk` ran against a stale apt index pinned to an openjdk-21 patch (21.0.10+7-1~22.04) the Ubuntu mirror has since purged, returning 404 -> exit 100. Refresh the index first, matching what check_sbt / check_wget / check_curl already do.