### PR TITLE
chore(node-shared): scalafmt RewardQualifiedFacilitatorsSuite

### DIFF
--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/RewardQualifiedFacilitatorsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/RewardQualifiedFacilitatorsSuite.scala
@@ -74,9 +74,10 @@ object RewardQualifiedFacilitatorsSuite extends SimpleIOSuite {
       promoteThreshold = PromoteThreshold
     )
 
-    expect.same(SortedSet(a), result) and
-      expect(!result.contains(b), "b is climbing (score 40 < 100) and must not earn yet") and
-      expect(!result.contains(c), "c has no evidence entry (fresh probation seat) and must not earn yet")
+    expect
+      .same(SortedSet(a), result)
+      .and(expect(!result.contains(b), "b is climbing (score 40 < 100) and must not earn yet"))
+      .and(expect(!result.contains(c), "c has no evidence entry (fresh probation seat) and must not earn yet"))
   }
 
   pureTest("falls back to paying everyone when no facilitator meets the threshold (post-restart refill)") {
@@ -115,7 +116,8 @@ object RewardQualifiedFacilitatorsSuite extends SimpleIOSuite {
       promoteThreshold = PromoteThreshold
     )
 
-    expect.same(SortedSet(a), result) and
-      expect(!result.contains(b), "b signed 4/6 with 2 misses (score 50) and must stay below the threshold")
+    expect
+      .same(SortedSet(a), result)
+      .and(expect(!result.contains(b), "b signed 4/6 with 2 misses (score 50) and must stay below the threshold"))
   }
 }


### PR DESCRIPTION
## Summary
`RewardQualifiedFacilitatorsSuite.scala` (from #1543) fails the now-enforced `nodeShared/Test/scalafmtCheck`, which broke the Release workflow on the `develop -> release/integrationnet` merge (run 29523921718). #1543 branched before #1544 made the format check enforceable, so its PR CI accepted the file.

## Changes
* **Modified** - `RewardQualifiedFacilitatorsSuite.scala`: two infix `and` expectation chains reformatted to the method-chained `.and(...)` form scalafmt requires. Whitespace/formatting only, no behavior change.

## Testing
Formatter output verified stable: `nodeShared/Test/scalafmtOnly` on the fixed file produces byte-identical output (sha256 checked before/after). The suite's 5 tests were green in the last full run; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
