### PR TITLE
fix: update BioFi genesis address in state channel allow list

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
@@ -119,7 +119,7 @@ object StateChannelAllowanceLists {
               "1391276cd637be03331ae5914a5a063c549fbcc6515b140d1ccc0af7c67631804991ba0dae4c1d95b84f77dc812dd71ed2a1817e50c92b722e9b8182683366ed"
             ),
           // BioFi
-          Address("DAG8ZnY1voFrENbSfwe8eT9WC6EeKTUejw7JYek4") ->
+          Address("DAG2JaVh5yYiPCGLLEFi6tfkKk77WA4FzivVdBek") ->
             NonEmptySet.of(
               "9002807a99139d207c7b20d3065f72dbf77c8563e1a2e6d2969f64928c6082dbacfb399d67bacbc62a7997fc69b8dd5c035e3acf6ed696da7f4cebee5f76cdc8",
               "866d3c60d9ea2ed7b3db2a04ba736ae8b00a0c20e98e270ddda3c73602f348ef4ce5d65e55daa52221310ebb25b826b1de495664917a3f510f6b82226d12ffe7",


### PR DESCRIPTION
## Summary

Updates the BioFi genesis address in the state channel allowance list (`StateChannelAllowanceLists`) to `DAG2JaVh5yYiPCGLLEFi6tfkKk77WA4FzivVdBek`.

The allowed PeerId signing set for this entry is unchanged.

## Test plan

- [ ] Confirm the new address is the correct BioFi genesis address
- [ ] `sbt nodeShared/compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)