### PR TITLE
fix(ci): make format/lint checks enforceable and pin publish version to tag

### DIFF
--- a/.github/workflows/check-scala-code.yml
+++ b/.github/workflows/check-scala-code.yml
@@ -23,6 +23,8 @@ jobs:
         uses: "./.github/templates/actions/setup_java_and_scala"
 
       - name: Run with 21 🚀
-        run: sbt --error 'scalafixAll --check --rules OrganizeImports;scalafmtCheckAll;test'
+        # scalafmtCheckAll first: it needs no compilation, so formatting failures
+        # surface in seconds instead of after a full build
+        run: sbt --error 'scalafmtCheckAll;scalafixAll --check --rules OrganizeImports;test'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -55,6 +55,10 @@ jobs:
           sbt ci-release
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
+          # Priority-1 version override in build.sbt: pins the version for the whole
+          # sbt session so a dirtied working tree cannot shift the sonatype staging
+          # path between publishSigned and the release step
+          RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
           # Use sonatypeCentralRelease (sbt-sonatype) instead of sonaRelease (sbt 1.11.0+)
           # Required because project is on sbt 1.9.8
           CI_SONATYPE_RELEASE: sonatypeCentralRelease
@@ -63,3 +67,6 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.MVN_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.MVN_USERNAME }}
+
+      - name: Fail if the build mutated the workspace
+        run: git diff --exit-code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: "./.github/templates/actions/setup_java_and_scala"
 
       - name: Test
-        run: sbt 'scalafixAll --check --rules OrganizeImports;scalafmtCheckAll;test'
+        run: sbt 'scalafmtCheckAll;scalafixAll --check --rules OrganizeImports;test'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/testnet-release.yml
+++ b/.github/workflows/testnet-release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: "./.github/templates/actions/setup_java_and_scala"
 
       - name: Test
