### PR TITLE
fix(gossip): unwedge a returning peer's rumor chain, and make fork-recovery runnable

### DIFF
--- a/.github/workflows/e2e-just-test.yml
+++ b/.github/workflows/e2e-just-test.yml
@@ -98,8 +98,19 @@ jobs:
           - { name: dag-cluster,            tests: "dag-cluster" }
           - { name: delegated-staking,      tests: "delegated-staking" }
           - { name: token-lock-replacement, tests: "token-lock-replacement" }
-          # TODO: re-enable once PR #1485 is merged
-          # - { name: fork-recovery,          tests: "fork-recovery", extra-args: "--num-gl0=5", runner: "Ubuntu-22-64-core" }
+          # DISABLED on a NODE bug, not a test bug. The Phase-1 gate was unsatisfiable and is now
+          # fixed (see docker/bin/test-fork-recovery.sh); phases 1 and 2 pass, and the cluster keeps
+          # producing snapshots while a seated peer is isolated. Phase 3 then wedges: on restore,
+          # peers re-graft the returning node into the gossip mesh but leave it at
+          # WaitingForObserving in their cluster registry, while the node itself reports Ready.
+          # Consensus derives committees from peerHistory rather than that registry, so it can elect
+          # the returning node LEADER -- whose Proposal/Signature declarations every peer then
+          # ignores. Observed locally 2026-07-31: ordinal 41 held for 900s with all 5 nodes Ready and
+          # at tip. Re-enable once that rejoin/leader-eligibility mismatch is fixed; the entry below
+          # is correct as written, including the timeout (the test's own budget is ~40 min, so the
+          # 30 min default would have killed it regardless).
+          # The previous note here blocked on PR #1485, which was closed without ever merging.
+          # - { name: fork-recovery,          tests: "fork-recovery", extra-args: "--num-gl0=5", runner: "Ubuntu-22-64-core", timeout: 60 }
           - { name: currency,               tests: "currency" }
           - { name: rewards,                tests: "rewards" }
           - { name: token-locks,            tests: "token-locks" }

--- a/docker/bin/test-fork-recovery.sh
+++ b/docker/bin/test-fork-recovery.sh
@@ -68,6 +68,27 @@ get_facilitator_count() {
   echo "${result:-0}"
 }
 
