### PR TITLE
fix(currency-l1): route estimate-fee responses around a scalac backend crash

### DIFF
--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/EstimatedFeeResponse.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/EstimatedFeeResponse.scala
@@ -8,13 +8,18 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.security.hash.Hash
 
-import derevo.circe.magnolia.encoder
-import derevo.derive
+import io.circe.Encoder
 
-@derive(encoder)
 case class EstimatedFeeResponse(fee: Amount, address: Option[Address], updateHash: Hash)
 
 object EstimatedFeeResponse {
+  // Explicit encoder instead of the magnolia derivation (`@derive(encoder)`): the CI Build JARs
+  // job crashes the scalac 2.13.18 backend emitting this class's derived encoder ("an unexpected
+  // type representation reached the compiler backend ... magnolia.Param[...] => Return"; the
+  // compiler asks to file a scala/bug). Same JSON shape and key order as the derived instance.
+  implicit val encoder: Encoder[EstimatedFeeResponse] =
+    Encoder.forProduct3("fee", "address", "updateHash")(r => (r.fee, r.address, r.updateHash))
+
   def apply(ef: EstimatedFee, updateHash: Hash): EstimatedFeeResponse =
     ef match {
       case Zero            => EstimatedFeeResponse(fee = Amount.empty, address = none, updateHash)

--- a/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/TransactionRoutes.scala
+++ b/modules/currency-l1/src/main/scala/io/constellationnetwork/currency/l1/http/TransactionRoutes.scala
@@ -11,12 +11,11 @@ import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.signature.Signed.{ProofsHasher, SignedHasher}
 
 import eu.timepit.refined.auto._
-import io.circe.shapes._
+import io.circe.Json
+import io.circe.syntax._
 import org.http4s.HttpRoutes
 import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder}
 import org.http4s.dsl.Http4sDsl
-import shapeless._
-import shapeless.syntax.singleton._
 
 final case class TransactionRoutes[F[_]: Async](
   transactionFeeEstimator: Option[TransactionFeeEstimator[F]],
@@ -40,7 +39,12 @@ final case class TransactionRoutes[F[_]: Async](
           case Some(estimator) => estimator.estimate(hashedTransaction)
           case None            => TransactionFee.zero.pure[F]
         }
-        response <- Ok(("fee" ->> fee.value.value) :: HNil)
+        // Plain Json.obj instead of the shapeless singleton-record encoder
+        // (`("fee" ->> ...) :: HNil` with io.circe.shapes): the CI Build JARs job crashes the
+        // scalac 2.13.18 backend on the singleton-typed record it produces ("assertion failed:
+        // type R" / "ClassBType.info not yet assigned" while emitting this file). Identical
+        // JSON: {"fee": <long>}.
+        response <- Ok(Json.obj("fee" -> fee.value.value.asJson))
       } yield response
   }
 }


### PR DESCRIPTION
## Summary
Unblocks CI for every open PR. Since #1544, the `Build JARs` job fails on all branches with a scalac 2.13.18 backend crash while emitting currency-l1 (`"an unexpected type representation reached the compiler backend"`, `"ClassBType.info not yet assigned"`, `"assertion failed: type R"` -- the compiler itself asks to file a scala/bug), which skips the entire E2E matrix. Branch-independence is proven: a whitespace-only PR (#1545) failed identically, while #1543 passed the same job pre-#1544. The crash names the same two derivation sites in every failing run but does not reproduce outside CI (warm, clean-slate, and cold-clone runs of the exact `assembly.sh` sequence pass locally with and without `CI=true`), so this routes around the fragile derivations rather than chasing the environment trigger.

## Changes
* **Modified** - `EstimatedFeeResponse.scala`: explicit `Encoder.forProduct3` replaces the magnolia-derived `@derive(encoder)`; identical JSON shape and key order.
* **Modified** - `TransactionRoutes.scala`: plain `Json.obj("fee" -> ...)` replaces the shapeless singleton-record response (`("fee" ->> ...) :: HNil` via `io.circe.shapes`), whose singleton-typed encoder is the `type R` representation leaking into the backend; identical JSON (`{"fee": <long>}`). Drops the shapeless imports.

## Testing
On the fixed sources: `currencyL1` main + Test scopes compile; `scalafmtCheck` passes in both scopes; the exact failing CI command (`CI=true sbt "set ThisBuild/version := 99.99.99-SNAPSHOT" sdk/publishLocal`) exits 0. The real verdict is this PR's own `Build JARs` job -- it exercises the previously-crashing pipeline end to end; if it greens here, rebasing/rerunning the blocked PRs (#1547) clears them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
