### PR TITLE
fix(l1): coordinate L1 storage mutations to fix fork/lost-sync/lastTxnRef

### DIFF
--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -343,7 +343,8 @@ abstract class CurrencyL1App(
               validators.allowSpend,
               keyPair,
               nodeId,
-              storages.globalL0Alignment
+              storages.globalL0Alignment,
+              storages.storageMutationLock
             )
             .merge {
               TokenLock.run[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, Run](
@@ -361,7 +362,8 @@ abstract class CurrencyL1App(
                 validators.tokenLock,
                 keyPair,
                 nodeId,
-                storages.globalL0Alignment
+                storages.globalL0Alignment,
+                storages.storageMutationLock
               )
             }
             .merge(stateChannel.runtime)

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/CurrencyL1App.scala
@@ -169,7 +169,8 @@ abstract class CurrencyL1App(
         services.globalL0.pullGlobalSnapshot,
         services.globalL0,
         storages.globalL0Alignment,
-        sharedStorages.mptStore
+        sharedStorages.mptStore,
+        storages.storageMutationLock
       )
       programs = Programs
         .make[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotInfo, Run](

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/Swap.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/Swap.scala
@@ -4,7 +4,7 @@ import java.security.KeyPair
 
 import cats.Applicative
 import cats.effect.kernel.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.all._
 
 import scala.concurrent.duration._
@@ -47,7 +47,8 @@ object Swap {
     allowSpendValidator: AllowSpendValidator[F],
     selfKeyPair: KeyPair,
     selfId: PeerId,
-    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F]
+    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
+    storageMutationLock: Mutex[F]
   ): Stream[F, Unit] = {
 
     def logger = Slf4jLogger.getLogger[F]
@@ -165,17 +166,18 @@ object Swap {
             }.flatMap {
               _.toList.traverse {
                 case (hash, signedBlock) =>
-                  services.allowSpendBlock
-                    .accept(signedBlock, snapshotOrdinal)
-                    .handleErrorWith { error =>
-                      for {
-                        _ <- logger.warn(error)(s"Failed acceptance of an allow spend block with ${hash.show}")
-                        _ <- globalL0AlignmentStorage.updateShouldRedownload(
-                          value = true,
-                          reasons = List(s"Allow spend block acceptance failed for ${hash.show}: ${error.getMessage}")
-                        )
-                      } yield ()
-                    }
+                  storageMutationLock.lock.surround {
+                    services.allowSpendBlock
+                      .accept(signedBlock, snapshotOrdinal)
+                  }.handleErrorWith { error =>
+                    for {
+                      _ <- logger.warn(error)(s"Failed acceptance of an allow spend block with ${hash.show}")
+                      _ <- globalL0AlignmentStorage.updateShouldRedownload(
+                        value = true,
+                        reasons = List(s"Allow spend block acceptance failed for ${hash.show}: ${error.getMessage}")
+                      )
+                    } yield ()
+                  }
               }
             }.void
           case None => ().pure[F]

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/TokenLock.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/TokenLock.scala
@@ -4,7 +4,7 @@ import java.security.KeyPair
 
 import cats.Applicative
 import cats.effect.kernel.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.all._
 
 import scala.concurrent.duration._
@@ -49,7 +49,8 @@ object TokenLock {
     tokenLockValidator: TokenLockValidator[F],
     selfKeyPair: KeyPair,
     selfId: PeerId,
-    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F]
+    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
+    storageMutationLock: Mutex[F]
   ): Stream[F, Unit] = {
 
     def logger = Slf4jLogger.getLogger[F]
@@ -167,17 +168,18 @@ object TokenLock {
             }.flatMap {
               _.toList.traverse {
                 case (hash, signedBlock) =>
-                  services.tokenLockBlock
-                    .accept(signedBlock, snapshotOrdinal)
-                    .handleErrorWith { error =>
-                      for {
-                        _ <- logger.warn(error)(s"Failed acceptance of a token lock block with ${hash.show}")
-                        _ <- globalL0AlignmentStorage.updateShouldRedownload(
-                          value = true,
-                          reasons = List(s"Token Lock block acceptance failed for ${hash.show}: ${error.getMessage}")
-                        )
-                      } yield ()
-                    }
+                  storageMutationLock.lock.surround {
+                    services.tokenLockBlock
+                      .accept(signedBlock, snapshotOrdinal)
+                  }.handleErrorWith { error =>
+                    for {
+                      _ <- logger.warn(error)(s"Failed acceptance of a token lock block with ${hash.show}")
+                      _ <- globalL0AlignmentStorage.updateShouldRedownload(
+                        value = true,
+                        reasons = List(s"Token Lock block acceptance failed for ${hash.show}: ${error.getMessage}")
+                      )
+                    } yield ()
+                  }
               }
             }.void
           case None => ().pure[F]

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -326,13 +326,21 @@ object Engine {
           def combine(roundId: RoundId)(updates: List[DataTransactions]): F[Option[DataApplicationBlock]] =
             NonEmptyList.fromList(updates).traverse { allUpdates =>
               getHashes(allUpdates.toList, dataApplication.serializeUpdate).flatMap { hashesList =>
-                NonEmptyList
-                  .fromList(hashesList)
-                  .fold(
+                // Canonicalize bundle ordering across facilitators. Each facilitator merges updates from its own
+                // Set/Map (and prepends its OWN proposal first), so without a deterministic sort the resulting
+                // dataTransactionsHashes -- and therefore the block hash -- differs per node, the aggregated multisig
+                // fails to verify, and every round with >=2 contributing facilitators is cancelled. Sorting by the
+                // content-derived per-bundle hashes (already computed here) yields byte-identical blocks on every node.
+                val sortedByHash = allUpdates.toList
+                  .zip(hashesList)
+                  .sortBy { case (_, bundleHashes) => bundleHashes.toList.map(_.value).mkString }
+
+                (NonEmptyList.fromList(sortedByHash.map(_._1)), NonEmptyList.fromList(sortedByHash.map(_._2))) match {
+                  case (Some(sortedUpdates), Some(sortedHashes)) =>
+                    DataApplicationBlock(roundId, sortedUpdates, sortedHashes).pure[F]
+                  case _ =>
                     new IllegalStateException("Could not find DataApplicationBlock hashes").raiseError[F, DataApplicationBlock]
-                  ) { hashes =>
-                    DataApplicationBlock(roundId, allUpdates, hashes).pure[F]
-                  }
+                }
               }
             }
 

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/dataApplication/consensus/Engine.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/dataApplication/consensus/Engine.scala
@@ -331,9 +331,11 @@ object Engine {
                 // dataTransactionsHashes -- and therefore the block hash -- differs per node, the aggregated multisig
                 // fails to verify, and every round with >=2 contributing facilitators is cancelled. Sorting by the
                 // content-derived per-bundle hashes (already computed here) yields byte-identical blocks on every node.
+                // Delimiter-separated key: correct regardless of per-hash length (a delimiter-less concat could in
+                // theory be ambiguous across bundle/hash boundaries for a future variable-length hash).
                 val sortedByHash = allUpdates.toList
                   .zip(hashesList)
-                  .sortBy { case (_, bundleHashes) => bundleHashes.toList.map(_.value).mkString }
+                  .sortBy { case (_, bundleHashes) => bundleHashes.toList.map(_.value).mkString(":") }
 
                 (NonEmptyList.fromList(sortedByHash.map(_._1)), NonEmptyList.fromList(sortedByHash.map(_._2))) match {
                   case (Some(sortedUpdates), Some(sortedHashes)) =>

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
@@ -189,7 +189,7 @@ object CurrencySnapshotProcessor {
               allowSpendStorage,
               tokenLockStorage
             ).flatMap {
-              case (as, bs, lcss, ts, als, tls) =>
+              case (as, bs, lcss, ts, als, tls, replayLock) =>
                 type Success = NonEmptyList[Alignment]
                 type Agg = (NonEmptyList[Hashed[CurrencyIncrementalSnapshot]], List[Alignment])
                 type Result = Option[Success]
@@ -230,7 +230,7 @@ object CurrencySnapshotProcessor {
                           case _: Ignore =>
                             Applicative[F].pure(none[Success].asRight[Agg])
                           case alignment =>
-                            processAlignment(alignment, bs, ts, als, tls, lcss, as, mptStore, storageMutationLock).as {
+                            processAlignment(alignment, bs, ts, als, tls, lcss, as, mptStore, replayLock).as {
                               val updatedAgg = agg :+ alignment
 
                               NonEmptyList.fromList(nextSnapshots) match {
@@ -293,7 +293,11 @@ object CurrencySnapshotProcessor {
           LastSnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
           TransactionStorage[F],
           AllowSpendStorage[F],
-          TokenLockStorage[F]
+          TokenLockStorage[F],
+          // A dedicated, uncontended lock for the intermediate-replay processAlignment below: those storages are
+          // private throwaway copies (built here) that no other fiber can observe, so the replay must NOT serialize
+          // on the shared storageMutationLock. The real commit (against the live storages) still uses the shared one.
+          Mutex[F]
         )
       ] = {
         val bs = blockStorage.getState().flatMap(BlockStorage.make[F](_))
@@ -329,7 +333,7 @@ object CurrencySnapshotProcessor {
                 TokenLockStorage.make(lastTxs, _, ctlv)
               }
           }
-        (as, bs, lcss, ts, als, tls).mapN((_, _, _, _, _, _))
+        (as, bs, lcss, ts, als, tls, Mutex[F]).mapN((_, _, _, _, _, _, _))
       }
 
       // We are extracting all currency snapshots, but we don't assume that all the state channel binaries need to be

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/domain/snapshot/programs/CurrencySnapshotProcessor.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.currency.l1.domain.snapshot.programs
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.effect.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.all._
 import cats.{Applicative, Parallel}
 
@@ -64,7 +64,8 @@ object CurrencySnapshotProcessor {
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     l0Service: GlobalL0Service[F],
     globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
-    mptStore: MptStore[F, GlobalStateKey]
+    mptStore: MptStore[F, GlobalStateKey],
+    storageMutationLock: Mutex[F]
   ): CurrencySnapshotProcessor[F] =
     new CurrencySnapshotProcessor[F] {
       def process(
@@ -229,7 +230,7 @@ object CurrencySnapshotProcessor {
                           case _: Ignore =>
                             Applicative[F].pure(none[Success].asRight[Agg])
                           case alignment =>
-                            processAlignment(alignment, bs, ts, als, tls, lcss, as, mptStore).as {
+                            processAlignment(alignment, bs, ts, als, tls, lcss, as, mptStore, storageMutationLock).as {
                               val updatedAgg = agg :+ alignment
 
                               NonEmptyList.fromList(nextSnapshots) match {
@@ -256,7 +257,8 @@ object CurrencySnapshotProcessor {
                     tokenLockStorage,
                     lastCurrencySnapshotStorage,
                     addressStorage,
-                    mptStore
+                    mptStore,
+                    storageMutationLock
                   )
                 }.flatMap { results =>
                   setGlobalSnapshot >>

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/modules/Storages.scala
@@ -1,7 +1,7 @@
 package io.constellationnetwork.currency.l1.modules
 
 import cats.effect.kernel.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -70,6 +70,7 @@ object Storages {
       allowSpendBlockStorage <- AllowSpendBlockStorage.make[F]
       identifierStorage <- IdentifierStorage.make[F]
       globalL0AlignmentStorage <- GlobalL0AlignmentStorage.make[F]
+      mutationLock <- Mutex[F]
     } yield
       new Storages[F, P, S, SI] {
         val address = addressStorage
@@ -89,6 +90,7 @@ object Storages {
         val tokenLockBlock = tokenLockBlockStorage
         val identifier = identifierStorage
         val globalL0Alignment: GlobalL0AlignmentStorage[F] = globalL0AlignmentStorage
+        val storageMutationLock = mutationLock
       }
 }
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
@@ -174,10 +174,10 @@ class GlobalSnapshotAlignment[F[_]: Async: HasherSelector: SecurityProvider, P <
             operationName = s"Process single snapshot ${SnapshotReference.fromHashedSnapshot(snapshot).show}"
           )
         case Right(snapshots) =>
-          withRetry(
-            operation = performSnapshotsBatchProcessing(snapshots),
-            operationName = s"Process ${snapshots.size} snapshots batch"
-          )
+          // No outer withRetry here: performSnapshotsBatchProcessing already retries each snapshot internally and
+          // recovers (returns the applied prefix + schedules redownload) rather than raising, so a wrapping retry
+          // would never fire.
+          performSnapshotsBatchProcessing(snapshots)
       }
 
     def logResults(results: List[SnapshotProcessingResult]): F[Unit] =

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/GlobalSnapshotAlignment.scala
@@ -203,20 +203,29 @@ class GlobalSnapshotAlignment[F[_]: Async: HasherSelector: SecurityProvider, P <
   ): F[List[SnapshotProcessingResult]] =
     (snapshots, List.empty[SnapshotProcessingResult]).tailRecM {
       case (snapshot :: nextSnapshots, aggResults) =>
-        HasherSelector[F].withCurrent { implicit hasher =>
-          programs.snapshotProcessor
-            .process(snapshot.asRight[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)])
-        }
+        // Retry THIS snapshot transiently before giving up -- a momentary createContext/MPT hiccup should not
+        // escalate to a full redownload. Only after retries are exhausted do we STOP the batch and schedule a
+        // redownload. Crucially we no longer skip-and-continue past a failed snapshot: continuing processed later
+        // snapshots against an unadvanced lastSnapshot, turning them all into NotNext -> Ignore and silently
+        // dropping the remainder of the batch (then forcing a full redownload for what may have been transient).
+        withRetry(
+          operation = HasherSelector[F].withCurrent { implicit hasher =>
+            programs.snapshotProcessor
+              .process(snapshot.asRight[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)])
+          },
+          operationName = s"Process snapshot ${SnapshotReference.fromHashedSnapshot(snapshot).show}"
+        )
           .map(result => (nextSnapshots, aggResults :+ result).asLeft[List[SnapshotProcessingResult]])
           .handleErrorWith { e =>
-            val message = s"Failed to process snapshot ${SnapshotReference.fromHashedSnapshot(snapshot).show}, skipping"
-            for {
-              _ <- storages.globalL0Alignment.updateShouldRedownload(
-                value = true,
-                reasons = List(message)
-              )
-              _ <- logger.error(e)(message)
-            } yield (nextSnapshots, aggResults).asLeft[List[SnapshotProcessingResult]]
+            val message =
+              s"Failed to process snapshot ${SnapshotReference.fromHashedSnapshot(snapshot).show} after retries; stopping batch and scheduling redownload"
+            storages.globalL0Alignment.updateShouldRedownload(
+              value = true,
+              reasons = List(message)
+            ) >>
+              logger
+                .error(e)(message)
+                .as(aggResults.asRight[(List[Hashed[GlobalIncrementalSnapshot]], List[SnapshotProcessingResult])])
           }
 
       case (Nil, aggResults) =>

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -205,7 +205,8 @@ object Main
           validators.allowSpend,
           keyPair,
           nodeId,
-          storages.globalL0Alignment
+          storages.globalL0Alignment,
+          storages.storageMutationLock
         )
       }
 
@@ -225,7 +226,8 @@ object Main
           validators.tokenLock,
           keyPair,
           nodeId,
-          storages.globalL0Alignment
+          storages.globalL0Alignment,
+          storages.storageMutationLock
         )
       }
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Main.scala
@@ -126,7 +126,8 @@ object Main
         services.globalL0.pullGlobalSnapshot,
         services.globalL0,
         storages.globalL0Alignment,
-        sharedStorages.mptStore
+        sharedStorages.mptStore,
+        storages.storageMutationLock
       )
       programs = Programs.make(sharedPrograms, p2pClient, storages, snapshotProcessor)
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/StateChannel.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/StateChannel.scala
@@ -24,7 +24,7 @@ import io.constellationnetwork.dag.l1.domain.consensus.block.BlockConsensusOutpu
 import io.constellationnetwork.dag.l1.domain.consensus.block.Validator.{canStartInspectionTrigger, canStartOwnConsensus, isPeerInputValid}
 import io.constellationnetwork.dag.l1.domain.consensus.block._
 import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient.L1OutputSubmissionResult
-import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient.L1OutputSubmissionResult.{Accepted, ParentOrdinalGapTooLarge, Rejected}
+import io.constellationnetwork.dag.l1.http.p2p.L0BlockOutputClient.L1OutputSubmissionResult._
 import io.constellationnetwork.dag.l1.http.p2p.P2PClient
 import io.constellationnetwork.dag.l1.modules._
 import io.constellationnetwork.ext.fs2.StreamOps
@@ -173,13 +173,17 @@ class StateChannel[
 
   private val storeBlock: Pipe[F, FinalBlock, Unit] =
     _.evalMapLocked(blockStoringS) { fb =>
-      storages.lastSnapshot.getHeight.map(_.getOrElse(Height.MinValue)).flatMap { lastSnapshotHeight =>
-        if (lastSnapshotHeight < fb.hashedBlock.height)
-          storages.block.store(fb.hashedBlock).handleErrorWith(e => logger.debug(e)("Block storing failed."))
-        else
-          logger.debug(
-            s"Block can't be stored! Block height not above last snapshot height! block:${fb.hashedBlock.height} <= snapshot: $lastSnapshotHeight"
-          )
+      // Hold the storage-mutation lock across the height-check AND the store so the decision cannot race
+      // alignment's setSnapshot + adjustToMajority (which together move the snapshot height and the block set).
+      storages.storageMutationLock.lock.surround {
+        storages.lastSnapshot.getHeight.map(_.getOrElse(Height.MinValue)).flatMap { lastSnapshotHeight =>
+          if (lastSnapshotHeight < fb.hashedBlock.height)
+            storages.block.store(fb.hashedBlock).handleErrorWith(e => logger.debug(e)("Block storing failed."))
+          else
+            logger.debug(
+              s"Block can't be stored! Block height not above last snapshot height! block:${fb.hashedBlock.height} <= snapshot: $lastSnapshotHeight"
+            )
+        }
       }
     }
 
@@ -193,6 +197,7 @@ class StateChannel[
   private def submissionOutcome(result: L1OutputSubmissionResult): String =
     result match {
       case Accepted                    => "accepted"
+      case _: AwaitingParent           => "awaiting_parent"
       case _: ParentOrdinalGapTooLarge => "parent_ordinal_gap_too_large"
       case _: Rejected                 => "rejected"
     }
@@ -316,6 +321,10 @@ class StateChannel[
   private def bufferFailedL0Delivery(block: Signed[Block], result: L1OutputSubmissionResult): F[Unit] =
     result match {
       case Accepted => Async[F].unit
+      // 202: L0 holds it awaiting a parent. Keep it buffered and re-send until L0 includes it (200) -- otherwise
+      // L0's TTL/overflow eviction silently loses it and the address chain stalls.
+      case _: AwaitingParent =>
+        appendToL0ResendBuffer(List(block), "awaiting_parent")
       case gap: ParentOrdinalGapTooLarge =>
         bufferBackfillForGap(block, gap)
       case _: Rejected =>
@@ -377,8 +386,14 @@ class StateChannel[
             case (hash, signedBlock) =>
               logger.debug(s"Acceptance of a block $hash starts!") >>
                 HasherSelector[F].withCurrent { implicit hasher =>
-                  services.block
-                    .accept(signedBlock)
+                  // Serialize the whole validate+commit against the alignment commit (processAlignment). accept is
+                  // pure local validation + in-memory storage mutation (no network, no MPT build), so holding the
+                  // lock across it is cheap and makes the read-balance/compute/write-balance step atomic w.r.t.
+                  // alignment -- closing the balance-divergence and block-state races.
+                  storages.storageMutationLock.lock.surround {
+                    services.block
+                      .accept(signedBlock)
+                  }
                 }.handleErrorWith { error =>
                   for {
                     _ <- logger.warn(error)(s"Failed acceptance of a block with ${hash.show}")

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/StateChannel.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/StateChannel.scala
@@ -386,10 +386,14 @@ class StateChannel[
             case (hash, signedBlock) =>
               logger.debug(s"Acceptance of a block $hash starts!") >>
                 HasherSelector[F].withCurrent { implicit hasher =>
-                  // Serialize the whole validate+commit against the alignment commit (processAlignment). accept is
-                  // pure local validation + in-memory storage mutation (no network, no MPT build), so holding the
-                  // lock across it is cheap and makes the read-balance/compute/write-balance step atomic w.r.t.
-                  // alignment -- closing the balance-divergence and block-state races.
+                  // Serialize the whole accept against the alignment commit (processAlignment) on the shared
+                  // storageMutationLock. NOTE: this region is deliberately COARSE -- it includes block hashing and
+                  // ECDSA signature verification (blockAcceptanceManager.acceptBlock) and per-tx hashing, not only the
+                  // in-memory writes -- so the read-balance / compute / write-balance step is atomic w.r.t. alignment
+                  // (closing the balance-divergence and block-state races). This is acceptable because blockAcceptance
+                  // is a single serial 1s-tick stream whose only contender for the lock is the 10s alignment commit.
+                  // The heavy MPT trie build and all network I/O are NOT under this lock (they stay outside, in
+                  // processAlignment's updateMptStorage and in the L0 output/pull paths).
                   storages.storageMutationLock.lock.surround {
                     services.block
                       .accept(signedBlock)

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/StateChannel.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/StateChannel.scala
@@ -448,6 +448,10 @@ object StateChannel {
     txHasher: Hasher[F]
   ): F[StateChannel[F, P, S, SI, R]] =
     for {
+      // These per-stream semaphores guard each consensus stream against SELF-overlap (a tick starting before the
+      // previous one finished). Cross-path serialization between the acceptance/store commit and the L0->L1 alignment
+      // commit is a separate concern handled by storages.storageMutationLock, which is always acquired INNERMOST
+      // (inside these semaphores), so the two locking layers never form a cycle.
       blockAcceptanceS <- Semaphore(1)
       blockCreationS <- Semaphore(1)
       blockStoringS <- Semaphore(1)

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Swap.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/Swap.scala
@@ -4,7 +4,7 @@ import java.security.KeyPair
 
 import cats.Applicative
 import cats.effect.kernel.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.all._
 
 import scala.concurrent.duration._
@@ -58,7 +58,8 @@ object Swap {
     allowSpendValidator: AllowSpendValidator[F],
     selfKeyPair: KeyPair,
     selfId: PeerId,
-    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F]
+    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
+    storageMutationLock: Mutex[F]
   ): Stream[F, Unit] = {
 
     def logger = Slf4jLogger.getLogger[F]
@@ -176,17 +177,18 @@ object Swap {
             }.flatMap {
               _.toList.traverse {
                 case (hash, signedBlock) =>
-                  services.allowSpendBlock
-                    .accept(signedBlock, snapshotOrdinal)
-                    .handleErrorWith { error =>
-                      for {
-                        _ <- logger.warn(error)(s"Failed acceptance of an allow spend block with ${hash.show}")
-                        _ <- globalL0AlignmentStorage.updateShouldRedownload(
-                          value = true,
-                          reasons = List(s"Allow spend block acceptance failed for ${hash.show}: ${error.getMessage}")
-                        )
-                      } yield ()
-                    }
+                  storageMutationLock.lock.surround {
+                    services.allowSpendBlock
+                      .accept(signedBlock, snapshotOrdinal)
+                  }.handleErrorWith { error =>
+                    for {
+                      _ <- logger.warn(error)(s"Failed acceptance of an allow spend block with ${hash.show}")
+                      _ <- globalL0AlignmentStorage.updateShouldRedownload(
+                        value = true,
+                        reasons = List(s"Allow spend block acceptance failed for ${hash.show}: ${error.getMessage}")
+                      )
+                    } yield ()
+                  }
               }
             }.void
           case None => ().pure[F]

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/TokenLock.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/TokenLock.scala
@@ -4,7 +4,7 @@ import java.security.KeyPair
 
 import cats.Applicative
 import cats.effect.kernel.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.all._
 
 import scala.concurrent.duration._
@@ -54,7 +54,8 @@ object TokenLock {
     tokenLockValidator: TokenLockValidator[F],
     selfKeyPair: KeyPair,
     selfId: PeerId,
-    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F]
+    globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
+    storageMutationLock: Mutex[F]
   ): Stream[F, Unit] = {
 
     def logger = Slf4jLogger.getLogger[F]
@@ -170,17 +171,18 @@ object TokenLock {
         }.flatMap {
           _.toList.traverse {
             case (hash, signedBlock) =>
-              services.tokenLockBlock
-                .accept(signedBlock, SnapshotOrdinal.MinValue)
-                .handleErrorWith { error =>
-                  for {
-                    _ <- logger.warn(error)(s"Failed acceptance of a token lock block with ${hash.show}")
-                    _ <- globalL0AlignmentStorage.updateShouldRedownload(
-                      value = true,
-                      reasons = List(s"Token Lock block acceptance failed for ${hash.show}: ${error.getMessage}")
-                    )
-                  } yield ()
-                }
+              storageMutationLock.lock.surround {
+                services.tokenLockBlock
+                  .accept(signedBlock, SnapshotOrdinal.MinValue)
+              }.handleErrorWith { error =>
+                for {
+                  _ <- logger.warn(error)(s"Failed acceptance of a token lock block with ${hash.show}")
+                  _ <- globalL0AlignmentStorage.updateShouldRedownload(
+                    value = true,
+                    reasons = List(s"Token Lock block acceptance failed for ${hash.show}: ${error.getMessage}")
+                  )
+                } yield ()
+              }
           }
         }.void
       }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/address/storage/AddressStorage.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/address/storage/AddressStorage.scala
@@ -7,5 +7,14 @@ trait AddressStorage[F[_]] {
   def getState: F[Map[Address, Balance]]
   def getBalance(address: Address): F[Balance]
   def updateBalances(addressBalances: Map[Address, Balance]): F[Unit]
+
+  /** Atomically replace the entire balance map in a single operation.
+    *
+    * This is the crash-/race-safe form of `clean >> updateBalances(m)`: that two-op sequence allows a concurrent `updateBalances(delta)`
+    * (from the live block-acceptance path) to interleave between the `clean` and the update, leaving a stray `delta` balance that survives
+    * every subsequent incremental alignment. `replaceAll` closes that window structurally, so two nodes applying the same global snapshot
+    * converge to identical balances.
+    */
+  def replaceAll(addressBalances: Map[Address, Balance]): F[Unit]
   def clean: F[Unit]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/block/BlockStorage.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/block/BlockStorage.scala
@@ -152,7 +152,45 @@ class BlockStorage[F[_]: Sync: Random](blocks: MapRef[F, ProofsHash, Option[Stor
         }.flatMap(_.liftTo[F])
       }.void
 
-    addMajorityBlocks >>
+    // Precondition dry-run (all-or-nothing): verify EVERY block this call will touch is in the state its sub-step
+    // expects, BEFORE mutating anything. checkAlignment computed these sets from a snapshot of block state taken
+    // OUTSIDE the storage-mutation lock, so by the time this (locked) apply runs a concurrent acceptance may have
+    // moved a block; a sub-step would then raise mid-sequence, leaving block storage PARTIALLY reconciled with no
+    // rollback. Bailing here (mutating nothing) lets the caller retry/redownload from a clean state. The predicates
+    // mirror exactly the `modify` match arms of the sub-steps above.
+    def adjustPreconditionViolations(all: Map[ProofsHash, StoredBlock]): List[String] = {
+      def check(label: String, hashes: Set[ProofsHash])(expected: Option[StoredBlock] => Boolean): List[String] =
+        hashes.toList.collect { case h if !expected(all.get(h)) => s"$label[${h.show}]=${all.get(h).show}" }
+
+      val isAddable: Option[StoredBlock] => Boolean = {
+        case Some(_: WaitingBlock) | Some(_: PostponedBlock) | None => true
+        case _                                                      => false
+      }
+
+      check("toAdd", toAdd.map(_._1.proofsHash))(isAddable) ++
+        check("toMarkMajority", toMarkMajority.map(_._1)) { case Some(_: AcceptedBlock) => true; case _ => false } ++
+        check("acceptedToRemove", acceptedToRemove) { case Some(_: AcceptedBlock) => true; case _ => false } ++
+        check("obsoleteToRemove", obsoleteToRemove) {
+          case Some(_: WaitingBlock) | Some(_: PostponedBlock) => true; case _ => false
+        } ++
+        check("toReset", toReset) { case Some(_: AcceptedBlock) => true; case _ => false } ++
+        check("tipsToDeprecate", tipsToDeprecate) { case Some(MajorityBlock(_, _, Active)) => true; case _ => false } ++
+        check("tipsToRemove", tipsToRemove) { case Some(MajorityBlock(_, _, Deprecated)) => true; case _ => false } ++
+        check("activeTipsToAdd", activeTipsToAdd.map(_.block.hash))(isAddable) ++
+        check("deprecatedTipsToAdd", deprecatedTipsToAdd.map(_.hash))(isAddable) ++
+        check("postponedToWaiting", postponedToWaiting) { case Some(_: PostponedBlock) => true; case _ => false }
+    }
+
+    val checkPreconditions: F[Unit] =
+      blocks.toMap.flatMap { all =>
+        adjustPreconditionViolations(all) match {
+          case Nil        => ().pure[F]
+          case violations => Sync[F].raiseError[Unit](UnexpectedBlockStatesWhenAdjustingToMajority(violations))
+        }
+      }
+
+    checkPreconditions >>
+      addMajorityBlocks >>
       markMajorityBlocks >>
       removeAcceptedNonMajorityBlocks >>
       removeObsoleteBlocks >>
@@ -376,6 +414,12 @@ object BlockStorage {
 
     val errorMessage: String =
       s"Block to be added during majority update with hash: $hash not found in expected state! But got: $got"
+  }
+
+  case class UnexpectedBlockStatesWhenAdjustingToMajority(violations: List[String]) extends BlockMajorityUpdateError {
+
+    val errorMessage: String =
+      s"adjustToMajority preconditions not met (block state drifted since reconciliation), mutating nothing: ${violations.mkString("; ")}"
   }
 
   sealed trait TipUpdateError extends BlockStorageError

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/DAGSnapshotProcessor.scala
@@ -2,6 +2,7 @@ package io.constellationnetwork.dag.l1.domain.snapshot.programs
 
 import cats.Parallel
 import cats.effect.Async
+import cats.effect.std.Mutex
 import cats.syntax.all._
 
 import io.constellationnetwork.dag.l1.domain.address.storage.AddressStorage
@@ -38,7 +39,8 @@ object DAGSnapshotProcessor {
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     l0Service: GlobalL0Service[F],
     globalL0AlignmentStorage: GlobalL0AlignmentStorage[F],
-    mptStore: MptStore[F, GlobalStateKey]
+    mptStore: MptStore[F, GlobalStateKey],
+    storageMutationLock: Mutex[F]
   ): SnapshotProcessor[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo] =
     new SnapshotProcessor[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
 
@@ -86,7 +88,8 @@ object DAGSnapshotProcessor {
               tokenLockStorage,
               lastGlobalSnapshotStorage,
               addressStorage,
-              mptStore
+              mptStore,
+              storageMutationLock
             )
           )
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
@@ -489,10 +489,10 @@ abstract class SnapshotProcessor[
                               postponedToWaiting
                             )
 
-                          globalL0AlignmentStorage.consumeShouldRedownload.flatMap { shouldRedownload =>
-                            validateTipsAlignment() >>
-                              determineAlignment(shouldRedownload)
-                          }
+                          // Validate tips BEFORE consuming the redownload flag: if tips are misaligned (raises),
+                          // we must NOT have cleared a pending redownload request that the next cycle still needs.
+                          validateTipsAlignment() >>
+                            globalL0AlignmentStorage.consumeShouldRedownload.flatMap(determineAlignment)
                       }
                     }
 
@@ -586,10 +586,9 @@ abstract class SnapshotProcessor[
                               postponedToWaiting
                             )
 
-                          globalL0AlignmentStorage.consumeShouldRedownload.flatMap { shouldRedownload =>
-                            validateTipsAlignment() >>
-                              determineHeightAlignment(shouldRedownload)
-                          }
+                          // Validate tips BEFORE consuming the redownload flag (see AlignedAtNewOrdinal branch).
+                          validateTipsAlignment() >>
+                            globalL0AlignmentStorage.consumeShouldRedownload.flatMap(determineHeightAlignment)
                       }
                     }
 

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
@@ -133,8 +133,24 @@ abstract class SnapshotProcessor[
 
         // Commit the in-memory storage mutations under the shared lock so they cannot interleave with a concurrent
         // block-acceptance commit (BlockService.accept). The MPT build and lastN update stay OUTSIDE the lock.
+        // Validate the majority-ref preconditions BEFORE any mutation (still under the lock). If local state drifted
+        // from the reconciliation snapshot (a concurrent accept landed between checkAlignment's lock-free read and
+        // this apply), abort with nothing mutated and let the caller schedule a redownload -- rather than mutating
+        // block storage in adjustToMajority and only then having advanceMajorityRefs raise (a cross-store partial
+        // commit that cannot be cleanly retried).
+        val checkMajorityRefPreconditions: F[Unit] =
+          (
+            transactionStorage.majorityRefsViolations(txRefsToMarkMajority),
+            allowSpendStorage.majorityRefsViolations(allowSpendRefsToMarkMajority),
+            tokenLockStorage.majorityRefsViolations(tokenLockRefsToMarkMajority)
+          ).mapN(_ ++ _ ++ _).flatMap {
+            case Nil        => Async[F].unit
+            case violations => MajorityRefsDiverged(violations).raiseError[F, Unit]
+          }
+
         storageMutationLock.lock.surround {
-          adjustToMajority >>
+          checkMajorityRefPreconditions >>
+            adjustToMajority >>
             markTxRefsAsMajority >>
             setSnapshot
         } >>
@@ -182,8 +198,21 @@ abstract class SnapshotProcessor[
           case _ => Async[F].unit
         }
 
+        // See AlignedAtNewOrdinal: validate majority-ref preconditions before any mutation to avoid a cross-store
+        // partial commit when local state drifted since the lock-free reconciliation read.
+        val checkMajorityRefPreconditions: F[Unit] =
+          (
+            transactionStorage.majorityRefsViolations(txRefsToMarkMajority),
+            allowSpendStorage.majorityRefsViolations(allowSpendRefsToMarkMajority),
+            tokenLockStorage.majorityRefsViolations(tokenLockRefsToMarkMajority)
+          ).mapN(_ ++ _ ++ _).flatMap {
+            case Nil        => Async[F].unit
+            case violations => MajorityRefsDiverged(violations).raiseError[F, Unit]
+          }
+
         storageMutationLock.lock.surround {
-          adjustToMajority >>
+          checkMajorityRefPreconditions >>
+            adjustToMajority >>
             markTxRefsAsMajority >>
             setSnapshot
         } >>
@@ -741,5 +770,11 @@ object SnapshotProcessor {
   case class TipsGotMisaligned(deprecatedToAdd: Set[ProofsHash], activeToDeprecate: Set[ProofsHash]) extends SnapshotProcessingError {
     override def getMessage: String =
       s"Tips got misaligned! Check the implementation! deprecatedToAdd -> $deprecatedToAdd not equal activeToDeprecate -> $activeToDeprecate"
+  }
+
+  case class MajorityRefsDiverged(violations: List[String]) extends SnapshotProcessingError {
+    override def getMessage: String =
+      s"Majority tx/allow-spend/token-lock refs diverged from local state (drift since reconciliation), scheduling redownload " +
+        s"and mutating nothing: ${violations.mkString(", ")}"
   }
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessor.scala
@@ -2,6 +2,7 @@ package io.constellationnetwork.dag.l1.domain.snapshot.programs
 
 import cats.data.NonEmptyList
 import cats.effect.Async
+import cats.effect.std.Mutex
 import cats.syntax.all._
 import cats.{Applicative, MonadThrow, Parallel}
 
@@ -87,7 +88,8 @@ abstract class SnapshotProcessor[
     tokenLockStorage: TokenLockStorage[F],
     lastSnapshotStorage: LastSnapshotStorage[F, S, SI],
     addressStorage: AddressStorage[F],
-    mptStore: MptStore[F, GlobalStateKey]
+    mptStore: MptStore[F, GlobalStateKey],
+    storageMutationLock: Mutex[F]
   )(
     implicit hasher: Hasher[F],
     stateProofSelector: StateProofSelector
@@ -129,9 +131,13 @@ abstract class SnapshotProcessor[
           case _ => Async[F].unit
         }
 
-        adjustToMajority >>
-          markTxRefsAsMajority >>
-          setSnapshot >>
+        // Commit the in-memory storage mutations under the shared lock so they cannot interleave with a concurrent
+        // block-acceptance commit (BlockService.accept). The MPT build and lastN update stay OUTSIDE the lock.
+        storageMutationLock.lock.surround {
+          adjustToMajority >>
+            markTxRefsAsMajority >>
+            setSnapshot
+        } >>
           updateMptStorage >>
           setLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             Aligned(
@@ -176,9 +182,11 @@ abstract class SnapshotProcessor[
           case _ => Async[F].unit
         }
 
-        adjustToMajority >>
-          markTxRefsAsMajority >>
-          setSnapshot >>
+        storageMutationLock.lock.surround {
+          adjustToMajority >>
+            markTxRefsAsMajority >>
+            setSnapshot
+        } >>
           updateMptStorage >>
           setLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             Aligned(
@@ -198,8 +206,7 @@ abstract class SnapshotProcessor[
           ) >> onDownload(snapshot, state)
 
         val setBalances: F[Unit] =
-          addressStorage.clean >>
-            addressStorage.updateBalances(state.balances)
+          addressStorage.replaceAll(state.balances)
 
         val setTransactionRefs: F[Unit] =
           transactionStorage.initByRefs(state.lastTxRefs, snapshot.ordinal)
@@ -216,10 +223,12 @@ abstract class SnapshotProcessor[
           case _ => Async[F].unit
         }
 
-        adjustToMajority >>
-          setBalances >>
-          setTransactionRefs >>
-          setInitialSnapshot >>
+        storageMutationLock.lock.surround {
+          adjustToMajority >>
+            setBalances >>
+            setTransactionRefs >>
+            setInitialSnapshot
+        } >>
           updateMptStorage >>
           setInitialLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             DownloadPerformed(
@@ -254,8 +263,7 @@ abstract class SnapshotProcessor[
           ) >> onRedownload(snapshot, state)
 
         val setBalances: F[Unit] =
-          addressStorage.clean >>
-            addressStorage.updateBalances(state.balances)
+          addressStorage.replaceAll(state.balances)
 
         val setTransactionRefs: F[Unit] =
           transactionStorage.replaceByRefs(state.lastTxRefs, snapshot.ordinal)
@@ -269,10 +277,12 @@ abstract class SnapshotProcessor[
           case _ => Async[F].unit
         }
 
-        adjustToMajority >>
-          setBalances >>
-          setTransactionRefs >>
-          setSnapshot >>
+        storageMutationLock.lock.surround {
+          adjustToMajority >>
+            setBalances >>
+            setTransactionRefs >>
+            setSnapshot
+        } >>
           updateMptStorage >>
           setLastNSnapshots(snapshot, state).as[SnapshotProcessingResult] {
             RedownloadPerformed(
@@ -417,11 +427,11 @@ abstract class SnapshotProcessor[
                             }
 
                           def handleRedownloadRequired(shouldRedownload: ShouldRedownload): F[Alignment] =
-                            for {
-                              _ <- logger.info(s"Should redownload provided. Reason: ${shouldRedownload.reason.mkString(",")}")
-                              _ <- globalL0AlignmentStorage.clean()
-                              alignment = createRedownloadNeeded()
-                            } yield alignment
+                            // The flag was already read-and-cleared atomically by consumeShouldRedownload below,
+                            // so no separate clean() is needed (and a concurrently-raised flag is preserved).
+                            logger
+                              .info(s"Should redownload provided. Reason: ${shouldRedownload.reason.mkString(",")}")
+                              .as(createRedownloadNeeded())
 
                           def createRedownloadNeeded(): Alignment =
                             RedownloadNeeded(
@@ -450,7 +460,7 @@ abstract class SnapshotProcessor[
                               postponedToWaiting
                             )
 
-                          globalL0AlignmentStorage.getShouldRedownload.flatMap { shouldRedownload =>
+                          globalL0AlignmentStorage.consumeShouldRedownload.flatMap { shouldRedownload =>
                             validateTipsAlignment() >>
                               determineAlignment(shouldRedownload)
                           }
@@ -513,11 +523,11 @@ abstract class SnapshotProcessor[
                             onlyInMajority.isEmpty && acceptedToRemove.isEmpty
 
                           def handleRedownloadRequired(shouldRedownload: ShouldRedownload): F[Alignment] =
-                            for {
-                              _ <- logger.info(s"Should redownload provided. Reason: ${shouldRedownload.reason.mkString(",")}")
-                              _ <- globalL0AlignmentStorage.clean()
-                              alignment = createRedownloadNeeded()
-                            } yield alignment
+                            // The flag was already read-and-cleared atomically by consumeShouldRedownload below,
+                            // so no separate clean() is needed (and a concurrently-raised flag is preserved).
+                            logger
+                              .info(s"Should redownload provided. Reason: ${shouldRedownload.reason.mkString(",")}")
+                              .as(createRedownloadNeeded())
 
                           def createAlignedAtNewHeight(): Alignment =
                             AlignedAtNewHeight(
@@ -547,7 +557,7 @@ abstract class SnapshotProcessor[
                               postponedToWaiting
                             )
 
-                          globalL0AlignmentStorage.getShouldRedownload.flatMap { shouldRedownload =>
+                          globalL0AlignmentStorage.consumeShouldRedownload.flatMap { shouldRedownload =>
                             validateTipsAlignment() >>
                               determineHeightAlignment(shouldRedownload)
                           }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/ContextualTransactionValidator.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/ContextualTransactionValidator.scala
@@ -124,9 +124,13 @@ object ContextualTransactionValidator {
         txs match {
           case Some(txs) =>
             resolveConflict(transaction, txs) match {
-              case noConflict @ NoConflict(_) => (noConflict, txs.some).asRight
+              case noConflict @ NoConflict(_)   => (noConflict, txs.some).asRight
               case canOverride @ CanOverride(_) =>
-                (canOverride, txs.filterNot { case (ordinal, _) => ordinal > transaction.ordinal }.some).asRight
+                // Drop the entry AT transaction.ordinal too (>=, not >): that stored WaitingTx is being REPLACED by
+                // this higher-fee transaction. Keeping it (the old `>`) left it in the validation context, so the
+                // balance and rate-limit checks double-counted the overridden tx's amount+fee and could wrongly
+                // reject a legitimate fee-bump with InsufficientBalance / TransactionLimited.
+                (canOverride, txs.filterNot { case (ordinal, _) => ordinal >= transaction.ordinal }.some).asRight
               case CannotOverride(_, existing, current) => Conflict(transaction.ordinal, existing.hash, current.hash).asLeft
             }
           case None => (NoConflict(transaction), none).asRight

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorage.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorage.scala
@@ -121,6 +121,25 @@ class TransactionStorage[F[_]: Async](
           }
     }
 
+  /** Pure precondition check (no mutation) for `advanceMajorityRefs`: returns the addresses for which advancing to the given majority ref
+    * would FAIL (no matching local AcceptedTx and not already a MajorityTx at that ref, and not the empty special case). Run BEFORE any
+    * storage mutation in processAlignment so a divergence aborts the whole apply cleanly, instead of `advanceMajorityRefs` raising AFTER
+    * block storage was already mutated (cross-store partial commit). The predicate mirrors the accept conditions of `advanceMajorityRefs`
+    * exactly.
+    */
+  def majorityRefsViolations(refs: Map[Address, TransactionReference]): F[List[String]] =
+    refs.toList.traverse {
+      case (source, majorityTxRef) =>
+        transactionsR(source).get.map { maybeStored =>
+          val stored = maybeStored.getOrElse(SortedMap.empty[TransactionOrdinal, StoredTransaction])
+          val ok =
+            (stored.isEmpty && majorityTxRef === TransactionReference.empty) ||
+              stored.exists { case (_, a: AcceptedTx) => a.ref === majorityTxRef; case _ => false } ||
+              stored.exists { case (_, m: MajorityTx) => m.ref === majorityTxRef; case _ => false }
+          if (ok) none[String] else s"tx:${source.show}->${majorityTxRef.show}".some
+        }
+    }.map(_.flatten)
+
   def accept(hashedTx: Hashed[Transaction]): F[Unit] = {
     val parent = hashedTx.signed.value.parent
     val source = hashedTx.signed.value.source

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorage.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorage.scala
@@ -68,30 +68,57 @@ class TransactionStorage[F[_]: Async](
   def replaceByRefs(refs: Map[Address, TransactionReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
     refs.toList.traverse_ {
       case (address, reference) =>
-        val initial = SortedMap(reference.ordinal -> MajorityTx(reference, snapshotOrdinal))
-        transactionsR(address).set(initial.some)
+        transactionsR(address).update { maybeStored =>
+          val majority: StoredTransaction = MajorityTx(reference, snapshotOrdinal)
+          // Reset the address to the majority ref, but PRESERVE in-flight Waiting/Processing txs strictly ABOVE it.
+          // A blind `.set` dropped a ProcessingTx that a concurrent consensus round was about to return via putBack
+          // (putBack only restores ProcessingTx), silently losing a valid in-flight client tx. Accepted txs above the
+          // majority ARE discarded -- a redownload makes the majority ref the source of truth.
+          val preserved = maybeStored.toList.flatMap(_.collect {
+            case entry @ (ordinal, _: WaitingTx) if ordinal > reference.ordinal    => entry
+            case entry @ (ordinal, _: ProcessingTx) if ordinal > reference.ordinal => entry
+          })
+          (SortedMap(reference.ordinal -> majority) ++ preserved).some
+        }
     }
 
   def advanceMajorityRefs(refs: Map[Address, TransactionReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
     refs.toList.traverse_ {
       case (source, majorityTxRef) =>
-        transactionsR(source).modify[Either[MarkingTransactionReferenceAsMajorityError, Unit]] { maybeStored =>
-          val stored = maybeStored.getOrElse(SortedMap.empty[TransactionOrdinal, StoredTransaction])
+        transactionsR(source)
+          .modify[Either[MarkingTransactionReferenceAsMajorityError, Unit]] { maybeStored =>
+            val stored = maybeStored.getOrElse(SortedMap.empty[TransactionOrdinal, StoredTransaction])
 
-          if (stored.isEmpty && majorityTxRef === TransactionReference.empty) {
-            val updated = stored + (majorityTxRef.ordinal -> MajorityTx(majorityTxRef, snapshotOrdinal))
-            (updated.some, ().asRight)
-          } else {
-            stored.collectFirst { case (_, a @ AcceptedTx(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
-              val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
+            if (stored.isEmpty && majorityTxRef === TransactionReference.empty) {
+              val updated = stored + (majorityTxRef.ordinal -> MajorityTx(majorityTxRef, snapshotOrdinal))
+              (updated.some, ().asRight)
+            } else {
+              stored.collectFirst { case (_, a @ AcceptedTx(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
+                val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
 
-              remaining + (majorityTx.ordinal -> MajorityTx(TransactionReference.of(majorityTx), snapshotOrdinal))
-            } match {
-              case Some(updated) => (updated.some, ().asRight)
-              case None          => (maybeStored, UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, None).asLeft)
+                remaining + (majorityTx.ordinal -> MajorityTx(TransactionReference.of(majorityTx), snapshotOrdinal))
+              } match {
+                case Some(updated) => (updated.some, ().asRight)
+                // Idempotent re-mark: the ref is already stored as MajorityTx (advanced by a prior alignment).
+                // getLastProcessedTransaction already reports the correct ref, so this is a no-op, not a divergence.
+                case None if stored.exists { case (_, m: MajorityTx) => m.ref === majorityTxRef; case _ => false } =>
+                  (maybeStored, ().asRight)
+                case None =>
+                  (
+                    maybeStored,
+                    UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, getLastProcessedTransaction(stored)).asLeft
+                  )
+              }
             }
           }
-        }
+          .flatMap {
+            case Right(_) => Async[F].unit
+            // Previously the Either was discarded, silently leaving the local ref stale while the snapshot advanced.
+            // Surface it: this is a genuine local-vs-majority divergence that must escalate to a redownload.
+            case Left(e) =>
+              logger.warn(s"advanceMajorityRefs could not mark majority ref for source=${source.show}: ${e.getMessage}") >>
+                e.raiseError[F, Unit]
+          }
     }
 
   def accept(hashedTx: Hashed[Transaction]): F[Unit] = {

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/L0BlockOutputClient.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/L0BlockOutputClient.scala
@@ -21,6 +21,11 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 trait L0BlockOutputClient[F[_]] {
+
+  /** LOSSY: collapses the result to a bare Boolean, mapping an awaiting-parent HTTP 202 to `false` (indistinguishable from a real
+    * rejection). Prefer `sendL1OutputDetailed`, which distinguishes Accepted / AwaitingParent / gap / rejection so the caller can
+    * retain-and-resend a 202 instead of dropping it. (Only reachable today via the unused L0CurrencyBlockOutputClient.)
+    */
   def sendL1Output(output: Signed[Block]): PeerResponse[F, Boolean]
   def sendL1OutputDetailed(output: Signed[Block]): PeerResponse[F, L0BlockOutputClient.L1OutputSubmissionResult]
   def sendDataApplicationBlock(block: Signed[DataApplicationBlock])(

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/L0BlockOutputClient.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/http/p2p/L0BlockOutputClient.scala
@@ -41,6 +41,15 @@ object L0BlockOutputClient {
       val accepted: Boolean = true
     }
 
+    /** L0 accepted the block into its awaiting-parent mempool (HTTP 202) but has NOT yet included it in a snapshot, because a parent tx
+      * ordinal is not yet finalized. This is PROVISIONAL: L0 evicts awaiting-parent entries on a TTL/overflow, so a 202 must NOT be treated
+      * as terminal -- the block stays buffered and is re-sent until L0 confirms inclusion with a 200. A contiguous stuck chain always gets
+      * 202 (never the 4xx that triggers backfill), so dropping it here was a silent, unrecoverable loss.
+      */
+    case class AwaitingParent(statusCode: Int) extends L1OutputSubmissionResult {
+      val accepted: Boolean = false
+    }
+
     case class ParentOrdinalGapTooLarge(
       currentLastTxOrdinal: Long,
       parentOrdinal: Long,
@@ -113,7 +122,13 @@ object L0BlockOutputClient {
           // Surface the actual status + body so the real failure mode is diagnosable.
           c.run(req.withEntity(output)).use { resp =>
             if (resp.status.isSuccess)
-              Async[F].pure(L1OutputSubmissionResult.Accepted)
+              // 202 Accepted == awaiting-parent (provisional, keep re-sending); 200 Ok == included (terminal).
+              if (resp.status.code == 202)
+                logger
+                  .debug("[L1-OUTPUT] L0 holding block awaiting parent (202); retained for re-send until included")
+                  .as(L1OutputSubmissionResult.AwaitingParent(resp.status.code): L1OutputSubmissionResult)
+              else
+                Async[F].pure(L1OutputSubmissionResult.Accepted: L1OutputSubmissionResult)
             else
               resp.bodyText.compile.string.flatMap { body =>
                 val result = L1OutputSubmissionResult.rejected(resp.status.code, resp.status.reason, body)

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/infrastructure/address/storage/AddressStorage.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/infrastructure/address/storage/AddressStorage.scala
@@ -28,6 +28,9 @@ object AddressStorage {
       def updateBalances(addressBalances: Map[Address, Balance]): F[Unit] =
         balances.update(_ ++ addressBalances)
 
+      def replaceAll(addressBalances: Map[Address, Balance]): F[Unit] =
+        balances.set(addressBalances)
+
       def clean: F[Unit] =
         balances.set(Map.empty)
     }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
@@ -90,10 +90,13 @@ trait Storages[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]] {
   val tokenLockBlock: TokenLockBlockStorage[F]
   val globalL0Alignment: GlobalL0AlignmentStorage[F]
 
-  /** Single fair-FIFO lock serializing the in-memory storage COMMIT performed by the live block-acceptance path (BlockService.accept, block
-    * store) against the commit performed by the L0->L1 alignment path (SnapshotProcessor.processAlignment). It guards only microsecond
-    * Ref/MapRef writes -- never network I/O, hashing of whole snapshots, or the MPT trie build -- so L1 keeps producing/aligning while it
-    * is held.
+  /** Single fair-FIFO lock serializing the live block-acceptance path against the L0->L1 alignment commit
+    * (SnapshotProcessor.processAlignment), so the two never interleave their storage mutations. Scope is asymmetric by design: the
+    * ALIGNMENT side holds it only across in-memory Ref/MapRef writes (the MPT trie build, createContext and lastN update stay OUTSIDE),
+    * while the ACCEPTANCE side holds it across the whole accept -- including block/tx hashing and signature verification -- so the
+    * read-compute-write of balances is atomic w.r.t. alignment (acceptable because acceptance is a serial 1s-tick stream; network I/O and
+    * the MPT build are never under the lock). Lock ordering: the per-stream semaphores are always acquired OUTSIDE this mutex and it is
+    * never re-acquired reentrantly, so there is no cycle.
     */
   val storageMutationLock: Mutex[F]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
@@ -90,13 +90,13 @@ trait Storages[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]] {
   val tokenLockBlock: TokenLockBlockStorage[F]
   val globalL0Alignment: GlobalL0AlignmentStorage[F]
 
-  /** Single fair-FIFO lock serializing the live block-acceptance path against the L0->L1 alignment commit
+  /** Single fair-FIFO lock serializing live DAG/swap/token-lock block acceptance against the L0->L1 alignment commit
     * (SnapshotProcessor.processAlignment), so the two never interleave their storage mutations. Scope is asymmetric by design: the
     * ALIGNMENT side holds it only across in-memory Ref/MapRef writes (the MPT trie build, createContext and lastN update stay OUTSIDE),
-    * while the ACCEPTANCE side holds it across the whole accept -- including block/tx hashing and signature verification -- so the
-    * read-compute-write of balances is atomic w.r.t. alignment (acceptable because acceptance is a serial 1s-tick stream; network I/O and
-    * the MPT build are never under the lock). Lock ordering: the per-stream semaphores are always acquired OUTSIDE this mutex and it is
-    * never re-acquired reentrantly, so there is no cycle.
+    * while the ACCEPTANCE side holds it across the whole accept -- including block/tx hashing and signature verification -- so each
+    * read-compute-write of shared balances/refs is atomic w.r.t. alignment (acceptable because acceptance is a serial tick stream; network
+    * I/O and the MPT build are never under the lock). Lock ordering: the per-stream semaphores are always acquired OUTSIDE this mutex and
+    * it is never re-acquired reentrantly, so there is no cycle.
     */
   val storageMutationLock: Mutex[F]
 }

--- a/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
+++ b/modules/dag-l1/src/main/scala/io/constellationnetwork/dag/l1/modules/Storages.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.dag.l1.modules
 
 import cats.Parallel
 import cats.effect.kernel.Async
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -51,6 +51,7 @@ object Storages {
       tokenLockStorage <- TokenLockStorage.make[F](TokenLockReference.empty, contextualTokenLockValidator)
       tokenLockBlockStorage <- TokenLockBlockStorage.make[F]
       globalL0AlignmentStorage <- GlobalL0AlignmentStorage.make[F]
+      mutationLock <- Mutex[F]
     } yield
       new Storages[F, P, S, SI] {
         val address = addressStorage
@@ -68,6 +69,7 @@ object Storages {
         val tokenLock = tokenLockStorage
         val tokenLockBlock = tokenLockBlockStorage
         val globalL0Alignment = globalL0AlignmentStorage
+        val storageMutationLock = mutationLock
       }
 }
 
@@ -87,4 +89,11 @@ trait Storages[F[_], P <: StateProof, S <: Snapshot, SI <: SnapshotInfo[P]] {
   val tokenLock: TokenLockStorage[F]
   val tokenLockBlock: TokenLockBlockStorage[F]
   val globalL0Alignment: GlobalL0AlignmentStorage[F]
+
+  /** Single fair-FIFO lock serializing the in-memory storage COMMIT performed by the live block-acceptance path (BlockService.accept, block
+    * store) against the commit performed by the L0->L1 alignment path (SnapshotProcessor.processAlignment). It guards only microsecond
+    * Ref/MapRef writes -- never network I/O, hashing of whole snapshots, or the MPT trie build -- so L1 keeps producing/aligning while it
+    * is held.
+    */
+  val storageMutationLock: Mutex[F]
 }

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockServiceSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockServiceSuite.scala
@@ -84,6 +84,8 @@ object BlockServiceSuite extends MutableIOSuite with Checkers {
 
       override def updateBalances(addressBalances: Map[Address, Balance]): IO[Unit] = IO.unit
 
+      override def replaceAll(addressBalances: Map[Address, Balance]): IO[Unit] = IO.unit
+
       override def clean: IO[Unit] = ???
 
     }

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockStorageSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/block/BlockStorageSuite.scala
@@ -1,0 +1,50 @@
+package io.constellationnetwork.dag.l1.domain.block
+
+import cats.effect.IO
+import cats.effect.std.Random
+
+import io.constellationnetwork.dag.l1.domain.block.BlockStorage._
+import io.constellationnetwork.schema.BlockReference
+import io.constellationnetwork.schema.height.Height
+import io.constellationnetwork.security.hash.ProofsHash
+
+import eu.timepit.refined.auto._
+import weaver.SimpleIOSuite
+
+object BlockStorageSuite extends SimpleIOSuite {
+
+  // Regression (B2): adjustToMajority must be all-or-nothing. Its precondition dry-run runs before any mutation, so if
+  // a referenced block is not in the state the corresponding sub-step expects (e.g. local state drifted since the
+  // lock-free reconciliation read), it aborts with UnexpectedBlockStatesWhenAdjustingToMajority and mutates NOTHING --
+  // avoiding a partial, unrollback-able reconciliation that would wedge the node.
+  test("adjustToMajority aborts atomically (mutates nothing) when a referenced block is in an unexpected state") {
+    val hash = ProofsHash("aaaa")
+    val ref = BlockReference(Height(10L), hash)
+    // toMarkMajority expects an AcceptedBlock, but here the block is already a MajorityBlock -> precondition violation.
+    val initial: Map[ProofsHash, StoredBlock] = Map(hash -> MajorityBlock(ref, 0L, Active))
+
+    for {
+      implicit0(r: Random[IO]) <- Random.scalaUtilRandom[IO]
+      bs <- BlockStorage.make[IO](initial)
+      outcome <- bs.adjustToMajority(toMarkMajority = Set((hash, 1L))).attempt
+      after <- bs.getState()
+    } yield
+      expect.all(
+        outcome.fold(_.isInstanceOf[UnexpectedBlockStatesWhenAdjustingToMajority], _ => false),
+        after == initial
+      )
+  }
+
+  test("adjustToMajority applies when all preconditions hold") {
+    val hash = ProofsHash("bbbb")
+    val ref = BlockReference(Height(10L), hash)
+    val initial: Map[ProofsHash, StoredBlock] = Map(hash -> MajorityBlock(ref, 0L, Active))
+
+    for {
+      implicit0(r: Random[IO]) <- Random.scalaUtilRandom[IO]
+      bs <- BlockStorage.make[IO](initial)
+      _ <- bs.adjustToMajority(tipsToDeprecate = Set(hash))
+      after <- bs.getState()
+    } yield expect(after.get(hash).exists { case MajorityBlock(_, _, Deprecated) => true; case _ => false })
+  }
+}

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -4,7 +4,7 @@ import java.security.KeyPair
 
 import cats.data.{NonEmptyList, NonEmptySet}
 import cats.effect._
-import cats.effect.std.Random
+import cats.effect.std.{Mutex, Random}
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -315,6 +315,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                   SnapshotOrdinal.MinValue
                 )
               }
+              storageMutationLock <- Mutex[IO].asResource
               snapshotProcessor = {
                 val addressStorage = new AddressStorage[IO] {
                   def getState: IO[Map[Address, Balance]] =
@@ -324,6 +325,9 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                     balancesR.get.map(b => b(address))
 
                   def updateBalances(addressBalances: Map[Address, balance.Balance]): IO[Unit] =
+                    balancesR.update(_ ++ addressBalances)
+
+                  def replaceAll(addressBalances: Map[Address, balance.Balance]): IO[Unit] =
                     balancesR.set(addressBalances)
 
                   def clean: IO[Unit] = balancesR.set(Map.empty)
@@ -369,7 +373,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                     globalL0Service.pullGlobalSnapshot,
                     globalL0Service,
                     globalL0AlignmentStorage,
-                    mptStore
+                    mptStore,
+                    storageMutationLock
                   )
               }
               keys <- (

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/ContextualTransactionValidatorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/ContextualTransactionValidatorSuite.scala
@@ -290,6 +290,37 @@ object ContextualTransactionValidatorSuite extends MutableIOSuite with Checkers 
       )
   }
 
+  // Regression (TX-07): a higher-fee override must NOT be double-counted with the WaitingTx it replaces. The override
+  // and the replaced tx share an ordinal; with the old `>` filter the replaced tx stayed in the validation context, so
+  // the rate-limit cap was charged for BOTH and the override was wrongly rejected as TransactionLimited. With the `>=`
+  // fix only the override is counted, so it validates. Fails on a revert to `>`.
+  test("fee-bump override is not double-counted against the rate limit (TX-07)") { res =>
+    implicit val (hasher, sp, ks, js) = res
+    implicit val kryoHasher: SignedHasher[IO] = SignedHasher(Hasher.forKryo[IO])
+    implicit val proofsHasher: ProofsHasher[IO] = ProofsHasher(Hasher.forJson[IO])
+    for {
+      kp <- KeyPairGenerator.makeKeyPair
+      majorityTx <- genTransaction(kp, TransactionReference.empty, TransactionFee.zero).flatMap(_.toHashedHybrid)
+      majorityTxRef = TransactionReference.of(majorityTx)
+      conflictingTx <- genTransaction(kp, majorityTxRef, TransactionFee(1L)).flatMap(_.toHashedHybrid)
+      conflictingTxRef = TransactionReference.of(conflictingTx)
+      txs = SortedMap(
+        majorityTxRef.ordinal -> MajorityTx(majorityTxRef, SnapshotOrdinal.MinValue),
+        conflictingTxRef.ordinal -> WaitingTx(conflictingTx)
+      )
+      // 2x baseBalance => the cap comfortably admits ONE below-min-fee tx but not two; the second (the double-counted
+      // replaced tx under `>`) blows the cap.
+      balance = Balance(200000000L)
+      lastSnapshotOrdinal = SnapshotOrdinal.unsafeApply(durationToOrdinals(config.timeToWaitForBaseBalance))
+      validator = ContextualTransactionValidator.make(config, None)
+      overrideTx <- genTransaction(kp, majorityTxRef, TransactionFee(2L)).flatMap(_.toHashedHybrid)
+      result = validator.validate(
+        overrideTx,
+        TransactionValidatorContext(txs.some, balance, TransactionReference.empty, lastSnapshotOrdinal)
+      )
+    } yield expect.eql(true, result.isValid)
+  }
+
   test("Transaction does not override existing non-waiting transaction") { res =>
     implicit val (hasher, sp, ks, js) = res
     for {

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorageSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/transaction/TransactionStorageSuite.scala
@@ -216,4 +216,32 @@ object TransactionStorageSuite extends SimpleIOSuite with TransactionGenerator {
         } yield expect.same(NonEmptyList.fromList(txsA.toList ::: txsB.toList), pulled)
     }
   }
+
+  // Regression (B3): replaceByRefs (the RedownloadNeeded reset) must PRESERVE in-flight Waiting/Processing txs
+  // strictly above the new majority ref. The old blind `.set` wiped a ProcessingTx that a concurrently-cancelled
+  // consensus round was about to return via putBack (putBack only restores ProcessingTx), silently losing a valid
+  // in-flight client tx.
+  test("replaceByRefs preserves an in-flight ProcessingTx above the new majority ref") {
+    testResources.use {
+      case (transactionStorage, _, key1, address1, _, address2, sp, h, txHasher, _, _) =>
+        implicit val securityProvider = sp
+        implicit val hasher = h
+
+        for {
+          txsA <- generateTransactions(address1, key1, address2, 2, TransactionFee(1L), kHasher = txHasher, jHasher = h)
+          _ <- txsA.toList.traverse(transactionStorage.tryPut(_, SnapshotOrdinal.MinValue, Balance(NonNegLong.MaxValue)))
+          // Waiting -> Processing for the whole chain (as a started consensus round would do).
+          _ <- transactionStorage.pull(10L)
+          // Majority advanced only to the FIRST tx; the second is still an in-flight ProcessingTx.
+          majorityRef = TransactionReference(txsA.head.ordinal, txsA.head.hash)
+          _ <- transactionStorage.replaceByRefs(Map(address1 -> majorityRef), SnapshotOrdinal.MinValue)
+          state <- transactionStorage.getState
+          stored = state.getOrElse(address1, SortedMap.empty[TransactionOrdinal, StoredTransaction])
+        } yield
+          expect.all(
+            stored.get(txsA.head.ordinal).exists { case _: MajorityTx => true; case _ => false },
+            stored.get(txsA.last.ordinal).exists { case _: ProcessingTx => true; case _ => false }
+          )
+    }
+  }
 }

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/infrastructure/address/storage/AddressStorageSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/infrastructure/address/storage/AddressStorageSuite.scala
@@ -73,4 +73,28 @@ object AddressStorageSuite extends SimpleIOSuite with Checkers {
         } yield expect.same(get, Balance.empty)
     }
   }
+
+  // Regression (A1): replaceAll publishes the majority balance map in ONE atomic set, replacing the whole map and
+  // dropping any address not present in it. This is the crash-/race-safe replacement for `clean >> updateBalances`,
+  // whose two-op form let a concurrent updateBalances(delta) leak a stray balance past the clean. Unlike
+  // updateBalances (which MERGES), replaceAll must NOT retain a pre-existing address that is absent from the new map.
+  test("replaceAll replaces the entire balance map, dropping addresses absent from it") {
+    val gen = for {
+      address1 <- addressGen
+      address2 <- addressGen
+      balance1 <- balanceGen
+      balance2 <- balanceGen
+    } yield (address1, address2, balance1, balance2)
+
+    forall(gen) {
+      case (address1, address2, balance1, balance2) =>
+        for {
+          ref <- Ref.of[IO, Map[Address, Balance]](Map(address1 -> balance1))
+          storage = AddressStorage.make[IO](ref)
+          _ <- storage.replaceAll(Map(address2 -> balance2))
+          get1 <- storage.getBalance(address1)
+          get2 <- storage.getBalance(address2)
+        } yield expect.all(get2 === balance2, address1 === address2 || get1 === Balance.empty)
+    }
+  }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/globalAlignment/GlobalL0AlignmentStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/globalAlignment/GlobalL0AlignmentStorage.scala
@@ -9,6 +9,14 @@ trait GlobalL0AlignmentStorage[F[_]] {
 
   def updateShouldRedownload(value: Boolean, reasons: List[String]): F[Unit]
 
+  /** Atomically read the current flag and reset it to empty in one operation.
+    *
+    * Replaces the racy `getShouldRedownload` ... later `clean()` pair: with two separate ops a concurrent `updateShouldRedownload(true)`
+    * landing between the read and the clear was silently wiped by the unconditional `set(empty)`. `getAndSet` consumes exactly the value
+    * the caller acts on; any flag raised afterwards survives for the next cycle.
+    */
+  def consumeShouldRedownload: F[ShouldRedownload]
+
   def clean(): F[Unit]
 }
 
@@ -20,6 +28,9 @@ object GlobalL0AlignmentStorage {
     new GlobalL0AlignmentStorage[F] {
       def getShouldRedownload: F[ShouldRedownload] =
         shouldRedownload.get
+
+      def consumeShouldRedownload: F[ShouldRedownload] =
+        shouldRedownload.getAndSet(ShouldRedownload.empty)
 
       def updateShouldRedownload(value: Boolean, reasons: List[String]): F[Unit] =
         shouldRedownload.update { current =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/globalAlignment/GlobalL0AlignmentStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/globalAlignment/GlobalL0AlignmentStorage.scala
@@ -5,8 +5,6 @@ import cats.effect.kernel.Ref
 import cats.syntax.all._
 
 trait GlobalL0AlignmentStorage[F[_]] {
-  def getShouldRedownload: F[ShouldRedownload]
-
   def updateShouldRedownload(value: Boolean, reasons: List[String]): F[Unit]
 
   /** Atomically read the current flag and reset it to empty in one operation.
@@ -16,8 +14,6 @@ trait GlobalL0AlignmentStorage[F[_]] {
     * the caller acts on; any flag raised afterwards survives for the next cycle.
     */
   def consumeShouldRedownload: F[ShouldRedownload]
-
-  def clean(): F[Unit]
 }
 
 object GlobalL0AlignmentStorage {
@@ -26,9 +22,6 @@ object GlobalL0AlignmentStorage {
 
   def make[F[_]: Async](shouldRedownload: Ref[F, ShouldRedownload]): GlobalL0AlignmentStorage[F] =
     new GlobalL0AlignmentStorage[F] {
-      def getShouldRedownload: F[ShouldRedownload] =
-        shouldRedownload.get
-
       def consumeShouldRedownload: F[ShouldRedownload] =
         shouldRedownload.getAndSet(ShouldRedownload.empty)
 
@@ -40,8 +33,5 @@ object GlobalL0AlignmentStorage {
             ShouldRedownload(value, reasons)
           }
         }
-
-      def clean(): F[Unit] =
-        shouldRedownload.set(ShouldRedownload.empty)
     }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/AllowSpendStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/AllowSpendStorage.scala
@@ -82,24 +82,51 @@ class AllowSpendStorage[F[_]: Async](
   def advanceMajorityRefs(refs: Map[Address, AllowSpendReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
     refs.toList.traverse_ {
       case (source, majorityTxRef) =>
-        allowSpendsR(source).modify[Either[MarkingAllowSpendReferenceAsMajorityError, Unit]] { maybeStored =>
-          val stored = maybeStored.getOrElse(SortedMap.empty[AllowSpendOrdinal, StoredAllowSpend])
+        allowSpendsR(source)
+          .modify[Either[MarkingAllowSpendReferenceAsMajorityError, Unit]] { maybeStored =>
+            val stored = maybeStored.getOrElse(SortedMap.empty[AllowSpendOrdinal, StoredAllowSpend])
 
-          if (stored.isEmpty && majorityTxRef === AllowSpendReference.empty) {
-            val updated = stored + (majorityTxRef.ordinal -> MajorityAllowSpend(majorityTxRef, snapshotOrdinal))
-            (updated.some, ().asRight)
-          } else {
-            stored.collectFirst { case (_, a @ AcceptedAllowSpend(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
-              val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
+            if (stored.isEmpty && majorityTxRef === AllowSpendReference.empty) {
+              val updated = stored + (majorityTxRef.ordinal -> MajorityAllowSpend(majorityTxRef, snapshotOrdinal))
+              (updated.some, ().asRight)
+            } else {
+              stored.collectFirst { case (_, a @ AcceptedAllowSpend(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
+                val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
 
-              remaining + (majorityTx.ordinal -> MajorityAllowSpend(AllowSpendReference.of(majorityTx), snapshotOrdinal))
-            } match {
-              case Some(updated) => (updated.some, ().asRight)
-              case None          => (maybeStored, UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, None).asLeft)
+                remaining + (majorityTx.ordinal -> MajorityAllowSpend(AllowSpendReference.of(majorityTx), snapshotOrdinal))
+              } match {
+                case Some(updated) => (updated.some, ().asRight)
+                // Idempotent re-mark: the ref is already stored as MajorityAllowSpend (advanced by a prior alignment).
+                case None if stored.exists { case (_, m: MajorityAllowSpend) => m.ref === majorityTxRef; case _ => false } =>
+                  (maybeStored, ().asRight)
+                case None =>
+                  (maybeStored, UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, None).asLeft)
+              }
             }
           }
-        }
+          .flatMap {
+            case Right(_) => Async[F].unit
+            // Surface the divergence (do not swallow the Left): a stale local-vs-majority allow-spend ref must escalate
+            // to a redownload, consistent with TransactionStorage.advanceMajorityRefs.
+            case Left(e) =>
+              logger.warn(s"advanceMajorityRefs could not mark majority allow-spend ref for source=${source.show}: ${e.getMessage}") >>
+                e.raiseError[F, Unit]
+          }
     }
+
+  /** Pure precondition check (no mutation) for `advanceMajorityRefs`; see TransactionStorage.majorityRefsViolations. */
+  def majorityRefsViolations(refs: Map[Address, AllowSpendReference]): F[List[String]] =
+    refs.toList.traverse {
+      case (source, majorityTxRef) =>
+        allowSpendsR(source).get.map { maybeStored =>
+          val stored = maybeStored.getOrElse(SortedMap.empty[AllowSpendOrdinal, StoredAllowSpend])
+          val ok =
+            (stored.isEmpty && majorityTxRef === AllowSpendReference.empty) ||
+              stored.exists { case (_, a: AcceptedAllowSpend) => a.ref === majorityTxRef; case _ => false } ||
+              stored.exists { case (_, m: MajorityAllowSpend) => m.ref === majorityTxRef; case _ => false }
+          if (ok) none[String] else s"allowSpend:${source.show}->${majorityTxRef.show}".some
+        }
+    }.map(_.flatten)
 
   def accept(hashedTx: Hashed[AllowSpend]): F[Unit] = {
     val parent = hashedTx.signed.value.parent

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/tokenlock/TokenLockStorage.scala
@@ -78,24 +78,51 @@ class TokenLockStorage[F[_]: Async: Hasher](
   def advanceMajorityRefs(refs: Map[Address, TokenLockReference], snapshotOrdinal: SnapshotOrdinal): F[Unit] =
     refs.toList.traverse_ {
       case (source, majorityTxRef) =>
-        tokenLocksR(source).modify[Either[MarkingTokenLockReferenceAsMajorityError, Unit]] { maybeStored =>
-          val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
+        tokenLocksR(source)
+          .modify[Either[MarkingTokenLockReferenceAsMajorityError, Unit]] { maybeStored =>
+            val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
 
-          if (stored.isEmpty && majorityTxRef === TokenLockReference.empty) {
-            val updated = stored + (majorityTxRef.ordinal -> MajorityTokenLock(majorityTxRef, snapshotOrdinal))
-            (updated.some, ().asRight)
-          } else {
-            stored.collectFirst { case (_, a @ AcceptedTokenLock(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
-              val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
+            if (stored.isEmpty && majorityTxRef === TokenLockReference.empty) {
+              val updated = stored + (majorityTxRef.ordinal -> MajorityTokenLock(majorityTxRef, snapshotOrdinal))
+              (updated.some, ().asRight)
+            } else {
+              stored.collectFirst { case (_, a @ AcceptedTokenLock(tx)) if a.ref === majorityTxRef => tx }.map { majorityTx =>
+                val remaining = stored.filter { case (ordinal, _) => ordinal > majorityTx.ordinal }
 
-              remaining + (majorityTx.ordinal -> MajorityTokenLock(TokenLockReference.of(majorityTx), snapshotOrdinal))
-            } match {
-              case Some(updated) => (updated.some, ().asRight)
-              case None          => (maybeStored, UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, None).asLeft)
+                remaining + (majorityTx.ordinal -> MajorityTokenLock(TokenLockReference.of(majorityTx), snapshotOrdinal))
+              } match {
+                case Some(updated) => (updated.some, ().asRight)
+                // Idempotent re-mark: the ref is already stored as MajorityTokenLock (advanced by a prior alignment).
+                case None if stored.exists { case (_, m: MajorityTokenLock) => m.ref === majorityTxRef; case _ => false } =>
+                  (maybeStored, ().asRight)
+                case None =>
+                  (maybeStored, UnexpectedStateWhenMarkingTxRefAsMajority(source, majorityTxRef, None).asLeft)
+              }
             }
           }
-        }
+          .flatMap {
+            case Right(_) => Async[F].unit
+            // Surface the divergence (do not swallow the Left): a stale local-vs-majority token-lock ref must escalate
+            // to a redownload, consistent with TransactionStorage.advanceMajorityRefs.
+            case Left(e) =>
+              logger.warn(s"advanceMajorityRefs could not mark majority token-lock ref for source=${source.show}: ${e.getMessage}") >>
+                e.raiseError[F, Unit]
+          }
     }
+
+  /** Pure precondition check (no mutation) for `advanceMajorityRefs`; see TransactionStorage.majorityRefsViolations. */
+  def majorityRefsViolations(refs: Map[Address, TokenLockReference]): F[List[String]] =
+    refs.toList.traverse {
+      case (source, majorityTxRef) =>
+        tokenLocksR(source).get.map { maybeStored =>
+          val stored = maybeStored.getOrElse(SortedMap.empty[TokenLockOrdinal, StoredTokenLock])
+          val ok =
+            (stored.isEmpty && majorityTxRef === TokenLockReference.empty) ||
+              stored.exists { case (_, a: AcceptedTokenLock) => a.ref === majorityTxRef; case _ => false } ||
+              stored.exists { case (_, m: MajorityTokenLock) => m.ref === majorityTxRef; case _ => false }
+          if (ok) none[String] else s"tokenLock:${source.show}->${majorityTxRef.show}".some
+        }
+    }.map(_.flatten)
 
   def accept(hashedTx: Hashed[TokenLock]): F[Unit] = {
     val parent = hashedTx.signed.value.parent


### PR DESCRIPTION
## Why

L1 layers (dag-l1, currency-l1, data-l1) have been forking, losing sync, holding
divergent POV, and rejecting `lastTxnRef`. An audit of all L1↔L0 sync paths found a
**systemic root cause**:

> L1 sync is ~7 uncoordinated concurrent fs2 loops mutating shared in-memory storage.
> The L0→L1 alignment writer holds **none** of the consensus semaphores, runs against
> the **live** singleton storages (no copy-isolation), and applies a **non-atomic,
> fail-fast, no-rollback** sequence. The load-bearing divergence is `AddressStorage`'s
> two-op `clean` + `updateBalances` interleaving with the live acceptance path's balance
> delta — a stray balance leaks past `clean` and persists, so two honest nodes applying
> the **same** global snapshot end with different balances → balance / `lastTxnRef` rejections.

This PR lands the **P0 + P1** fixes from the audit on one branch.

## What

### P0 — decoupled quick wins
- **A1** `AddressStorage.replaceAll` — atomic whole-map balance publish replaces the racy `clean`+`updateBalances` (kills the load-bearing divergence).
- **A2** `advanceMajorityRefs` now surfaces its `Either` (+log) instead of silently swallowing a local-vs-majority divergence (idempotent re-mark stays a no-op).
- **A3** `GlobalL0AlignmentStorage.consumeShouldRedownload` — atomic `getAndSet` so a concurrently-raised redownload flag isn't dropped by a separate `clean()`.
- **A4** `L0BlockOutputClient` — HTTP `202` (awaiting-parent) is treated as **provisional**, not terminal; the block stays buffered for re-send until L0 confirms inclusion (`200`).
- **A5** data-l1 `Engine.combine` — canonical-sort merged data updates by content hash so every facilitator builds a byte-identical block (multisig stops failing; ≥2-facilitator rounds can finalize).

### P1 — coordination core
- **B1** `storageMutationLock` (`cats.effect.std.Mutex`, fair FIFO) shared by `BlockService.accept`/block-store and `SnapshotProcessor.processAlignment`'s commit. Wraps **only** microsecond in-memory writes — never network, hashing, or the MPT trie build — so L1 stays live while aligning.
- **B2** `adjustToMajority` precondition dry-run — all-or-nothing; on block-state drift it aborts before any mutation and schedules a redownload (no partial, unrollback-able reconciliation).
- **B3** `replaceByRefs` preserves in-flight `Waiting`/`Processing` txs above the new majority ref (fixes the `pull → align → putBack` silent drop).
- **B4** batch processing retries a failing snapshot transiently and stops at the first exhausted failure instead of skipping over a gap (a transient hiccup no longer escalates to a full redownload).

### Bonus (from the transaction-storage audit)
- **TX-07** `ContextualTransactionValidator` no longer double-counts an overridden tx's `amount+fee` in the balance/limit checks on a fee-bump (`>=` instead of `>`).

## Tests
- New regression tests: `AddressStorageSuite` (`replaceAll` replaces the whole map), `TransactionStorageSuite` (`replaceByRefs` preserves an in-flight `ProcessingTx`).
- All **dag-l1** suites green (35/35), incl. the mutex-affected `SnapshotProcessorSuite`/`BlockServiceSuite` and TX-07's validator suite; dag-l0 cutter suite green (4/4). `sbt runLinter` clean.
- Full Docker E2E (`just test`) not run in this PR.

## Scope notes / deferred follow-ups
- No wire/snapshot/P2P-schema change — every change is per-node and reversible (mixed-version-cluster safe).
- The three legacy semaphores are intentionally kept alongside the new mutex during transition (harmless redundancy; retire in a separate PR).
- **Deferred:** A6 (dag-l0 `GlobalSnapshotEventCutter` — its comparator is non-antisymmetric; needs a topological *total* order co-designed with its suite) and the full **P2** hardening set (currency/swap/token-lock resend coverage, tip validation, pull quorum/chain verification, `CL_RAISE_ON_FOLLOWER_DIVERGENCE` default-on, sync-gate gap tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
