### PR TITLE
fix: defer ordinal 2 consensus until the initial Owner message is available

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -145,6 +145,8 @@ object Services {
         sharedStorages.lastGlobalSnapshot
       )
 
+      identifier <- storages.identifier.get
+
       consensus <- CurrencySnapshotConsensus
         .make[F](
           sharedServices.gossip,
@@ -152,6 +154,7 @@ object Services {
           keyPair,
           seedlist,
           cfg.collateral.amount,
+          identifier,
           storages.cluster,
           storages.node,
           storages.lastSyncGlobalSnapshot,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -155,6 +155,7 @@ object Services {
           storages.cluster,
           storages.node,
           storages.lastSyncGlobalSnapshot,
+          feeCalculator,
           maybeRewards,
           cfg.snapshot,
           client,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -27,6 +27,7 @@ import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
 import io.constellationnetwork.node.shared.infrastructure.snapshot.{CurrencySnapshotCreator, CurrencySnapshotValidator}
 import io.constellationnetwork.node.shared.snapshot.currency._
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.peer.PeerId
@@ -45,6 +46,7 @@ object CurrencySnapshotConsensus {
     keyPair: KeyPair,
     seedlist: Option[Set[SeedlistEntry]],
     collateral: Amount,
+    metagraphId: Address,
     clusterStorage: ClusterStorage[F],
     nodeStorage: NodeStorage[F],
     lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
@@ -106,7 +108,7 @@ object CurrencySnapshotConsensus {
           getGlobalSnapshotByOrdinal
         )
       consensusStateCreator = CurrencySnapshotConsensusStateCreator
-        .make[F](consensusFunctions, consensusStorage, lastGlobalSnapshotStorage, feeCalculator, gossip, selfId, seedlist)
+        .make[F](consensusFunctions, consensusStorage, lastGlobalSnapshotStorage, feeCalculator, gossip, selfId, seedlist, metagraphId)
       consensusStateRemover = CurrencySnapshotConsensusStateRemover.make[F](consensusStorage, gossip)
       consensusStatusOps = CurrencySnapshotConsensusOps.make
       stateUpdater = ConsensusStateUpdater.make(

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -21,6 +21,7 @@ import io.constellationnetwork.node.shared.domain.gossip.Gossip
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.rewards.Rewards
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSyncGlobalSnapshotStorage
+import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
 import io.constellationnetwork.node.shared.infrastructure.consensus._
 import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.node.RestartService
@@ -47,6 +48,7 @@ object CurrencySnapshotConsensus {
     clusterStorage: ClusterStorage[F],
     nodeStorage: NodeStorage[F],
     lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
+    feeCalculator: FeeCalculator[F],
     maybeRewards: Option[Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
     snapshotConfig: SnapshotConfig,
     client: Client[F],
@@ -104,7 +106,7 @@ object CurrencySnapshotConsensus {
           getGlobalSnapshotByOrdinal
         )
       consensusStateCreator = CurrencySnapshotConsensusStateCreator
-        .make[F](consensusFunctions, consensusStorage, lastGlobalSnapshotStorage, gossip, selfId, seedlist)
+        .make[F](consensusFunctions, consensusStorage, lastGlobalSnapshotStorage, feeCalculator, gossip, selfId, seedlist)
       consensusStateRemover = CurrencySnapshotConsensusStateRemover.make[F](consensusStorage, gossip)
       consensusStatusOps = CurrencySnapshotConsensusOps.make
       stateUpdater = ConsensusStateUpdater.make(

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -18,7 +18,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.message.Cons
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.node.shared.snapshot.currency._
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.currencyMessage.{MessageType, fetchOwnerAddress}
+import io.constellationnetwork.schema.currencyMessage.{MessageOrdinal, MessageType, fetchOwnerAddress}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 
@@ -57,9 +57,19 @@ object CurrencySnapshotConsensusStateCreator {
         .map(_.map(feeCalculator.isFeeRequired).getOrElse(feeCalculator.isFeeRequired(SnapshotOrdinal.unsafeApply(Long.MaxValue))))
         .ifM(pendingOwnerMessageExists, true.pure[F])
 
-  val isOwnerMessageEvent: CurrencySnapshotEvent => Boolean = {
-    case CurrencyMessageEvent(message) => message.messageType === MessageType.Owner
-    case _                             => false
+  /** Matches the initial Owner message for this metagraph: an Owner message whose parent ordinal is the minimum, i.e. the one that takes
+    * the special ordinal-2 acceptance path (see `CurrencySnapshotAcceptanceManager`). A type-only `Owner` match could instead be satisfied
+    * by an Owner event for a different metagraph or by a non-initial Owner message with the wrong parent ordinal, which would open the gate
+    * but be rejected by message acceptance and allow ordinal 2 to finalize without an accepted Owner.
+    */
+  def isInitialOwnerMessageEvent(
+    metagraphId: Address
+  ): CurrencySnapshotEvent => Boolean = {
+    case CurrencyMessageEvent(message) =>
+      message.messageType === MessageType.Owner &&
+      message.metagraphId === metagraphId &&
+      message.parentOrdinal === MessageOrdinal.MinValue
+    case _ => false
   }
 
   def make[F[_]: Async](
@@ -69,7 +79,8 @@ object CurrencySnapshotConsensusStateCreator {
     feeCalculator: FeeCalculator[F],
     gossip: Gossip[F],
     selfId: PeerId,
-    seedlist: Option[Set[SeedlistEntry]]
+    seedlist: Option[Set[SeedlistEntry]],
+    metagraphId: Address
   ): CurrencySnapshotConsensusStateCreator[F] = new CurrencySnapshotConsensusStateCreator[F] {
     private val logger = Slf4jLogger.getLogger[F]
 
@@ -84,7 +95,7 @@ object CurrencySnapshotConsensusStateCreator {
         fetchOwnerAddress(lastOutcome.finished.context.snapshotInfo),
         lastGlobalSnapshotStorage.getOrdinal,
         feeCalculator,
-        consensusStorage.existsEvent(isOwnerMessageEvent)
+        consensusStorage.existsEvent(isInitialOwnerMessageEvent(metagraphId))
       ).ifM(
         consensusStorage
           .condModifyState(key)(toCreateStateFn(facilitateConsensus(key, lastOutcome, maybeTrigger, resources)))

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -10,13 +10,17 @@ import io.constellationnetwork.domain.seedlist.SeedlistEntry
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.node.shared.domain.gossip.Gossip
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
 import io.constellationnetwork.node.shared.infrastructure.consensus._
 import io.constellationnetwork.node.shared.infrastructure.consensus.declaration.Facility
 import io.constellationnetwork.node.shared.infrastructure.consensus.message.ConsensusPeerDeclaration
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.node.shared.snapshot.currency._
+import io.constellationnetwork.schema.currencyMessage.{MessageType, fetchOwnerAddress}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
+
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 abstract class CurrencySnapshotConsensusStateCreator[F[_]: Sync]
     extends ConsensusStateCreator[
@@ -35,20 +39,51 @@ object CurrencySnapshotConsensusStateCreator {
     consensusFns: CurrencySnapshotConsensusFunctions[F],
     consensusStorage: CurrencyConsensusStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    feeCalculator: FeeCalculator[F],
     gossip: Gossip[F],
     selfId: PeerId,
     seedlist: Option[Set[SeedlistEntry]]
   ): CurrencySnapshotConsensusStateCreator[F] = new CurrencySnapshotConsensusStateCreator[F] {
+    private val logger = Slf4jLogger.getLogger[F]
+
+    private val initialOwnerMessageOrdinal = SnapshotOrdinal.unsafeApply(2L)
+
     def tryFacilitateConsensus(
       key: CurrencySnapshotKey,
       lastOutcome: CurrencyConsensusOutcome,
       maybeTrigger: Option[ConsensusTrigger],
       resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
     ): F[StateCreateResult] =
-      consensusStorage
-        .condModifyState(key)(toCreateStateFn(facilitateConsensus(key, lastOutcome, maybeTrigger, resources)))
-        .flatMap(evalEffect)
-        .flatTap(logIfCreatedState)
+      canStartOwnedConsensus(key, lastOutcome).ifM(
+        consensusStorage
+          .condModifyState(key)(toCreateStateFn(facilitateConsensus(key, lastOutcome, maybeTrigger, resources)))
+          .flatMap(evalEffect)
+          .flatTap(logIfCreatedState),
+        logger
+          .warn(
+            s"Deferring consensus for key ${key.show}: waiting for the initial Owner message to set the metagraph owner " +
+              s"before creating the first fee-paying snapshot, otherwise it gets rejected by the global L0"
+          )
+          .as(none)
+      )
+
+    /** The initial Owner message can only be accepted at snapshot ordinal 2 and the global L0 charges snapshot fees to the owner address
+      * from that ordinal on. Producing snapshot 2 without the Owner message dooms every subsequent snapshot to rejection, so the round must
+      * not start until the message is available for inclusion.
+      */
+    private def canStartOwnedConsensus(key: CurrencySnapshotKey, lastOutcome: CurrencyConsensusOutcome): F[Boolean] =
+      if (key =!= initialOwnerMessageOrdinal || fetchOwnerAddress(lastOutcome.finished.context.snapshotInfo).isDefined)
+        true.pure[F]
+      else
+        lastGlobalSnapshotStorage.getOrdinal
+          .map(_.map(feeCalculator.isFeeRequired).getOrElse(feeCalculator.isFeeRequired(SnapshotOrdinal.unsafeApply(Long.MaxValue))))
+          .ifM(
+            consensusStorage.existsEvent {
+              case CurrencyMessageEvent(message) => message.messageType === MessageType.Owner
+              case _                             => false
+            },
+            true.pure[F]
+          )
 
     private def facilitateConsensus(
       key: CurrencySnapshotKey,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.currency.l0.snapshot
 
+import cats.Monad
 import cats.effect.kernel.Clock
 import cats.effect.{Async, Sync}
 import cats.syntax.all._
@@ -16,6 +17,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.declaration.
 import io.constellationnetwork.node.shared.infrastructure.consensus.message.ConsensusPeerDeclaration
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.node.shared.snapshot.currency._
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.currencyMessage.{MessageType, fetchOwnerAddress}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
@@ -35,6 +37,31 @@ abstract class CurrencySnapshotConsensusStateCreator[F[_]: Sync]
 
 object CurrencySnapshotConsensusStateCreator {
 
+  val InitialOwnerMessageOrdinal: SnapshotOrdinal = SnapshotOrdinal.unsafeApply(2L)
+
+  /** The initial Owner message can only be accepted at snapshot ordinal 2 and the global L0 charges snapshot fees to the owner address from
+    * that ordinal on. Producing snapshot 2 without the Owner message dooms every subsequent snapshot to rejection, so the round must not
+    * start until the message is available for inclusion.
+    */
+  def canStartOwnedConsensus[F[_]: Monad](
+    key: CurrencySnapshotKey,
+    maybeOwnerAddress: Option[Address],
+    getLastGlobalSnapshotOrdinal: F[Option[SnapshotOrdinal]],
+    feeCalculator: FeeCalculator[F],
+    pendingOwnerMessageExists: F[Boolean]
+  ): F[Boolean] =
+    if (key =!= InitialOwnerMessageOrdinal || maybeOwnerAddress.isDefined)
+      true.pure[F]
+    else
+      getLastGlobalSnapshotOrdinal
+        .map(_.map(feeCalculator.isFeeRequired).getOrElse(feeCalculator.isFeeRequired(SnapshotOrdinal.unsafeApply(Long.MaxValue))))
+        .ifM(pendingOwnerMessageExists, true.pure[F])
+
+  val isOwnerMessageEvent: CurrencySnapshotEvent => Boolean = {
+    case CurrencyMessageEvent(message) => message.messageType === MessageType.Owner
+    case _                             => false
+  }
+
   def make[F[_]: Async](
     consensusFns: CurrencySnapshotConsensusFunctions[F],
     consensusStorage: CurrencyConsensusStorage[F],
@@ -46,15 +73,19 @@ object CurrencySnapshotConsensusStateCreator {
   ): CurrencySnapshotConsensusStateCreator[F] = new CurrencySnapshotConsensusStateCreator[F] {
     private val logger = Slf4jLogger.getLogger[F]
 
-    private val initialOwnerMessageOrdinal = SnapshotOrdinal.unsafeApply(2L)
-
     def tryFacilitateConsensus(
       key: CurrencySnapshotKey,
       lastOutcome: CurrencyConsensusOutcome,
       maybeTrigger: Option[ConsensusTrigger],
       resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind]
     ): F[StateCreateResult] =
-      canStartOwnedConsensus(key, lastOutcome).ifM(
+      canStartOwnedConsensus(
+        key,
+        fetchOwnerAddress(lastOutcome.finished.context.snapshotInfo),
+        lastGlobalSnapshotStorage.getOrdinal,
+        feeCalculator,
+        consensusStorage.existsEvent(isOwnerMessageEvent)
+      ).ifM(
         consensusStorage
           .condModifyState(key)(toCreateStateFn(facilitateConsensus(key, lastOutcome, maybeTrigger, resources)))
           .flatMap(evalEffect)
@@ -66,24 +97,6 @@ object CurrencySnapshotConsensusStateCreator {
           )
           .as(none)
       )
-
-    /** The initial Owner message can only be accepted at snapshot ordinal 2 and the global L0 charges snapshot fees to the owner address
-      * from that ordinal on. Producing snapshot 2 without the Owner message dooms every subsequent snapshot to rejection, so the round must
-      * not start until the message is available for inclusion.
-      */
-    private def canStartOwnedConsensus(key: CurrencySnapshotKey, lastOutcome: CurrencyConsensusOutcome): F[Boolean] =
-      if (key =!= initialOwnerMessageOrdinal || fetchOwnerAddress(lastOutcome.finished.context.snapshotInfo).isDefined)
-        true.pure[F]
-      else
-        lastGlobalSnapshotStorage.getOrdinal
-          .map(_.map(feeCalculator.isFeeRequired).getOrElse(feeCalculator.isFeeRequired(SnapshotOrdinal.unsafeApply(Long.MaxValue))))
-          .ifM(
-            consensusStorage.existsEvent {
-              case CurrencyMessageEvent(message) => message.messageType === MessageType.Owner
-              case _                             => false
-            },
-            true.pure[F]
-          )
 
     private def facilitateConsensus(
       key: CurrencySnapshotKey,

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreatorSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreatorSuite.scala
@@ -7,7 +7,10 @@ import cats.syntax.all._
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration.DurationInt
 
-import io.constellationnetwork.currency.l0.snapshot.CurrencySnapshotConsensusStateCreator.{canStartOwnedConsensus, isOwnerMessageEvent}
+import io.constellationnetwork.currency.l0.snapshot.CurrencySnapshotConsensusStateCreator.{
+  canStartOwnedConsensus,
+  isInitialOwnerMessageEvent
+}
 import io.constellationnetwork.currency.l0.snapshot.schema.{CurrencyConsensusKind, CurrencyConsensusOutcome}
 import io.constellationnetwork.currency.schema.currency.CurrencySnapshotContext
 import io.constellationnetwork.node.shared.config.types.{ConsensusConfig, EventCutterConfig}
@@ -62,9 +65,13 @@ object CurrencySnapshotConsensusStateCreatorSuite extends SimpleIOSuite {
   private def dummyProofs: NonEmptySet[SignatureProof] =
     NonEmptySet.one(SignatureProof(Id(Hex("")), Signature(Hex(""))))
 
-  private def messageEvent(messageType: MessageType): CurrencySnapshotEvent = {
+  private def messageEvent(
+    messageType: MessageType,
+    parentOrdinal: MessageOrdinal = MessageOrdinal.MinValue,
+    messageMetagraphId: Address = metagraphId
+  ): CurrencySnapshotEvent = {
     val address = if (messageType === MessageType.Owner) ownerAddress else stakingAddress
-    CurrencyMessageEvent(Signed(CurrencyMessage(messageType, address, metagraphId, MessageOrdinal.MinValue), dummyProofs))
+    CurrencyMessageEvent(Signed(CurrencyMessage(messageType, address, messageMetagraphId, parentOrdinal), dummyProofs))
   }
 
   test("defers the ordinal 2 round when fees are required and no Owner message is pending") {
@@ -103,12 +110,23 @@ object CurrencySnapshotConsensusStateCreatorSuite extends SimpleIOSuite {
       .map(result => expect(!result))
   }
 
-  pureTest("isOwnerMessageEvent matches Owner messages and nothing else") {
-    expect(isOwnerMessageEvent(messageEvent(MessageType.Owner)))
-      .and(expect(!isOwnerMessageEvent(messageEvent(MessageType.Staking))))
+  pureTest("isInitialOwnerMessageEvent matches only the initial Owner message for this metagraph") {
+    val ownerInitial = isInitialOwnerMessageEvent(metagraphId)(messageEvent(MessageType.Owner))
+    val staking = isInitialOwnerMessageEvent(metagraphId)(messageEvent(MessageType.Staking))
+    val wrongMetagraph = isInitialOwnerMessageEvent(metagraphId)(
+      messageEvent(MessageType.Owner, messageMetagraphId = stakingAddress)
+    )
+    val nonInitialOwner = isInitialOwnerMessageEvent(metagraphId)(
+      messageEvent(MessageType.Owner, parentOrdinal = MessageOrdinal(1L).toOption.get)
+    )
+
+    expect(ownerInitial, "the initial Owner message for this metagraph must match")
+      .and(expect(!staking, "a Staking message must not match"))
+      .and(expect(!wrongMetagraph, "an Owner message for a different metagraph must not match"))
+      .and(expect(!nonInitialOwner, "a non-initial Owner message must not match"))
   }
 
-  test("existsEvent finds a pending Owner message in the consensus event queue") {
+  test("existsEvent finds a pending initial Owner message in the consensus event queue") {
     val consensusConfig = ConsensusConfig(
       timeTriggerInterval = 43.seconds,
       declarationTimeout = 50.seconds,
@@ -130,14 +148,14 @@ object CurrencySnapshotConsensusStateCreatorSuite extends SimpleIOSuite {
         CurrencyConsensusOutcome,
         CurrencyConsensusKind
       ](consensusConfig)
-      emptyResult <- storage.existsEvent(isOwnerMessageEvent)
+      emptyResult <- storage.existsEvent(isInitialOwnerMessageEvent(metagraphId))
       _ <- storage.addEvents(Map(peerId -> List((Ordinal.MinValue, messageEvent(MessageType.Staking)))))
-      stakingOnlyResult <- storage.existsEvent(isOwnerMessageEvent)
+      stakingOnlyResult <- storage.existsEvent(isInitialOwnerMessageEvent(metagraphId))
       _ <- storage.addEvents(Map(peerId -> List((Ordinal.MinValue, messageEvent(MessageType.Owner)))))
-      ownerResult <- storage.existsEvent(isOwnerMessageEvent)
+      ownerResult <- storage.existsEvent(isInitialOwnerMessageEvent(metagraphId))
     } yield
-      expect(!emptyResult, "an empty event queue must not report a pending Owner message")
-        .and(expect(!stakingOnlyResult, "a Staking-only event queue must not report a pending Owner message"))
-        .and(expect(ownerResult, "the pending Owner message must be found in the event queue"))
+      expect(!emptyResult, "an empty event queue must not report a pending initial Owner message")
+        .and(expect(!stakingOnlyResult, "a Staking-only event queue must not report a pending initial Owner message"))
+        .and(expect(ownerResult, "the pending initial Owner message must be found in the event queue"))
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreatorSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreatorSuite.scala
@@ -1,0 +1,143 @@
+package io.constellationnetwork.currency.l0.snapshot
+
+import cats.data.NonEmptySet
+import cats.effect.IO
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+import scala.concurrent.duration.DurationInt
+
+import io.constellationnetwork.currency.l0.snapshot.CurrencySnapshotConsensusStateCreator.{canStartOwnedConsensus, isOwnerMessageEvent}
+import io.constellationnetwork.currency.l0.snapshot.schema.{CurrencyConsensusKind, CurrencyConsensusOutcome}
+import io.constellationnetwork.currency.schema.currency.CurrencySnapshotContext
+import io.constellationnetwork.node.shared.config.types.{ConsensusConfig, EventCutterConfig}
+import io.constellationnetwork.node.shared.domain.statechannel.{FeeCalculator, FeeCalculatorConfig}
+import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusStorage
+import io.constellationnetwork.node.shared.snapshot.currency.{CurrencyMessageEvent, CurrencySnapshotArtifact, CurrencySnapshotEvent}
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.currencyMessage.{CurrencyMessage, MessageOrdinal, MessageType}
+import io.constellationnetwork.schema.gossip.Ordinal
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
+import weaver.SimpleIOSuite
+
+/** Regression suite for the ordinal 2 consensus gate.
+  *
+  * The initial Owner message can only be accepted at currency snapshot ordinal 2 and, on fee-charging networks, the global L0 charges the
+  * snapshot fee to the owner address from that ordinal on. When the ordinal 2 round raced ahead of the Owner message submission, snapshot 2
+  * was produced without an owner, the global L0 could not charge the fee and rejected the binary, permanently rejecting every subsequent
+  * snapshot of the metagraph. The gate defers the ordinal 2 round until the Owner message is available for inclusion.
+  */
+object CurrencySnapshotConsensusStateCreatorSuite extends SimpleIOSuite {
+
+  private val ordinal2 = SnapshotOrdinal.unsafeApply(2L)
+  private val ordinal3 = SnapshotOrdinal.unsafeApply(3L)
+  private val feeActivationOrdinal = SnapshotOrdinal.unsafeApply(2572684L)
+  private val currentGlobalOrdinal = SnapshotOrdinal.unsafeApply(6700000L)
+
+  private val ownerAddress = Address("DAG132WVZ4sL9z8Vs13okM6iCNLwTT5qf5miReFT")
+  private val stakingAddress = Address("DAG7WM7isHYDYwkwqTkkwoajkdH5m3nHssx1GKCW")
+  private val metagraphId = Address("DAG8ZnY1voFrENbSfwe8eT9WC6EeKTUejw7JYek4")
+
+  private val mainnetLikeFeeConfig = FeeCalculatorConfig(
+    baseFee = 100000L,
+    stakingWeight = NonNegBigDecimal.unsafeFrom(BigDecimal(0)),
+    computationalCost = 1L,
+    proWeight = NonNegBigDecimal.unsafeFrom(BigDecimal(0))
+  )
+
+  private val feesActive: FeeCalculator[IO] =
+    FeeCalculator.make[IO](SortedMap(feeActivationOrdinal -> mainnetLikeFeeConfig))
+
+  private val feesNever: FeeCalculator[IO] =
+    FeeCalculator.make[IO](SortedMap.empty)
+
+  private def dummyProofs: NonEmptySet[SignatureProof] =
+    NonEmptySet.one(SignatureProof(Id(Hex("")), Signature(Hex(""))))
+
+  private def messageEvent(messageType: MessageType): CurrencySnapshotEvent = {
+    val address = if (messageType === MessageType.Owner) ownerAddress else stakingAddress
+    CurrencyMessageEvent(Signed(CurrencyMessage(messageType, address, metagraphId, MessageOrdinal.MinValue), dummyProofs))
+  }
+
+  test("defers the ordinal 2 round when fees are required and no Owner message is pending") {
+    canStartOwnedConsensus[IO](ordinal2, none, currentGlobalOrdinal.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(!result))
+  }
+
+  test("starts the ordinal 2 round once an Owner message is pending") {
+    canStartOwnedConsensus[IO](ordinal2, none, currentGlobalOrdinal.some.pure[IO], feesActive, true.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts rounds other than ordinal 2 regardless of pending messages") {
+    canStartOwnedConsensus[IO](ordinal3, none, currentGlobalOrdinal.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts the ordinal 2 round when the owner is already set in the last context") {
+    canStartOwnedConsensus[IO](ordinal2, ownerAddress.some, currentGlobalOrdinal.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts the ordinal 2 round when fees are never required (no fee configs)") {
+    canStartOwnedConsensus[IO](ordinal2, none, currentGlobalOrdinal.some.pure[IO], feesNever, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts the ordinal 2 round when the fee config only activates at a later global ordinal") {
+    val beforeActivation = SnapshotOrdinal.unsafeApply(10L)
+    canStartOwnedConsensus[IO](ordinal2, none, beforeActivation.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("defers the ordinal 2 round when the global ordinal is unknown but fee configs exist") {
+    canStartOwnedConsensus[IO](ordinal2, none, none[SnapshotOrdinal].pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(!result))
+  }
+
+  pureTest("isOwnerMessageEvent matches Owner messages and nothing else") {
+    expect(isOwnerMessageEvent(messageEvent(MessageType.Owner)))
+      .and(expect(!isOwnerMessageEvent(messageEvent(MessageType.Staking))))
+  }
+
+  test("existsEvent finds a pending Owner message in the consensus event queue") {
+    val consensusConfig = ConsensusConfig(
+      timeTriggerInterval = 43.seconds,
+      declarationTimeout = 50.seconds,
+      declarationRangeLimit = 3L,
+      lockDuration = 10.seconds,
+      peersDeclarationTimeout = 10.seconds,
+      eventCutter = EventCutterConfig(maxBinarySizeBytes = 20971520, maxUpdateNodeParametersSize = 100)
+    )
+    val peerId = PeerId(Hex("00"))
+
+    for {
+      storage <- ConsensusStorage.make[
+        IO,
+        CurrencySnapshotEvent,
+        CurrencySnapshotKey,
+        CurrencySnapshotArtifact,
+        CurrencySnapshotContext,
+        CurrencySnapshotStatus,
+        CurrencyConsensusOutcome,
+        CurrencyConsensusKind
+      ](consensusConfig)
+      emptyResult <- storage.existsEvent(isOwnerMessageEvent)
+      _ <- storage.addEvents(Map(peerId -> List((Ordinal.MinValue, messageEvent(MessageType.Staking)))))
+      stakingOnlyResult <- storage.existsEvent(isOwnerMessageEvent)
+      _ <- storage.addEvents(Map(peerId -> List((Ordinal.MinValue, messageEvent(MessageType.Owner)))))
+      ownerResult <- storage.existsEvent(isOwnerMessageEvent)
+    } yield
+      expect(!emptyResult, "an empty event queue must not report a pending Owner message")
+        .and(expect(!stakingOnlyResult, "a Staking-only event queue must not report a pending Owner message"))
+        .and(expect(ownerResult, "the pending Owner message must be found in the event queue"))
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/ConsensusStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/ConsensusStorage.scala
@@ -36,6 +36,8 @@ trait ConsensusStorage[F[_], Event, Key, Artifact, Context, Status, Outcome, Kin
 
   def containsEvent(events: Event): F[Boolean]
 
+  def existsEvent(predicate: Event => Boolean): F[Boolean]
+
   def addEvents(events: Map[PeerId, List[(Ordinal, Event)]]): F[Unit]
 
   def pullEvents(upperBound: Bound): F[Map[PeerId, List[(Ordinal, Event)]]]
@@ -225,6 +227,14 @@ object ConsensusStorage {
             keys.existsM { peerId =>
               eventsR(peerId).get
                 .map(_.exists(_.events.exists { case (_, e) => e == event }))
+            }
+          }
+
+        def existsEvent(predicate: Event => Boolean): F[Boolean] =
+          eventsR.keys.flatMap { keys =>
+            keys.existsM { peerId =>
+              eventsR(peerId).get
+                .map(_.exists(_.events.exists { case (_, e) => predicate(e) }))
             }
           }
 


### PR DESCRIPTION
## Problem

A customer metagraph (BioFi) got permanently stuck on mainnet: every currency snapshot from ordinal 2 onward was rejected by the global L0, and the only recovery was rolling back to ordinal 1 and retrying.

Root cause is a startup race that is fatal because two protocol rules intersect exactly at currency snapshot ordinal 2:

1. **The initial Owner message can only be accepted at ordinal 2.** `CurrencySnapshotAcceptanceManager` only uses the lenient `validateInitialOwner` path when `snapshotOrdinal === 2 && parentOrdinal === 0`.
2. **Ordinal 2 is the first fee-charged snapshot.** Genesis (0) and the first incremental (1) are fee-exempt; from ordinal 2 on, the global L0 charges the snapshot fee to the **Owner** address (`GlobalSnapshotStateChannelEventsProcessor.processCurrencySnapshots`). With no owner in the snapshot, `maybeFeeAddress = None`, the binary is not accepted, and the metagraph chain is broken at ordinal 2 forever.

The ordinal 2 consensus round starts as soon as the node is Ready, and its event cut (`consensusStorage.getUpperBound` in the Facility declaration) races against the Owner/Staking message submission via `CurrencyMessageRoutes`. The customer's ML0 log shows the round for key 2 being created at `08:11:47,826` while the Owner message was only accepted at `08:11:47,975` — that run won the race by ~150ms of luck; the run that blocked the customer lost it.

## Fix

The currency L0 now defers facilitating the ordinal 2 round until the initial Owner message is available for inclusion, whenever fees are required:

- `ConsensusStorage`: new read-only `existsEvent(predicate)` to peek at pending events (`containsEvent` only supports exact equality).
- `CurrencySnapshotConsensusStateCreator`: `canStartOwnedConsensus` gate before creating the consensus state — if the key is ordinal 2, the last context has no owner, and `FeeCalculator.isFeeRequired` (at the last known global ordinal, conservatively "ever required" when unknown), the round is deferred with a warning log until a pending Owner `CurrencyMessageEvent` exists. The next event/time trigger re-evaluates.
- `CurrencySnapshotConsensus` / currency-l0 `Services`: wire the existing `FeeCalculator` through.

Environments without fee configs (e.g. Dev) are unaffected: `isFeeRequired` is false, so metagraphs that never send owner messages keep working as before.

With the gate, snapshot 2 deterministically carries the Owner message, the global L0 fills Owner/Staking from it, charges the fee to the owner balance, and accepts the chain — no more rollback loops.

## Note for the affected customer

Independently of this fix, their ML0 log also shows `BinaryPoster - [Queue] Empty allowance list not allowed in [Mainnet], skipping`: the deployed jar predates their allowlist registration (#1516), so binaries are never posted. They need to run a build that includes `53c5ace2b`.

## Testing

- `sbt currencyL0/compile` (includes node-shared) passes, scalafix clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)