+# Helper: the cluster's tip, as the MEDIAN ordinal across reachable gl0 nodes.
+#
+# Deliberately not MONITOR_NODE's own ordinal. The monitor is just gl0-0; it is not guaranteed to
+# be in the committee and it can itself fall behind and recover, which silently weakens every check
+# built on it. Observed on 2026-07-31: a run "passed" its catch-up criterion with iso_ord=51 against
+# a monitor stuck at 41 while the real cluster tip was 58 -- the isolated node had not caught up at
+# all, it was merely ahead of a second lagging node.
+#
+# Median rather than max so a single raced-ahead node cannot make the target unreachable, and
+# rather than min so a single laggard cannot make it trivially satisfiable.
+get_cluster_tip() {
+  local ords=()
+  local i o
+  for i in $(seq 0 $((NUM_GL0 - 1))); do
+    o=$(get_ordinal "gl0-${i}")
+    [ -n "$o" ] && ords+=("$o")
+  done
+  [ "${#ords[@]}" -eq 0 ] && return 0
+  printf '%s\n' "${ords[@]}" | sort -n | awk '{a[NR]=$1} END {print a[int((NR+1)/2)]}'
+}
+
 # Helper: peer id of a node, from the key material node-key-env-setup.sh syncs into nodes/<i>/.
 peer_id_of() {
   local idx=${1##gl0-}
@@ -332,7 +353,7 @@ fi
 echo "  Isolation target: $ISOLATION_NODE (seated committee:${committee_nodes})"
 
 # Record pre-isolation state from monitor (a validator)
-pre_ordinal=$(get_ordinal "$MONITOR_NODE")
+pre_ordinal=$(get_cluster_tip)
 pre_isolation_ordinal=$(get_ordinal "$ISOLATION_NODE" 2>/dev/null || echo "$pre_ordinal")
 echo "  Pre-isolation ordinal: $pre_ordinal (monitor), $pre_isolation_ordinal (isolated node)"
 
@@ -403,7 +424,7 @@ echo "  $ISOLATION_NODE isolated. Waiting ${ISOLATION_DURATION}s for cluster to 
 sleep "$ISOLATION_DURATION"
 
 # Check cluster advanced
-post_isolation_ordinal=$(get_ordinal "$MONITOR_NODE")
+post_isolation_ordinal=$(get_cluster_tip)
 echo "  Cluster advanced: ordinal $pre_ordinal → $post_isolation_ordinal"
 
 if [ -z "$post_isolation_ordinal" ] || [ "$post_isolation_ordinal" -le "$pre_ordinal" ]; then
@@ -440,7 +461,7 @@ while [ "$(date +%s)" -lt "$recovery_deadline" ]; do
   iso_fac=$(get_facilitator_count "$ISOLATION_NODE")
   iso_completed=$(get_completed_rounds_after "$ISOLATION_NODE" "$post_isolation_ordinal")
   fork_events=$(get_fork_events "$ISOLATION_NODE")
-  monitor_ord=$(get_ordinal "$MONITOR_NODE")
+  monitor_ord=$(get_cluster_tip)
 
   echo "  [${elapsed}s] $ISOLATION_NODE: facilitators=${iso_fac:-?} completedAfterIsolation=$iso_completed forkEvents=$fork_events clusterOrdinal=${monitor_ord:-?}"
 
@@ -488,7 +509,7 @@ done
 echo ""
 echo "Phase 4: Verifying results..."
 
-final_ordinal=$(get_ordinal "$MONITOR_NODE")
+final_ordinal=$(get_cluster_tip)
 final_fac=$(get_facilitator_count "$MONITOR_NODE")
 final_fork_events=$(get_fork_events "$ISOLATION_NODE")
 recovery_elapsed=$(( $(date +%s) - recovery_start ))

--- a/docker/bin/test-fork-recovery.sh
+++ b/docker/bin/test-fork-recovery.sh
@@ -42,7 +42,7 @@ STABILIZE_WAIT=480      # seconds to wait for initial cluster stability (nodes n
 echo "================================================"
 echo "Fork Recovery Test"
 echo "================================================"
-echo "  Isolation node: $ISOLATION_NODE"
+echo "  Isolation node: $ISOLATION_NODE (provisional; re-selected from the seated committee in Phase 1)"
 echo "  Monitor node:   $MONITOR_NODE"
 echo "  Isolation time: ${ISOLATION_DURATION}s"
 echo "  Recovery timeout: ${RECOVERY_TIMEOUT}s"
@@ -56,12 +56,37 @@ get_ordinal() {
   curl -s "http://localhost:${port}/global-snapshots/latest" 2>/dev/null | jq -r '.value.ordinal // empty' 2>/dev/null || echo ""
 }
 
-# Helper: get facilitator count from latest consensus log
+# Helper: get facilitator count from latest consensus log.
+# Reporting only -- do NOT gate on this. It returns the node's LAST-EVER logged value, so two
+# nodes sampled at the same instant can report counts from different rounds; with a committee
+# that legitimately oscillates (e.g. 4<->5) that skew reads as disagreement. Phase 1 uses
+# get_committee_peer_ids instead. Bounded tail: the full log is tens of MB by Phase 3.
 get_facilitator_count() {
   local node=$1
   local result
-  result=$(docker logs "$node" 2>&1 | grep "facilitators=" | tail -1 | sed -n 's/.*facilitators=\([0-9]*\).*/\1/p' | head -1 || true)
+  result=$(docker logs --tail 2000 "$node" 2>&1 | grep "facilitators=" | tail -1 | sed -n 's/.*facilitators=\([0-9]*\).*/\1/p' | head -1 || true)
   echo "${result:-0}"
+}
+
+# Helper: peer id of a node, from the key material node-key-env-setup.sh syncs into nodes/<i>/.
+peer_id_of() {
+  local idx=${1##gl0-}
+  tr -d '[:space:]' < "nodes/${idx}/peer_id" 2>/dev/null || true
+}
+
+# Helper: the round-start committee of the most recently finalized round, read from the SIGNED
+# ARTIFACT rather than from logs. Every node carries identical bytes here (it is covered by the
+# artifact signature), so one query describes the whole cluster's view -- no cross-node skew.
+#
+# Off-by-one: the committee for ordinal N is recorded in snapshot N+1. Snapshot N's own
+# peerHistory only holds entries up to N-1.
+get_committee_peer_ids() {
+  local port=$((GL0_PORT_PREFIX * 100))
+  local tip
+  tip=$(curl -s --max-time 5 "http://localhost:${port}/global-snapshots/latest" 2>/dev/null | jq -r '.value.ordinal // empty' 2>/dev/null || true)
+  { [ -z "$tip" ] || [ "$tip" -lt 1 ]; } && return 0
+  curl -s --max-time 5 "http://localhost:${port}/global-snapshots/${tip}" 2>/dev/null |
+    jq -r --arg o "$((tip - 1))" '.value.peerHistory.controllerEvidence[$o].roundStartFacilitators // [] | .[]' 2>/dev/null || true
 }
 
 # Helper: get node state
@@ -76,7 +101,7 @@ get_node_state() {
 get_fork_events() {
   local node=$1
   local result
-  result=$(docker logs "$node" 2>&1 | grep -c "Fork divergence\|FORK_CHECKS_PASSED\|fork.*detect" 2>/dev/null || true)
+  result=$(docker logs --tail 20000 "$node" 2>&1 | grep -c "Fork divergence\|FORK_CHECKS_PASSED\|fork.*detect" 2>/dev/null || true)
   echo "${result:-0}"
 }
 
@@ -85,11 +110,15 @@ get_fork_events() {
 # "[CONSENSUS:LIFECYCLE] round=SnapshotOrdinal(N) role=n/a event=CONSENSUS_FINISHED". The previous
 # marker ("Round finished ordinal=N") was demoted to DEBUG: it fired per signature-evaluation poll
 # (~150x/round), not per round, and was a top log-volume source at cluster scale.
+#
+# Scoped with `docker logs --since` (set to the moment the network was restored) so the scan cost
+# stays flat instead of re-reading a log that reaches tens of MB by the end of Phase 3, and so
+# rounds the node finished BEFORE isolation can never be miscounted as recovery evidence.
 get_completed_rounds_after() {
   local node=$1
   local after_ordinal=$2
   local result
-  result=$(docker logs "$node" 2>&1 | grep "event=CONSENSUS_FINISHED" | sed -n 's/.*round=SnapshotOrdinal(\([0-9]*\)).*/\1/p' | awk -v min="$after_ordinal" '$1 > min' | wc -l || true)
+  result=$(docker logs ${RECOVERY_SINCE:+--since "$RECOVERY_SINCE"} "$node" 2>&1 | grep "event=CONSENSUS_FINISHED" | sed -n 's/.*round=SnapshotOrdinal(\([0-9]*\)).*/\1/p' | awk -v min="$after_ordinal" '$1 > min' | wc -l || true)
   echo "${result:-0}"
 }
 
@@ -188,73 +217,119 @@ fi
 # as ISOLATION_NODE is still in that committee. What matters is that every
 # CURRENTLY-IN-COMMITTEE peer is at tip.
 #
-# We approximate "in committee" by "reports a non-zero fac that matches the
-# monitor's fac AND is reachable (ord is defined)". Peers that B1 has evicted
-# typically drop off the cluster/info endpoint or report fac=0.
-echo "  Waiting for $ISOLATION_NODE + all committee peers to agree on tip (fac>=3, spread<=1 across committee, 3+ consecutive rounds)..."
+# "In committee" is read from the signed artifact (roundStartFacilitators), NOT inferred from
+# logs. The previous gate compared a COUNT OF AGREEING NODES against the committee SIZE
+# (`committee_size == mon_fac`), which is only satisfiable when the committee is the entire
+# cluster -- the opposite of the paragraph above. Replayed against a real 5-node run it passed
+# 2 of 17 samples and never twice consecutively, so the 3-in-a-row requirement could not be met:
+# a healthy cluster unanimously reporting fac=4 scored committee_size=5 vs mon_fac=4 and was
+# rejected. It also compared each node's LAST-EVER logged count, i.e. values from different
+# rounds, which a 4<->5 oscillation renders as a false split.
+#
+# ISOLATION_NODE is chosen here rather than fixed at gl0-(N-1): the hypothesis is about "some
+# in-committee peer", and the highest-index node is the likeliest to be churning in and out.
+echo "  Waiting for the signed round-start committee to be seated and at tip (size>=3, spread<=1, 3+ consecutive samples)..."
 stable_rounds=0
 stab_deadline=$(($(date +%s) + 600))
 MIN_COMMITTEE=3
-while [ "$(date +%s)" -lt "$stab_deadline" ] && [ "$stable_rounds" -lt 3 ]; do
-  iso_ord=$(get_ordinal "$ISOLATION_NODE")
-  iso_fac=$(get_facilitator_count "$ISOLATION_NODE")
-  mon_ord=$(get_ordinal "$MONITOR_NODE")
-  mon_fac=$(get_facilitator_count "$MONITOR_NODE")
 
-  # Build full status line + find the set of peers currently in the committee
-  # (fac matches monitor's fac AND ordinal is reachable).
-  status_line=""
+declare -A NODE_OF_PEER=()
+for i in $(seq 0 $((NUM_GL0 - 1))); do
+  pid=$(peer_id_of "gl0-${i}")
+  [ -n "$pid" ] && NODE_OF_PEER["$pid"]="gl0-${i}"
+done
+[ "${#NODE_OF_PEER[@]}" -eq 0 ] && fail "No peer ids under nodes/*/peer_id (node-key-env-setup.sh did not run?)"
+
+committee_nodes=""
+pinned_target=""
+while [ "$(date +%s)" -lt "$stab_deadline" ] && [ "$stable_rounds" -lt 3 ]; do
+  mon_ord=$(get_ordinal "$MONITOR_NODE")
+  committee_peers=$(get_committee_peer_ids)
+
+  committee_size=0
   committee_min_ord=""
   committee_max_ord=""
-  committee_size=0
-  committee_view_agrees=true
-  for i in $(seq 0 $((NUM_GL0 - 1))); do
-    node="gl0-${i}"
-    nf=$(get_facilitator_count "$node")
+  unmapped=0
+  unreachable=0
+  seated_nodes=""
+  status_line=""
+  for pid in $committee_peers; do
+    committee_size=$((committee_size + 1))
+    node="${NODE_OF_PEER[$pid]:-}"
+    if [ -z "$node" ]; then
+      # A seated peer we cannot address (should not happen on this rig) -- treat as unhealthy
+      # rather than silently narrowing the committee.
+      unmapped=$((unmapped + 1))
+      status_line="${status_line} ${pid:0:8}:unmapped"
+      continue
+    fi
+    seated_nodes="${seated_nodes} ${node}"
     no=$(get_ordinal "$node")
-    status_line="${status_line} ${node}:ord=${no:-?}/fac=${nf:-?}"
-    # A peer is "in this committee" if it's reachable AND agrees with monitor
-    # on the facilitator set size.
-    if [ -n "$no" ] && [ -n "$nf" ] && [ "$nf" = "${mon_fac:-0}" ] && [ "$nf" -gt 0 ]; then
-      committee_size=$((committee_size + 1))
-      if [ -z "$committee_min_ord" ] || [ "$no" -lt "$committee_min_ord" ]; then
-        committee_min_ord=$no
-      fi
-      if [ -z "$committee_max_ord" ] || [ "$no" -gt "$committee_max_ord" ]; then
-        committee_max_ord=$no
-      fi
-    elif [ -n "$nf" ] && [ "$nf" != "${mon_fac:-0}" ] && [ "$nf" -gt 0 ]; then
-      # Peer has a fac view that disagrees with monitor — that's a split.
-      committee_view_agrees=false
+    status_line="${status_line} ${node}:ord=${no:-?}"
+    if [ -z "$no" ]; then
+      unreachable=$((unreachable + 1))
+      continue
+    fi
+    if [ -z "$committee_min_ord" ] || [ "$no" -lt "$committee_min_ord" ]; then
+      committee_min_ord=$no
+    fi
+    if [ -z "$committee_max_ord" ] || [ "$no" -gt "$committee_max_ord" ]; then
+      committee_max_ord=$no
     fi
   done
 
-  in_sync=false
   spread="?"
   if [ -n "$committee_min_ord" ] && [ -n "$committee_max_ord" ]; then
     spread=$((committee_max_ord - committee_min_ord))
   fi
-  if [ -n "$iso_ord" ] && [ -n "$mon_ord" ] \
-     && [ "${iso_fac:-0}" -ge "$MIN_COMMITTEE" ] \
-     && [ "${iso_fac:-0}" = "${mon_fac:-0}" ] \
-     && [ "$committee_view_agrees" = "true" ] \
-     && [ "$committee_size" = "${mon_fac:-0}" ] \
+
+  # Deterministic target: the highest-index seated peer that is not the monitor. Iterate NODE
+  # INDICES, not $seated_nodes -- that list is in roundStartFacilitators order, which is sorted by
+  # peer id, so taking its last element would pick an arbitrary node that changes between runs.
+  candidate=""
+  for i in $(seq $((NUM_GL0 - 1)) -1 0); do
+    node="gl0-${i}"
+    [ "$node" = "$MONITOR_NODE" ] && continue
+    case " ${seated_nodes} " in *" ${node} "*) candidate=$node; break ;; esac
+  done
+
+  # Pin the target across the whole 3-sample window. The precondition being established is that
+  # THIS peer is reliably in-committee, so if it drops out mid-window the window must restart.
+  # The rest of the committee may churn freely -- a 4<->5 oscillation is normal here, and demanding
+  # an identical seated set three times running would reproduce the unsatisfiable old gate.
+  if [ -n "$pinned_target" ]; then
+    case " ${seated_nodes} " in
+      *" ${pinned_target} "*) candidate=$pinned_target ;;
+      *) candidate="" ;;
+    esac
+  fi
+
+  in_sync=false
+  if [ -n "$mon_ord" ] && [ -n "$candidate" ] \
+     && [ "$committee_size" -ge "$MIN_COMMITTEE" ] \
+     && [ "$unmapped" -eq 0 ] && [ "$unreachable" -eq 0 ] \
      && [ "$spread" != "?" ] && [ "$spread" -le 1 ]; then
     in_sync=true
   fi
 
   if [ "$in_sync" = "true" ]; then
     stable_rounds=$((stable_rounds + 1))
-    echo "    Round $stable_rounds/3 committee=${committee_size} at tip (spread=$spread) iso=${iso_ord}/${iso_fac} mon=${mon_ord}/${mon_fac} [${status_line# }]"
+    committee_nodes="$seated_nodes"
+    pinned_target="$candidate"
+    ISOLATION_NODE="$candidate"
+    echo "    Sample $stable_rounds/3 committee=${committee_size} at tip (spread=$spread) target=$ISOLATION_NODE [${status_line# }]"
   else
     stable_rounds=0
-    echo "    Waiting (committee_size=${committee_size}/${mon_fac:-?} spread=$spread iso_fac=${iso_fac:-?} mon_fac=${mon_fac:-?} view_agrees=$committee_view_agrees) [${status_line# }]"
+    pinned_target=""
+    echo "    Waiting (committee=${committee_size} spread=$spread unmapped=$unmapped unreachable=$unreachable target=${candidate:-none}) [${status_line# }]"
   fi
-  sleep 45
+  sleep 30
 done
 if [ "$stable_rounds" -lt 3 ]; then
-  fail "Cluster never reached committee-tip sync within 600s (every in-committee peer must be at tip for isolation to work with supermajority quorum)"
+  fail "Signed committee never reached tip within 600s (every seated peer must be at tip for isolation to work with supermajority quorum)"
 fi
+
+echo "  Isolation target: $ISOLATION_NODE (seated committee:${committee_nodes})"
 
 # Record pre-isolation state from monitor (a validator)
 pre_ordinal=$(get_ordinal "$MONITOR_NODE")
@@ -344,6 +419,10 @@ echo "  Cluster produced $advancement snapshots while $ISOLATION_NODE was isolat
 echo ""
 echo "Phase 3: Restoring $ISOLATION_NODE network..."
 
+# Anchor for get_completed_rounds_after's `docker logs --since`. Taken BEFORE the flush so no
+# post-restore round can fall outside the window.
+RECOVERY_SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
 docker exec --privileged "$ISOLATION_NODE" iptables -F 2>&1 || \
   echo "  Warning: iptables flush failed"
 
@@ -421,7 +500,8 @@ echo "    Fork events on $ISOLATION_NODE: $final_fork_events"
 echo "    Recovery time: ${recovery_elapsed}s"
 
 # Check for any abandonment tracker activity
-abandonment_count=$(docker logs "$ISOLATION_NODE" 2>&1 | grep -c "ROUND_ABANDONED_TRACKED" 2>/dev/null || echo "0")
+# `grep -c` prints 0 AND exits 1 on no match, so a `|| echo 0` fallback would emit "0\n0".
+abandonment_count=$(docker logs --tail 20000 "$ISOLATION_NODE" 2>&1 | grep -c "ROUND_ABANDONED_TRACKED" || true)
 echo "    Round abandonments on $ISOLATION_NODE: $abandonment_count"
 
 if [ "$recovered" != "true" ]; then

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/gossip/GossipDaemon.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/gossip/GossipDaemon.scala
@@ -11,7 +11,7 @@ import io.constellationnetwork.node.shared.config.types.GossipDaemonConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.domain.collateral.Collateral
 import io.constellationnetwork.node.shared.domain.healthcheck.LocalHealthcheck
-import io.constellationnetwork.node.shared.infrastructure.gossip.RumorStorage.{AddSuccess, CounterTooHigh}
+import io.constellationnetwork.node.shared.infrastructure.gossip.RumorStorage.{AddSuccess, ChainRestarted, CounterTooHigh}
 import io.constellationnetwork.node.shared.infrastructure.gossip.p2p.GossipClient
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.schema.generation.Generation
@@ -137,7 +137,18 @@ object GossipDaemon {
                     result === CounterTooHigh && rumor.origin === selfId && rumor.ordinal.generation === generation
                   )
               }
-              .map(_ === AddSuccess)
+              .flatTap { result =>
+                // Previously a silent drop. Worth a WARN: it means a range of this peer's rumors is
+                // permanently lost, and it is the signature of a peer that was unreachable for longer
+                // than its own rumor buffer.
+                logger
+                  .warn(
+                    s"Restarted rumor chain for origin=${rumor.origin.show} at ordinal=${rumor.ordinal.show}; " +
+                      s"the preceding range is unrecoverable and was skipped"
+                  )
+                  .whenA(result === ChainRestarted)
+              }
+              .map(result => result === AddSuccess || result === ChainRestarted)
           case _ => rumorStorage.addCommonRumorIfUnseen(hashedRumor.asInstanceOf[Hashed[CommonRumorRaw]])
         }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/gossip/RumorStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/gossip/RumorStorage.scala
