### PR TITLE
fix(currency-l0): harden StateChannelBinarySender against disconnection & restart loops

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/metrics.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/metrics.scala
@@ -19,9 +19,13 @@ object metrics {
   def updateFailedConfirmingStateChannelBinaryMetrics[F[_]: Monad: Metrics](): F[Unit] =
     Metrics[F].incrementCounter("dag_binaries_failed_confirmation")
 
+  def updateDroppedStateChannelBinaryMetrics[F[_]: Monad: Metrics](): F[Unit] =
+    Metrics[F].incrementCounter("dag_binaries_state_channel_dropped_total")
+
   private def getTrackerStateTags(state: TrackerState): TagSeq =
     Seq(
       ("binaries_tracked_number", state.tracked.size.toString),
+      ("binaries_in_flight", state.inFlight.size.toString),
       ("binaries_cap", state.cap.toString),
       ("binaries_retry_mode", state.retryMode.toString),
       ("binaries_no_confirmations_since_retry_count", state.noConfirmationsSinceRetryCount.toString),

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -98,7 +98,8 @@ object Services {
         stateChannelAllowanceLists,
         selfId,
         cfg.environment,
-        customPeersAllowanceList
+        customPeersAllowanceList,
+        storages.cluster
       )
 
       l0NodeContext = L0NodeContext

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/BinaryPoster.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/BinaryPoster.scala
@@ -1,6 +1,5 @@
 package io.constellationnetwork.currency.l0.snapshot.services
 
-import cats.Applicative
 import cats.data.{NonEmptyList, NonEmptySet}
 import cats.effect.Async
 import cats.syntax.all._
@@ -34,73 +33,61 @@ class BinaryPoster[F[_]: Async](
   private val sendRetries = 5
   private val allowedEmptyAllowanceList = List(Dev, Testnet, Integrationnet)
 
-  def post(
+  /** Decide whether THIS node should post `binary`.
+    *
+    *   - Honours the (unchanged) allowance gate: a node not permitted to send for this metagraph returns false.
+    *   - `force = true` (retry-mode escalation): every permitted node sends, guaranteeing the stalled binary reaches the global L0 even if
+    *     its deterministic owner is unavailable. The global L0 de-dups by hash.
+    *   - `force = false` (normal mode): only the deterministically-chosen, currently-alive owner sends.
+    */
+  def shouldSelfSend(
+    binary: Hashed[StateChannelSnapshotBinary],
+    alivePeers: Option[Set[PeerId]],
+    force: Boolean
+  ): F[Boolean] =
+    allowedPeersForSelection(binary).map {
+      case None => false // not permitted to send for this metagraph / environment
+      case Some(allowedPeers) =>
+        if (force) true
+        else {
+          val binarySigners = binary.signed.proofs.map(_.id.toPeerId).toList
+          val owner = PeerSelector.pickDeterministicPeer(binarySigners, allowedPeers, selfId, binary.lastSnapshotHash, alivePeers)
+          owner === selfId
+        }
+    }
+
+  /** Post the binary to a global L0 peer, with bounded retries. Marks the binary as transport-sent on success. */
+  def sendSelf(
     binary: Hashed[StateChannelSnapshotBinary],
     lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]]
-  ): F[Option[PeerId]] = {
+  ): F[Unit] =
+    performPost(binary, lastGlobalSnapshotSigners)
+
+  /** Returns Some(peers usable for deterministic selection) when this node is permitted to send, else None. Mirrors the previous
+    * allowance-gating semantics exactly.
+    */
+  private def allowedPeersForSelection(binary: Hashed[StateChannelSnapshotBinary]): F[Option[List[PeerId]]] = {
     val customPeersAllowed: List[PeerId] =
       customPeersAllowanceList.map(_.toList.map(_.peerId)).getOrElse(Nil)
 
-    checkAllowanceAndPost(binary, lastGlobalSnapshotSigners, customPeersAllowed)
-  }
-
-  private def checkAllowanceAndPost(
-    binary: Hashed[StateChannelSnapshotBinary],
-    lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]],
-    customPeersAllowed: List[PeerId]
-  ): F[Option[PeerId]] =
     stateChannelAllowanceLists match {
       case Some(allowanceLists) =>
-        identifierStorage.get.flatMap { metagraphId =>
+        identifierStorage.get.map { metagraphId =>
           allowanceLists.get(metagraphId) match {
             case Some(allowedPeers) =>
-              if (allowedPeers.contains(selfId)) {
-                pickPeerAndSend(binary, lastGlobalSnapshotSigners, customPeersAllowed.filter(allowedPeers.contains))
-              } else {
-                logger.info(s"[Queue] Self not in allowance list, skipping send") >>
-                  none[PeerId].pure
-              }
-            case None =>
-              handleEmptyAllowanceList(binary, lastGlobalSnapshotSigners, customPeersAllowed)
+              if (allowedPeers.contains(selfId)) customPeersAllowed.filter(allowedPeers.contains).some
+              else none
+            case None => emptyAllowancePeers(customPeersAllowed)
           }
         }
       case None =>
-        handleEmptyAllowanceList(binary, lastGlobalSnapshotSigners, customPeersAllowed)
-    }
-
-  private def handleEmptyAllowanceList(
-    binary: Hashed[StateChannelSnapshotBinary],
-    lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]],
-    customPeersAllowed: List[PeerId]
-  ): F[Option[PeerId]] =
-    if (allowedEmptyAllowanceList.contains(environment)) {
-      pickPeerAndSend(binary, lastGlobalSnapshotSigners, customPeersAllowed)
-    } else {
-      logger.info(s"[Queue] Empty allowance list not allowed in [$environment], skipping") >>
-        none[PeerId].pure
-    }
-
-  private def pickPeerAndSend(
-    binary: Hashed[StateChannelSnapshotBinary],
-    lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]],
-    allowedPeers: List[PeerId]
-  ): F[Option[PeerId]] = {
-    val binarySigners = binary.signed.proofs.map(_.id.toPeerId).toList
-    val peerToSendSnapshot = PeerSelector.pickDeterministicPeer(
-      binarySigners,
-      allowedPeers,
-      selfId,
-      binary.lastSnapshotHash
-    )
-
-    if (peerToSendSnapshot === selfId) {
-      logger.info(s"[Queue] Self selected to send binary ${binary.hash}") >>
-        performPost(binary, lastGlobalSnapshotSigners).as(peerToSendSnapshot.some)
-    } else {
-      logger.info(s"[Queue] Peer $peerToSendSnapshot selected to send binary ${binary.hash}") >>
-        peerToSendSnapshot.some.pure
+        emptyAllowancePeers(customPeersAllowed).pure[F]
     }
   }