-        run: sbt 'scalafixAll --check --rules OrganizeImports;scalafmtCheckAll;test'
+        run: sbt 'scalafmtCheckAll;scalafixAll --check --rules OrganizeImports;test'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -111,8 +111,11 @@ bloopExportJarClassifiers in Global := Some(Set("sources"))
 
 lazy val commonSettings = Seq(
   scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
-  scalafmtOnCompile := true,
-  scalafixOnCompile := true,
+  // On-compile rewrites are a local dev convenience only. In CI they silently repair
+  // the workspace before *Check tasks run (making them pass vacuously) and dirty the
+  // git tree, which shifts the dynver-derived version mid-publish.
+  scalafmtOnCompile := !sys.env.contains("CI"),
+  scalafixOnCompile := !sys.env.contains("CI"),
   resolvers ++= List(
     Resolver.sonatypeRepo("snapshots")
   )

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/rewards/GlobalDelegatedRewardsDistributorSuite.scala
@@ -1781,10 +1781,10 @@ object GlobalDelegatedRewardsDistributorSuite extends SimpleIOSuite with Checker
     )
 
     def distributeWithAddress1Stake(
-                                     distributor: DelegatedRewardsDistributor[IO],
-                                     address1Stake: Long,
-                                     incresedAaddress1Stake: Option[Long]
-                                   ): IO[Amount] = {
+      distributor: DelegatedRewardsDistributor[IO],
+      address1Stake: Long,
+      incresedAaddress1Stake: Option[Long]
+    ): IO[Amount] = {
       val stakes = SortedMap(
         address1 -> SortedSet(stakeRecord(address1, address1Stake, incresedAaddress1Stake)),
         address2 -> SortedSet(stakeRecord(address2, 1000L, none))

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/dataApplication/DataApplicationTraverseSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/dataApplication/DataApplicationTraverseSuite.scala
@@ -101,8 +101,7 @@ object DataApplicationTraverseSuite extends MutableIOSuite {
     def getLastSynchronizedGlobalSnapshot: IO[Option[GlobalIncrementalSnapshot]] = IO.raiseError(new NotImplementedError)
     def getLastSynchronizedGlobalSnapshotCombined: IO[Option[(GlobalIncrementalSnapshot, GlobalSnapshotInfo)]] =
       IO.raiseError(new NotImplementedError)
-    def getLastSynchronizedAllowSpends
-      : IO[Option[SortedMap[Option[Address], SortedMap[Address, SortedSet[Signed[AllowSpend]]]]]] =
+    def getLastSynchronizedAllowSpends: IO[Option[SortedMap[Option[Address], SortedMap[Address, SortedSet[Signed[AllowSpend]]]]]] =
       IO.raiseError(new NotImplementedError)
     def getLastSynchronizedTokenLocks: IO[Option[SortedMap[Address, SortedSet[Signed[TokenLock]]]]] =
       IO.raiseError(new NotImplementedError)
@@ -194,7 +193,7 @@ object DataApplicationTraverseSuite extends MutableIOSuite {
             traverse.applyCache(storage, DataState(TestOnChain, TestCalculated, SortedSet.empty), startingSnapshot)
         }
         seen <- observed.get
-      } yield expect(seen == List(Some(ord(10L)), Some(ord(11L)))) and expect(result._2 == ord(12L))
+      } yield expect(seen == List(Some(ord(10L)), Some(ord(11L)))).and(expect(result._2 == ord(12L)))
   }
 
   test("applyCache rejects a non-contiguous cache (guards the predecessor-threading invariant)") {


### PR DESCRIPTION
## Summary
The `Publish SDK` job for `v4.1.0-rc.1` failed with `[BUNDLE_ZIP_ERROR] .../target/sonatype-staging/4.1.0-rc.1+dirty.build12` on every attempt. Root cause: `scalafmtOnCompile`/`scalafixOnCompile` silently rewrite unformatted sources during any CI compile. This (a) neuters the format gate — `scalafixAll --check` compiles first, auto-repairing the workspace, so the subsequent `scalafmtCheckAll` passes vacuously — and (b) dirties the git tree during `sbt ci-release`, so the dynver-derived version shifts from `4.1.0-rc.1` to `4.1.0-rc.1+dirty.buildN` between `publishSigned` (which staged the bundle) and `sonatypeCentralRelease` (which looked it up).

Two test suites with formatting violations reached `develop` through the always-green gate; one of them (`DataApplicationTraverseSuite`, in the sdk dependency closure) is what dirtied the publish workspace.

## Changes
* **Modified** – `build.sbt`: `scalafmtOnCompile`/`scalafixOnCompile` are now disabled when `CI` is set. On-compile rewrites remain a local dev convenience; in CI the `*Check` tasks are the enforcement and must see the tree as committed.
* **Modified** – `check-scala-code.yml`, `release.yml`, `testnet-release.yml`: run `scalafmtCheckAll` before the compile-heavy scalafix check, so formatting failures surface in seconds.
* **Modified** – `publish-sdk.yml`: pass `RELEASE_TAG` (the priority-1 version override in `build.sbt`) to `sbt ci-release`, pinning the version for the whole session so no workspace mutation can shift the staging path again; add a `git diff --exit-code` step so any build-time source mutation fails loudly instead of surfacing as a cryptic Sonatype error.
* **Modified** – `GlobalDelegatedRewardsDistributorSuite.scala`, `DataApplicationTraverseSuite.scala`: applied scalafmt (whitespace-only).

## Testing
* Reproduced the failure locally at `v4.1.0-rc.1`: standalone `scalafmtCheckAll` fails on exactly the two suites fixed here, while `compile` (as triggered by `ci-release`) silently rewrites them — matching the `scalafmt: Reformatted 1 Scala sources` line and subsequent `+dirty` version flip in the failed run's log.
* Ran `CI=true sbt 'scalafmtCheckAll;scalafixAll --check --rules OrganizeImports'` on this branch with the new settings: passes, and the working tree stays clean (no self-healing).
* `test` is intentionally left to CI; source changes are formatting-only.

After merge: merge `develop` into `release/integrationnet` and tag `v4.1.0-rc.2` to retry the SDK publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