@@ -56,6 +56,21 @@ object RumorStorage {
   case object CounterTooLow extends AddResult
   case object GenerationTooLow extends AddResult
 
+  /** The origin's chain was restarted from the incoming rumor because the gap ahead of our head was provably unclosable. Treated as success
+    * by the daemon (the rumor is consumed), but reported distinctly so it can be logged: it means we permanently dropped a range of that
+    * peer's rumors.
+    */
+  case object ChainRestarted extends AddResult
+
+  /** True when `incoming` is so far ahead of our chain head that the intervening rumors cannot still exist anywhere.
+    *
+    * Every node retains at most `capacity` rumors per origin (`peerRumorsCapacity`), so once the gap exceeds that, even the origin itself
+    * has evicted counter `head + 1` and `peerRound`'s `PeerRumorInquiryRequest` can never make the chain consecutive again. Strictly
+    * greater-than, so a gap of exactly `capacity` -- still closable, the origin holds that range -- keeps waiting for the inquiry.
+    */
+  def isGapUnclosable(head: Counter, incoming: Counter, capacity: PosLong): Boolean =
+    incoming.value.value - head.value.value > capacity.value
+
   case class NonEmptyChainWrapper[A](chain: NonEmptyChain[A], size: PosLong)
 
   object NonEmptyChainWrapper {
@@ -175,6 +190,21 @@ object RumorStorage {
                   )
                 else if (headCounter.next > rumorCounter)
                   (wrapper, (CounterTooLow, unit))
+                else if (RumorStorage.isGapUnclosable(headCounter, rumorCounter, cfg.peerRumorsCapacity))
+                  // The missing range is wider than any node retains (peerRumorsCapacity per origin),
+                  // so peerRound's inquiry can never fetch counter head+1 from anyone -- the chain
+                  // would stay non-consecutive forever and EVERY subsequent rumor from this origin
+                  // would be silently dropped, including its NodeState and consensus declarations.
+                  // Observed as a permanent mute: a peer isolated longer than its own rumor buffer
+                  // returns, is still seated by consensus (committees derive from peerHistory, not
+                  // from gossip reachability), gets elected leader, and the chain wedges because no
+                  // follower can hear it. Restart the chain from this rumor instead. Safety is
+                  // unaffected -- rumors are signature-validated independently of chain position,
+                  // and the bound cannot be reached by transient reordering.
+                  (
+                    NonEmptyChainWrapper.one(rumor),
+                    (ChainRestarted, lastOrdinalsR.update(_.updated(rumor.origin, rumor.ordinal)))
+                  )
                 else
                   (wrapper, (CounterTooHigh, unit))
               else if (headGen < rumorGen)

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/gossip/RumorChainGapSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/gossip/RumorChainGapSuite.scala
@@ -1,0 +1,84 @@
+package io.constellationnetwork.node.shared.infrastructure.gossip
+
+import io.constellationnetwork.schema.gossip.Counter
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosLong
+import weaver.SimpleIOSuite
+
+/** Guards the unclosable-gap bound that lets a returning peer's rumor chain restart.
+  *
+  * Background: `addPeerRumorIfConsecutive` accepts a peer rumor only when its counter is exactly `head + 1`. A peer that is unreachable for
+  * longer than its own rumor buffer therefore comes back permanently muted -- every rumor it sends is `CounterTooHigh` and silently dropped,
+  * including its `NodeState` broadcasts and all of its consensus declarations. Because committees derive from `peerHistory` rather than from
+  * gossip reachability, such a peer can still be seated and elected leader, at which point no follower can hear it and the chain wedges.
+  * Observed on a 5-node rig: ordinal 41 held for 900s with all nodes Ready and at tip.
+  *
+  * The bound below is what makes the restart safe to do automatically: it fires only when the missing range provably cannot be served by
+  * anyone, so it can never pre-empt the ordinary `peerRound` inquiry repair.
+  */
+object RumorChainGapSuite extends SimpleIOSuite {
+
+  private def counter(n: Long): Counter = Counter(PosLong.unsafeFrom(n))
+
+  private val capacity: PosLong = PosLong.unsafeFrom(50L)
+
+  pureTest("a consecutive counter is never treated as an unclosable gap") {
+    expect(
+      !RumorStorage.isGapUnclosable(counter(100L), counter(101L), capacity),
+      "head+1 is the normal accept path and must never restart the chain"
+    )
+  }
+
+  pureTest("a gap smaller than the retention window waits for the inquiry to repair it") {
+    expect(
+      !RumorStorage.isGapUnclosable(counter(100L), counter(120L), capacity),
+      "a 20-rumor gap is still held by the origin, so peerRound can fetch counter 101"
+    )
+  }
+
+  pureTest("a gap of exactly the retention window is still closable") {
+    expect(
+      !RumorStorage.isGapUnclosable(counter(100L), counter(150L), capacity),
+      "the origin retains its last 50 rumors, so counter 101 is the oldest it can still serve"
+    )
+  }
+
+  pureTest("a gap one beyond the retention window is unclosable") {
+    expect(
+      RumorStorage.isGapUnclosable(counter(100L), counter(151L), capacity),
+      "counter 101 has been evicted everywhere, so waiting for it would mute the peer forever"
+    )
+  }
+
+  pureTest("a long isolation produces an unclosable gap") {
+    expect(
+      RumorStorage.isGapUnclosable(counter(100L), counter(5000L), capacity),
+      "a peer isolated for hundreds of rounds must be able to restart its chain"
+    )
+  }
+
+  pureTest("a counter at or below the head is never an unclosable gap") {
+    expect(
+      !RumorStorage.isGapUnclosable(counter(100L), counter(100L), capacity),
+      "an equal counter is a duplicate, handled as CounterTooLow"
+    ) and
+      expect(
+        !RumorStorage.isGapUnclosable(counter(100L), counter(40L), capacity),
+        "a counter below the head must not be mistaken for a forward gap"
+      )
+  }
+
+  pureTest("the bound scales with the configured capacity") {
+    val small: PosLong = PosLong.unsafeFrom(2L)
+
+    expect(
+      !RumorStorage.isGapUnclosable(counter(10L), counter(12L), small),
+      "a gap of exactly the (small) capacity is still closable"
+    ) and
+      expect(
+        RumorStorage.isGapUnclosable(counter(10L), counter(13L), small),
+        "one beyond the (small) capacity is unclosable"
+      )
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/gossip/RumorChainGapSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/gossip/RumorChainGapSuite.scala
@@ -9,10 +9,10 @@ import weaver.SimpleIOSuite
 /** Guards the unclosable-gap bound that lets a returning peer's rumor chain restart.
   *
   * Background: `addPeerRumorIfConsecutive` accepts a peer rumor only when its counter is exactly `head + 1`. A peer that is unreachable for
-  * longer than its own rumor buffer therefore comes back permanently muted -- every rumor it sends is `CounterTooHigh` and silently dropped,
-  * including its `NodeState` broadcasts and all of its consensus declarations. Because committees derive from `peerHistory` rather than from
-  * gossip reachability, such a peer can still be seated and elected leader, at which point no follower can hear it and the chain wedges.
-  * Observed on a 5-node rig: ordinal 41 held for 900s with all nodes Ready and at tip.
+  * longer than its own rumor buffer therefore comes back permanently muted -- every rumor it sends is `CounterTooHigh` and silently
+  * dropped, including its `NodeState` broadcasts and all of its consensus declarations. Because committees derive from `peerHistory` rather
+  * than from gossip reachability, such a peer can still be seated and elected leader, at which point no follower can hear it and the chain
+  * wedges. Observed on a 5-node rig: ordinal 41 held for 900s with all nodes Ready and at tip.
   *
   * The bound below is what makes the restart safe to do automatically: it fires only when the missing range provably cannot be served by
   * anyone, so it can never pre-empt the ordinary `peerRound` inquiry repair.
@@ -62,11 +62,12 @@ object RumorChainGapSuite extends SimpleIOSuite {
     expect(
       !RumorStorage.isGapUnclosable(counter(100L), counter(100L), capacity),
       "an equal counter is a duplicate, handled as CounterTooLow"
-    ) and
+    ).and(
       expect(
         !RumorStorage.isGapUnclosable(counter(100L), counter(40L), capacity),
         "a counter below the head must not be mistaken for a forward gap"
       )
+    )
   }
 
   pureTest("the bound scales with the configured capacity") {
@@ -75,10 +76,11 @@ object RumorChainGapSuite extends SimpleIOSuite {
     expect(
       !RumorStorage.isGapUnclosable(counter(10L), counter(12L), small),
       "a gap of exactly the (small) capacity is still closable"
-    ) and
+    ).and(
       expect(
         RumorStorage.isGapUnclosable(counter(10L), counter(13L), small),
         "one beyond the (small) capacity is unclosable"
       )
+    )
   }
 }


### PR DESCRIPTION
## Summary
The `fork-recovery` e2e was disabled as "never passing". Its Phase-1 gate was arithmetically unsatisfiable, so the test had never actually run. Fixing the gate let it run, and it immediately found a real node bug: **a peer that is unreachable for longer than its own rumor buffer comes back permanently muted, and because consensus can still elect it leader, the whole cluster freezes.** This PR fixes the harness, fixes that bug, and hardens the pass criterion.

The matrix entry is still commented, because one further recovery gap remains (below). Nothing here can affect existing CI jobs.

## Changes
* **Fixed (node)** - `RumorStorage`: a peer rumor is accepted only at exactly `head + 1`, and the repair path (`peerRound`'s inquiry) is bounded by `peer-rumors-capacity` (50) per origin. Once the gap exceeds that, the missing range is evicted everywhere, the chain can never be made consecutive, and every later rumor from that origin is dropped as `CounterTooHigh` - silently, with no log line. `isGapUnclosable(head, incoming, capacity)` restarts the chain when, and only when, the gap provably cannot be served by anyone (`incoming - head > capacity`). Reported as a distinct `ChainRestarted` result and logged at WARN.
* **Fixed (test)** - Phase-1 gate now derives the committee from the signed artifact (`snapshot[N+1].peerHistory.controllerEvidence[N].roundStartFacilitators`) instead of comparing log-scraped facilitator counts. Isolation target is picked from the seated set by node index and pinned across the 3-sample window, while the rest of the committee may churn.
* **Fixed (test)** - the catch-up criterion now measures the median ordinal across reachable nodes rather than `MONITOR_NODE`'s own.
* **Modified** - `docker logs` scans bounded with `--tail`; recovery counting anchored with `--since` at restore; a `grep -c` fallback that emitted two zeros.
* **Modified** - `.github/workflows/e2e-just-test.yml`: comment only, plus `timeout: 60` on the still-commented entry.

## Why the old gate could never pass
`[ "$committee_size" = "$mon_fac" ]` compared a **count of agreeing nodes** to the **committee size** - equal only when the committee is the whole cluster, contradicting the gate's own comment ("Committee size doesn't have to be N"). Replayed against a live 5-node run:

```
+270    fac=5 5 5 5 5   ord=21 21 21 21 21   PASS
+315    fac=4 4 4 4 4   ord=24 24 24 24 24   fail(size=5 vs mon_fac=4)   <- healthy, unanimous, rejected
+360    fac=5 5 5 5 4   ord=27 27 27 27 26   fail(agrees=false)          <- sampling skew, not disagreement
gate passed 2 / 17 sample points, never twice in a row
```

It requires 3 consecutive. The inputs were also each node's *last-ever* logged count, so nodes were compared across different rounds and a legitimate 4<->5 oscillation read as a split. Fixed gate: 3 consecutive in ~90s.

Two incidental findings: **PR #1485, the stated re-enable blocker, was closed without merging**, and the entry had no `timeout:`, inheriting 30 min against a ~40 min test.

## The node bug, measured
Run with the old code, isolating a seated peer for 270s:

```
21:35:40   peers:  "Peer b5534065 is unresponsive"
21:37:58.1 peers:  "Syncing 1 missing events to newly grafted peer b5534065"   <- gossip re-graft
21:37:58.9 gl0-3:  WaitingForDownload -> WaitingForObserving -> Observing -> Ready (208 ms)
```

The returning node is re-grafted into the gossip mesh but its rumor chain is never repaired, so every rumor it sends is dropped:

| | Proposal decls | Signature decls |
|---|---|---|
| gl0-3 (leader) | 21 | 21 |
| all four peers | 0 | 0 |

Peers kept it at `WaitingForObserving` while it reported `Ready`. Consensus derives committees from `peerHistory`, not gossip reachability, so it seated the node **and elected it leader**; the leader logged `Quorum reached: 3/3` while followers sat in `CollectingProposals` emitting `FORCED_VIEW_CHANGE`. View change could not route around it - the round is re-created at view 0, deterministically re-electing the same leader. **Ordinal 41 held for 900+s with all five nodes Ready and at tip.**

## Consensus safety
**Behavior-only. Not consensus-breaking.**
* It governs only which rumors a node accepts into its **local** store - no artifact content, signature, committee derivation, evidence field or reward computation changes.
* `peerRumorsCapacity` lives in `RumorStorageConfig`, not `ConsensusConfig`; it is not folded into `deterministicConfigHash` (verified against the hash body in `types.scala`). Divergent values cannot cause peer rejection or a fork.
* Divergent local rumor sets are already an expected condition - that is precisely why `canonicalCompletedSigners` uses proposal-carried, round-start-frozen data rather than locally observed proofs.
* `validateRumor` runs before `tryAddRumorToStore`, so a restarted chain cannot admit anything that was not already signature-valid.
* The change strictly *accepts more* rumors, only in a state where previously all were dropped forever. It cannot make a healthy node reject something it used to accept.

## Testing
`RumorChainGapSuite` (new, 7 tests) pins the bound in both directions, at the exact boundary, for a long isolation, for counters at or below the head, and for scaling with capacity. `nodeShared` compiles; scalafmt clean in a fresh session.

Live 5-node rig, with the fix:
* chain restart fired on all five nodes (`Restarted rumor chain for origin=345647c8 at ordinal=...counter=502`)
* the returning node went from permanently muted to fully gossiping - pushing events to all four peers, receiving declarations for later rounds
* peers moved it off `WaitingForObserving`
* **the cluster kept producing, 41 -> 58, instead of freezing**

## Why the matrix entry is still commented
The fix changes the failure shape from "entire cluster halts" to "one node lags", which is a large severity reduction but not yet a clean recovery. After rejoining, the node promotes to `Ready` at a target computed when its download began and never backfills: it participated in round 59 while still serving `latest=51`, with `completedAfterIsolation=0`.

That is a third, separate issue in the download/recovery path. It is also behavior-only - no signed content or validation changes - but it sits where the documented historical failure mode is a cluster-wide false-lagging recovery cascade (the trap that made the first #1533 attempt wrong), so it wants deliberate review rather than a bolt-on. `downloadReadyPromotionAllowed` already models an `Ahead` verdict from a 409, which is the likely place for a narrow fix. Until then the test correctly fails, and enabling it would make CI red.

## Review notes
* `CL_QUORUM_THRESHOLD_FRACTION: "1.0"` in this workflow is **dead config** - absent from both compose files and every generated `.env`, so nodes use the conf default. If it were ever plumbed through, `QuorumPolicy.fromFraction` takes the unanimity branch and isolating any committee member becomes an unrecoverable wedge by construction.
* PR #1551 also touches `e2e-just-test.yml` a few lines below and widens CI node-log collection past index 2; distinct hunks, should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
