### PR TITLE
fix(currency-l0): allow coordinated solo rollback recovery

### DIFF
--- a/docs/consensus/README.md
+++ b/docs/consensus/README.md
@@ -287,6 +287,19 @@ The "always-handled" cases (rumors, `CheckUpdate`, `PeerObserved`, and the cert 
 
 The handler also force-completes a stuck round when an `InitializeFromDownload` arrives in `Observing` while still BUSY (recovery's stale-round escape hatch); under any other node state it re-queues the command after 1s without blocking the event loop.
 
+### Currency L0 rollback committee recovery
+
+Currency L0 rollback normally initializes the next consensus outcome from the
+rolled-back snapshot's proof signers. A fully stopped metagraph can use
+`run-rollback --allow-solo-consensus` on exactly one coordinated recovery node
+to bootstrap progress before the other nodes rejoin as ordinary validators.
+The flag is off by default and two isolated uses can create conflicting
+histories. See the
+[Currency L0 single-node rollback recovery runbook](../operations/currency-l0-solo-rollback.md)
+for the compatibility boundary, committee-regrowth trace, metrics, and rollout
+procedure, and distribute the corresponding
+[operator release note](../release/currency-l0-solo-rollback.md) before use.
+
 ### Round-Blocked States
 
 > **Note (v2 change):** The FSM blocks round starts when the node is in recovery or leaving states to prevent infinite loops.

--- a/docs/operations/currency-l0-solo-rollback.md
+++ b/docs/operations/currency-l0-solo-rollback.md
@@ -1,0 +1,211 @@
+# Currency L0 single-node rollback recovery
+
+`currency-l0 run-rollback --allow-solo-consensus` is an opt-in recovery escape
+hatch for a fully stopped metagraph. It lets exactly one rollback node seed the
+next Currency L0 consensus outcome with itself instead of inheriting every proof
+signer from the checkpoint.
+
+This is an operational override, not a normal startup mode. Running it on two
+isolated nodes can produce two valid but conflicting histories.
+
+> **DANGER — never persist this flag.** Do not add
+> `--allow-solo-consensus` to a systemd unit, container entrypoint, deployment
+> manifest, environment variable, or monitoring/automatic-restart command. It
+> is authorized for one manually coordinated rollback invocation only. An
+> automatic restart that repeats the override while nodes are isolated can
+> create a competing history. Disable automatic restarts before recovery and
+> restore the normal command, without the flag, before re-enabling them.
+
+## Why it is needed
+
+Normal Currency L0 rollback derives `Facilitators` and `EligibleFacilitators`
+from the rolled-back snapshot's proof signers. That is the safe default while a
+quorum of those signers is available. When the entire metagraph stops, however,
+a single restarted signer inherits a multi-peer committee and cannot finalize
+the next ordinal.
+
+A normal validator cannot break that cycle on a stopped chain. Currency L0's
+download program observes through `tip + 4` before it starts facilitating
+(`snapshot/programs/Download.scala`, `observationOffset` and `observe`). Those
+four snapshots do not exist until the inherited committee makes progress, while
+the inherited committee is waiting for the joining validator.
+
+The override breaks only that cycle:
+
+1. The selected node completes the ordinary rollback and initializes its
+   consensus outcome with `{self}`.
+2. A singleton Currency L0 committee has a unanimity quorum of one. The stall
+   infeasibility gate also deliberately applies only when Core has at least two
+   members (`StallDetector.readyParticipationStatus`).
+3. The node produces the snapshots required by a joining validator's four-
+   ordinal observation window.
+4. Returning validators join normally and re-enter through the existing
+   quorum-certified admission path.
+
+## Safety and compatibility contract
+
+- The flag defaults to false. Without it, proof-signer ordering and the
+  pre-existing non-signer self-only fallback are unchanged.
+- It adds no snapshot field, state-proof field, activation ordinal, or
+  deterministic configuration input. Existing snapshot decoders and state-
+  proof verification are unchanged.
+- It does intentionally choose a different initial facilitator set for the
+  first post-rollback outcome. Consequently the new history's facilitator set,
+  `facilitatorsHash`, proof population, and later consensus history differ from
+  the history that normal multi-signer rollback would have produced. This is
+  the purpose of the recovery operation, not config-hash neutrality between two
+  simultaneously running rollback nodes.
+- Runtime flags are not part of the jar/config handshake. The software cannot
+  reliably detect a second isolated recovery node: before session creation and
+  peer discovery, local cluster storage can legitimately be empty. Operational
+  coordination is therefore the safety boundary.
+- Deploy the same jar to every metagraph node, but pass the flag to exactly one
+  process and exactly one rollback invocation.
+
+Currency L0 validator startup now sets the existing `validatorMode` marker,
+matching DAG L0. `ConsensusRoundRunner` uses that marker to prevent a joining
+validator whose temporary local view contains only itself from producing a
+competing solo history. Rollback startup does not set validator mode, because
+the designated recovery node must be able to produce the bootstrap rounds.
+
+## Why the committee grows back
+
+The recovery node does not remain permanently solo when returning peers are
+healthy:
+
+- A joining validator can finish `Download.observe` once the solo node is
+  advancing. `startFacilitatingAfterDownload` initializes it from the observed
+  outcome.
+- `ConsensusEventLoop` collects registration keys from responsive peers in
+  `Observing`, `WaitingForReady`, and `Ready`. `ConsensusStorage.registerPeer`
+  records both the reported key and its successor, and registrations remain
+  candidates on later keys until the peer leaves.
+- Open Ready-at-tip admission votes use the current Core quorum. For a singleton
+  Currency L0 committee with `quorum-threshold-fraction = 1.0`, that quorum is
+  one. Membership still changes only after an `AdmissionCertificate` is carried
+  in an accepted proposal.
+- `ConsensusPeerController.applyCertifiedAdmissions` appends the certified
+  peer to the canonical parent committee. Below the emergency active floor
+  (default `activeFacilitatorFloor = 4`), active admission retains all available
+  selected peers. `CommitteeBuilder` then promotes as many available healthy
+  peers as it can toward IntegrationNet's Core floor of nine; the floor does not
+  invent unavailable seats.
+
+Admission certificates attached to one proposal are bounded by the existing
+`activeAdmissionMaxExpansionPerRound` setting (default one). Normal active-set
+expansion is additionally cadenced by
+`activeAdmissionExpansionIntervalRounds` in the Currency state creator (default
+one). The below-floor emergency path deliberately retains all available
+selected peers, so cadence cannot strand a recovered one-to-three-node
+metagraph below its safety floor. If the release bundle also gates open vote and
+certificate emission on a wider cadence, a returning peer waits for the next
+eligible cadence ordinal; penalty/probation readmission remains its separate
+recovery lane. In a three-node metagraph, two accepted admission certificates
+therefore restore all three peers, and the available supply causes all three to
+be classified Core. Network delay and proposal timing can add rounds, so this
+is a protocol bound on admission rate rather than a wall-clock SLA.
+
+## Rollback and metagraph sync-data interaction
+
+The flag is consumed only after `programs.rollback.rollback` returns the chosen
+Currency snapshot and context. The `metagraphSyncData` fast-path lookup,
+fallback snapshot walk, state reconstruction, cleanup, and storage
+initialization all run exactly as before. The flag changes only the facilitator
+lists used to seed `CurrencyConsensusOutcome` after rollback has completed.
+
+## DAG L0 parity
+
+DAG L0 rollback also derives its committee from checkpoint proof signers, but a
+Global L0 singleton override has different network-wide safety and operational
+requirements. This change deliberately does not add a DAG L0 flag and does not
+move the small Currency-specific policy helper into `node-shared`. Sharing the
+helper would expose an operation whose safety contract is not shared.
+
+## Coordinated recovery runbook
+
+### Preconditions
+
+1. Confirm the metagraph is fully stopped and record its last accepted Currency
+   snapshot ordinal and hash from Global L0.
+2. Disable systemd/container/monitoring automatic restarts and stop every
+   Currency L0 process. Verify that no other node is advancing or running
+   rollback from the same checkpoint.
+3. Deploy the same recovery-capable jar to all nodes.
+4. Select one stable node as the sole recovery producer. Do not start rollback
+   on the other nodes.
+5. Pass `--allow-solo-consensus` only on the operator's one-shot command line.
+   Do not edit any persistent service or monitoring configuration to add it.
+
+### Bootstrap the producer
+
+1. Start the selected node with its normal rollback arguments plus
+   `--allow-solo-consensus`.
+2. Confirm the startup warning contains `DANGER` and "Exactly one coordinated
+   recovery node".
+3. Confirm:
+   - `dag_consensus_rollback_bootstrap_total{mode="forced_self_only"}` increments;
+   - `dag_consensus_rollback_proof_signer_count` reports the checkpoint signer
+     count;
+   - `dag_consensus_rollback_bootstrap_facilitator_count` is `1`.
+4. Wait until at least five new Currency ordinals have finalized. This proves
+   both solo progress and enough chain depth for the first validator's `tip + 4`
+   observation.
+5. Before any service manager or monitor is re-enabled, confirm its configured
+   command is the ordinary startup command and contains no
+   `--allow-solo-consensus` flag.
+
+Stop and investigate if a second node reports `forced_self_only`, if Global L0
+shows competing Currency snapshot hashes, or if the producer cannot advance.
+
+### Rejoin validators one at a time
+
+1. Start node 2 with normal `run-validator` and join it to the producer.
+2. Wait for node 2 to become `Ready`, then confirm the consensus committee and
+   snapshot proofs contain both peers. Do not infer success from cluster
+   membership alone.
+3. Start node 3 with normal `run-validator` and repeat the checks until committee
+   membership and proofs contain all three peers.
+4. Confirm ordinals continue advancing at the expected cadence, then re-enable
+   monitoring and automatic restarts.
+
+The rollback flag is not used by either joining validator. A
+`dag_consensus_validator_solo_blocked` increment during a transient one-peer
+local view is a safety action; it should cease once the node follows the
+producer's outcome and is admitted.
+
+## Source anchors
+
+These line references describe the branch at the time this runbook was written:
+
+- CLI default and explicit flag:
+  [`method.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala#L243-L283).
+- Default-vs-forced bootstrap selection, warning, and metrics:
+  [`CurrencyL0App.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala#L73-L79)
+  and the [rollback call site](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala#L432-L466).
+- Currency validator-mode initialization:
+  [`CurrencyL0App.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala#L321-L359)
+  and the shared solo-production guard in
+  [`ConsensusRoundRunner.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusRoundRunner.scala#L102-L129).
+- Rollback fast-path and `metagraphSyncData` resolution:
+  [`Rollback.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala#L75-L160).
+- Four-ordinal observation and facilitation handoff:
+  [`Download.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Download.scala#L75-L173).
+- Peer registration lifecycle and persistence:
+  [`ConsensusEventLoop.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/ConsensusEventLoop.scala#L316-L330)
+  and
+  [`ConsensusStorage.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/ConsensusStorage.scala#L925-L957).
+- Singleton admission quorum and stall feasibility:
+  [`StallDetector.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala#L1330-L1365)
+  and the [feasibility check](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/StallDetector.scala#L1596-L1619).
+- Certified committee append:
+  [`ConsensusPeerController.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/ConsensusPeerController.scala#L185-L193)
+  and
+  [`CurrencySnapshotConsensusStateAdvancer.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala#L398-L403).
+- Emergency floor, expansion budget, and cadence defaults:
+  [`types.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala#L327-L365);
+  cadence application:
+  [`CurrencySnapshotConsensusStateCreator.scala`](../../modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala#L267-L274).
+- IntegrationNet Core floor:
+  [`currency-l0.conf`](../../modules/currency-l0/src/main/resources/currency-l0.conf#L25-L34);
+  deterministic tier construction:
+  [`CommitteeBuilder.scala`](../../modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/CommitteeBuilder.scala#L147-L230).

--- a/docs/release/currency-l0-solo-rollback.md
+++ b/docs/release/currency-l0-solo-rollback.md
@@ -1,0 +1,48 @@
+# Currency L0 rollback recovery: operator release note
+
+This release adds an opt-in Currency L0 recovery command for a fully stopped
+metagraph:
+
+```text
+currency-l0 run-rollback ... --allow-solo-consensus
+```
+
+The override lets one designated rollback node seed the next consensus outcome
+with itself so it can produce the snapshots that returning validators need for
+their observation window. The flag is off by default. Normal rollback continues
+to preserve the checkpoint proof-signer committee and ordering.
+
+## Operator-visible behavior change
+
+Currency L0 now marks `run-validator` processes as validators at startup, as
+DAG L0 already does. A validator whose temporary local view contains only
+itself will no longer produce a competing solo history. Consequently, restarting
+only one former validator is not a recovery procedure for a fully stopped
+metagraph. Use the coordinated rollback procedure when that situation occurs.
+
+This is an intentional fork-safety tradeoff. It does not change snapshot or
+state-proof schemas, signed message schemas, deterministic configuration, or
+behavior for a normally operating cluster.
+
+## Required operational controls
+
+> **DANGER — never persist `--allow-solo-consensus`.** Do not put it in a
+> systemd unit, container entrypoint, deployment manifest, environment variable,
+> or monitoring/automatic-restart command. It is a one-node, one-invocation
+> outage-recovery override. Repeating it automatically on isolated nodes can
+> create conflicting valid histories.
+
+Before using it:
+
+1. Confirm the metagraph is fully stopped and disable every automatic restart.
+2. Deploy the same jar to all metagraph nodes.
+3. Run rollback with the flag on exactly one designated producer.
+4. Confirm that producer advances at least five ordinals.
+5. Rejoin the remaining nodes one at a time with ordinary `run-validator`.
+6. Remove the flag from the operator command and verify all persistent launch
+   configurations remain flag-free before restoring monitoring.
+
+See the full
+[Currency L0 single-node rollback recovery runbook](../operations/currency-l0-solo-rollback.md)
+for safety checks, metrics, committee-regrowth expectations, and stop
+conditions.

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -28,6 +28,7 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.state._
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.EventTrigger
 import io.constellationnetwork.node.shared.infrastructure.gossip.event.{ChainTip, EventGossipConfig, EventGossipDaemon}
 import io.constellationnetwork.node.shared.infrastructure.gossip.{GossipDaemon, RumorHandlers}
+import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastCheckpointInfo
 import io.constellationnetwork.node.shared.infrastructure.statechannel.StateChannelAllowanceLists
 import io.constellationnetwork.node.shared.resources.MkHttpServer.ServerName
@@ -65,6 +66,17 @@ trait OverridableL0 extends TessellationIOApp[Run] {
   def customArtifacts(
     lastCurrencySnapshot: Signed[CurrencyIncrementalSnapshot]
   ): Option[SortedSet[SharedArtifact]] = None
+}
+
+object CurrencyL0App {
+
+  private[currency] def rollbackBootstrapFacilitators(
+    nodeId: PeerId,
+    proofSigners: List[PeerId],
+    allowSoloConsensus: Boolean
+  ): List[PeerId] =
+    if (allowSoloConsensus || !proofSigners.contains(nodeId)) List(nodeId)
+    else proofSigners
 }
 
 abstract class CurrencyL0App(
@@ -309,7 +321,8 @@ abstract class CurrencyL0App(
             _ <- StateChannel.performGlobalL0PeerDiscovery[IO](storages, programs)
             innerProgram <- other match {
               case rv: RunValidator =>
-                storages.identifier.setInitial(rv.identifier) >>
+                storages.node.setValidatorMode >>
+                  storages.identifier.setInitial(rv.identifier) >>
                   HasherSelector[IO].withCurrent { implicit hs =>
                     StateChannel.performGlobalL0SnapshotProcess(
                       storages,
@@ -342,7 +355,8 @@ abstract class CurrencyL0App(
                   )
 
               case m: RunValidatorWithJoinAttempt =>
-                storages.identifier.setInitial(m.identifier) >>
+                storages.node.setValidatorMode >>
+                  storages.identifier.setInitial(m.identifier) >>
                   gossipDaemon.startAsRegularValidator >>
                   HasherSelector[IO].withCurrent { implicit hs =>
                     StateChannel.performGlobalL0SnapshotProcess(
@@ -418,12 +432,36 @@ abstract class CurrencyL0App(
                         )
                       }
                       hashedSnapshot <- currencySnapshot.toHashed[IO]
-                      // Derive Facilitators/EligibleFacilitators from the signed snapshot's proofs so
-                      // every node rolling back seeds an IDENTICAL outcome. If this node was NOT a
-                      // signer, fall back to self-only so it can solo-produce. See dag-l0 Main.scala
-                      // for full rationale.
+                      // By default, derive both facilitator sets from the signed snapshot's proofs
+                      // so signer nodes seed an identical outcome. A non-signer keeps the existing
+                      // self-only fallback. The explicit recovery override also forces self-only,
+                      // accepting the documented risk of conflicting histories.
                       signers = currencySnapshot.proofs.toSortedSet.toList.map(_.id.toPeerId)
-                      bootstrapFacilitators = if (signers.contains(nodeId)) signers else List(nodeId)
+                      bootstrapFacilitators =
+                        CurrencyL0App.rollbackBootstrapFacilitators(nodeId, signers, rr.allowSoloConsensus)
+                      bootstrapMode =
+                        if (rr.allowSoloConsensus) "forced_self_only"
+                        else if (bootstrapFacilitators === signers) "proof_signers"
+                        else "self_only_fallback"
+                      _ <- logger
+                        .warn(
+                          s"DANGER: Currency L0 rollback is forcing self-only consensus at ordinal=${currencySnapshot.ordinal}. " +
+                            s"Exactly one coordinated recovery node may use this override. " +
+                            s"nodeId=${nodeId.value.value.take(8)} proofSigners=${signers.map(_.value.value.take(8)).mkString(",")}"
+                        )
+                        .whenA(rr.allowSoloConsensus)
+                      _ <- Metrics[IO].incrementCounter(
+                        "dag_consensus_rollback_bootstrap_total",
+                        Seq(Metrics.unsafeLabelName("mode") -> bootstrapMode)
+                      )
+                      _ <- Metrics[IO].updateGauge(
+                        "dag_consensus_rollback_proof_signer_count",
+                        signers.size.toLong
+                      )
+                      _ <- Metrics[IO].updateGauge(
+                        "dag_consensus_rollback_bootstrap_facilitator_count",
+                        bootstrapFacilitators.size.toLong
+                      )
                       // Restore consensus-derived peer-behavior counters from the rollback
                       // snapshot if present. Older snapshots have `peerHistory = None` and the
                       // cluster bootstraps from zero just as before. See dag-l0 mirror for the

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/cli/method.scala
@@ -252,10 +252,19 @@ object method {
     globalL0Peer: L0Peer,
     identifier: Address,
     trustRatingsPath: Option[Path],
-    allowanceListPath: Option[AllowanceListPath]
+    allowanceListPath: Option[AllowanceListPath],
+    allowSoloConsensus: Boolean = false
   ) extends Run
 
   object RunRollback extends WithOpts[RunRollback] {
+
+    private[currency] val allowSoloConsensusOpts: Opts[Boolean] =
+      Opts
+        .flag(
+          "allow-solo-consensus",
+          "DANGER: seed rollback consensus with this node only; use on exactly one node during coordinated recovery"
+        )
+        .orFalse
 
     val opts: Opts[RunRollback] = Opts.subcommand("run-rollback", "Run rollback mode") {
       (
@@ -270,7 +279,8 @@ object method {
         GlobalL0PeerOpts.opts,
         L0TokenIdentifierOpts.opts,
         trustRatingsPathOpts,
-        AllowanceListPath.opts
+        AllowanceListPath.opts,
+        allowSoloConsensusOpts
       ).mapN(RunRollback.apply)
     }
   }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/CurrencyL0AppSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/CurrencyL0AppSuite.scala
@@ -1,0 +1,206 @@
+package io.constellationnetwork.currency.l0
+
+import cats.data.NonEmptySet
+import cats.effect.IO
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.concurrent.duration._
+
+import io.constellationnetwork.currency.l0.cli.method
+import io.constellationnetwork.node.shared.config.types.{ConsensusConfig, EventCutterConfig}
+import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusPeerController.{AdmissionInput, AdmissionSizing}
+import io.constellationnetwork.node.shared.infrastructure.consensus.declaration.{AdmissionReason, AdmissionVote}
+import io.constellationnetwork.node.shared.infrastructure.consensus.engine.AdmissionCertificateBuilder
+import io.constellationnetwork.node.shared.infrastructure.consensus.state.QuorumPolicy
+import io.constellationnetwork.node.shared.infrastructure.consensus.{CommitteeBuilder, ConsensusPeerController}
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import com.monovore.decline.Command
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
+import weaver.SimpleIOSuite
+
+object CurrencyL0AppSuite extends SimpleIOSuite {
+
+  private val self: PeerId = PeerId(Hex("aa" * 64))
+  private val peerB: PeerId = PeerId(Hex("bb" * 64))
+  private val peerC: PeerId = PeerId(Hex("cc" * 64))
+  private val facilitatorsHash: Hash = Hash.fromBytes("FACILITATORS".getBytes("UTF-8"))
+  private val lastSnapshotHash: Hash = Hash.fromBytes("LAST_SNAPSHOT".getBytes("UTF-8"))
+
+  // Mirrors the Currency L0 IntegrationNet values relevant to AdmissionSizing.from:
+  // activeFacilitatorFloor defaults to 4, coreCommitteeSize resolves to 9,
+  // consensus.maxFacilitatorCount is 20, and active target/max are not configured.
+  private val integrationNetCoreFloor = 9
+  private val integrationNetConsensusConfig =
+    ConsensusConfig(
+      timeTriggerInterval = 10.seconds,
+      declarationTimeout = 10.seconds,
+      declarationRangeLimit = 100L,
+      lockDuration = 10.seconds,
+      eventCutter = EventCutterConfig(
+        maxBinarySizeBytes = PosInt(1024),
+        maxUpdateNodeParametersSize = PosInt(1024)
+      ),
+      maxFacilitatorCount = Some(PosInt(20)),
+      activeFacilitatorFloor = 4,
+      activeFacilitatorTarget = None,
+      activeFacilitatorMax = None
+    )
+
+  test("rollback preserves proof-signer order by default when self signed the checkpoint") {
+    val signers = List(peerC, self, peerB)
+
+    IO(
+      expect.same(
+        signers,
+        CurrencyL0App.rollbackBootstrapFacilitators(self, signers, allowSoloConsensus = false)
+      )
+    )
+  }
+
+  test("rollback preserves the existing self-only fallback when self did not sign the checkpoint") {
+    val signers = List(peerB, peerC)
+
+    IO(
+      expect.same(
+        List(self),
+        CurrencyL0App.rollbackBootstrapFacilitators(self, signers, allowSoloConsensus = false)
+      )
+    )
+  }
+
+  test("allow-solo-consensus forces a self-only bootstrap despite multiple proof signers") {
+    val signers = List(self, peerB, peerC)
+
+    IO(
+      expect.same(
+        List(self),
+        CurrencyL0App.rollbackBootstrapFacilitators(self, signers, allowSoloConsensus = true)
+      )
+    )
+  }
+
+  test("allow-solo-consensus CLI option defaults off and requires the explicit flag") {
+    val command = Command("currency-l0-test", "test parser")(method.RunRollback.allowSoloConsensusOpts)
+
+    IO(
+      expect.same(Some(false), command.parse(Seq.empty).toOption) &&
+        expect.same(Some(true), command.parse(Seq("--allow-solo-consensus")).toOption)
+    )
+  }
+
+  test("a singleton rollback committee can form an admission certificate from its own vote") {
+    val singleton = CurrencyL0App.rollbackBootstrapFacilitators(
+      self,
+      List(self, peerB, peerC),
+      allowSoloConsensus = true
+    )
+    val admissionQuorum = QuorumPolicy.fromFraction(singleton.size, fraction = 1.0)
+    val vote =
+      Signed(
+        AdmissionVote(
+          targetPeer = peerB,
+          reason = AdmissionReason.ReadyAtTip,
+          facilitatorsHash = facilitatorsHash,
+          lastSnapshotHash = lastSnapshotHash
+        ),
+        NonEmptySet.of(SignatureProof(Id(self.value), Signature(Hex("00"))))
+      )
+    val certificate =
+      AdmissionCertificateBuilder.build(
+        target = peerB,
+        reason = AdmissionReason.ReadyAtTip,
+        facilitatorsHash = facilitatorsHash,
+        lastSnapshotHash = lastSnapshotHash,
+        votes = Map(self -> vote),
+        quorumSize = admissionQuorum,
+        witnessPool = singleton.toSet
+      )
+    val excludedVoter =
+      AdmissionCertificateBuilder.build(
+        target = peerB,
+        reason = AdmissionReason.ReadyAtTip,
+        facilitatorsHash = facilitatorsHash,
+        lastSnapshotHash = lastSnapshotHash,
+        votes = Map(self -> vote),
+        quorumSize = admissionQuorum,
+        witnessPool = Set.empty
+      )
+
+    IO(
+      expect.same(1, admissionQuorum) &&
+        expect(certificate.exists(_.votes.length == 1), s"singleton vote should form a certificate: $certificate") &&
+        expect(
+          excludedVoter.swap.exists(_.code.startsWith("under_quorum")),
+          s"the same vote must not count outside the witness pool: $excludedVoter"
+        )
+    )
+  }
+
+  test("certified returning peers are retained and promoted below the IntegrationNet emergency floor") {
+    val singleton = CurrencyL0App.rollbackBootstrapFacilitators(
+      self,
+      List(self, peerB, peerC),
+      allowSoloConsensus = true
+    )
+    val afterFirstCertificate = ConsensusPeerController.applyCertifiedAdmissions(singleton, List(peerB))
+    val afterSecondCertificate = ConsensusPeerController.applyCertifiedAdmissions(afterFirstCertificate, List(peerC))
+    val firstCommittees = committeesFor(afterFirstCertificate)
+    val secondCommittees = committeesFor(afterSecondCertificate)
+    val resolvedSizing =
+      AdmissionSizing.from(
+        integrationNetConsensusConfig,
+        coreCommitteeSize = integrationNetCoreFloor,
+        selectedSize = afterSecondCertificate.size
+      )
+
+    IO(
+      expect.same(AdmissionSizing(4, 9, 20), resolvedSizing) &&
+        expect.same(List(self, peerB), firstCommittees._1) &&
+        expect.same(List(self, peerB), firstCommittees._2) &&
+        expect.same(List(self, peerB, peerC), secondCommittees._1) &&
+        expect.same(List(self, peerB, peerC), secondCommittees._2)
+    )
+  }
+
+  private def committeesFor(selected: List[PeerId]): (List[PeerId], List[PeerId]) = {
+    val active = ConsensusPeerController
+      .chooseActive(
+        AdmissionInput(
+          selected = selected,
+          recentSigners = SortedMap.empty[SnapshotOrdinal, SortedSet[PeerId]],
+          latestRoundStartFacilitators = Set.empty,
+          peerQuality = Map.empty,
+          activeScores = Map.empty,
+          sizing = AdmissionSizing.from(
+            integrationNetConsensusConfig,
+            coreCommitteeSize = integrationNetCoreFloor,
+            selectedSize = selected.size
+          ),
+          minParticipationObservations = 10,
+          minParticipationRatio = 0.5,
+          config = ConsensusPeerController.Config.default
+        )
+      )
+      .active
+    val core = CommitteeBuilder
+      .build(
+        candidates = active,
+        priorTiers = SortedMap.empty,
+        peerQuality = Map.empty,
+        coreFloor = integrationNetCoreFloor,
+        minObservations = 10,
+        minRatio = 0.5
+      )
+      .core
+
+    active -> core
+  }
+}


### PR DESCRIPTION
## Summary

- add the opt-in Currency L0 `run-rollback --allow-solo-consensus` recovery override
- seed the post-rollback facilitator and eligible sets with only the designated recovery node when explicitly enabled
- preserve the existing proof-signer rollback behavior and ordering when the flag is absent
- mark Currency L0 `run-validator` startup as validator mode, matching DAG L0 and blocking accidental solo production from a transient one-peer view
- add rollback bootstrap warnings, mode/count metrics, focused regression coverage, an operator release note, and a coordinated recovery runbook

## Why

A fully stopped metagraph can deadlock during recovery. Normal rollback inherits the checkpoint's proof-signer committee, so one restarted signer cannot finalize the next ordinal. Returning validators cannot help until their `tip + 4` observation window completes, but those snapshots cannot exist while consensus is stopped.

The override lets exactly one coordinated rollback node produce the missing snapshots. Other nodes then rejoin through ordinary `run-validator` and the existing quorum-certified admission path.

## Safety and compatibility

- The flag defaults to `false`; default signer selection is an exact re-expression of the existing behavior.
- This changes no snapshot/state-proof schema, signed consensus message, deterministic configuration hash, or activation ordinal.
- The flag is an operational input and intentionally changes the new post-rollback facilitator history when used.
- It must be used on exactly one node for exactly one rollback invocation.
- It must never be persisted in systemd, container, deployment, or monitoring restart configuration. The runbook requires automatic restarts to be disabled during recovery.
- The same jar should be deployed to all metagraph nodes; only the designated producer receives the one-shot flag.

See `docs/operations/currency-l0-solo-rollback.md` and `docs/release/currency-l0-solo-rollback.md`.

## Verification

- `currencyL0/testOnly io.constellationnetwork.currency.l0.CurrencyL0AppSuite`: 6 passed, 0 failed
- `currencyL0/test`: 43 passed, 0 failed
- `git diff --check`: clean

The focused coverage verifies default compatibility, explicit CLI opt-in, forced self-only selection, quorum-one certificate formation through the singleton witness-pool filter, and post-certificate 1 -> 2 -> 3 active/Core growth using IntegrationNet-derived admission sizing.

A full stopped-cluster recovery E2E is intentionally left to the deployed staging metagraph before operational reliance.
