### PR TITLE
fix: defer ordinal 2 consensus until the initial Owner message is available (develop)

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -173,6 +173,7 @@ object Services {
           storages.cluster,
           storages.node,
           storages.lastSyncGlobalSnapshot,
+          feeCalculator,
           maybeRewards,
           cfg.snapshot,
           cfg.environment,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -24,6 +24,7 @@ import io.constellationnetwork.node.shared.domain.gossip.Gossip
 import io.constellationnetwork.node.shared.domain.node.NodeStorage
 import io.constellationnetwork.node.shared.domain.rewards.Rewards
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSyncGlobalSnapshotStorage
+import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
 import io.constellationnetwork.node.shared.http.p2p.PeerResponse
 import io.constellationnetwork.node.shared.infrastructure.consensus._
 import io.constellationnetwork.node.shared.infrastructure.consensus.engine._
@@ -69,6 +70,7 @@ object CurrencySnapshotConsensus {
     clusterStorage: ClusterStorage[F],
     nodeStorage: NodeStorage[F],
     lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
+    feeCalculator: FeeCalculator[F],
     maybeRewards: Option[Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
     snapshotConfig: SnapshotConfig,
     environment: AppEnvironment,
@@ -214,6 +216,7 @@ object CurrencySnapshotConsensus {
           consensusFns,
           consensusStorage,
           lastGlobalSnapshotStorage,
+          feeCalculator,
           gossip,
           selfId,
           seedlist,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -3,6 +3,7 @@ package io.constellationnetwork.currency.l0.snapshot
 import cats.effect.kernel.Clock
 import cats.effect.{Async, Sync}
 import cats.syntax.all._
+import cats.{Functor, Monad}
 
 import scala.collection.immutable.SortedMap
 
@@ -14,6 +15,7 @@ import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.node.shared.config.types.ConsensusConfig
 import io.constellationnetwork.node.shared.domain.gossip.Gossip
 import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSnapshotStorage
+import io.constellationnetwork.node.shared.domain.statechannel.FeeCalculator
 import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusLog.{Category, Event}
 import io.constellationnetwork.node.shared.infrastructure.consensus._
 import io.constellationnetwork.node.shared.infrastructure.consensus.declaration.Facility
@@ -25,6 +27,8 @@ import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.selfhealth.LocalHealthMonitor
 import io.constellationnetwork.node.shared.snapshot.currency._
 import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.currencyMessage.{MessageType, fetchOwnerAddress}
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.hash.Hash
 
@@ -45,10 +49,43 @@ abstract class CurrencySnapshotConsensusStateCreator[F[_]: Sync]
 
 object CurrencySnapshotConsensusStateCreator {
 
+  val InitialOwnerMessageOrdinal: SnapshotOrdinal = SnapshotOrdinal.unsafeApply(2L)
+
+  /** The initial Owner message can only be accepted at snapshot ordinal 2 and the global L0 charges snapshot fees to the owner address from
+    * that ordinal on. Producing snapshot 2 without the Owner message dooms every subsequent snapshot to rejection, so the round must not
+    * start until the message is available for inclusion.
+    */
+  def canStartOwnedConsensus[F[_]: Monad](
+    key: CurrencySnapshotKey,
+    maybeOwnerAddress: Option[Address],
+    getLastGlobalSnapshotOrdinal: F[Option[SnapshotOrdinal]],
+    feeCalculator: FeeCalculator[F],
+    pendingOwnerMessageExists: F[Boolean]
+  ): F[Boolean] =
+    if (key =!= InitialOwnerMessageOrdinal || maybeOwnerAddress.isDefined)
+      true.pure[F]
+    else
+      getLastGlobalSnapshotOrdinal
+        .map(_.map(feeCalculator.isFeeRequired).getOrElse(feeCalculator.isFeeRequired(SnapshotOrdinal.unsafeApply(Long.MaxValue))))
+        .ifM(pendingOwnerMessageExists, true.pure[F])
+
+  def pendingOwnerMessageExists[F[_]: Functor](
+    eventMempool: EventMempool[F, CurrencySnapshotEvent, CurrencyStateKey]
+  ): F[Boolean] =
+    eventMempool.snapshot().map {
+      _.events.exists {
+        _.signed.value match {
+          case CurrencyMessageEvent(message) => message.messageType === MessageType.Owner
+          case _                             => false
+        }
+      }
+    }
+
   def make[F[_]: Async: Metrics](
     consensusFns: CurrencySnapshotConsensusFunctions[F],
     consensusStorage: CurrencyConsensusStorage[F],
     lastGlobalSnapshotStorage: LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
+    feeCalculator: FeeCalculator[F],
     gossip: Gossip[F],
     selfId: PeerId,
     seedlist: Option[Set[SeedlistEntry]],
@@ -74,10 +111,24 @@ object CurrencySnapshotConsensusStateCreator {
       resources: ConsensusResources[CurrencySnapshotArtifact, CurrencyConsensusKind],
       priorAbandonmentCount: Int
     ): F[StateCreateResult] =
-      consensusStorage
-        .condModifyState(key)(toCreateStateFn(facilitateConsensus(key, lastOutcome, maybeTrigger, resources, priorAbandonmentCount)))
-        .flatMap(evalEffect)
-        .flatTap(logIfCreated)
+      canStartOwnedConsensus(
+        key,
+        fetchOwnerAddress(lastOutcome.finished.context.snapshotInfo),
+        lastGlobalSnapshotStorage.getOrdinal,
+        feeCalculator,
+        pendingOwnerMessageExists(eventMempool)
+      ).ifM(
+        consensusStorage
+          .condModifyState(key)(toCreateStateFn(facilitateConsensus(key, lastOutcome, maybeTrigger, resources, priorAbandonmentCount)))
+          .flatMap(evalEffect)
+          .flatTap(logIfCreated),
+        logger
+          .warn(
+            s"Deferring consensus for key ${key.show}: waiting for the initial Owner message to set the metagraph owner " +
+              s"before creating the first fee-paying snapshot, otherwise it gets rejected by the global L0"
+          )
+          .as(none)
+      )
 
     // Reads the stored self-Facility and re-sends via direct push. Mirrors dag-l0.
     def retransmitOwnFacility(key: CurrencySnapshotKey, targets: Set[PeerId]): F[Unit] =

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreatorSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreatorSuite.scala
@@ -1,0 +1,132 @@
+package io.constellationnetwork.currency.l0.snapshot
+
+import cats.data.NonEmptySet
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL0Service, DataTransaction}
+import io.constellationnetwork.currency.l0.infrastructure.mempool.CurrencyEventMempool
+import io.constellationnetwork.currency.l0.snapshot.CurrencySnapshotConsensusStateCreator.{canStartOwnedConsensus, pendingOwnerMessageExists}
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.domain.statechannel.{FeeCalculator, FeeCalculatorConfig}
+import io.constellationnetwork.node.shared.snapshot.currency.{CurrencyMessageEvent, CurrencySnapshotEvent}
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.currencyMessage.{CurrencyMessage, MessageOrdinal, MessageType}
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
+import io.circe.Encoder
+import weaver.MutableIOSuite
+
+/** Regression suite for the ordinal 2 consensus gate.
+  *
+  * The initial Owner message can only be accepted at currency snapshot ordinal 2 and, on fee-charging networks, the global L0 charges the
+  * snapshot fee to the owner address from that ordinal on. When the ordinal 2 round raced ahead of the Owner message submission, snapshot 2
+  * was produced without an owner, the global L0 could not charge the fee and rejected the binary, permanently rejecting every subsequent
+  * snapshot of the metagraph. The gate defers the ordinal 2 round until the Owner message is available for inclusion.
+  */
+object CurrencySnapshotConsensusStateCreatorSuite extends MutableIOSuite {
+
+  type Res = (Hasher[IO], JsonSerializer[IO])
+
+  override def sharedResource: Resource[IO, Res] =
+    for {
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
+      h = Hasher.forJson[IO]
+    } yield (h, j)
+
+  private val ordinal2 = SnapshotOrdinal.unsafeApply(2L)
+  private val ordinal3 = SnapshotOrdinal.unsafeApply(3L)
+  private val feeActivationOrdinal = SnapshotOrdinal.unsafeApply(2572684L)
+  private val currentGlobalOrdinal = SnapshotOrdinal.unsafeApply(6700000L)
+
+  private val ownerAddress = Address("DAG132WVZ4sL9z8Vs13okM6iCNLwTT5qf5miReFT")
+  private val stakingAddress = Address("DAG7WM7isHYDYwkwqTkkwoajkdH5m3nHssx1GKCW")
+  private val metagraphId = Address("DAG8ZnY1voFrENbSfwe8eT9WC6EeKTUejw7JYek4")
+
+  private val mainnetLikeFeeConfig = FeeCalculatorConfig(
+    baseFee = 100000L,
+    stakingWeight = NonNegBigDecimal.unsafeFrom(BigDecimal(0)),
+    computationalCost = 1L,
+    proWeight = NonNegBigDecimal.unsafeFrom(BigDecimal(0))
+  )
+
+  private val feesActive: FeeCalculator[IO] =
+    FeeCalculator.make[IO](SortedMap(feeActivationOrdinal -> mainnetLikeFeeConfig))
+
+  private val feesNever: FeeCalculator[IO] =
+    FeeCalculator.make[IO](SortedMap.empty)
+
+  private def dummyProofs: NonEmptySet[SignatureProof] =
+    NonEmptySet.one(SignatureProof(Id(Hex("")), Signature(Hex(""))))
+
+  private def messageEvent(messageType: MessageType): Signed[CurrencySnapshotEvent] = {
+    val message = CurrencyMessage(messageType, if (messageType === MessageType.Owner) ownerAddress else stakingAddress, metagraphId, MessageOrdinal.MinValue)
+    Signed[CurrencySnapshotEvent](CurrencyMessageEvent(Signed(message, dummyProofs)), dummyProofs)
+  }
+
+  test("defers the ordinal 2 round when fees are required and no Owner message is pending") { _ =>
+    canStartOwnedConsensus[IO](ordinal2, none, currentGlobalOrdinal.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(!result))
+  }
+
+  test("starts the ordinal 2 round once an Owner message is pending") { _ =>
+    canStartOwnedConsensus[IO](ordinal2, none, currentGlobalOrdinal.some.pure[IO], feesActive, true.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts rounds other than ordinal 2 regardless of pending messages") { _ =>
+    canStartOwnedConsensus[IO](ordinal3, none, currentGlobalOrdinal.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts the ordinal 2 round when the owner is already set in the last context") { _ =>
+    canStartOwnedConsensus[IO](ordinal2, ownerAddress.some, currentGlobalOrdinal.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts the ordinal 2 round when fees are never required (no fee configs)") { _ =>
+    canStartOwnedConsensus[IO](ordinal2, none, currentGlobalOrdinal.some.pure[IO], feesNever, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("starts the ordinal 2 round when the fee config only activates at a later global ordinal") { _ =>
+    val beforeActivation = SnapshotOrdinal.unsafeApply(10L)
+    canStartOwnedConsensus[IO](ordinal2, none, beforeActivation.some.pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(result))
+  }
+
+  test("defers the ordinal 2 round when the global ordinal is unknown but fee configs exist") { _ =>
+    canStartOwnedConsensus[IO](ordinal2, none, none[SnapshotOrdinal].pure[IO], feesActive, false.pure[IO])
+      .map(result => expect(!result))
+  }
+
+  test("pendingOwnerMessageExists finds a pending Owner message in the mempool") {
+    case (h, _) =>
+      implicit val hasher: Hasher[IO] = h
+      implicit val dtEncoder: Encoder[DataTransaction] = DataTransactionCodecs.encoder(none[BaseDataApplicationL0Service[IO]])
+
+      for {
+        mempool <- CurrencyEventMempool.make[IO](CurrencyEventMempool.defaultConfig)
+        emptyResult <- pendingOwnerMessageExists(mempool)
+        staking <- mempool.add(messageEvent(MessageType.Staking))
+        stakingOnlyResult <- pendingOwnerMessageExists(mempool)
+        owner <- mempool.add(messageEvent(MessageType.Owner))
+        ownerResult <- pendingOwnerMessageExists(mempool)
+      } yield
+        expect(!emptyResult, "empty mempool must not report a pending Owner message")
+          .and(expect(staking.isRight, s"staking event should be accepted by the mempool, got $staking"))
+          .and(expect(!stakingOnlyResult, "a Staking-only mempool must not report a pending Owner message"))
+          .and(expect(owner.isRight, s"owner event should be accepted by the mempool, got $owner"))
+          .and(expect(ownerResult, "the pending Owner message must be found in the mempool"))
+  }
+}


### PR DESCRIPTION
Port of #1553 (release/mainnet) to develop, adapted to the EventMempool architecture, plus a regression suite.

## Problem

A customer metagraph (BioFi) got permanently stuck on mainnet: every currency snapshot from ordinal 2 onward was rejected by the global L0, and the only recovery was rolling back to ordinal 1 and retrying.

Root cause is a startup race that is fatal because two protocol rules intersect exactly at currency snapshot ordinal 2:

1. **The initial Owner message can only be accepted at ordinal 2.** Message acceptance only uses the lenient `validateInitialOwner` path when `snapshotOrdinal === 2 && parentOrdinal === 0` (`MessageValidationOpsManager` on develop).
2. **Ordinal 2 is the first fee-charged snapshot.** Genesis (0) and the first incremental (1) are fee-exempt; from ordinal 2 on, the global L0 charges the snapshot fee to the **Owner** address. With no owner in the snapshot, there is no fee address, the binary is not accepted, and the metagraph chain is broken at ordinal 2 forever.

The ordinal 2 consensus round starts as soon as the node is Ready and races against the Owner/Staking message submission. The customer's ML0 log shows the round for key 2 being created at `08:11:47,826` while the Owner message was only accepted at `08:11:47,975`.

## Fix

The currency L0 defers facilitating the ordinal 2 round until the initial Owner message is available for inclusion, whenever fees are required:

- `CurrencySnapshotConsensusStateCreator`: gate before creating the consensus state — if the key is ordinal 2, the last context has no owner, and `FeeCalculator.isFeeRequired` (at the last known global ordinal, conservatively "ever required" when unknown), the round is deferred with a warning log until a pending Owner `CurrencyMessageEvent` exists in the event mempool. The gate decision (`canStartOwnedConsensus`) and the mempool predicate (`pendingOwnerMessageExists`) are exposed on the companion object for testability, following the pattern of the existing consensus suites.
- `CurrencySnapshotConsensus` / currency-l0 `Services`: wire the existing `FeeCalculator` through.

Environments without fee configs (e.g. Dev) are unaffected: `isFeeRequired` is false, so metagraphs that never send owner messages keep working as before.

## Regression tests

`CurrencySnapshotConsensusStateCreatorSuite` (8 tests, all passing):

- defers the ordinal 2 round when fees are required and no Owner message is pending (the regression)
- starts the ordinal 2 round once an Owner message is pending
- starts rounds other than ordinal 2 regardless of pending messages
- starts the ordinal 2 round when the owner is already set in the last context
- starts the ordinal 2 round when fees are never required (no fee configs)
- starts the ordinal 2 round when the fee config only activates at a later global ordinal
- defers the ordinal 2 round when the global ordinal is unknown but fee configs exist
- `pendingOwnerMessageExists` finds a pending Owner message in a real `EventMempool` and ignores Staking-only content

## Testing

- `sbt currencyL0/compile` passes
- `sbt "currencyL0/testOnly ...CurrencySnapshotConsensusStateCreatorSuite"`: Total 8, Failed 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)