+
+  private def emptyAllowancePeers(customPeersAllowed: List[PeerId]): Option[List[PeerId]] =
+    if (allowedEmptyAllowanceList.contains(environment)) customPeersAllowed.some
+    else none
 
   private def performPost(
     binary: Hashed[StateChannelSnapshotBinary],

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/BinaryTracker.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/BinaryTracker.scala
@@ -2,7 +2,6 @@ package io.constellationnetwork.currency.l0.snapshot.services
 
 import cats.effect.Ref
 import cats.effect.kernel.Async
-import cats.kernel.Eq
 import cats.syntax.all._
 
 import scala.collection.immutable.Queue
@@ -26,7 +25,10 @@ case class PendingBinary(
   binary: Hashed[StateChannelSnapshotBinary],
   currencySnapshotOrdinal: SnapshotOrdinal,
   enqueuedAtOrdinal: SnapshotOrdinal,
-  sendsSoFar: NonNegLong
+  sendsSoFar: NonNegLong,
+  // Global ordinal at which this node last *attempted* to post this binary itself.
+  // Used to pace re-sends (resend until confirmed, not until merely delivered once).
+  lastAttemptAtOrdinal: Option[SnapshotOrdinal]
 ) extends TrackedBinary
 
 case class ConfirmedBinary(
@@ -47,6 +49,9 @@ object GlobalSnapshotConfirmationProof {
 
 case class TrackerState(
   tracked: Queue[TrackedBinary],
+  // Hashes of binaries this node currently has an in-flight self-send for.
+  // Guarantees we never fork two concurrent posts of the same binary. Always a subset of pending hashes.
+  inFlight: Set[Hash],
   cap: NonNegLong,
   retryMode: Boolean,
   noConfirmationsSinceRetryCount: NonNegLong,
@@ -56,6 +61,7 @@ case class TrackerState(
 object TrackerState {
   def empty: TrackerState = TrackerState(
     tracked = Queue.empty[TrackedBinary],
+    inFlight = Set.empty[Hash],
     cap = NonNegLong.unsafeFrom(4L),
     retryMode = false,
     noConfirmationsSinceRetryCount = NonNegLong.MinValue,
@@ -64,56 +70,125 @@ object TrackerState {
 }
 
 trait BinaryTracker[F[_]] {
+
+  /** Append a binary to the send queue. Non-blocking. Returns false (and does not append) when the queue is at its bound, so a confirmation
+    * stall can never grow the queue without limit (OOM-induced restart loops).
+    */
   def enqueue(
     binary: Hashed[StateChannelSnapshotBinary],
     currencySnapshotOrdinal: SnapshotOrdinal,
     enqueuedAtGlobal: SnapshotOrdinal
-  ): F[Unit]
+  ): F[Boolean]
+
+  /** Record a successful transport (HTTP 2xx) of a binary. Does NOT mark it confirmed and does NOT suppress re-sending: only a
+    * global-snapshot confirmation (markAsConfirmed) stops re-sends.
+    */
   def markAsSent(binaryHash: Hash): F[Unit]
-  def markAsConfirmed(confirmedHashes: Set[Hash], proof: GlobalSnapshotConfirmationProof): F[Unit]
+
+  /** Atomically claim the right to post `binaryHash` (de-dup against concurrent / overlapping ticks). Stamps the attempt ordinal when
+    * provided. Returns false if already in flight or no longer pending.
+    */
+  def tryBeginSend(binaryHash: Hash, attemptedAt: Option[SnapshotOrdinal]): F[Boolean]
+
+  /** Release the in-flight claim for `binaryHash` (call from a guarantee so cancellation also releases). */
+  def endSend(binaryHash: Hash): F[Unit]
+
+  /** Pending binaries in chain order (FIFO == ascending currency ordinal), capped to `limit`. */
   def getPendingToRetry(cap: Int): F[List[PendingBinary]]
+
   def getState: F[TrackerState]
   def updateState(f: TrackerState => TrackerState): F[Unit]
+
+  /** Generic atomic read-modify-write, used to apply a full confirmation transition without tearing. */
+  def modify[A](f: TrackerState => (TrackerState, A)): F[A]
+
   def clear: F[Unit]
-  def pruneConfirmed: F[Unit]
 }
 
 object BinaryTracker {
-  def make[F[_]: Async]: F[BinaryTracker[F]] =
+
+  /** Pure: mark as confirmed every entry at or before the highest index whose hash is confirmed (the chain invariant guarantees
+    * predecessors of a confirmed binary are themselves on-chain), and drop those hashes from the in-flight set.
+    */
+  def markConfirmedUpToHighest(
+    state: TrackerState,
+    confirmedHashes: Set[Hash],
+    proof: GlobalSnapshotConfirmationProof
+  ): TrackerState = {
+    val indexedTracked = state.tracked.zipWithIndex
+
+    val maybeHighestConfirmationIndex = indexedTracked.collect {
+      case (p: PendingBinary, index) if confirmedHashes.contains(p.binary.hash) => index
+    }.maxOption
+
+    val updatedTracked = indexedTracked.map {
+      case (pendingBinary: PendingBinary, index) if index <= maybeHighestConfirmationIndex.getOrElse(-1) =>
+        ConfirmedBinary(pendingBinary, proof)
+      case (other, _) => other
+    }
+
+    state.copy(
+      tracked = updatedTracked,
+      inFlight = state.inFlight.diff(confirmedHashes)
+    )
+  }
+
+  /** Pure: drop confirmed entries and reconcile in-flight to the surviving pending hashes (prevents leaks). */
+  def pruneConfirmed(state: TrackerState): TrackerState = {
+    val keptTracked = state.tracked.filterNot(_.isInstanceOf[ConfirmedBinary])
+    val pendingHashes = keptTracked.collect { case p: PendingBinary => p.binary.hash }.toSet
+    state.copy(tracked = keptTracked, inFlight = state.inFlight.intersect(pendingHashes))
+  }
+
+  def make[F[_]: Async](maxTrackedBinaries: Int = 10000): F[BinaryTracker[F]] =
     Ref.of[F, TrackerState](TrackerState.empty).map { stateRef =>
       new BinaryTracker[F] {
-        def enqueue(binary: Hashed[StateChannelSnapshotBinary], currencySnapshotOrdinal: SnapshotOrdinal, enqueuedAt: SnapshotOrdinal)
-          : F[Unit] =
-          stateRef.update { state =>
-            state.copy(tracked = state.tracked :+ PendingBinary(binary, currencySnapshotOrdinal, enqueuedAt, NonNegLong.MinValue))
+        def enqueue(
+          binary: Hashed[StateChannelSnapshotBinary],
+          currencySnapshotOrdinal: SnapshotOrdinal,
+          enqueuedAt: SnapshotOrdinal
+        ): F[Boolean] =
+          stateRef.modify { state =>
+            if (state.tracked.size >= maxTrackedBinaries) (state, false)
+            else
+              (
+                state.copy(
+                  tracked = state.tracked :+ PendingBinary(binary, currencySnapshotOrdinal, enqueuedAt, NonNegLong.MinValue, none)
+                ),
+                true
+              )
           }
 
         def markAsSent(binaryHash: Hash): F[Unit] =
           stateRef.update { state =>
             val updatedTracked = state.tracked.map {
-              case PendingBinary(binary, currencySnapshotOrdinal, enqueuedAt, sendsSoFar) if binary.hash === binaryHash =>
-                PendingBinary(binary, currencySnapshotOrdinal, enqueuedAt, NonNegLong.unsafeFrom(sendsSoFar.value + 1))
+              case p: PendingBinary if p.binary.hash === binaryHash =>
+                p.copy(sendsSoFar = NonNegLong.unsafeFrom(p.sendsSoFar.value + 1))
               case other => other
             }
             state.copy(tracked = updatedTracked)
           }
 
-        def markAsConfirmed(confirmedHashes: Set[Hash], proof: GlobalSnapshotConfirmationProof): F[Unit] =
-          stateRef.update { state =>
-            val indexedTracked = state.tracked.zipWithIndex
-
-            val maybeHighestConfirmationIndex = indexedTracked.collect {
-              case (PendingBinary(binaryData, _, _, _), index) if confirmedHashes.contains(binaryData.hash) => index
-            }.maxOption
-
-            val updatedTracked = indexedTracked.map {
-              case (pendingBinary @ PendingBinary(_, _, _, _), index) if index <= maybeHighestConfirmationIndex.getOrElse(-1) =>
-                ConfirmedBinary(pendingBinary, proof)
-              case (other, _) => other
+        def tryBeginSend(binaryHash: Hash, attemptedAt: Option[SnapshotOrdinal]): F[Boolean] =
+          stateRef.modify { state =>
+            val isPending = state.tracked.exists {
+              case p: PendingBinary => p.binary.hash === binaryHash
+              case _                => false
             }
-
-            state.copy(tracked = updatedTracked)
+            if (!isPending || state.inFlight.contains(binaryHash)) (state, false)
+            else {
+              val updatedTracked = attemptedAt.fold(state.tracked) { ordinal =>
+                state.tracked.map {
+                  case p: PendingBinary if p.binary.hash === binaryHash => p.copy(lastAttemptAtOrdinal = ordinal.some)
+                  case other                                            => other
+                }
+              }
+              (state.copy(inFlight = state.inFlight + binaryHash, tracked = updatedTracked), true)
+            }
           }
+
+        def endSend(binaryHash: Hash): F[Unit] =
+          stateRef.update(state => state.copy(inFlight = state.inFlight - binaryHash))
 
         def getPendingToRetry(cap: Int): F[List[PendingBinary]] =
           stateRef.get.map { state =>
@@ -124,13 +199,9 @@ object BinaryTracker {
 
         def updateState(f: TrackerState => TrackerState): F[Unit] = stateRef.update(f)
 
-        def clear: F[Unit] = stateRef.set(TrackerState.empty)
+        def modify[A](f: TrackerState => (TrackerState, A)): F[A] = stateRef.modify(f)
 
-        def pruneConfirmed: F[Unit] =
-          stateRef.update { state =>
-            val updatedTracked = state.tracked.filterNot(_.isInstanceOf[ConfirmedBinary])
-            state.copy(tracked = updatedTracked)
-          }
+        def clear: F[Unit] = stateRef.set(TrackerState.empty)
       }
     }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/PeerSelector.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/PeerSelector.scala
@@ -8,21 +8,39 @@ import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.hash.Hash
 
 object PeerSelector {
+
+  /** Deterministically pick the single metagraph node responsible for posting a binary.
+    *
+    * `alivePeers` is the set of currently-responsive peers (plus self). When provided, dead peers are removed from the candidate set BEFORE
+    * selection, so a binary is never assigned to a node that cannot send it; if no candidate is alive, this node takes over
+    * (self-fallback). When `None` (liveness unknown), no filtering is applied and selection degrades to the pure deterministic behaviour.
+    * Selection is stable across nodes that share the same alive view, so exactly one node selects itself in the common case.
+    */
   def pickDeterministicPeer(
     binarySigners: List[PeerId],
     allowedPeers: List[PeerId],
     selfId: PeerId,
-    lastSnapshotHash: Hash
-  ): PeerId =
+    lastSnapshotHash: Hash,
+    alivePeers: Option[Set[PeerId]]
+  ): PeerId = {
+    def keepLive(peers: List[PeerId]): List[PeerId] =
+      alivePeers.fold(peers)(live => peers.filter(p => live.contains(p) || p === selfId))
+
     if (binarySigners.isEmpty) {
       selfId
-    } else if (binarySigners.size === 1) {
-      binarySigners.head
-    } else if (allowedPeers.isEmpty) {
-      selectFromSigners(binarySigners, lastSnapshotHash)
     } else {
-      selectFromEligiblePeers(binarySigners, allowedPeers, selfId, lastSnapshotHash)
+      val liveSigners = keepLive(binarySigners)
+      if (liveSigners.isEmpty) {
+        selfId
+      } else if (liveSigners.size === 1) {
+        liveSigners.head
+      } else if (allowedPeers.isEmpty) {
+        selectFromSigners(liveSigners, lastSnapshotHash)
+      } else {
+        selectFromEligiblePeers(liveSigners, keepLive(allowedPeers), lastSnapshotHash)
+      }
     }
+  }
 
   private def selectFromSigners(signers: List[PeerId], seed: Hash): PeerId = {
     val sortedSigners = signers.sortBy(_.toString)
@@ -33,12 +51,13 @@ object PeerSelector {
   private def selectFromEligiblePeers(
     binarySigners: List[PeerId],
     allowedPeers: List[PeerId],
-    selfId: PeerId,
     lastSnapshotHash: Hash
   ): PeerId = {
     val eligiblePeers = binarySigners.filter(allowedPeers.contains)
     if (eligiblePeers.isEmpty) {
-      selfId
+      // No signer is in the allowance list: fall back to a single deterministic signer rather than `selfId`,
+      // which would make every node post the same binary (thundering herd).
+      selectFromSigners(binarySigners, lastSnapshotHash)
     } else {
       val sortedEligible = eligiblePeers.sortBy(_.toString)
       val offset = computeOffset(sortedEligible, lastSnapshotHash)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/PeerSelector.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/PeerSelector.scala
@@ -11,10 +11,16 @@ object PeerSelector {
 
   /** Deterministically pick the single metagraph node responsible for posting a binary.
     *
-    * `alivePeers` is the set of currently-responsive peers (plus self). When provided, dead peers are removed from the candidate set BEFORE
-    * selection, so a binary is never assigned to a node that cannot send it; if no candidate is alive, this node takes over
-    * (self-fallback). When `None` (liveness unknown), no filtering is applied and selection degrades to the pure deterministic behaviour.
-    * Selection is stable across nodes that share the same alive view, so exactly one node selects itself in the common case.
+    * The PRIMARY owner and the rotation order are computed over the FULL candidate set (liveness-independent), seeded by `lastSnapshotHash`
+    * — so every node, regardless of its local view of who is alive, agrees on the same primary and the same ordering. `alivePeers` is then
+    * used ONLY to skip past dead peers along that shared rotation and let the next live one (or self) take over.
+    *
+    * Consequences:
+    *   - When the primary is alive, it always selects itself (it sees itself alive), so there is exactly one sender — no dependency on
+    *     other nodes agreeing about anyone's liveness.
+    *   - When the primary is dead, nodes converge on the same next-in-rotation live peer; transient alive-view disagreement can at worst
+    *     cause a (harmless, hash-deduplicated) duplicate send, never silence.
+    *   - When `alivePeers` is None (liveness unknown), selection degrades to the pure deterministic primary.
     */
   def pickDeterministicPeer(
     binarySigners: List[PeerId],
@@ -22,48 +28,33 @@ object PeerSelector {
     selfId: PeerId,
     lastSnapshotHash: Hash,
     alivePeers: Option[Set[PeerId]]
-  ): PeerId = {
-    def keepLive(peers: List[PeerId]): List[PeerId] =
-      alivePeers.fold(peers)(live => peers.filter(p => live.contains(p) || p === selfId))
-
-    if (binarySigners.isEmpty) {
-      selfId
-    } else {
-      val liveSigners = keepLive(binarySigners)
-      if (liveSigners.isEmpty) {
-        selfId
-      } else if (liveSigners.size === 1) {
-        liveSigners.head
-      } else if (allowedPeers.isEmpty) {
-        selectFromSigners(liveSigners, lastSnapshotHash)
-      } else {
-        selectFromEligiblePeers(liveSigners, keepLive(allowedPeers), lastSnapshotHash)
-      }
+  ): PeerId =
+    candidateSet(binarySigners, allowedPeers) match {
+      case Nil => selfId
+      case candidates =>
+        val sorted = candidates.distinct.sortBy(_.toString)
+        val primaryIdx = computeOffset(sorted, lastSnapshotHash)
+        alivePeers match {
+          case None => sorted(primaryIdx)
+          case Some(live) =>
+            val n = sorted.size
+            (0 until n).iterator
+              .map(i => sorted((primaryIdx + i) % n))
+              .find(p => live.contains(p) || p === selfId)
+              .getOrElse(selfId)
+        }
     }
-  }
 
-  private def selectFromSigners(signers: List[PeerId], seed: Hash): PeerId = {
-    val sortedSigners = signers.sortBy(_.toString)
-    val offset = computeOffset(sortedSigners, seed)
-    sortedSigners(offset)
-  }
-
-  private def selectFromEligiblePeers(
-    binarySigners: List[PeerId],
-    allowedPeers: List[PeerId],
-    lastSnapshotHash: Hash
-  ): PeerId = {
-    val eligiblePeers = binarySigners.filter(allowedPeers.contains)
-    if (eligiblePeers.isEmpty) {
-      // No signer is in the allowance list: fall back to a single deterministic signer rather than `selfId`,
-      // which would make every node post the same binary (thundering herd).
-      selectFromSigners(binarySigners, lastSnapshotHash)
-    } else {
-      val sortedEligible = eligiblePeers.sortBy(_.toString)
-      val offset = computeOffset(sortedEligible, lastSnapshotHash)
-      sortedEligible(offset)
+  /** The liveness-independent candidate set: prefer signers intersected with the allowance list, but never let an empty intersection
+    * collapse to "self on every node" (thundering herd) — fall back to the full signer set.
+    */
+  private def candidateSet(binarySigners: List[PeerId], allowedPeers: List[PeerId]): List[PeerId] =
+    if (binarySigners.isEmpty) Nil
+    else if (allowedPeers.isEmpty) binarySigners
+    else {
+      val eligible = binarySigners.filter(allowedPeers.contains)
+      if (eligible.isEmpty) binarySigners else eligible
     }
-  }
 
   private def computeOffset(peers: List[PeerId], seed: Hash): Int = {
     val hashInput = seed.value + peers.map(_.toString).mkString("|")

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/RetryStrategy.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/RetryStrategy.scala
@@ -12,16 +12,21 @@ object RetryStrategy {
   private val noConfirmationsToTriggerRetryMode: PosLong = PosLong.unsafeFrom(5L)
   private val confirmedCountMultiplier: PosLong = PosLong.unsafeFrom(4L)
 
-  // Hard cap on the exponential backoff. Without it `Math.pow(2, exponent)` saturates to Long.MaxValue, which
-  // freezes `cap` at 0 for an unbounded number of snapshots (apparent permanent disconnection). With the clamp the
-  // longest silent window between cap-1 send attempts is 2^maxBackoffExponent confirmations.
-  private val maxBackoffExponent: NonNegLong = NonNegLong.unsafeFrom(6L)
+  // The send budget (`cap`) is NEVER allowed to reach 0. An external health monitor restarts the metagraph if the
+  // global network sees no metagraph snapshot for ~5 minutes; going silent would therefore GUARANTEE that restart.
+  // Instead we always keep posting at least the chain head every tick, so a recoverable stall heals before the
+  // restart window, and only a genuinely unrecoverable stall is left for the (clean, rollback-based) restart.
+  private val minCap: NonNegLong = NonNegLong.unsafeFrom(1L)
+
+  // Upper bound on the informational stall counter (how many confirmation-less ordinals we have seen at cap == 1).
+  // Purely for metrics; it no longer gates sending. Clamped so it cannot overflow.
+  private val maxStallExponent: NonNegLong = NonNegLong.unsafeFrom(6L)
 
   def shouldEnterRetryMode(state: TrackerState, currentOrdinal: SnapshotOrdinal): Boolean = {
     val hasStalled = state.tracked.exists {
       case PendingBinary(_, _, enqueuedAtOrdinal, _, _) =>
-        // Ignore not-yet-anchored binaries (enqueued before the first global ordinal was known) so we do not
-        // trip retry mode spuriously at startup, when enqueuedAtOrdinal defaults to MinValue.
+        // Ignore not-yet-anchored binaries (enqueued before the first global ordinal was known) so we do not trip
+        // retry mode spuriously at startup, when enqueuedAtOrdinal defaults to MinValue.
         enqueuedAtOrdinal =!= SnapshotOrdinal.MinValue &&
         currentOrdinal.value - enqueuedAtOrdinal.value >= noConfirmationsToTriggerRetryMode
       case _ => false
@@ -51,15 +56,12 @@ object RetryStrategy {
     } else {
       val confirmedCount = state.tracked.count(_.isInstanceOf[ConfirmedBinary])
 
-      if (confirmedCount > 0) {
+      if (confirmedCount > 0)
         updateCapOnConfirmations(state, confirmedCount)
-      } else if (state.cap.value > 1) {
+      else if (state.cap.value > minCap.value)
         decreaseCap(state)
-      } else if (state.cap.value == 1) {
-        enterBackoffMode(state)
-      } else {
-        updateBackoffCounter(state)
-      }
+      else
+        holdAtMinimum(state)
     }
 
   private def updateCapOnConfirmations(state: TrackerState, confirmedCount: Int): TrackerState = {
@@ -69,7 +71,7 @@ object RetryStrategy {
       Math.ceil(log2(state.tracked.length.toDouble)).toLong
     }.getOrElse(NonNegLong.MinValue)
     val proposedCap = state.cap.value + surplus.value
-    val updatedCap = NonNegLong.from(Math.min(proposedCap, maxCap)).getOrElse(NonNegLong.MinValue)
+    val updatedCap = NonNegLong.from(Math.max(Math.min(proposedCap, maxCap), minCap.value)).getOrElse(minCap)
 
     state.copy(
       cap = updatedCap,
@@ -78,32 +80,20 @@ object RetryStrategy {
     )
   }
 
+  // Shrink the per-tick send budget on a confirmation-less ordinal, but never below `minCap` (== 1).
   private def decreaseCap(state: TrackerState): TrackerState =
     state.copy(
-      cap = NonNegLong.from(state.cap.value - 1).getOrElse(NonNegLong.MinValue),
+      cap = NonNegLong.from(Math.max(state.cap.value - 1, minCap.value)).getOrElse(minCap),
       backoffExponent = NonNegLong.unsafeFrom(0L),
       noConfirmationsSinceRetryCount = NonNegLong.unsafeFrom(0L)
     )
 
-  private def enterBackoffMode(state: TrackerState): TrackerState =
+  // Already at the minimum budget and still no confirmations: KEEP sending the head every tick (never go silent),
+  // only advancing informational stall counters.
+  private def holdAtMinimum(state: TrackerState): TrackerState =
     state.copy(
-      cap = NonNegLong.unsafeFrom(0L),
-      backoffExponent = NonNegLong.from(Math.min(state.backoffExponent.value + 1L, maxBackoffExponent.value)).getOrElse(maxBackoffExponent),
-      noConfirmationsSinceRetryCount = NonNegLong.unsafeFrom(1L)
+      cap = minCap,
+      noConfirmationsSinceRetryCount = NonNegLong.from(state.noConfirmationsSinceRetryCount.value + 1).getOrElse(NonNegLong.MaxValue),
+      backoffExponent = NonNegLong.from(Math.min(state.backoffExponent.value + 1L, maxStallExponent.value)).getOrElse(maxStallExponent)
     )
-
-  private def updateBackoffCounter(state: TrackerState): TrackerState = {
-    val noConfirmationsSinceRetryCount =
-      NonNegLong.from(state.noConfirmationsSinceRetryCount.value + 1).getOrElse(NonNegLong.MaxValue)
-    val clampedExponent = Math.min(state.backoffExponent.value, maxBackoffExponent.value)
-    val updatedCap =
-      if (noConfirmationsSinceRetryCount.value >= Math.ceil(Math.pow(2.0, clampedExponent.toDouble)).toLong)
-        NonNegLong.unsafeFrom(1L)
-      else state.cap
-
-    state.copy(
-      cap = updatedCap,
-      noConfirmationsSinceRetryCount = noConfirmationsSinceRetryCount
-    )
-  }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/RetryStrategy.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/RetryStrategy.scala
@@ -12,9 +12,17 @@ object RetryStrategy {
   private val noConfirmationsToTriggerRetryMode: PosLong = PosLong.unsafeFrom(5L)
   private val confirmedCountMultiplier: PosLong = PosLong.unsafeFrom(4L)
 
+  // Hard cap on the exponential backoff. Without it `Math.pow(2, exponent)` saturates to Long.MaxValue, which
+  // freezes `cap` at 0 for an unbounded number of snapshots (apparent permanent disconnection). With the clamp the
+  // longest silent window between cap-1 send attempts is 2^maxBackoffExponent confirmations.
+  private val maxBackoffExponent: NonNegLong = NonNegLong.unsafeFrom(6L)
+
   def shouldEnterRetryMode(state: TrackerState, currentOrdinal: SnapshotOrdinal): Boolean = {
     val hasStalled = state.tracked.exists {
-      case PendingBinary(_, _, enqueuedAtOrdinal, _) =>
+      case PendingBinary(_, _, enqueuedAtOrdinal, _, _) =>
+        // Ignore not-yet-anchored binaries (enqueued before the first global ordinal was known) so we do not
+        // trip retry mode spuriously at startup, when enqueuedAtOrdinal defaults to MinValue.
+        enqueuedAtOrdinal =!= SnapshotOrdinal.MinValue &&
         currentOrdinal.value - enqueuedAtOrdinal.value >= noConfirmationsToTriggerRetryMode
       case _ => false
     }
@@ -24,8 +32,8 @@ object RetryStrategy {
     } else {
       val pendingCount = state.tracked.collect { case _: PendingBinary => 1 }.sum
       val allPendingAlreadySent = state.tracked.forall {
-        case PendingBinary(_, _, _, sendsSoFar) => sendsSoFar.value >= 1
-        case _                                  => true
+        case PendingBinary(_, _, _, sendsSoFar, _) => sendsSoFar.value >= 1
+        case _                                     => true
       }
 
       if (pendingCount <= state.cap.value && allPendingAlreadySent && !hasStalled)
@@ -37,7 +45,7 @@ object RetryStrategy {
 
   def updateRetryParameters(state: TrackerState, previousRetryMode: Boolean): TrackerState =
     if ((!state.retryMode && previousRetryMode) || state.tracked.isEmpty) {
-      TrackerState.empty.copy(tracked = state.tracked)
+      TrackerState.empty.copy(tracked = state.tracked, inFlight = state.inFlight)
     } else if (!state.retryMode) {
       state
     } else {
@@ -80,15 +88,16 @@ object RetryStrategy {
   private def enterBackoffMode(state: TrackerState): TrackerState =
     state.copy(
       cap = NonNegLong.unsafeFrom(0L),
-      backoffExponent = NonNegLong.from(state.backoffExponent.value + 1L).getOrElse(NonNegLong.MaxValue),
+      backoffExponent = NonNegLong.from(Math.min(state.backoffExponent.value + 1L, maxBackoffExponent.value)).getOrElse(maxBackoffExponent),
       noConfirmationsSinceRetryCount = NonNegLong.unsafeFrom(1L)
     )
 
   private def updateBackoffCounter(state: TrackerState): TrackerState = {
     val noConfirmationsSinceRetryCount =
       NonNegLong.from(state.noConfirmationsSinceRetryCount.value + 1).getOrElse(NonNegLong.MaxValue)
+    val clampedExponent = Math.min(state.backoffExponent.value, maxBackoffExponent.value)
     val updatedCap =
-      if (noConfirmationsSinceRetryCount.value >= Math.ceil(Math.pow(2.0, state.backoffExponent.value.toDouble)).toLong)
+      if (noConfirmationsSinceRetryCount.value >= Math.ceil(Math.pow(2.0, clampedExponent.toDouble)).toLong)
         NonNegLong.unsafeFrom(1L)
       else state.cap
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySender.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySender.scala
@@ -3,15 +3,16 @@ package io.constellationnetwork.currency.l0.snapshot.services
 import cats.Applicative
 import cats.data.NonEmptySet
 import cats.effect.std.Supervisor
+import cats.effect.syntax.all._
 import cats.effect.{Async, Temporal}
 import cats.syntax.all._
 
 import scala.concurrent.duration._
 
-import io.constellationnetwork.currency.l0.metrics.updateStateChannelRetryParametersMetrics
+import io.constellationnetwork.currency.l0.metrics.{updateDroppedStateChannelBinaryMetrics, updateStateChannelRetryParametersMetrics}
 import io.constellationnetwork.domain.allowance_list.AllowanceListEntry
 import io.constellationnetwork.env.AppEnvironment
-import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
+import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage}
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.http.p2p.clients.StateChannelSnapshotClient
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
@@ -23,6 +24,7 @@ import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.{Hashed, Hasher}
 import io.constellationnetwork.statechannel.StateChannelSnapshotBinary
 
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 trait StateChannelBinarySender[F[_]] {
@@ -46,12 +48,14 @@ object StateChannelBinarySender {
     stateChannelAllowanceLists: Option[Map[Address, NonEmptySet[PeerId]]],
     selfId: PeerId,
     environment: AppEnvironment,
-    customPeersAllowanceList: Option[Set[AllowanceListEntry]]
+    customPeersAllowanceList: Option[Set[AllowanceListEntry]],
+    cluster: ClusterStorage[F],
+    maxTrackedBinaries: Int = 10000
   )(implicit S: Supervisor[F]): F[StateChannelBinarySender[F]] = {
     val logger = Slf4jLogger.getLoggerFromName(this.getClass.getName)
 
     for {
-      tracker <- BinaryTracker.make[F]
+      tracker <- BinaryTracker.make[F](maxTrackedBinaries)
       poster = new BinaryPoster[F](
         identifierStorage,
         globalL0ClusterStorage,
@@ -67,6 +71,9 @@ object StateChannelBinarySender {
         poster,
         lastGlobalSnapshotStorage,
         identifierStorage,
+        cluster,
+        selfId,
+        fa => S.supervise(fa).void,
         logger
       )
       _ <- startBackgroundWorker(sender, lastGlobalSnapshotStorage, logger)
@@ -76,20 +83,22 @@ object StateChannelBinarySender {
   private def startBackgroundWorker[F[_]: Async](
     sender: StateChannelBinarySenderImpl[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
-    logger: org.typelevel.log4cats.SelfAwareStructuredLogger[F]
+    logger: SelfAwareStructuredLogger[F]
   )(implicit S: Supervisor[F]): F[Unit] = {
+
+    // A single tick. Errors are swallowed and logged here so a transient failure (e.g. reading cluster/storage)
+    // never tears down the stream, which would otherwise trigger the 1s restart path on every tick (restart loop).
+    def tick: F[Unit] =
+      lastGlobalSnapshotStorage.get.flatMap {
+        case Some(snapshot) => sender.processQueue(snapshot)
+        case None           => sender.processQueueWithoutSnapshot
+      }
+        .handleErrorWith(err => logger.warn(err)("[Queue] Processing tick failed; will retry on next tick"))
 
     def runWorker: F[Unit] =
       fs2.Stream
         .awakeEvery[F](5.seconds)
-        .evalMap(_ =>
-          lastGlobalSnapshotStorage.get.flatMap {
-            case Some(snapshot) =>
-              sender.processQueue(snapshot)
-            case None =>
-              sender.processQueueWithoutSnapshot
-          }
-        )
+        .evalMap(_ => tick)
         .compile
         .drain
         .handleErrorWith { err =>
@@ -100,107 +109,163 @@ object StateChannelBinarySender {
 
     S.supervise(runWorker).void
   }
+}
 
-  private class StateChannelBinarySenderImpl[F[_]: Async: Hasher: Metrics](
-    tracker: BinaryTracker[F],
-    poster: BinaryPoster[F],
-    lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
-    identifierStorage: IdentifierStorage[F],
-    logger: org.typelevel.log4cats.SelfAwareStructuredLogger[F]
-  )(implicit S: Supervisor[F])
-      extends StateChannelBinarySender[F] {
+private[services] class StateChannelBinarySenderImpl[F[_]: Async: Hasher: Metrics](
+  tracker: BinaryTracker[F],
+  poster: BinaryPoster[F],
+  lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+  identifierStorage: IdentifierStorage[F],
+  cluster: ClusterStorage[F],
+  selfId: PeerId,
+  // How a posting effect is scheduled. Production forks it on a Supervisor (non-blocking, fire-and-forget);
+  // tests pass identity to run it synchronously and observe ordering deterministically.
+  forkSend: F[Unit] => F[Unit],
+  logger: SelfAwareStructuredLogger[F]
+) extends StateChannelBinarySender[F] {
 
-    def enqueue(
-      binary: Hashed[StateChannelSnapshotBinary],
-      currencySnapshotOrdinal: SnapshotOrdinal,
-      lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]]
-    ): F[Unit] =
-      for {
-        currentGlobalOrdinal <- lastGlobalSnapshotStorage.getOrdinal.map(_.getOrElse(SnapshotOrdinal.MinValue))
-        _ <- tracker.enqueue(binary, currencySnapshotOrdinal, currentGlobalOrdinal)
-        _ <- logger.info(s"[Queue] Enqueued binary ${binary.hash} at ordinal $currencySnapshotOrdinal")
-      } yield ()
+  // Max pending binaries inspected per normal-mode tick (chain order). Retry mode uses the adaptive `cap`.
+  private val normalSendWindow = 10
+  // Re-post an unconfirmed binary if our last attempt was at least this many global ordinals ago. Avoids both
+  // stranding a delivered-but-unconfirmed binary (we keep re-sending until it is confirmed) and hammering the L0.
+  private val resendIntervalOrdinals = 2L
 
-    def confirm(globalSnapshot: Hashed[GlobalIncrementalSnapshot]): F[Unit] =
-      for {
-        identifier <- identifierStorage.get
-        confirmedHashes <- getConfirmedHashes(identifier, globalSnapshot)
-        state <- tracker.getState
-        oldRetryMode = state.retryMode
-        proof = GlobalSnapshotConfirmationProof.fromGlobalSnapshot(globalSnapshot)
-        _ <- tracker.markAsConfirmed(confirmedHashes, proof)
-        updatedState <- tracker.getState
-        retryMode = RetryStrategy.shouldEnterRetryMode(updatedState, globalSnapshot.ordinal)
-        _ <- tracker.updateState(_.copy(retryMode = retryMode))
-        _ <- tracker.updateState(RetryStrategy.updateRetryParameters(_, oldRetryMode))
-        _ <- tracker.pruneConfirmed
-        metricsState <- tracker.getState
-        _ <- updateStateChannelRetryParametersMetrics(metricsState)
-      } yield ()
+  def enqueue(
+    binary: Hashed[StateChannelSnapshotBinary],
+    currencySnapshotOrdinal: SnapshotOrdinal,
+    lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]]
+  ): F[Unit] =
+    for {
+      currentGlobalOrdinal <- lastGlobalSnapshotStorage.getOrdinal.map(_.getOrElse(SnapshotOrdinal.MinValue))
+      enqueued <- tracker.enqueue(binary, currencySnapshotOrdinal, currentGlobalOrdinal)
+      _ <-
+        if (enqueued)
+          logger.info(s"[Queue] Enqueued binary ${binary.hash} at ordinal $currencySnapshotOrdinal")
+        else
+          logger.error(
+            s"[Queue] Send queue is full (>= $normalSendWindow window, bound reached); dropping binary ${binary.hash} " +
+              s"at ordinal $currencySnapshotOrdinal. The chain head is not draining; metagraph may require resync."
+          ) >> updateDroppedStateChannelBinaryMetrics()
+    } yield ()
 
-    def clearPending: F[Unit] =
-      logger.info("[Queue] Clearing all pending binaries") >> tracker.clear
-
-    def processQueue(globalSnapshot: Hashed[GlobalIncrementalSnapshot]): F[Unit] = {
-      val lastGlobalSnapshotSigners = globalSnapshot.signed.proofs.map(_.id.toPeerId).some
-      tracker.getState.flatMap { state =>
-        if (state.retryMode) {
-          processRetryMode(state.cap.value.toInt, lastGlobalSnapshotSigners)
-        } else {
-          processNormalMode(lastGlobalSnapshotSigners)
-        }
+  def confirm(globalSnapshot: Hashed[GlobalIncrementalSnapshot]): F[Unit] =
+    for {
+      identifier <- identifierStorage.get
+      confirmedHashes <- getConfirmedHashes(identifier, globalSnapshot)
+      proof = GlobalSnapshotConfirmationProof.fromGlobalSnapshot(globalSnapshot)
+      // Whole confirmation transition applied atomically so a concurrent enqueue/worker can't act on torn state.
+      metricsState <- tracker.modify { state =>
+        val oldRetryMode = state.retryMode
+        val confirmed = BinaryTracker.markConfirmedUpToHighest(state, confirmedHashes, proof)
+        val retryMode = RetryStrategy.shouldEnterRetryMode(confirmed, globalSnapshot.ordinal)
+        val withMode = confirmed.copy(retryMode = retryMode)
+        val withParams = RetryStrategy.updateRetryParameters(withMode, oldRetryMode)
+        val pruned = BinaryTracker.pruneConfirmed(withParams)
+        (pruned, pruned)
       }
+      _ <- updateStateChannelRetryParametersMetrics(metricsState)
+    } yield ()
+
+  def clearPending: F[Unit] =
+    logger.info("[Queue] Clearing all pending binaries") >> tracker.clear
+
+  def processQueue(globalSnapshot: Hashed[GlobalIncrementalSnapshot]): F[Unit] = {
+    val signers = globalSnapshot.signed.proofs.map(_.id.toPeerId).some
+    val ordinal = globalSnapshot.ordinal
+    for {
+      alive <- aliveSet
+      state <- tracker.getState
+      _ <-
+        if (state.retryMode) processRetryMode(state.cap.value.toInt, signers, ordinal.some, alive)
+        else processNormalMode(signers, ordinal.some, alive)
+    } yield ()
+  }
+
+  def processQueueWithoutSnapshot: F[Unit] =
+    for {
+      alive <- aliveSet
+      state <- tracker.getState
+      _ <-
+        if (!state.retryMode) processNormalMode(none, none, alive)
+        else logger.info("[Queue] Retry mode active but no global snapshot available")
+    } yield ()
+
+  // Responsive metagraph peers plus self. None means "liveness unknown this tick" -> selection does not filter,
+  // degrading to the pure deterministic behaviour rather than wrongly treating everyone as dead.
+  private def aliveSet: F[Option[Set[PeerId]]] =
+    cluster.getResponsivePeers
+      .map(peers => (peers.map(_.id) + selfId).some)
+      .handleErrorWith { err =>
+        logger
+          .warn(err)("[Queue] Could not read responsive peers; not filtering by liveness this tick")
+          .as(none[Set[PeerId]])
+      }
+
+  private def processNormalMode(
+    signers: Option[NonEmptySet[PeerId]],
+    currentOrdinal: Option[SnapshotOrdinal],
+    alive: Option[Set[PeerId]]
+  ): F[Unit] =
+    tracker.getPendingToRetry(normalSendWindow).flatMap { pending =>
+      val due = pending.filter(p => isDueForResend(p, currentOrdinal))
+      if (due.nonEmpty)
+        logger.info(s"[Queue] Normal mode: ${due.size} binaries due for (re)send") >>
+          due.traverse_(p => attemptSelfSend(p, signers, alive, currentOrdinal, force = false))
+      else
+        Applicative[F].unit
     }
 
-    def processQueueWithoutSnapshot: F[Unit] =
-      tracker.getState.flatMap { state =>
-        if (!state.retryMode) {
-          processNormalMode(none)
-        } else {
-          logger.info("[Queue] Retry mode active but no global snapshot available") >>
-            Applicative[F].unit
-        }
-      }
-
-    private def processNormalMode(signers: Option[NonEmptySet[PeerId]]): F[Unit] =
-      tracker.getPendingToRetry(10).flatMap { pending =>
-        val unsent = pending.filter(_.sendsSoFar.value === 0L)
-        if (unsent.nonEmpty) {
-          logger.info(s"[Queue] Processing ${unsent.size} unsent binaries") >>
-            unsent.traverse_(p => sendBinaryInBackground(p, signers))
-        } else {
-          Applicative[F].unit
-        }
-      }
-
-    private def processRetryMode(cap: Int, signers: Option[NonEmptySet[PeerId]]): F[Unit] =
-      tracker.getPendingToRetry(cap).flatMap { toRetry =>
-        val sorted = toRetry.sortBy(_.currencySnapshotOrdinal.value.value)
-        if (sorted.nonEmpty) {
-          logger.info(s"[RetryMode] Processing ${sorted.size} binaries") >>
-            sorted.traverse_(p => sendBinaryInBackground(p, signers))
-        } else {
-          Applicative[F].unit
-        }
-      }
-
-    private def sendBinaryInBackground(
-      pending: PendingBinary,
-      signers: Option[NonEmptySet[PeerId]] = none
-    ): F[Unit] =
-      S.supervise(
-        poster
-          .post(pending.binary, signers)
-          .flatMap(peerId => logger.info(s"[Queue] Sent ${pending.binary.hash} via $peerId"))
-          .handleErrorWith(err => logger.warn(s"[Queue] Failed to send ${pending.binary.hash}: ${err.getMessage}"))
-      ).void
-
-    private def getConfirmedHashes(
-      identifier: Address,
-      globalSnapshot: Hashed[GlobalIncrementalSnapshot]
-    ): F[Set[Hash]] = {
-      val binaries = globalSnapshot.stateChannelSnapshots.get(identifier).toList.flatMap(_.toList)
-      binaries.traverse(_.toHashed).map(_.map(_.hash)).map(_.toSet)
+  private def processRetryMode(
+    cap: Int,
+    signers: Option[NonEmptySet[PeerId]],
+    currentOrdinal: Option[SnapshotOrdinal],
+    alive: Option[Set[PeerId]]
+  ): F[Unit] =
+    tracker.getPendingToRetry(cap).flatMap { toRetry =>
+      // Chain order; in retry mode every permitted node escalates to sending (force = true) so a binary whose
+      // deterministic owner is unavailable still reaches the global L0 (de-duplicated there by hash).
+      val sorted = toRetry.sortBy(_.currencySnapshotOrdinal.value.value)
+      if (sorted.nonEmpty)
+        logger.info(s"[RetryMode] Escalating send of ${sorted.size} binaries") >>
+          sorted.traverse_(p => attemptSelfSend(p, signers, alive, currentOrdinal, force = true))
+      else
+        Applicative[F].unit
     }
+
+  private def isDueForResend(p: PendingBinary, currentOrdinal: Option[SnapshotOrdinal]): Boolean =
+    p.lastAttemptAtOrdinal match {
+      case None       => true
+      case Some(last) => currentOrdinal.exists(o => o.value.value - last.value.value >= resendIntervalOrdinals)
+    }
+
+  private def attemptSelfSend(
+    p: PendingBinary,
+    signers: Option[NonEmptySet[PeerId]],
+    alive: Option[Set[PeerId]],
+    currentOrdinal: Option[SnapshotOrdinal],
+    force: Boolean
+  ): F[Unit] =
+    poster.shouldSelfSend(p.binary, alive, force).flatMap {
+      case false => Applicative[F].unit
+      case true =>
+        tracker.tryBeginSend(p.binary.hash, currentOrdinal).flatMap {
+          case false => Applicative[F].unit // already in flight on this node
+          case true =>
+            forkSend(
+              poster
+                .sendSelf(p.binary, signers)
+                .flatMap(_ => logger.info(s"[Queue] Posted ${p.binary.hash}"))
+                .handleErrorWith(err => logger.warn(s"[Queue] Failed to post ${p.binary.hash}: ${err.getMessage}"))
+                .guarantee(tracker.endSend(p.binary.hash))
+            )
+        }
+    }
+
+  private def getConfirmedHashes(
+    identifier: Address,
+    globalSnapshot: Hashed[GlobalIncrementalSnapshot]
+  ): F[Set[Hash]] = {
+    val binaries = globalSnapshot.stateChannelSnapshots.get(identifier).toList.flatMap(_.toList)
+    binaries.traverse(_.toHashed).map(_.map(_.hash)).map(_.toSet)
   }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySender.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySender.scala
@@ -73,6 +73,7 @@ object StateChannelBinarySender {
         identifierStorage,
         cluster,
         selfId,
+        maxTrackedBinaries,
         fa => S.supervise(fa).void,
         logger
       )
@@ -118,6 +119,7 @@ private[services] class StateChannelBinarySenderImpl[F[_]: Async: Hasher: Metric
   identifierStorage: IdentifierStorage[F],
   cluster: ClusterStorage[F],
   selfId: PeerId,
+  maxTrackedBinaries: Int,
   // How a posting effect is scheduled. Production forks it on a Supervisor (non-blocking, fire-and-forget);
   // tests pass identity to run it synchronously and observe ordering deterministically.
   forkSend: F[Unit] => F[Unit],
@@ -143,7 +145,7 @@ private[services] class StateChannelBinarySenderImpl[F[_]: Async: Hasher: Metric
           logger.info(s"[Queue] Enqueued binary ${binary.hash} at ordinal $currencySnapshotOrdinal")
         else
           logger.error(
-            s"[Queue] Send queue is full (>= $normalSendWindow window, bound reached); dropping binary ${binary.hash} " +
+            s"[Queue] Send queue is full (bound=$maxTrackedBinaries reached); dropping binary ${binary.hash} " +
               s"at ordinal $currencySnapshotOrdinal. The chain head is not draining; metagraph may require resync."
           ) >> updateDroppedStateChannelBinaryMetrics()
     } yield ()
@@ -194,7 +196,7 @@ private[services] class StateChannelBinarySenderImpl[F[_]: Async: Hasher: Metric
   // degrading to the pure deterministic behaviour rather than wrongly treating everyone as dead.
   private def aliveSet: F[Option[Set[PeerId]]] =
     cluster.getResponsivePeers
-      .map(peers => (peers.map(_.id) + selfId).some)
+      .map(peers => (peers.toList.map(_.id).toSet + selfId).some)
       .handleErrorWith { err =>
         logger
           .warn(err)("[Queue] Could not read responsive peers; not filtering by liveness this tick")
@@ -250,13 +252,17 @@ private[services] class StateChannelBinarySenderImpl[F[_]: Async: Hasher: Metric
       case true =>
         tracker.tryBeginSend(p.binary.hash, currentOrdinal).flatMap {
           case false => Applicative[F].unit // already in flight on this node
-          case true =>
+          case true  =>
+            // .guarantee releases the in-flight claim when the (forked) send finishes or is cancelled; the outer
+            // handleErrorWith covers the rare case where scheduling the fork itself fails, so the claim never leaks.
             forkSend(
               poster
                 .sendSelf(p.binary, signers)
                 .flatMap(_ => logger.info(s"[Queue] Posted ${p.binary.hash}"))
                 .handleErrorWith(err => logger.warn(s"[Queue] Failed to post ${p.binary.hash}: ${err.getMessage}"))
                 .guarantee(tracker.endSend(p.binary.hash))
+            ).handleErrorWith(err =>
+              logger.warn(err)(s"[Queue] Could not schedule send for ${p.binary.hash}") >> tracker.endSend(p.binary.hash)
             )
         }
     }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
@@ -2,13 +2,11 @@ package io.constellationnetwork.currency.l0.snapshot.services
 
 import java.security.KeyPair
 
-import cats.data.{Kleisli, NonEmptyList, NonEmptySet}
+import cats.data._
 import cats.effect._
-import cats.effect.std.Supervisor
 import cats.syntax.all._
 
 import scala.collection.immutable.SortedMap
-import scala.concurrent.duration._
 
 import io.constellationnetwork.currency.schema.currency.SnapshotFee
 import io.constellationnetwork.env.AppEnvironment
@@ -17,7 +15,7 @@ import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.generators.nonEmptyStringGen
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
-import io.constellationnetwork.node.shared.domain.cluster.storage.L0ClusterStorage
+import io.constellationnetwork.node.shared.domain.cluster.storage.{ClusterStorage, L0ClusterStorage}
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelValidator.StateChannelValidationError
 import io.constellationnetwork.node.shared.http.p2p.PeerResponse.PeerResponse
@@ -25,9 +23,11 @@ import io.constellationnetwork.node.shared.http.p2p.clients.StateChannelSnapshot
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.IdentifierStorage
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.cluster.{ClusterId, ClusterSessionToken}
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.generators.{chooseNumRefined, signedOf}
 import io.constellationnetwork.schema.height.Height
+import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer._
 import io.constellationnetwork.schema.{GlobalStateProofSelector, _}
 import io.constellationnetwork.security._
@@ -40,22 +40,15 @@ import io.constellationnetwork.statechannel.StateChannelSnapshotBinary
 
 import com.comcast.ip4s.{Host, Port}
 import eu.timepit.refined.auto._
-import eu.timepit.refined.cats._
 import eu.timepit.refined.types.numeric.NonNegLong
+import fs2.Stream
 import org.scalacheck.Gen
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import weaver.MutableIOSuite
 import weaver.scalacheck.Checkers
 
 object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
   implicit val globalStateProofSelector: GlobalStateProofSelector = GlobalStateProofSelector(SnapshotOrdinal(NonNegLong(Long.MaxValue)))
-
-  def mkEmptySnapshots(n: Long, keyPair: KeyPair)(
-    implicit hs: Hasher[IO],
-    sp: SecurityProvider[IO],
-    globalStateProofSelector: GlobalStateProofSelector,
-    jsonSerializer: JsonSerializer[IO]
-  ): IO[List[Hashed[GlobalIncrementalSnapshot]]] =
-    (1L to n).toList.traverse(ordinal => mkSnapshot(SnapshotOrdinal(NonNegLong.unsafeFrom(ordinal)), keyPair, List.empty))
 
   def mkSnapshot(ordinal: SnapshotOrdinal, keyPair: KeyPair, confirmedBinaries: List[Signed[StateChannelSnapshotBinary]])(
     implicit hs: Hasher[IO],
@@ -81,59 +74,67 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
       .flatMap(_.toHashed)
   }
 
-  def mkService(
+  // A cluster storage that reports a configurable set of responsive peers (default: none, i.e. only self is alive).
+  private def clusterStorage(responsive: Set[Peer] = Set.empty): ClusterStorage[IO] =
+    new ClusterStorage[IO] {
+      def getPeers: IO[Set[Peer]] = responsive.pure[IO]
+      def getResponsivePeers: IO[Set[Peer]] = responsive.pure[IO]
+      def getPeer(id: PeerId): IO[Option[Peer]] = none[Peer].pure[IO]
+      def addPeer(peer: Peer): IO[Boolean] = ???
+      def hasPeerId(id: PeerId): IO[Boolean] = ???
+      def hasPeerHostPort(host: Host, p2pPort: Port): IO[Boolean] = ???
+      def updatePeerState(id: PeerId, state: NodeState): IO[Boolean] = ???
+      def setPeerResponsiveness(id: PeerId, responsiveness: PeerResponsiveness): IO[Unit] = ???
+      def removePeer(id: PeerId): IO[Unit] = ???
+      def removePeers(ids: Set[PeerId]): IO[Unit] = ???
+      def peerChanges: Stream[IO, Ior[Peer, Peer]] = Stream.empty
+      def createToken: IO[ClusterSessionToken] = ???
+      def getToken: IO[Option[ClusterSessionToken]] = none[ClusterSessionToken].pure[IO]
+      def setToken(token: ClusterSessionToken): IO[Unit] = ???
+      def getClusterId: ClusterId = ???
+    }
+
+  /** Build the REAL StateChannelBinarySenderImpl with synchronous send scheduling, so that ordering and re-send behaviour are observable
+    * deterministically (no fire-and-forget races in the test).
+    */
+  def mkSender(
     identifier: Address,
-    currentOrdinal: SnapshotOrdinal,
+    enqueueAtOrdinal: SnapshotOrdinal,
     state: TrackerState,
     stateChannelAllowanceLists: Option[Map[Address, NonEmptySet[PeerId]]] = None,
     selfId: PeerId = PeerId(Hex("0000000000000000")),
-    environment: AppEnvironment = Dev
+    environment: AppEnvironment = Dev,
+    maxTrackedBinaries: Int = 10000
   )(
-    implicit sp: SecurityProvider[IO],
-    hs: Hasher[IO],
+    implicit hs: Hasher[IO],
     metrics: Metrics[IO]
-  ): Resource[IO, (StateChannelBinarySender[IO], BinaryTracker[IO], Ref[IO, List[Hashed[StateChannelSnapshotBinary]]])] =
+  ): Resource[IO, (StateChannelBinarySenderImpl[IO], BinaryTracker[IO], Ref[IO, List[Hashed[StateChannelSnapshotBinary]]])] =
     for {
       identifierStorage <- Resource.pure(new IdentifierStorage[IO] {
         def setInitial(address: Address): IO[Unit] = ???
-
         def get: IO[Address] = identifier.pure[IO]
       })
 
       globalL0ClusterStorage = new L0ClusterStorage[IO] {
         def getPeers: IO[NonEmptySet[L0Peer]] = ???
-
         def getPeer(id: PeerId): IO[Option[L0Peer]] = ???
-
         def getRandomPeer: IO[L0Peer] = L0Peer(PeerId(Hex("")), Host.fromString("0.0.0.0").get, Port.fromInt(100).get).pure[IO]
-
         def getRandomPeerExistentOnList(peers: List[PeerId]): IO[Option[L0Peer]] =
           L0Peer(PeerId(Hex("")), Host.fromString("0.0.0.0").get, Port.fromInt(100).get).some.pure[IO]
-
         def addPeers(l0Peers: Set[L0Peer]): IO[Unit] = ???
-
         def setPeers(l0Peers: NonEmptySet[L0Peer]): IO[Unit] = ???
-
         def removePeer(id: PeerId): IO[Unit] = IO.unit
       }
 
       lastSnapshotStorage = new LastSnapshotStorage[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
         def set(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): IO[Unit] = ???
-
         def setInitial(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): IO[Unit] = ???
-
         def get: IO[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
-
         def getCombined: IO[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = ???
-
         def getCombinedStream: fs2.Stream[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = ???
-
-        def getOrdinal: IO[Option[SnapshotOrdinal]] = currentOrdinal.some.pure[IO]
-
+        def getOrdinal: IO[Option[SnapshotOrdinal]] = enqueueAtOrdinal.some.pure[IO]
         def getHeight: IO[Option[Height]] = ???
-
         def clear: IO[Unit] = ().pure[IO]
-
         def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): IO[Unit] = ().pure[IO]
       }
 
@@ -151,7 +152,7 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
           }
       }
 
-      tracker <- Resource.eval(BinaryTracker.make[IO])
+      tracker <- Resource.eval(BinaryTracker.make[IO](maxTrackedBinaries))
       _ <- Resource.eval(tracker.updateState(_ => state))
 
       poster = new BinaryPoster[IO](
@@ -165,116 +166,20 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
         tracker
       )
 
-      supervisor <- Supervisor[IO]
+      logger = Slf4jLogger.getLogger[IO]
 
-      sender = new TestStateChannelBinarySender[IO](
+      sender = new StateChannelBinarySenderImpl[IO](
         tracker,
         poster,
         lastSnapshotStorage,
         identifierStorage,
-        supervisor
+        clusterStorage(),
+        selfId,
+        // Run posting synchronously so the test can observe send ordering / re-sends deterministically.
+        identity,
+        logger
       )
     } yield (sender, tracker, postedRef)
-
-  // Test implementation that exposes internal methods for testing
-  class TestStateChannelBinarySender[G[_]: Async: Hasher: Metrics](
-    tracker: BinaryTracker[G],
-    poster: BinaryPoster[G],
-    lastGlobalSnapshotStorage: LastSnapshotStorage[G, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
-    identifierStorage: IdentifierStorage[G],
-    supervisor: Supervisor[G]
-  ) extends StateChannelBinarySender[G] {
-
-    def enqueue(
-      binary: Hashed[StateChannelSnapshotBinary],
-      currencySnapshotOrdinal: SnapshotOrdinal,
-      lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]]
-    ): G[Unit] =
-      for {
-        currentGlobalOrdinal <- lastGlobalSnapshotStorage.getOrdinal.map(_.getOrElse(SnapshotOrdinal.MinValue))
-        _ <- tracker.enqueue(binary, currencySnapshotOrdinal, currentGlobalOrdinal)
-      } yield ()
-
-    // For testing: immediately process the queue after enqueuing
-    def process(
-      binary: Hashed[StateChannelSnapshotBinary],
-      lastGlobalSnapshotSigners: Option[NonEmptySet[PeerId]]
-    ): G[Unit] =
-      for {
-        currentOrdinal <- lastGlobalSnapshotStorage.getOrdinal.map(_.getOrElse(SnapshotOrdinal.MinValue))
-        _ <- enqueue(binary, currentOrdinal, lastGlobalSnapshotSigners)
-        state <- tracker.getState
-        _ <-
-          if (!state.retryMode) {
-            // In normal mode, send immediately for testing
-            poster.post(binary, lastGlobalSnapshotSigners).void
-          } else {
-            Async[G].unit
-          }
-      } yield ()
-
-    def confirm(globalSnapshot: Hashed[GlobalIncrementalSnapshot]): G[Unit] =
-      for {
-        identifier <- identifierStorage.get
-        confirmedHashes <- getConfirmedHashes(identifier, globalSnapshot)
-        state <- tracker.getState
-        oldRetryMode = state.retryMode
-        proof = GlobalSnapshotConfirmationProof.fromGlobalSnapshot(globalSnapshot)
-        _ <- tracker.markAsConfirmed(confirmedHashes, proof)
-        updatedState <- tracker.getState
-        retryMode = RetryStrategy.shouldEnterRetryMode(updatedState, globalSnapshot.ordinal)
-        _ <- tracker.updateState(_.copy(retryMode = retryMode))
-        _ <- tracker.updateState(RetryStrategy.updateRetryParameters(_, oldRetryMode))
-      } yield ()
-
-    // Manually trigger queue processing for tests (simulates background worker)
-    def processQueue(globalSnapshot: Hashed[GlobalIncrementalSnapshot]): G[Unit] =
-      tracker.getState.flatMap { state =>
-        if (state.retryMode) {
-          val lastGlobalSnapshotSigners = globalSnapshot.signed.proofs.map(_.id.toPeerId).some
-          tracker.getPendingToRetry(state.cap.value.toInt).flatMap { toRetry =>
-            toRetry.traverse_(pending => poster.post(pending.binary, lastGlobalSnapshotSigners).void)
-          }
-        } else {
-          // Process unsent binaries in normal mode
-          tracker.getPendingToRetry(10).flatMap { pending =>
-            val unsent = pending.filter(_.sendsSoFar.value === 0L)
-            unsent.traverse_(p => poster.post(p.binary, none).void)
-          }
-        }
-      }
-
-    def clearPending: G[Unit] = tracker.clear
-
-    private def getConfirmedHashes(
-      identifier: Address,
-      globalSnapshot: Hashed[GlobalIncrementalSnapshot]
-    ): G[Set[Hash]] = {
-      val binaries = globalSnapshot.stateChannelSnapshots.get(identifier).toList.flatMap(_.toList)
-      binaries.traverse(b => b.toHashed[G]).map(_.map(_.hash).toSet)
-    }
-  }
-
-  def mkGlobalSnapshotInfo(lastStateChannelSnapshotHashes: SortedMap[Address, Hash] = SortedMap.empty) =
-    GlobalSnapshotInfo(
-      lastStateChannelSnapshotHashes,
-      SortedMap.empty,
-      SortedMap.empty,
-      SortedMap.empty,
-      SortedMap.empty,
-      None,
-      None,
-      None,
-      None,
-      None,
-      Some(SortedMap.empty),
-      Some(SortedMap.empty),
-      Some(SortedMap.empty),
-      Some(SortedMap.empty),
-      Some(SortedMap.empty),
-      Some(SortedMap.empty),
-      Some(SortedMap.empty)
-    )
 
   type Res = (KryoSerializer[IO], Hasher[IO], SecurityProvider[IO], Metrics[IO], JsonSerializer[IO])
 
@@ -294,48 +199,165 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
       signedBinary <- signedOf(StateChannelSnapshotBinary(hash, content.getBytes, SnapshotFee.MinValue))
     } yield signedBinary
 
-  test("should add confirmation proof for confirmed binaries in the queue") { res =>
+  // ---------------------------------------------------------------------------------------------------------------
+  // Production path: normal-mode sending, confirmation + pruning (exercising the REAL impl, not a divergent double)
+  // ---------------------------------------------------------------------------------------------------------------
+
+  test("normal mode - enqueue then processQueue posts pending binaries") { res =>
     implicit val (_, hs, sp, metrics, j) = res
 
     forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
       (for {
         kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        (sender, tracker, _) <- mkService(
-          kp.getPublic.toAddress,
-          currentOrdinal = SnapshotOrdinal.MinValue,
-          state = TrackerState.empty
-        )
+        (sender, _, postedRef) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
         result <- Resource.eval(
           for {
             hashed <- binaries.traverse(_.toHashed)
-            _ <- hashed.traverse(binaryHashed => sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(binaryHashed, none))
-            globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, binaries)
-            _ <- sender.confirm(globalSnapshot)
-            state <- tracker.getState
-            currentOrdinal = SnapshotOrdinal.MinValue
-            expected = hashed.map { binary =>
-              ConfirmedBinary(
-                PendingBinary(binary, currentOrdinal, currentOrdinal, NonNegLong.unsafeFrom(0L)), // Changed from 0L to 1L
-                GlobalSnapshotConfirmationProof.fromGlobalSnapshot(globalSnapshot)
-              )
-            }
-          } yield expect.eql(state.tracked.toList, expected)
+            _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none))
+            _ <- sender.processQueueWithoutSnapshot
+            posted <- postedRef.get
+          } yield expect(posted.toSet.subsetOf(hashed.toSet)).and(expect(posted.nonEmpty))
         )
       } yield result).use(IO.pure)
     }
   }
 
-  test("should transition to retry mode when a snapshot is not confirmed for 5 or more ordinals") { res =>
+  test("confirm marks the chain prefix confirmed and prunes it from the queue") { res =>
+    implicit val (_, hs, sp, metrics, j) = res
+
+    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+      (for {
+        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
+        (sender, tracker, _) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
+        result <- Resource.eval(
+          for {
+            hashed <- binaries.traverse(_.toHashed)
+            _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none))
+            globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, binaries)
+            _ <- sender.confirm(globalSnapshot)
+            state <- tracker.getState
+          } yield expect(state.tracked.isEmpty).and(expect(state.inFlight.isEmpty))
+        )
+      } yield result).use(IO.pure)
+    }
+  }
+
+  test("confirm with no matching binaries leaves the queue untouched") { res =>
+    implicit val (_, hs, sp, metrics, j) = res
+
+    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+      (for {
+        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
+        (sender, tracker, _) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
+        result <- Resource.eval(
+          for {
+            hashed <- binaries.traverse(_.toHashed)
+            _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none))
+            globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, List.empty)
+            _ <- sender.confirm(globalSnapshot)
+            state <- tracker.getState
+          } yield expect.eql(state.tracked.size, hashed.size)
+        )
+      } yield result).use(IO.pure)
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // F4 — re-send until *confirmed*, not until merely delivered once
+  // ---------------------------------------------------------------------------------------------------------------
+
+  test("re-sends an unconfirmed binary on a later tick (delivery is not acceptance)") { res =>
     implicit val (_, hs, sp, metrics, j) = res
 
     forall(binaryGen) { binary =>
       (for {
         kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        (sender, tracker, _) <- mkService(kp.getPublic.toAddress, currentOrdinal = SnapshotOrdinal.MinValue, state = TrackerState.empty)
+        (sender, _, postedRef) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
         result <- Resource.eval(
           for {
             hashed <- binary.toHashed
-            _ <- sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(hashed, none)
+            _ <- sender.enqueue(hashed, SnapshotOrdinal(1L), none)
+            s1 <- mkSnapshot(SnapshotOrdinal(1L), kp, List.empty)
+            s3 <- mkSnapshot(SnapshotOrdinal(3L), kp, List.empty)
+            _ <- sender.processQueue(s1) // first attempt, stamps lastAttempt = 1
+            _ <- sender.processQueue(s3) // ordinal advanced by >= resend interval -> re-send
+            posted <- postedRef.get
+          } yield expect.eql(posted.count(_.hash === hashed.hash), 2)
+        )
+      } yield result).use(IO.pure)
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Retry mode escalation + chain ordering
+  // ---------------------------------------------------------------------------------------------------------------
+
+  test("retry mode escalates: every permitted node posts the stalled binaries, in chain order") { res =>
+    implicit val (_, hs, sp, metrics, j) = res
+
+    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+      (for {
+        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
+        (sender, tracker, postedRef) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
+        result <- Resource.eval(
+          for {
+            hashed <- binaries.traverse(_.toHashed)
+            _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none))
+            _ <- tracker.updateState(_.copy(retryMode = true, cap = NonNegLong.unsafeFrom(binaries.length.toLong)))
+            globalSnapshot <- mkSnapshot(SnapshotOrdinal(2L), kp, List.empty)
+            _ <- sender.processQueue(globalSnapshot)
+            posted <- postedRef.get
+          } yield expect.eql(posted.map(_.hash), hashed.map(_.hash)) // posted in enqueue/chain order
+        )
+      } yield result).use(IO.pure)
+    }
+  }
+
+  test("does not post when not on the allowance list (Mainnet, self excluded)") { res =>
+    implicit val (_, hs, sp, metrics, j) = res
+
+    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+      (for {
+        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
+        selfId = PeerId(Hex("0000000000000000"))
+        allowed = PeerId(Hex("000000000000011"))
+        allowanceList = Map(kp.getPublic.toAddress -> NonEmptySet.of(allowed))
+        (sender, _, postedRef) <- mkSender(
+          kp.getPublic.toAddress,
+          SnapshotOrdinal(1L),
+          TrackerState.empty.copy(retryMode = true, cap = NonNegLong.unsafeFrom(binaries.length.toLong)),
+          allowanceList.some,
+          selfId,
+          Mainnet
+        )
+        result <- Resource.eval(
+          for {
+            hashed <- binaries.traverse(_.toHashed)
+            _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none))
+            globalSnapshot <- mkSnapshot(SnapshotOrdinal(2L), kp, List.empty)
+            _ <- sender.processQueue(globalSnapshot) // even retry-mode escalation must respect the allowance gate
+            posted <- postedRef.get
+          } yield expect.eql(posted.size, 0)
+        )
+      } yield result).use(IO.pure)
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Retry FSM transitions (unchanged logic, exercised through the REAL atomic confirm)
+  // ---------------------------------------------------------------------------------------------------------------
+
+  test("transitions to retry mode when a binary is unconfirmed for >= 5 ordinals") { res =>
+    implicit val (_, hs, sp, metrics, j) = res
+
+    forall(binaryGen) { binary =>
+      (for {
+        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
+        (sender, tracker, _) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
+        result <- Resource.eval(
+          for {
+            hashed <- binary.toHashed
+            _ <- sender.enqueue(hashed, SnapshotOrdinal(1L), none) // enqueuedAt = 1 (not MinValue)
             globalSnapshot <- mkSnapshot(SnapshotOrdinal(6L), kp, List.empty)
             _ <- sender.confirm(globalSnapshot)
             state <- tracker.getState
@@ -345,142 +367,48 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
     }
   }
 
-  test("normal mode - process should enqueue and send a binary right away") { res =>
+  test("does NOT enter retry mode for a not-yet-anchored binary (enqueuedAt == MinValue)") { res =>
     implicit val (_, hs, sp, metrics, j) = res
 
-    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+    forall(binaryGen) { binary =>
       (for {
         kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        (sender, tracker, postedRef) <- mkService(
-          kp.getPublic.toAddress,
-          currentOrdinal = SnapshotOrdinal.MinValue,
-          state = TrackerState.empty.copy(retryMode = false)
-        )
+        // enqueueAtOrdinal = MinValue simulates startup before any global snapshot is known
+        (sender, tracker, _) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal.MinValue, TrackerState.empty)
         result <- Resource.eval(
           for {
-            hashed <- binaries.traverse(_.toHashed)
-            _ <- hashed.traverse(binary => sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(binary, none))
+            hashed <- binary.toHashed
+            _ <- sender.enqueue(hashed, SnapshotOrdinal(1L), none)
+            globalSnapshot <- mkSnapshot(SnapshotOrdinal(6L), kp, List.empty)
+            _ <- sender.confirm(globalSnapshot)
             state <- tracker.getState
-            posted <- postedRef.get
-          } yield
-            expect(state.tracked.nonEmpty)
-              .and(expect(state.tracked.map {
-                case PendingBinary(binary, _, _, _)    => binary
-                case ConfirmedBinary(pendingBinary, _) => pendingBinary.binary
-              }.toSet.subsetOf(hashed.toSet)))
-              .and(expect(posted.toSet.subsetOf(hashed.toSet)))
+          } yield expect(!state.retryMode)
         )
       } yield result).use(IO.pure)
     }
   }
 
-  test("retry mode - should switch to normal mode if cap >= enqueued count, all sent and no stalled") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
-
-    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
-      (for {
-        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        (sender, tracker, _) <- mkService(
-          kp.getPublic.toAddress,
-          currentOrdinal = SnapshotOrdinal.MinValue,
-          state = TrackerState.empty.copy(
-            retryMode = true,
-            cap = NonNegLong.unsafeFrom(binaries.length.toLong)
-          )
-        )
-        result <- Resource.eval(
-          for {
-            hashed <- binaries.traverse(_.toHashed)
-            _ <- hashed.traverse(binary => sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(binary, none))
-
-            globalSnapshot <- mkSnapshot(SnapshotOrdinal(5L), kp, List.empty)
-            _ <- sender.confirm(globalSnapshot)
-            capReachedButNoSendsSoFar <- tracker.getState
-
-            _ <- tracker.updateState { state =>
-              state.copy(
-                tracked = state.tracked.map {
-                  case pending @ PendingBinary(_, _, _, _) =>
-                    pending.copy(sendsSoFar = NonNegLong.unsafeFrom(1L), enqueuedAtOrdinal = SnapshotOrdinal(0L))
-                  case confirmed => confirmed
-                },
-                cap = NonNegLong.unsafeFrom(state.tracked.length.toLong)
-              )
-            }
-            _ <- sender.confirm(globalSnapshot)
-            capReachedAllSentButHasStalled <- tracker.getState
-
-            _ <- tracker.updateState { state =>
-              state.copy(
-                tracked = state.tracked.map {
-                  case pending @ PendingBinary(_, _, _, _) =>
-                    pending.copy(sendsSoFar = NonNegLong.unsafeFrom(1L), enqueuedAtOrdinal = SnapshotOrdinal(1L))
-                  case confirmed => confirmed
-                },
-                cap = NonNegLong.unsafeFrom(state.tracked.length.toLong)
-              )
-            }
-            _ <- sender.confirm(globalSnapshot)
-            capReachedAllSentAndNoStalled <- tracker.getState
-          } yield
-            expect(capReachedButNoSendsSoFar.retryMode)
-              .and(expect(capReachedAllSentButHasStalled.retryMode))
-              .and(expect(!capReachedAllSentAndNoStalled.retryMode))
-        )
-      } yield result).use(IO.pure)
-    }
-  }
-
-  test("retry mode - process should enqueue binary without sending") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
-
-    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
-      (for {
-        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        (sender, tracker, postedRef) <- mkService(
-          kp.getPublic.toAddress,
-          currentOrdinal = SnapshotOrdinal.MinValue,
-          state = TrackerState.empty.copy(retryMode = true)
-        )
-        result <- Resource.eval(
-          for {
-            hashed <- binaries.traverse(_.toHashed)
-            _ <- hashed.traverse(binary => sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(binary, none))
-            state <- tracker.getState
-            posted <- postedRef.get
-          } yield
-            expect(state.tracked.nonEmpty)
-              .and(expect(state.tracked.map {
-                case PendingBinary(binary, _, _, _)    => binary
-                case ConfirmedBinary(pendingBinary, _) => pendingBinary.binary
-              }.toSet.subsetOf(hashed.toSet)))
-              .and(expect(posted.isEmpty))
-        )
-      } yield result).use(IO.pure)
-    }
-  }
-
-  test("retry mode - cap should decrement by 1 if no confirmations") { res =>
+  test("retry mode - cap decrements by 1 on a confirmation-less ordinal") { res =>
     implicit val (_, hs, sp, metrics, j) = res
 
     val gen = for {
       binary <- binaryGen
-      cap <- chooseNumRefined(NonNegLong.unsafeFrom(1L), NonNegLong.unsafeFrom(100L))
+      cap <- chooseNumRefined(NonNegLong.unsafeFrom(2L), NonNegLong.unsafeFrom(100L))
     } yield (binary, cap)
 
     forall(gen) {
       case (binary, cap) =>
         (for {
           kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-          (sender, tracker, _) <- mkService(
+          (sender, tracker, _) <- mkSender(
             kp.getPublic.toAddress,
-            currentOrdinal = SnapshotOrdinal.MinValue,
-            state = TrackerState.empty.copy(cap = cap, retryMode = true)
+            SnapshotOrdinal(1L),
+            TrackerState.empty.copy(cap = cap, retryMode = true)
           )
           result <- Resource.eval(
             for {
-              hashedBinary <- binary.toHashed
-              _ <- sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(hashedBinary, none)
+              hashed <- binary.toHashed
+              _ <- sender.enqueue(hashed, SnapshotOrdinal(1L), none)
               globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, List.empty)
               prevState <- tracker.getState
               _ <- sender.confirm(globalSnapshot)
@@ -491,366 +419,147 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
     }
   }
 
-  test("retry mode - cap should increment with every confirmation but no more than 4*confirmedCount") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
+  // ---------------------------------------------------------------------------------------------------------------
+  // F5 — bounded exponential backoff
+  // ---------------------------------------------------------------------------------------------------------------
 
-    val gen = for {
-      nBinaries <- Gen.nonEmptyListOf(binaryGen)
-      binary <- binaryGen
-      binaries = nBinaries :+ binary
-      howManyToConfirm <- Gen.choose(1, binaries.length - 1)
-      confirmedBinaries = binaries.take(howManyToConfirm)
-    } yield (binaries, confirmedBinaries)
-
-    forall(gen) {
-      case (binaries, confirmedBinaries) =>
-        (for {
-          kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-          (sender, tracker, _) <- mkService(
-            kp.getPublic.toAddress,
-            currentOrdinal = SnapshotOrdinal.MinValue,
-            state = TrackerState.empty.copy(
-              cap = NonNegLong.unsafeFrom(1L),
-              retryMode = true
-            )
-          )
-          result <- Resource.eval(
-            for {
-              _ <- binaries.traverse_(bin =>
-                bin.toHashed.flatMap(binary => sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(binary, none))
-              )
-              globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, confirmedBinaries)
-              prevState <- tracker.getState
-              _ <- sender.confirm(globalSnapshot)
-              state <- tracker.getState
-            } yield expect(state.cap.value >= prevState.cap.value).and(expect(state.cap.value <= confirmedBinaries.length * 4))
-          )
-        } yield result).use(IO.pure)
-    }
-  }
-
-  test("retry mode - should switch to exponential mode when cap goes to 0") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
+  test("backoff exponent is clamped and never overflows the wait threshold") { res =>
+    implicit val (_, hs, sp, _, _) = res
 
     forall(binaryGen) { binary =>
-      (for {
-        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        (sender, tracker, _) <- mkService(
-          kp.getPublic.toAddress,
-          currentOrdinal = SnapshotOrdinal.MinValue,
-          state = TrackerState.empty.copy(cap = NonNegLong.unsafeFrom(1L), retryMode = true)
+      for {
+        hashed <- binary.toHashed
+        // cap == 1, no confirmations, already at the clamp -> entering backoff must keep the exponent at the clamp (6),
+        // not grow it to 7 (which would eventually saturate Math.pow(2, exponent) and freeze sending forever).
+        pending = PendingBinary(hashed, SnapshotOrdinal(1L), SnapshotOrdinal(1L), NonNegLong.unsafeFrom(1L), none)
+        stalled = TrackerState.empty.copy(
+          tracked = scala.collection.immutable.Queue[TrackedBinary](pending),
+          cap = NonNegLong.unsafeFrom(1L),
+          retryMode = true,
+          backoffExponent = NonNegLong.unsafeFrom(6L)
         )
-        result <- Resource.eval(
-          for {
-            hashedBinary <- binary.toHashed
-            _ <- sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(hashedBinary, none)
-            globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, List.empty)
-            _ <- sender.confirm(globalSnapshot)
-            state <- tracker.getState
-          } yield
-            expect
-              .eql(state.cap.value, 0L)
-              .and(expect.eql(state.backoffExponent.value, 1L))
-              .and(expect.eql(state.noConfirmationsSinceRetryCount.value, 1L))
-        )
-      } yield result).use(IO.pure)
+        afterBackoff = RetryStrategy.updateRetryParameters(stalled, previousRetryMode = true)
+      } yield
+        expect
+          .eql(afterBackoff.backoffExponent.value, 6L)
+          .and(expect.eql(afterBackoff.cap.value, 0L))
     }
   }
 
-  test("retry mode (exponential) - increments exponent if passed 2^n without confirmations and resets counter") { res =>
+  // ---------------------------------------------------------------------------------------------------------------
+  // F6 — bounded queue (backpressure instead of unbounded growth -> OOM/restart loop)
+  // ---------------------------------------------------------------------------------------------------------------
+
+  test("enqueue is bounded: drops (returns false) once the queue is full") { res =>
     implicit val (_, hs, sp, metrics, j) = res
 
-    val gen = for {
-      binary <- binaryGen
-      exponent <- chooseNumRefined(NonNegLong.unsafeFrom(1L), NonNegLong.unsafeFrom(100L))
-    } yield (binary, exponent)
-
-    forall(gen) {
-      case (binary, exponent) =>
-        (for {
-          kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-          (sender, tracker, _) <- mkService(
-            kp.getPublic.toAddress,
-            currentOrdinal = SnapshotOrdinal.MinValue,
-            state = TrackerState.empty.copy(
-              cap = NonNegLong.unsafeFrom(1L),
-              retryMode = true,
-              backoffExponent = exponent,
-              noConfirmationsSinceRetryCount = NonNegLong.unsafeFrom(Math.pow(2.0, exponent.value.toDouble).toLong - 1L)
-            )
-          )
-          result <- Resource.eval(
-            for {
-              hashedBinary <- binary.toHashed
-              _ <- sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(hashedBinary, none)
-              snapshot <- mkSnapshot(ordinal = SnapshotOrdinal.MinValue, kp, List.empty)
-              prevState <- tracker.getState
-              _ <- sender.confirm(snapshot) >>
-                sender.asInstanceOf[TestStateChannelBinarySender[IO]].processQueue(snapshot)
-              state <- tracker.getState
-            } yield
-              expect
-                .eql(state.backoffExponent.value, prevState.backoffExponent.value + 1L)
-                .and(expect.eql(state.noConfirmationsSinceRetryCount, NonNegLong.unsafeFrom(1L)))
-                .and(expect.eql(state.cap, NonNegLong.unsafeFrom(0L)))
-          )
-        } yield result).use(IO.pure)
-    }
-  }
-
-  test("should reject when not on allowance list") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
-
-    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+    forall(Gen.listOfN(5, binaryGen)) { binaries =>
       (for {
-        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
-        selfId = PeerId(Hex("0000000000000000"))
-        allowed = PeerId(Hex("000000000000011"))
-        allowanceList = Map(kp.getPublic.toAddress -> NonEmptySet.of(allowed))
-
-        (sender, tracker, postedRef) <- mkService(
-          kp.getPublic.toAddress,
-          currentOrdinal = SnapshotOrdinal.MinValue,
-          state = TrackerState.empty,
-          allowanceList.some,
-          selfId,
-          Mainnet
-        )
+        tracker <- Resource.eval(BinaryTracker.make[IO](maxTrackedBinaries = 3))
         result <- Resource.eval(
           for {
             hashed <- binaries.traverse(_.toHashed)
-            _ <- hashed.traverse(binaryHashed => sender.asInstanceOf[TestStateChannelBinarySender[IO]].process(binaryHashed, none))
-            globalSnapshot <- mkSnapshot(SnapshotOrdinal(1L), kp, binaries)
-            _ <- sender.confirm(globalSnapshot)
+            outcomes <- hashed.traverse(b => tracker.enqueue(b, SnapshotOrdinal(1L), SnapshotOrdinal(1L)))
             state <- tracker.getState
-            expected = hashed.map { binary =>
-              ConfirmedBinary(
-                PendingBinary(binary, SnapshotOrdinal.MinValue, SnapshotOrdinal.MinValue, NonNegLong.unsafeFrom(0L)),
-                GlobalSnapshotConfirmationProof.fromGlobalSnapshot(globalSnapshot)
-              )
-            }
-            posted <- postedRef.get
           } yield
-            expect.all(
-              state.tracked.toList === expected,
-              posted.size === 0
-            )
+            expect
+              .eql(state.tracked.size, 3)
+              .and(expect.eql(outcomes.count(identity), 3))
+              .and(expect.eql(outcomes.count(o => !o), 2))
         )
       } yield result).use(IO.pure)
     }
   }
 
-  test("should pick deterministic peer to send snapshots - with allowed peers") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
-    val selfId = PeerId(Hex("123"))
+  // ---------------------------------------------------------------------------------------------------------------
+  // F8 — per-binary in-flight de-duplication
+  // ---------------------------------------------------------------------------------------------------------------
 
-    val lastSigners: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("456")), PeerId(Hex("789")))
-    val lastSigners1: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("789")), PeerId(Hex("456")))
-    val lastSigners2: List[PeerId] = List(PeerId(Hex("456")), PeerId(Hex("123")), PeerId(Hex("789")))
-    val lastSigners3: List[PeerId] = List(PeerId(Hex("456")), PeerId(Hex("789")), PeerId(Hex("123")))
-    val lastSigners4: List[PeerId] = List(PeerId(Hex("789")), PeerId(Hex("123")), PeerId(Hex("456")))
-    val lastSigners5: List[PeerId] = List(PeerId(Hex("789")), PeerId(Hex("456")), PeerId(Hex("123")))
+  test("tryBeginSend de-duplicates concurrent sends of the same binary") { res =>
+    implicit val (_, hs, sp, _, _) = res
 
-    val allowedPeers: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("456")), PeerId(Hex("789")))
-    for {
-      selectedPeer <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners,
-          allowedPeers,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer1 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners1,
-          allowedPeers,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer2 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners2,
-          allowedPeers,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer3 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners3,
-          allowedPeers,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer4 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners4,
-          allowedPeers,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer5 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners5,
-          allowedPeers,
-          selfId,
-          Hash.empty
-        )
-      )
-    } yield
-      expect.all(
-        selectedPeer.value.value === selectedPeer1.value.value,
-        selectedPeer1.value.value === selectedPeer2.value.value,
-        selectedPeer2.value.value === selectedPeer3.value.value,
-        selectedPeer3.value.value === selectedPeer4.value.value,
-        selectedPeer4.value.value === selectedPeer5.value.value,
-        selectedPeer5.value.value === "456"
-      )
+    forall(binaryGen) { binary =>
+      for {
+        tracker <- BinaryTracker.make[IO]()
+        hashed <- binary.toHashed
+        _ <- tracker.enqueue(hashed, SnapshotOrdinal(1L), SnapshotOrdinal(1L))
+        first <- tracker.tryBeginSend(hashed.hash, none)
+        second <- tracker.tryBeginSend(hashed.hash, none) // already in flight
+        _ <- tracker.endSend(hashed.hash)
+        third <- tracker.tryBeginSend(hashed.hash, none) // released -> allowed again
+        unknown <- tracker.tryBeginSend(Hash("deadbeef"), none) // not pending -> refused
+      } yield
+        expect(first)
+          .and(expect(!second))
+          .and(expect(third))
+          .and(expect(!unknown))
+    }
   }
 
-  test("should pick deterministic peer to send snapshots - without allowed peers") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
-    val selfId = PeerId(Hex("123"))
+  // ---------------------------------------------------------------------------------------------------------------
+  // markConfirmedUpToHighest pure semantics (chain-prefix confirmation)
+  // ---------------------------------------------------------------------------------------------------------------
 
-    val lastSigners: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("456")), PeerId(Hex("789")))
-    val lastSigners1: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("789")), PeerId(Hex("456")))
-    val lastSigners2: List[PeerId] = List(PeerId(Hex("456")), PeerId(Hex("123")), PeerId(Hex("789")))
-    val lastSigners3: List[PeerId] = List(PeerId(Hex("456")), PeerId(Hex("789")), PeerId(Hex("123")))
-    val lastSigners4: List[PeerId] = List(PeerId(Hex("789")), PeerId(Hex("123")), PeerId(Hex("456")))
-    val lastSigners5: List[PeerId] = List(PeerId(Hex("789")), PeerId(Hex("456")), PeerId(Hex("123")))
+  test("markConfirmedUpToHighest confirms every entry up to the highest confirmed index") { res =>
+    implicit val (_, hs, sp, _, _) = res
 
-    for {
-      selectedPeer <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners,
-          List.empty,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer1 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners1,
-          List.empty,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer2 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners2,
-          List.empty,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer3 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners3,
-          List.empty,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer4 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners4,
-          List.empty,
-          selfId,
-          Hash.empty
-        )
-      )
-      selectedPeer5 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners5,
-          List.empty,
-          selfId,
-          Hash.empty
-        )
-      )
-    } yield
-      expect.all(
-        selectedPeer.value.value === selectedPeer1.value.value,
-        selectedPeer1.value.value === selectedPeer2.value.value,
-        selectedPeer2.value.value === selectedPeer3.value.value,
-        selectedPeer3.value.value === selectedPeer4.value.value,
-        selectedPeer4.value.value === selectedPeer5.value.value,
-        selectedPeer5.value.value === "456"
-      )
+    forall(Gen.listOfN(4, binaryGen)) { binaries =>
+      for {
+        hashed <- binaries.traverse(_.toHashed)
+        pendings = hashed.map(b => PendingBinary(b, SnapshotOrdinal(1L), SnapshotOrdinal(1L), NonNegLong.MinValue, none))
+        state = TrackerState.empty.copy(tracked = scala.collection.immutable.Queue[TrackedBinary](pendings: _*))
+        // confirm only the *second* binary's hash -> entries at index 0 and 1 become confirmed, 2 and 3 stay pending
+        proof = GlobalSnapshotConfirmationProof(Hash("aa"), SnapshotOrdinal(1L), EpochProgress.MinValue)
+        confirmed = BinaryTracker.markConfirmedUpToHighest(state, Set(hashed(1).hash), proof)
+        confirmedCount = confirmed.tracked.count(_.isInstanceOf[ConfirmedBinary])
+        pendingCount = confirmed.tracked.count(_.isInstanceOf[PendingBinary])
+      } yield expect.eql(confirmedCount, 2).and(expect.eql(pendingCount, 2))
+    }
   }
 
-  test("should pick deterministic peer to send snapshots - without allowed peers - different hash") { res =>
-    implicit val (_, hs, sp, metrics, j) = res
-    val selfId = PeerId(Hex("123"))
+  // ---------------------------------------------------------------------------------------------------------------
+  // F1/F2 — liveness-aware deterministic peer selection with self-fallback
+  // ---------------------------------------------------------------------------------------------------------------
 
-    val lastSigners: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("456")), PeerId(Hex("789")))
-    val lastSigners1: List[PeerId] = List(PeerId(Hex("123")), PeerId(Hex("789")), PeerId(Hex("456")))
-    val lastSigners2: List[PeerId] = List(PeerId(Hex("456")), PeerId(Hex("123")), PeerId(Hex("789")))
-    val lastSigners3: List[PeerId] = List(PeerId(Hex("456")), PeerId(Hex("789")), PeerId(Hex("123")))
-    val lastSigners4: List[PeerId] = List(PeerId(Hex("789")), PeerId(Hex("123")), PeerId(Hex("456")))
-    val lastSigners5: List[PeerId] = List(PeerId(Hex("789")), PeerId(Hex("456")), PeerId(Hex("123")))
+  test("liveness: a dead deterministic owner is skipped and a live peer (or self) takes over") { _ =>
+    val a = PeerId(Hex("aaa"))
+    val b = PeerId(Hex("bbb"))
+    val c = PeerId(Hex("ccc"))
+    val signers = List(a, b, c)
 
-    for {
-      selectedPeer <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners,
-          List.empty,
-          selfId,
-          Hash("123")
-        )
-      )
-      selectedPeer1 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners1,
-          List.empty,
-          selfId,
-          Hash("123")
-        )
-      )
-      selectedPeer2 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners2,
-          List.empty,
-          selfId,
-          Hash("123")
-        )
-      )
-      selectedPeer3 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners3,
-          List.empty,
-          selfId,
-          Hash("123")
-        )
-      )
-      selectedPeer4 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners4,
-          List.empty,
-          selfId,
-          Hash("123")
-        )
-      )
-      selectedPeer5 <- IO.pure(
-        PeerSelector.pickDeterministicPeer(
-          lastSigners5,
-          List.empty,
-          selfId,
-          Hash("123")
-        )
-      )
-    } yield
-      expect.all(
-        selectedPeer.value.value === selectedPeer1.value.value,
-        selectedPeer1.value.value === selectedPeer2.value.value,
-        selectedPeer2.value.value === selectedPeer3.value.value,
-        selectedPeer3.value.value === selectedPeer4.value.value,
-        selectedPeer4.value.value === selectedPeer5.value.value,
-        selectedPeer5.value.value === "123"
-      )
+    // Pure deterministic choice with full liveness (everyone alive)
+    val ownerAllAlive = PeerSelector.pickDeterministicPeer(signers, Nil, a, Hash("seed"), Some(Set(a, b, c)))
+    // The chosen owner is now dead -> must NOT be selected
+    val ownerWithoutChosen = PeerSelector.pickDeterministicPeer(signers, Nil, a, Hash("seed"), Some(Set(a, b, c) - ownerAllAlive))
+    // Nobody among signers is alive (and self is none of them) -> self takes over
+    val self = PeerId(Hex("eee"))
+    val ownerNoneAlive = PeerSelector.pickDeterministicPeer(signers, Nil, self, Hash("seed"), Some(Set.empty[PeerId]))
+
+    IO {
+      expect(signers.contains(ownerAllAlive))
+        .and(expect(ownerWithoutChosen =!= ownerAllAlive))
+        .and(expect(signers.contains(ownerWithoutChosen)))
+        .and(expect.eql(ownerNoneAlive, self))
+    }
+  }
+
+  test("liveness None degrades to pure deterministic selection (stable across nodes)") { _ =>
+    val signers = List(PeerId(Hex("123")), PeerId(Hex("456")), PeerId(Hex("789")))
+    val self = PeerId(Hex("123"))
+    val a = PeerSelector.pickDeterministicPeer(signers, signers, self, Hash.empty, None)
+    val b = PeerSelector.pickDeterministicPeer(signers.reverse, signers.reverse, self, Hash.empty, None)
+    IO(expect.eql(a.value.value, b.value.value).and(expect.eql(a.value.value, "456")))
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // F9 — empty eligible set must not make every node post (no thundering herd)
+  // ---------------------------------------------------------------------------------------------------------------
+
+  test("empty eligible set falls back to a single deterministic signer, not self") { _ =>
+    val signers = List(PeerId(Hex("aaa")), PeerId(Hex("bbb")))
+    val disjointAllowed = List(PeerId(Hex("ccc")), PeerId(Hex("ddd")))
+    val self = PeerId(Hex("eee"))
+    val selected = PeerSelector.pickDeterministicPeer(signers, disjointAllowed, self, Hash("seed"), None)
+    IO(expect(signers.contains(selected)).and(expect(selected =!= self)))
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelBinarySenderSuite.scala
@@ -175,6 +175,7 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
         identifierStorage,
         clusterStorage(),
         selfId,
+        maxTrackedBinaries,
         // Run posting synchronously so the test can observe send ordering / re-sends deterministically.
         identity,
         logger
@@ -203,10 +204,13 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
   // Production path: normal-mode sending, confirmation + pruning (exercising the REAL impl, not a divergent double)
   // ---------------------------------------------------------------------------------------------------------------
 
-  test("normal mode - enqueue then processQueue posts pending binaries") { res =>
+  test("normal mode - posts every pending binary exactly once, in chain order") { res =>
     implicit val (_, hs, sp, metrics, j) = res
 
-    forall(Gen.nonEmptyListOf(binaryGen)) { binaries =>
+    // Keep the list within the normal-mode window (10) so we can assert the full, ordered set was posted.
+    val gen = Gen.choose(1, 8).flatMap(n => Gen.listOfN(n, binaryGen))
+
+    forall(gen) { binaries =>
       (for {
         kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
         (sender, _, postedRef) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty)
@@ -216,7 +220,7 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
             _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none))
             _ <- sender.processQueueWithoutSnapshot
             posted <- postedRef.get
-          } yield expect(posted.toSet.subsetOf(hashed.toSet)).and(expect(posted.nonEmpty))
+          } yield expect.eql(posted.map(_.hash), hashed.map(_.hash))
         )
       } yield result).use(IO.pure)
     }
@@ -420,17 +424,17 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
   }
 
   // ---------------------------------------------------------------------------------------------------------------
-  // F5 — bounded exponential backoff
+  // F5 — never go silent: cap floors at 1 (silence would guarantee the external 5-min health restart)
   // ---------------------------------------------------------------------------------------------------------------
 
-  test("backoff exponent is clamped and never overflows the wait threshold") { res =>
+  test("retry mode never silences: cap floors at 1 even after a long confirmation drought") { res =>
     implicit val (_, hs, sp, _, _) = res
 
     forall(binaryGen) { binary =>
       for {
         hashed <- binary.toHashed
-        // cap == 1, no confirmations, already at the clamp -> entering backoff must keep the exponent at the clamp (6),
-        // not grow it to 7 (which would eventually saturate Math.pow(2, exponent) and freeze sending forever).
+        // Already at the minimum budget, retry mode, no confirmations: cap must STAY at 1 (never 0), so the head
+        // keeps being posted every tick. The stall exponent advances (clamped) only for observability.
         pending = PendingBinary(hashed, SnapshotOrdinal(1L), SnapshotOrdinal(1L), NonNegLong.unsafeFrom(1L), none)
         stalled = TrackerState.empty.copy(
           tracked = scala.collection.immutable.Queue[TrackedBinary](pending),
@@ -438,11 +442,12 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
           retryMode = true,
           backoffExponent = NonNegLong.unsafeFrom(6L)
         )
-        afterBackoff = RetryStrategy.updateRetryParameters(stalled, previousRetryMode = true)
+        // Apply the transition repeatedly to simulate many confirmation-less ordinals.
+        afterMany = (1 to 20).foldLeft(stalled)((s, _) => RetryStrategy.updateRetryParameters(s, previousRetryMode = true))
       } yield
         expect
-          .eql(afterBackoff.backoffExponent.value, 6L)
-          .and(expect.eql(afterBackoff.cap.value, 0L))
+          .eql(afterMany.cap.value, 1L)
+          .and(expect(afterMany.backoffExponent.value <= 6L))
     }
   }
 
@@ -466,6 +471,27 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
               .eql(state.tracked.size, 3)
               .and(expect.eql(outcomes.count(identity), 3))
               .and(expect.eql(outcomes.count(o => !o), 2))
+        )
+      } yield result).use(IO.pure)
+    }
+  }
+
+  test("sender enqueue caps the queue (drop path does not throw and keeps the prefix)") { res =>
+    implicit val (_, hs, sp, metrics, j) = res
+
+    forall(Gen.listOfN(6, binaryGen)) { binaries =>
+      (for {
+        kp <- Resource.eval(KeyPairGenerator.makeKeyPair)
+        (sender, tracker, _) <- mkSender(kp.getPublic.toAddress, SnapshotOrdinal(1L), TrackerState.empty, maxTrackedBinaries = 4)
+        result <- Resource.eval(
+          for {
+            hashed <- binaries.traverse(_.toHashed)
+            _ <- hashed.traverse_(b => sender.enqueue(b, SnapshotOrdinal(1L), none)) // exercises the drop log + metric branch
+            state <- tracker.getState
+          } yield
+            expect
+              .eql(state.tracked.size, 4)
+              .and(expect.eql(state.tracked.collect { case p: PendingBinary => p.binary.hash }.toList, hashed.take(4).map(_.hash)))
         )
       } yield result).use(IO.pure)
     }
@@ -526,20 +552,22 @@ object StateChannelBinarySenderSuite extends MutableIOSuite with Checkers {
     val b = PeerId(Hex("bbb"))
     val c = PeerId(Hex("ccc"))
     val signers = List(a, b, c)
-
-    // Pure deterministic choice with full liveness (everyone alive)
-    val ownerAllAlive = PeerSelector.pickDeterministicPeer(signers, Nil, a, Hash("seed"), Some(Set(a, b, c)))
-    // The chosen owner is now dead -> must NOT be selected
-    val ownerWithoutChosen = PeerSelector.pickDeterministicPeer(signers, Nil, a, Hash("seed"), Some(Set(a, b, c) - ownerAllAlive))
-    // Nobody among signers is alive (and self is none of them) -> self takes over
+    // self is deliberately NOT a signer, so the self-fallback does not mask the "next live peer takes over" path.
     val self = PeerId(Hex("eee"))
-    val ownerNoneAlive = PeerSelector.pickDeterministicPeer(signers, Nil, self, Hash("seed"), Some(Set.empty[PeerId]))
+
+    // The primary owner is computed over the full signer set (liveness-independent) and is alive here.
+    val primary = PeerSelector.pickDeterministicPeer(signers, Nil, self, Hash("seed"), Some(Set(a, b, c)))
+    // Kill the primary: a different, still-alive signer must take over (never silence).
+    val stillAlive = Set(a, b, c) - primary
+    val takeover = PeerSelector.pickDeterministicPeer(signers, Nil, self, Hash("seed"), Some(stillAlive))
+    // Nobody among the signers is alive -> self takes over.
+    val noneAlive = PeerSelector.pickDeterministicPeer(signers, Nil, self, Hash("seed"), Some(Set.empty[PeerId]))
 
     IO {
-      expect(signers.contains(ownerAllAlive))
-        .and(expect(ownerWithoutChosen =!= ownerAllAlive))
-        .and(expect(signers.contains(ownerWithoutChosen)))
-        .and(expect.eql(ownerNoneAlive, self))
+      expect(signers.contains(primary))
+        .and(expect(takeover =!= primary))
+        .and(expect(stillAlive.contains(takeover)))
+        .and(expect.eql(noneAlive, self))
     }
   }
 


### PR DESCRIPTION
## Why

Metagraphs intermittently lose connection with the hypergraph and get restarted. A meticulous audit of the currency-L0 `StateChannelBinarySender` (the path that posts `StateChannelSnapshotBinary` objects to the global L0) found a structural root cause plus several amplifiers. The global L0 accepts binaries only as a **strictly contiguous hash chain**, so a single binary that never arrives stalls the metagraph permanently — and a stall longer than ~5 min trips the external health monitor, which restarts the node (cleanly rolling back to the last network-confirmed snapshot via `programs/Rollback`).

## Root cause + amplifiers (all confirmed by adversarial review)

- **Dead assigned sender, no failover** — each binary was deterministically assigned to exactly one metagraph node with no liveness awareness; if that node was down, *nobody* sent it → permanent chain gap.
- **Retry never re-routed** — retries re-picked the same dead node.
- **"Sent" meant delivered (HTTP 200), not accepted** — a delivered-but-rejected binary was never re-sent in normal mode.
- **Backoff could go silent** (`cap → 0`, with a saturating `2^exp`) — silence guarantees the 5-min restart.
- **Unbounded, non-durable queue** — a stall grew it until OOM → kill → restart loop.
- **Worker crash-looped** — any tick error tore down the stream (1s restart).
- Plus: no in-flight de-dup, non-atomic confirm, spurious startup retry-mode, empty-eligible thundering herd.

## What this PR does

- **Liveness-aware, deterministic owner selection with self-fallback.** Primary owner + rotation are computed over the **full signer set** (so every node agrees regardless of its local liveness view); liveness only skips dead peers along that shared rotation. Exactly one sender when the primary is alive; never silence.
- **Retry-mode escalation** — when stalled, every permitted node posts the head (the global L0 de-dups by hash), guaranteeing delivery even if the owner is down.
- **Re-send until *confirmed*** (not until merely delivered once), paced by global ordinal.
- **Never silent**: retry `cap` floors at **1** — we always keep posting at least the chain head, so recoverable stalls heal well before the 5-min restart window.
- **Bounded send queue** with drop + metric/log (`dag_binaries_state_channel_dropped_total`) instead of unbounded growth → OOM.
- **Crash-resistant worker** — per-tick errors are logged and swallowed; the stream keeps ticking.
- **In-flight de-dup** (`tryBeginSend`/`endSend`, released even if scheduling fails), **atomic confirm transition**, startup not-yet-anchored guard, in-flight gauge metric.

Determinism note: consensus/snapshot production and rollback are untouched and fully deterministic. Only *delivery logistics* adapt to liveness, and the global L0 de-duplicates by hash — so the accepted chain is identical regardless of who delivers.

## Tests

The suite now drives the **real** `StateChannelBinarySenderImpl` (synchronous send scheduling) and the real atomic `confirm`, replacing a divergent test double. Regression coverage added for: chain-ordered sending, confirm+prune, re-send-until-confirmed, retry escalation, allowance gate, retry-mode entry + startup guard, never-silent cap floor, bounded queue (tracker + sender), in-flight de-dup, chain-prefix confirmation, liveness failover, deterministic fallback, no-thundering-herd. **Full currency-l0 suite green (31/31).** `scalafmtCheckAll` and `scalafix --check OrganizeImports` pass.

## ⚠️ One thing to confirm on deployment

The (pre-existing, unchanged) allowance gate only permits empty-allowance sending for `environment ∈ {Dev, Testnet, Integrationnet}`. With `stateChannelAllowanceLists = None` for currency-L0, a node running literally as `Mainnet` would not post via this path. Since metagraphs on the Mainnet hypergraph do connect, their effective `CL_APP_ENV` is in the allowed set (typically `Integrationnet`). Please confirm the deployed env so we know this path is active where expected. The gate was intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)