### PR TITLE
style(node-shared): scalafmt RewardQualifiedFacilitatorsSuite

### DIFF
--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/RewardQualifiedFacilitatorsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/RewardQualifiedFacilitatorsSuite.scala
@@ -74,9 +74,10 @@ object RewardQualifiedFacilitatorsSuite extends SimpleIOSuite {
       promoteThreshold = PromoteThreshold
     )
 
-    expect.same(SortedSet(a), result) and
-      expect(!result.contains(b), "b is climbing (score 40 < 100) and must not earn yet") and
-      expect(!result.contains(c), "c has no evidence entry (fresh probation seat) and must not earn yet")
+    expect
+      .same(SortedSet(a), result)
+      .and(expect(!result.contains(b), "b is climbing (score 40 < 100) and must not earn yet"))
+      .and(expect(!result.contains(c), "c has no evidence entry (fresh probation seat) and must not earn yet"))
   }
 
   pureTest("falls back to paying everyone when no facilitator meets the threshold (post-restart refill)") {
@@ -115,7 +116,8 @@ object RewardQualifiedFacilitatorsSuite extends SimpleIOSuite {
       promoteThreshold = PromoteThreshold
     )
 
-    expect.same(SortedSet(a), result) and
-      expect(!result.contains(b), "b signed 4/6 with 2 misses (score 50) and must stay below the threshold")
+    expect
+      .same(SortedSet(a), result)
+      .and(expect(!result.contains(b), "b signed 4/6 with 2 misses (score 50) and must stay below the threshold"))
   }
 }


### PR DESCRIPTION
## Summary
`RewardQualifiedFacilitatorsSuite` (from #1543) fails the now-enforced `nodeShared/Test/scalafmtCheck`, first hit by the Release workflow on the `develop -> release/integrationnet` merge (run 29523921718). #1543 branched before #1544 made the format check enforceable, so its PR CI accepted two infix `and` expectation chains the enforced check rejects.

## Changes
* **Modified** - reformatted the two `expect.same(...) and expect(...)` chains to the method-chained `.and(...)` form scalafmt requires. Whitespace-only, 12 lines, one file.

## Testing
Formatter idempotence verified: `nodeShared/Test/scalafmtOnly` on the fixed file produces byte-identical output (sha256 checked before/after). Unblocks the Release workflow once merged and `develop` is re-merged into `release/integrationnet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
