### PR TITLE
fix: prepend last currency snapshot before loadChain during rollback (3.5.x backport of #1466)

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/StoragesInitializer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/StoragesInitializer.scala
@@ -90,14 +90,19 @@ object StoragesInitializer {
   ) =
     for {
       _ <- Logger[F].info(s"Initializing currency snapshot storages")
-      _ <- (maybeCurrencySnapshot, maybeCurrencySnapshotInfo).mapN { (currencySnapshot, currencySnapshotInfo) =>
-        val ordinal = currencySnapshot.ordinal
-        Logger[F].info(s"Prepending currency snapshot with ordinal=$ordinal") >>
-          storages.snapshot.prepend(currencySnapshot, currencySnapshotInfo) >>
-          Logger[F].info(s"Successfully prepended currency snapshot with ordinal=$ordinal")
-      }.fold(
-        MonadThrow[F].raiseError[Unit](new IllegalArgumentException("Currency snapshot and info must both be provided or both be absent"))
-      )(identity)
+      _ <- (maybeCurrencySnapshot, maybeCurrencySnapshotInfo) match {
+        case (Some(currencySnapshot), Some(currencySnapshotInfo)) =>
+          val ordinal = currencySnapshot.ordinal
+          Logger[F].info(s"Prepending currency snapshot with ordinal=$ordinal") >>
+            storages.snapshot.prepend(currencySnapshot, currencySnapshotInfo).flatMap { prepended =>
+              if (prepended) Logger[F].info(s"Successfully prepended currency snapshot with ordinal=$ordinal")
+              else Logger[F].info(s"Currency snapshot with ordinal=$ordinal already in storage, skipping prepend")
+            }
+        case (None, None) =>
+          Logger[F].info(s"No currency snapshot provided, skipping prepend")
+        case _ =>
+          MonadThrow[F].raiseError[Unit](new IllegalArgumentException("Currency snapshot and info must both be provided or both be absent"))
+      }
       _ <- Logger[F].info(s"Successfully initialized currency snapshot storages")
     } yield ()
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -87,7 +87,8 @@ object Programs {
       storages.currencySnapshotCleanup,
       storages.globalSnapshotsWithStateFileStorage,
       storages.globalSnapshotsWithStateDeltasFileStorage,
-      services.globalSnapshotContextFunctions
+      services.globalSnapshotContextFunctions,
+      storages.snapshot
     )
 
     new Programs[F](sharedPrograms.peerDiscovery, globalL0PeerDiscovery, sharedPrograms.joining, download, genesis, rollback) {}

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala
@@ -59,7 +59,8 @@ object Rollback {
     currencySnapshotCleanupStorage: CurrencySnapshotCleanupStorage[F],
     globalSnapshotsWithStateLocalFileSystemStorage: GlobalSnapshotsWithStateLocalFileSystemStorage[F],
     globalSnapshotsWithStateDeltasLocalFileSystemStorage: GlobalSnapshotsWithStateDeltasLocalFileSystemStorage[F],
-    globalSnapshotContextFunctions: GlobalSnapshotContextFunctions[F]
+    globalSnapshotContextFunctions: GlobalSnapshotContextFunctions[F],
+    snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo]
   )(implicit context: L0NodeContext[F]): Rollback[F] = new Rollback[F] {
     private val logger = Slf4jLogger.getLoggerFromName[F]("CurrencyRollback")
 
@@ -106,6 +107,15 @@ object Rollback {
       _ <- collateral
         .hasCollateral(nodeId)
         .flatMap(OwnCollateralNotSatisfied.raiseError[F, Unit].unlessA)
+
+      _ <- snapshotStorage.prepend(lastIncremental, lastInfo).flatMap { prepended =>
+        if (prepended)
+          logger.info(s"Prepended last currency snapshot ordinal=${lastIncremental.ordinal.show} to snapshot storage before loadChain")
+        else
+          logger.warn(
+            s"Could not prepend last currency snapshot ordinal=${lastIncremental.ordinal.show} to snapshot storage (already at different head); loadChain may diverge"
+          )
+      }
 
       _ <- dataApplication.map {
         case (da, cs) =>


### PR DESCRIPTION
## Problem

During `run-rollback`, `DataApplicationTraverse.loadChain` replays data blocks through the metagraph's `combine` **before** the currency `SnapshotStorage` receives its first `prepend` (`StoragesInitializer.initializeCurrencySnapshotStorages` only runs after `rollback` returns in `CurrencyL0App`). `L0NodeContext.getLastCurrencySnapshot` reads `snapshotStorage.headSnapshot` — an in-memory ref initialized to `none` with no disk fallback — so it is deterministically `None` for the entire replay.

Any metagraph whose `combine` reads `getLastCurrencySnapshot` (e.g. for `epochProgress`) crashes on **every** rollback that has to replay a snapshot containing data updates. On 2026-06-11 this took down all three DOR metagraph mainnet source nodes simultaneously (on-disk calculated state at metagraph ordinal 25361293, chain tip 25361302 → 9-snapshot replay → crash in the metagraph's combine), with the monitoring service crash-looping the rollback node every 5 minutes.

## Fix

Backports the `Rollback` prepend from a88c52388 (#1466, already on `develop` and in v4.0.8-alpha+): prepend `(lastIncremental, lastInfo)` to the snapshot storage **before** `loadChain`, so the replay context serves the rollback-point snapshot.

Scope intentionally limited to `currency-l0`:
- `Rollback`: prepend before `loadChain` (the core fix)
- `Programs`: pass `storages.snapshot` to `Rollback.make`
- `StoragesInitializer`: make the now-duplicate post-rollback prepend idempotent and honestly logged (it previously logged 'Successfully prepended' regardless of the discarded `Boolean` result)

The `node-shared`/`DataApplicationTraverse` hunks of a88c52388 are **not** included: on 3.5.x `LocalFileSystemStorage.write` already silently overwrites existing `snapshot_info` files (better-files `writeByteArray` → CREATE+TRUNCATE_EXISTING) and the duplicate prepend's return value is discarded, so neither defensive hunk is required to prevent a crash.

## Determinism note

With this fix the replayed `combine` calls see the **tip** snapshot's `epochProgress` rather than each replayed ordinal's true predecessor — identical semantics to #1466 on develop. For the DOR incident this is provably byte-exact (all 10 snapshots in the replay window share `epochProgress=1708272`, verified via block explorer). A follow-up for exact-replay semantics (serving each replayed snapshot's true predecessor) is worth discussing separately.

## Verification

- Cherry-picks cleanly onto `release/mainnet` (the three files are untouched between v3.5.12 and v3.5.18)
- Built with JDK 11 + `sbt sdk/publishLocal`; DOR metagraph compiles and its suite runs against the resulting artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)