### PR TITLE
fix(consensus): stabilize Tier-1 membership under load

### DIFF
--- a/docs/adr/0030-broad-tier1-signing-leases-and-canonical-admission.md
+++ b/docs/adr/0030-broad-tier1-signing-leases-and-canonical-admission.md
@@ -83,15 +83,23 @@ mechanics, with its existing controller-target gate preserved.
     proof-miss streaks for every peer in `currentTier1 intersect
     parentRoundCommittee`, then select one audit target from that complete,
     consensus-agreed set by rendezvous rank. A current Core member emits the existing
-    `EvictionVote(Silent)` only after the target is absent from three consecutive
-    locally finalized parent artifact proof sets **and** those locally observed
-    current-committee signers cannot support the finality floor for one additional
-    seat. Reuse
-    `TierTransitions.DemotionConsecutiveMisses`; reset a peer's streak on any observed
-    proof. The eviction headroom check is the exact inverse of the open-admission
-    invariant in decision 14. Newly admitted peers are not auditable until they have
-    had a parent-round signing opportunity. Restart, missing parent evidence, or a
-    non-consecutive parent ordinal clears local streaks, delaying eviction conservatively.
+    `EvictionVote(Silent)` only when all of the following hold:
+    - the target is absent from three consecutive locally finalized parent artifact
+      proof sets, reusing `TierTransitions.DemotionConsecutiveMisses`;
+    - those observations span at least `(DemotionConsecutiveMisses - 1) *
+      timeTriggerInterval`, preserving the normal elapsed observation window when
+      EventTrigger accelerates rounds;
+    - locally observed current-committee signers are below the finality floor for the
+      **current** committee; and
+    - the round is on the existing `activeAdmissionExpansionIntervalRounds` cadence.
+
+    Any observed proof resets both the count and elapsed-time streak. Newly admitted
+    peers are not auditable until they have had a parent-round signing opportunity.
+    Restart, missing parent evidence, or a non-consecutive parent ordinal clears local
+    streaks, delaying eviction conservatively. The count, monotonic time, and cadence
+    are local vote-emission policy only; certified membership remains authoritative.
+    This cadence applies only to the proactive Tier-1 finality audit. Certified Core
+    stall eviction remains an every-round liveness recovery path.
 11. A Tier-1 target requires a Core-quorum certificate. A Core-target stall eviction
     retains the wider deterministic historical witness pool; the target's frozen tier
     selects between these two existing lanes at both assembly and validation.
@@ -123,6 +131,19 @@ mechanics, with its existing controller-target gate preserved.
     raise the active finality requirement; applying the later floor would also make
     singleton growth impossible under unanimity. Currency L0 does not apply this gate
     because its unanimity policy could never prove an unseated `(n + 1)`th signer.
+    Use the related current-seat invariant to create an exact three-state membership
+    policy, where `S` is the locally observed current-committee signer count and `F(n)`
+    is the configured finality floor for committee size `n`:
+
+    ```text
+    expand: S >= F(n + 1)
+    hold:   F(n) <= S < F(n + 1)
+    evict:  S < F(n)
+    ```
+
+    The neutral hold band is intentional. Making eviction the boolean complement of
+    expansion causes deterministic boundary oscillation when `F(n) == F(n + 1)` but
+    `F(n + 2)` steps upward.
 15. Proposal validation counts distinct voter PeerIds in each AdmissionCertificate,
     not the number of signed vote wrappers. DAG and Currency apply the same rule as
     certificate assembly.
@@ -142,13 +163,14 @@ mechanics, with its existing controller-target gate preserved.
 - Core can remain small and reliable while Tier 1 grows toward the healthy Ready
   population. Tier-1 silence does not enter the normal liveness denominator.
 - Open-admission gossip is bounded to approximately one vote per Core member per
-  round instead of one vote per monitor tick and candidate.
-- Finality-audit gossip is also bounded to at most one eviction vote per Core member
-  per round. No vote is emitted until that node has observed three consecutive proof
-  misses for the selected target **and** lacks next-seat finality headroom. A slow
-  Tier-1 peer is therefore retained while the observed signer population can safely
-  support the seat. This is an audit-work budget, not a cap on Tier-1 membership or
-  rewards.
+  cadence opportunity instead of one vote per monitor tick and candidate.
+- Finality-audit gossip is bounded to at most one eviction vote per Core member on the
+  same five-round cadence as open expansion. No vote is emitted until that node has
+  observed three consecutive proof misses over the configured minimum elapsed window
+  for the selected target **and** the current committee is already below its own
+  finality floor. The neutral current-floor-to-next-floor band changes no membership,
+  preventing adjacent-size oscillation. This is an audit-work budget, not a cap on
+  Tier-1 membership or rewards.
 - A Tier-1 lease is removed only when enough Core nodes independently failed to
   observe its signature by their parent-round finalization cutoffs and the resulting
   certificate is accepted. The assertion is quorum-observed untimeliness, not proof

--- a/docs/adr/0030-broad-tier1-signing-leases-and-canonical-admission.md
+++ b/docs/adr/0030-broad-tier1-signing-leases-and-canonical-admission.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-04
 
-Updated: 2026-08-05
+Updated: 2026-08-10
 
 Status: Accepted
 
@@ -64,7 +64,11 @@ mechanics, with its existing controller-target gate preserved.
    reject new/open admission targets.
    Open Ready-at-tip votes and certificates are eligible only on the existing
    `activeAdmissionExpansionIntervalRounds` cadence. The shipped interval is five
-   rounds. Probation readmission is not cadence-gated.
+   rounds. Probation readmission is not cadence-gated. A `readmissionCountdown` map
+   entry remains probation authority when its value reaches zero; only an accepted
+   AdmissionCertificate removes the entry. When probation and open certificates
+   compete for the one-certificate proposal budget, probation recovery is selected
+   first and rendezvous ordering resolves peers within the same lane.
 7. Rendezvous-rank certificates only when constructing a proposal. Keep the legacy
    `AdmissionCertificate.ordering` at the apply-site defense-in-depth boundary.
 8. Do not change reward arithmetic or activation ordinals. Before
@@ -80,11 +84,14 @@ mechanics, with its existing controller-target gate preserved.
     parentRoundCommittee`, then select one audit target from that complete,
     consensus-agreed set by rendezvous rank. A current Core member emits the existing
     `EvictionVote(Silent)` only after the target is absent from three consecutive
-    locally finalized parent artifact proof sets. Reuse
+    locally finalized parent artifact proof sets **and** those locally observed
+    current-committee signers cannot support the finality floor for one additional
+    seat. Reuse
     `TierTransitions.DemotionConsecutiveMisses`; reset a peer's streak on any observed
-    proof. Newly admitted peers are not auditable until they have had a parent-round
-    signing opportunity. Restart, missing parent evidence, or a non-consecutive
-    parent ordinal clears local streaks, delaying eviction conservatively.
+    proof. The eviction headroom check is the exact inverse of the open-admission
+    invariant in decision 14. Newly admitted peers are not auditable until they have
+    had a parent-round signing opportunity. Restart, missing parent evidence, or a
+    non-consecutive parent ordinal clears local streaks, delaying eviction conservatively.
 11. A Tier-1 target requires a Core-quorum certificate. A Core-target stall eviction
     retains the wider deterministic historical witness pool; the target's frozen tier
     selects between these two existing lanes at both assembly and validation.
@@ -121,7 +128,9 @@ mechanics, with its existing controller-target gate preserved.
     certificate assembly.
 16. Report the actual finality requirement outside bootstrap from the frozen Core +
     Tier-1 committee floor, not the Core strict-majority diagnostic. Expose the
-    first-quorum finality margin and the open-admission cadence/headroom decision.
+    first-quorum finality margin, the open-admission cadence/headroom decision, the
+    Tier-1 eviction headroom decision, and sticky probation entries ready at countdown
+    zero.
 
 ## Consequences
 
@@ -135,9 +144,11 @@ mechanics, with its existing controller-target gate preserved.
 - Open-admission gossip is bounded to approximately one vote per Core member per
   round instead of one vote per monitor tick and candidate.
 - Finality-audit gossip is also bounded to at most one eviction vote per Core member
-  per round, and no vote is emitted until that node has observed three consecutive
-  proof misses for the selected target. This is an audit-work budget, not a cap on
-  Tier-1 membership or rewards.
+  per round. No vote is emitted until that node has observed three consecutive proof
+  misses for the selected target **and** lacks next-seat finality headroom. A slow
+  Tier-1 peer is therefore retained while the observed signer population can safely
+  support the seat. This is an audit-work budget, not a cap on Tier-1 membership or
+  rewards.
 - A Tier-1 lease is removed only when enough Core nodes independently failed to
   observe its signature by their parent-round finalization cutoffs and the resulting
   certificate is accepted. The assertion is quorum-observed untimeliness, not proof

--- a/docs/adr/0031-recovery-outcome-storage-alignment.md
+++ b/docs/adr/0031-recovery-outcome-storage-alignment.md
@@ -1,0 +1,58 @@
+# ADR-0031: Align application storage when recovery accepts a newer outcome
+
+Date: 2026-08-10
+
+Status: Accepted
+
+## Context
+
+Global-L0 incremental recovery downloads and observes snapshots before initializing
+consensus. The requested consensus outcome can be evicted while this handoff is in
+progress. In that case the specific-outcome endpoint returns Conflict and the client
+falls back to the peer's latest outcome.
+
+The existing initialization path accepted that newer outcome into consensus but left
+application snapshot storage at the ordinal that recovery had just observed. A captured
+IntegrationNet failure converged application storage at ordinal N, accepted consensus
+outcome N+1, then finalized N+2. `LastNGlobalSnapshotStorage.set` correctly rejected N+2
+as non-contiguous because it still required N+1, and subsequent `CheckUpdate` retries
+could not repair the torn handoff.
+
+A contemporaneous DownloadDaemon `aborting retry loop` message was not the cause. It
+followed an explicit successful recovery-convergence log and came from a queued state
+event cancelled after the download semaphore was released.
+
+## Decision
+
+1. Classify download initialization into three cases:
+   - exact key, artifact, and context: preserve the caller's recovery mode;
+   - different key from the latest-outcome fallback: accept it only through the
+     layer-specific storage-alignment hook and treat it as recovery;
+   - same key with a different artifact or context: reject it.
+2. Before Global L0 installs a different-key outcome into consensus, run one required
+   initialization sequence that:
+   - reset `LastNGlobalSnapshotStorage` to the accepted artifact/context;
+   - reset `LastSnapshotStorage` to the same pair;
+   - move the persisted snapshot head to that pair;
+   - rebuild the MPT from the accepted context at its ordinal; and
+   - remove locally held mempool events already committed by the accepted artifact.
+3. Store the accepted outcome key, rather than the originally requested stale key, in
+   the recovery marker.
+4. Keep Currency L0's layer hook inert because it does not use Global L0's incremental
+   recovery storage stack.
+5. Include current and incoming ordinal/hash in non-contiguous Last-N storage errors.
+
+## Consequences
+
+- Consensus and application storage begin the next round at the same accepted ordinal,
+  preventing the observed N/N+1/N+2 contiguity failure.
+- Failure of any alignment step prevents consensus initialization instead of allowing a
+  partially aligned node to become Ready; the normal recovery retry resets the stores
+  again before another attempt.
+- No artifact, snapshot, state-proof, consensus-message, or deterministic-configuration
+  schema changes. The behavior is node-local recovery plumbing.
+- The latest-outcome fallback and its ability to catch a recovering node up remain
+  unchanged.
+- Operators must correlate DownloadDaemon cancellation with the preceding convergence
+  result; cancellation after convergence is expected cleanup, not proof of an aborted
+  in-flight recovery.

--- a/docs/operations/v4.1-tier1-admission-rollout.md
+++ b/docs/operations/v4.1-tier1-admission-rollout.md
@@ -1,8 +1,9 @@
 # v4.1 Tier-1 admission and finality-audit rollout
 
 This runbook covers the Global-L0 broad Core + Tier-1 signing/reward committee,
-five-round open-admission cadence, exact next-seat headroom gate, and three-proof-miss
-Tier-1 eviction hysteresis introduced with ADR-0030.
+five-round proactive membership-change cadence, exact expand/hold/evict headroom policy, and
+round-plus-time Tier-1 eviction hysteresis introduced with ADR-0030. It also covers
+the recovery outcome-storage alignment in ADR-0031.
 
 It does not introduce a Global Incremental Snapshot, Global Snapshot Info, or Global
 Snapshot State Proof schema change. It adds no activation ordinal and does not change
@@ -47,10 +48,18 @@ inside the live cluster.
   next-seat invariant starts with the existing post-bootstrap full-committee floor.
 - Every node tracks actual local parent-proof misses for every auditable Tier-1 peer.
   A Core node emits the selected target's eviction vote only after three consecutive
-  misses **and** only when the locally observed current-committee signer population is
-  below the finality floor for one additional seat. Any observed proof resets that
-  peer. Restart, missing parent evidence, or a non-consecutive parent ordinal clears
-  the local history, delaying eviction.
+  misses spanning at least two configured `timeTriggerInterval` periods, **and** only
+  when the locally observed signer population is below the finality floor for the
+  committee already seated. Any observed proof resets both the round and elapsed-time
+  streak. Restart, missing parent evidence, or a non-consecutive parent ordinal clears
+  the local history, delaying eviction. Silent-audit votes use the same existing
+  five-round cadence as open expansion; penalty/probation recovery remains separate.
+  Core stall eviction is also a separate liveness-recovery lane and remains available
+  every round.
+- Membership has three exact states. If observed signers satisfy the next-seat floor,
+  expansion may proceed. If they satisfy the current floor but not the next-seat floor,
+  membership holds. Only a deficit against the current floor permits a silent-eviction
+  vote. This dead band prevents adjacent committee sizes from oscillating.
 - Outside bootstrap, finality remains the supermajority floor of the complete frozen
   Core + Tier-1 committee. The audit does not lower the current-round floor and cannot
   recover a committee that is already unable to finalize.
@@ -123,26 +132,37 @@ accepted proposal. A probation certificate may do so on any round.
 `dag_consensus_tier1_finality_audit_total{outcome=...}` distinguishes:
 
 - `signature_observed`: the selected target signed and its streak is reset;
-- `hysteresis_wait`: locally missed, but fewer than three consecutive misses;
-- `vote_emitted`: third-or-later consecutive miss caused this Core node to vote;
+- `round_hysteresis_wait`: locally missed, but fewer than three consecutive misses;
+- `duration_hysteresis_wait`: three misses occurred too quickly to span the configured
+  elapsed-time floor;
+- `vote_emitted`: the count, elapsed time, current-floor deficit, and cadence all
+  qualified, so this Core node voted;
+- `membership_hold`: current finality remains supported but the next seat is not, so
+  neither admission nor eviction is allowed;
 - `headroom_preserved`: the miss streak qualified, but the observed signer population
   could safely support one additional seat, so the node abstained;
+- `off_cadence`: an otherwise-qualified silent audit abstained until the next existing
+  membership-change cadence opportunity;
 - `already_voted`: the round-local vote already exists;
 - `missing_parent_evidence`: history was cleared instead of inferring a miss;
 - `error`: the audit failed open and the round continued.
 
-The `stage=tier1_finality_audit`, `stage=tier1_finality_audit_hysteresis`, and
-`stage=tier1_finality_audit_headroom_preserved` logs include miss counts, current
-committee size, observed current-committee signers, next finality floor, and margin.
+The `stage=tier1_finality_audit` and `stage=tier1_finality_audit_suppressed` logs
+include miss count and duration, current committee size/floor/margin, next-seat
+floor/margin, cadence eligibility, and the suppression outcome.
 
 | Metric | Expected meaning |
 |---|---|
 | `dag_consensus_tier1_finality_audit_current_committee_size` | Current Core + Tier-1 signing committee used for the local decision. |
 | `dag_consensus_tier1_finality_audit_observed_current_committee_signers` | Locally finalized parent proofs intersected with that committee. |
+| `dag_consensus_tier1_finality_audit_current_finality_floor` | Exact finality floor for the committee already seated. |
+| `dag_consensus_tier1_finality_audit_current_finality_margin` | Observed signers minus the current-seat floor. Negative is the only headroom state permitting silent eviction. |
 | `dag_consensus_tier1_finality_audit_next_committee_size` | Current committee plus exactly one seat. |
 | `dag_consensus_tier1_finality_audit_next_finality_floor` | Exact finality floor for one additional seat. |
-| `dag_consensus_tier1_finality_audit_finality_margin` | Observed signers minus the next-seat floor. Non-negative suppresses silence eviction. |
-| `dag_consensus_tier1_finality_audit_silent_eviction_allowed` | `1` only when next-seat headroom is absent; hysteresis must still qualify separately. |
+| `dag_consensus_tier1_finality_audit_finality_margin` | Observed signers minus the next-seat floor; retained for admission/headroom dashboard compatibility. |
+| `dag_consensus_tier1_finality_audit_membership_hold` | `1` in the neutral current-floor-to-next-floor band. |
+| `dag_consensus_tier1_finality_audit_cadence_allowed` | `1` only on the existing membership-change cadence. |
+| `dag_consensus_tier1_finality_audit_silent_eviction_allowed` | `1` only for a deficit against the current-seat floor; count, time, and cadence must still qualify separately. |
 | `dag_consensus_readmission_probation_size` | All probation map entries, including countdown zero. |
 | `dag_consensus_readmission_probation_ready_size` | Sticky probation entries at countdown zero, awaiting certified recovery. |
 
@@ -157,8 +177,9 @@ when all of the following hold across cadence opportunities:
 - proof count and actual finality requirement grow together without a sustained rise
   in view changes or round duration;
 - `acs_build_failed reason=under_quorum` is no longer the dominant admission outcome;
-- Tier-1 audit votes appear only after hysteresis and only without next-seat headroom,
-  rather than load-compressed rounds turning proof-tail latency into eviction churn;
+- Tier-1 audit votes appear only after round and elapsed-time hysteresis, on cadence,
+  and only during a current-floor deficit; load-compressed rounds and the neutral
+  next-seat boundary must not cause eviction churn;
 - Ready peers that remain healthy progressively enter Tier 1 instead of the committee
   ratcheting back to Core-only size.
 
@@ -187,3 +208,20 @@ For rollback:
 No metagraph software rollback is required solely because of the unchanged global
 snapshot/state-proof calculation, but normal cross-layer checkpoint coordination still
 applies.
+
+## Recovery handoff verification
+
+During incremental recovery, the specific consensus-outcome request can return HTTP
+Conflict after the cluster advances beyond the downloaded ordinal. The client then
+fetches the latest outcome. Before that newer outcome is installed into consensus,
+Global L0 must align `LastNGlobalSnapshotStorage`, `LastSnapshotStorage`, snapshot head,
+and MPT state to the accepted artifact/context and remove any newly observed mempool
+events already committed by it.
+
+Monitor `dag_consensus_download_newer_outcome_storage_aligned_total` and the structured
+`stage=newer_outcome_storage_aligned` log. A subsequent non-contiguous snapshot-storage
+error is a rollout blocker; its message now includes both current and incoming ordinal
+and hash. A DownloadDaemon `aborting retry loop` line is not independently evidence of
+a failed recovery: queued state events can be cancelled immediately after a successful
+`RecoveryDownload Converged` handoff. Correlate timestamps and ordinals before assigning
+causality.

--- a/docs/operations/v4.1-tier1-admission-rollout.md
+++ b/docs/operations/v4.1-tier1-admission-rollout.md
@@ -21,6 +21,11 @@ inside the live cluster.
   can add at most one seat every five rounds.
 - Penalty/probation readmission remains available every round through its existing
   wider witness lane. It does not wait for the open cadence or next-seat headroom.
+- Countdown zero remains part of the probation lane until a certificate is accepted.
+  If open and probation certificates compete for the one-certificate proposal budget,
+  probation recovery has priority. The node-local operational sidecar preserves zero-entry
+  membership through its existing integer field; the signed artifact's evidence-only
+  `peerHistory.perPeer` remains empty and unchanged.
 - A probation certificate may clear the target's carried `penaltyUntil` horizon.
   Applying that horizon as a validation blocker to the same recovery certificate
   would make readmission circular; non-probation/open targets remain penalty-blocked.
@@ -42,8 +47,10 @@ inside the live cluster.
   next-seat invariant starts with the existing post-bootstrap full-committee floor.
 - Every node tracks actual local parent-proof misses for every auditable Tier-1 peer.
   A Core node emits the selected target's eviction vote only after three consecutive
-  misses. Any observed proof resets that peer. Restart, missing parent evidence, or
-  a non-consecutive parent ordinal clears the local history, delaying eviction.
+  misses **and** only when the locally observed current-committee signer population is
+  below the finality floor for one additional seat. Any observed proof resets that
+  peer. Restart, missing parent evidence, or a non-consecutive parent ordinal clears
+  the local history, delaying eviction.
 - Outside bootstrap, finality remains the supermajority floor of the complete frozen
   Core + Tier-1 committee. The audit does not lower the current-round floor and cannot
   recover a committee that is already unable to finalize.
@@ -118,13 +125,26 @@ accepted proposal. A probation certificate may do so on any round.
 - `signature_observed`: the selected target signed and its streak is reset;
 - `hysteresis_wait`: locally missed, but fewer than three consecutive misses;
 - `vote_emitted`: third-or-later consecutive miss caused this Core node to vote;
+- `headroom_preserved`: the miss streak qualified, but the observed signer population
+  could safely support one additional seat, so the node abstained;
 - `already_voted`: the round-local vote already exists;
 - `missing_parent_evidence`: history was cleared instead of inferring a miss;
 - `error`: the audit failed open and the round continued.
 
-The `stage=tier1_finality_audit` and
-`stage=tier1_finality_audit_hysteresis` logs include the current and required miss
-counts.
+The `stage=tier1_finality_audit`, `stage=tier1_finality_audit_hysteresis`, and
+`stage=tier1_finality_audit_headroom_preserved` logs include miss counts, current
+committee size, observed current-committee signers, next finality floor, and margin.
+
+| Metric | Expected meaning |
+|---|---|
+| `dag_consensus_tier1_finality_audit_current_committee_size` | Current Core + Tier-1 signing committee used for the local decision. |
+| `dag_consensus_tier1_finality_audit_observed_current_committee_signers` | Locally finalized parent proofs intersected with that committee. |
+| `dag_consensus_tier1_finality_audit_next_committee_size` | Current committee plus exactly one seat. |
+| `dag_consensus_tier1_finality_audit_next_finality_floor` | Exact finality floor for one additional seat. |
+| `dag_consensus_tier1_finality_audit_finality_margin` | Observed signers minus the next-seat floor. Non-negative suppresses silence eviction. |
+| `dag_consensus_tier1_finality_audit_silent_eviction_allowed` | `1` only when next-seat headroom is absent; hysteresis must still qualify separately. |
+| `dag_consensus_readmission_probation_size` | All probation map entries, including countdown zero. |
+| `dag_consensus_readmission_probation_ready_size` | Sticky probation entries at countdown zero, awaiting certified recovery. |
 
 ## Health-dependent growth checks
 
@@ -137,8 +157,8 @@ when all of the following hold across cadence opportunities:
 - proof count and actual finality requirement grow together without a sustained rise
   in view changes or round duration;
 - `acs_build_failed reason=under_quorum` is no longer the dominant admission outcome;
-- Tier-1 audit votes appear only after hysteresis, rather than one slow round causing
-  eviction/readmission churn;
+- Tier-1 audit votes appear only after hysteresis and only without next-seat headroom,
+  rather than load-compressed rounds turning proof-tail latency into eviction churn;
 - Ready peers that remain healthy progressively enter Tier 1 instead of the committee
   ratcheting back to Core-only size.
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -362,7 +362,7 @@ object CurrencySnapshotConsensus {
           admissionVoter,
           (o: CurrencyConsensusOutcome) =>
             !o.recentProofSizes.values.exists(_ >= effectiveConsensusConfig.bootstrapCompleteProofsThreshold),
-          (o: CurrencyConsensusOutcome) => o.readmissionCountdown.filter(_._2 > 0).keySet,
+          (o: CurrencyConsensusOutcome) => ReadmissionMaintenance.probationPeers(o.readmissionCountdown),
           (o: CurrencyConsensusOutcome) => {
             val target = ActiveFacilitatorAdmission.activeAdmissionTarget(
               effectiveConsensusConfig.activeFacilitatorTarget,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -566,7 +566,7 @@ object CurrencySnapshotConsensusStateAdvancer {
         state: CurrencySnapshotConsensusState
       ): Set[PeerId] = {
         val committee = state.roundStartFacilitators.value.toSet
-        val probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        val probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
         val penalized = activeAdmissionPenaltyPeers(state)
         state.lastOutcome.finished.candidates.value -- committee -- probation -- penalized
       }
@@ -586,7 +586,7 @@ object CurrencySnapshotConsensusStateAdvancer {
       ): Option[PeerId] = {
         val excluded =
           state.roundStartFacilitators.value.toSet ++
-            state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet ++
+            ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown) ++
             activeAdmissionPenaltyPeers(state)
         val activeBelowTarget = state.roundStartFacilitators.value.size < activeAdmissionTarget(state)
 
@@ -605,7 +605,7 @@ object CurrencySnapshotConsensusStateAdvancer {
           now <- Async[F].monotonic
           acs <- consensusStorage.getAssembledAdmissionCertificates(state.key)
           activeBelowTarget = state.roundStartFacilitators.value.size < activeAdmissionTarget(state)
-          probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+          probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
           openAllowed = openExpansionAllowedAt(state)
           hasAdmissionEvidence =
             (openAllowed && openAdmissionNominees(state).nonEmpty) ||
@@ -628,12 +628,16 @@ object CurrencySnapshotConsensusStateAdvancer {
         state: CurrencySnapshotConsensusState,
         assembled: Set[AdmissionCertificate]
       ): F[List[AdmissionCertificate]] = {
-        val probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        val probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
         val openAllowed = openExpansionAllowedAt(state)
         val cadenceEligible = assembled.filter(cert => OpenAdmissionPolicy.certificateAllowed(cert.targetPeer, probation, openAllowed))
         val cadenceSuppressed = assembled -- cadenceEligible
-        val selection =
-          AdmissionCertificateSelector.selectForProposal(cadenceEligible, config.activeAdmissionMaxExpansionPerRound, state.entropy)
+        val selection = AdmissionCertificateSelector.selectForProposal(
+          cadenceEligible,
+          config.activeAdmissionMaxExpansionPerRound,
+          state.entropy,
+          probation
+        )
         val dropped = selection.dropped.toSet ++ cadenceSuppressed
         ConsensusLog
           .info(
@@ -1183,7 +1187,7 @@ object CurrencySnapshotConsensusStateAdvancer {
         val n = state.coreFacilitators.value.size
         val q = math.max(1, QuorumPolicy.fromFraction(n, config.quorumThresholdFraction))
         val committee = state.roundStartFacilitators.value.toSet
-        val probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        val probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
         val penalized = activeAdmissionPenaltyPeers(state)
         val expectedLastSnap: Hash = state.lastOutcome.finished.snapshotHash
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -103,6 +103,14 @@ object CurrencySnapshotConsensusStateAdvancer {
 
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](getClass)
 
+      // Currency L0 does not use Global L0's incremental-recovery storage stack. Preserve its
+      // existing download handoff; the Global L0 implementation overrides this hook with the
+      // layer-specific snapshot-store and MPT alignment required by incremental recovery.
+      override def synchronizeDownloadedOutcome(
+        artifact: Signed[CurrencySnapshotArtifact],
+        context: CurrencySnapshotContext
+      ): F[Unit] = Applicative[F].unit
+
       protected val clusterStorage: ClusterStorage[F] = clusterStorageInstance
       protected val config: ConsensusConfig = consensusConfig
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateCreator.scala
@@ -193,7 +193,7 @@ object CurrencySnapshotConsensusStateCreator {
         penalizedPeers = lastOutcome.removalPenalties.filter(_._2 > 0).keySet ++ certPenalizedPeers
 
         // B2 re-admission probation. Non-bypassable; see dag-l0 mirror.
-        probationPeers = lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        probationPeers = ReadmissionMaintenance.probationPeers(lastOutcome.readmissionCountdown)
 
         _ <- logger
           .debug(
@@ -208,10 +208,15 @@ object CurrencySnapshotConsensusStateCreator {
           .debug(
             s"Readmission probation for key=$key: ${probationPeers.size} probation peers" +
               (if (probationPeers.nonEmpty)
-                 s" [${lastOutcome.readmissionCountdown.filter(_._2 > 0).map(kv => s"${kv._1.value.value.take(8)}:${kv._2}").mkString(",")}]"
+                 s" [${lastOutcome.readmissionCountdown.map(kv => s"${kv._1.value.value.take(8)}:${kv._2}").mkString(",")}]"
                else "")
           )
           .whenA(probationPeers.nonEmpty)
+        _ <- Metrics[F].updateGauge("dag_consensus_readmission_probation_size", probationPeers.size.toLong)
+        _ <- Metrics[F].updateGauge(
+          "dag_consensus_readmission_probation_ready_size",
+          lastOutcome.readmissionCountdown.count { case (_, countdown) => countdown == 0 }.toLong
+        )
 
         // Per-peer quality gauges (Prometheus). With v19 cleanup, the quality-degradation
         // override in CommitteeBuilder demotes peers with cumulative ratio < minRatio to

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/schema.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/schema.scala
@@ -192,7 +192,7 @@ object schema {
               quality = peerQuality.getOrElse(pid, (0, 0)),
               removalPenalty = removalPenalties.getOrElse(pid, 0),
               cumulativeMissCount = cumulativeMissCounts.getOrElse(pid, 0L),
-              readmissionCountdown = readmissionCountdown.getOrElse(pid, 0),
+              readmissionCountdown = ReadmissionMaintenance.persistenceValue(readmissionCountdown, pid),
               deferralCountdown = deferralCountdown.getOrElse(pid, 0),
               // v16: Option-wrap so absent peers / pre-v16 readers see no key under
               // dropNullValues=true. Mirror of dag-l0 schema.

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -471,7 +471,7 @@ object GlobalSnapshotConsensus {
           evictionVoter,
           admissionVoter,
           (o: GlobalConsensusOutcome) => !o.recentProofSizes.values.exists(_ >= effectiveConsensusConfig.bootstrapCompleteProofsThreshold),
-          (o: GlobalConsensusOutcome) => o.readmissionCountdown.filter(_._2 > 0).keySet,
+          (o: GlobalConsensusOutcome) => ReadmissionMaintenance.probationPeers(o.readmissionCountdown),
           (o: GlobalConsensusOutcome) => o.finished.candidates.value,
           (key: GlobalSnapshotKey) =>
             ActiveFacilitatorAdmission.expansionAllowedAtOrdinal(

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -876,7 +876,7 @@ object GlobalSnapshotConsensusStateAdvancer {
         state: GlobalSnapshotConsensusState
       ): Set[PeerId] = {
         val committee = state.roundStartFacilitators.value.toSet
-        val probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        val probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
         val penalized = activeAdmissionPenaltyPeers(state)
         state.lastOutcome.finished.candidates.value -- committee -- probation -- penalized
       }
@@ -896,7 +896,7 @@ object GlobalSnapshotConsensusStateAdvancer {
       ): Option[PeerId] = {
         val excluded =
           state.roundStartFacilitators.value.toSet ++
-            state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet ++
+            ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown) ++
             activeAdmissionPenaltyPeers(state)
 
         Option
@@ -913,7 +913,7 @@ object GlobalSnapshotConsensusStateAdvancer {
         for {
           now <- Async[F].monotonic
           acs <- consensusStorage.getAssembledAdmissionCertificates(state.key)
-          probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+          probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
           openAllowed = openExpansionAllowedAt(state)
           hasAdmissionEvidence =
             (openAllowed && openAdmissionNominees(state).nonEmpty) ||
@@ -935,12 +935,16 @@ object GlobalSnapshotConsensusStateAdvancer {
         state: GlobalSnapshotConsensusState,
         assembled: Set[AdmissionCertificate]
       ): F[List[AdmissionCertificate]] = {
-        val probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        val probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
         val openAllowed = openExpansionAllowedAt(state)
         val cadenceEligible = assembled.filter(cert => OpenAdmissionPolicy.certificateAllowed(cert.targetPeer, probation, openAllowed))
         val cadenceSuppressed = assembled -- cadenceEligible
-        val selection =
-          AdmissionCertificateSelector.selectForProposal(cadenceEligible, config.activeAdmissionMaxExpansionPerRound, state.entropy)
+        val selection = AdmissionCertificateSelector.selectForProposal(
+          cadenceEligible,
+          config.activeAdmissionMaxExpansionPerRound,
+          state.entropy,
+          probation
+        )
         val dropped = selection.dropped.toSet ++ cadenceSuppressed
         ConsensusLog
           .info(
@@ -1994,7 +1998,7 @@ object GlobalSnapshotConsensusStateAdvancer {
         val n = state.coreFacilitators.value.size
         val q = math.max(1, QuorumPolicy.fromFraction(n, config.quorumThresholdFraction))
         val committee = state.roundStartFacilitators.value.toSet
-        val probation = state.lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        val probation = ReadmissionMaintenance.probationPeers(state.lastOutcome.readmissionCountdown)
         val penalized = activeAdmissionPenaltyPeers(state)
         val expectedLastSnap: Hash = state.lastOutcome.finished.snapshotHash
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -140,6 +140,24 @@ object GlobalSnapshotConsensusStateAdvancer {
 
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](getClass)
 
+      override def synchronizeDownloadedOutcome(
+        artifact: Signed[GlobalSnapshotArtifact],
+        context: GlobalSnapshotContext
+      ): F[Unit] =
+        HasherSelector[F].withCurrent { implicit hasher =>
+          for {
+            hashed <- artifact.toHashed
+            _ <- logger.info(
+              s"[RecoveryDownload] Aligning application storage to newer accepted consensus outcome ordinal=${artifact.ordinal.show}"
+            )
+            _ <- lastNGlobalSnapshotStorage.setForRecovery(hashed, context)
+            _ <- lastGlobalSnapshotStorage.setForRecovery(hashed, context)
+            _ <- globalSnapshotStorage.setHeadForRecovery(artifact, context)
+            _ <- context.allStateEntries[F].flatMap(mptStore.syncFull[Json](_, artifact.ordinal))
+            _ <- clearCommittedEvents(artifact.value)
+          } yield ()
+        }
+
       /** Savepoint taken before `createArtifact()` mutations. On round abandonment + retry at the same ordinal, this is restored before
         * re-building the proposal to ensure the MptStore starts from a clean pre-mutation state.
         *

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
@@ -6,6 +6,7 @@ import cats.effect.std.Queue
 import cats.syntax.all._
 
 import scala.collection.immutable.SortedMap
+import scala.concurrent.duration.FiniteDuration
 
 import io.constellationnetwork.dag.l0.infrastructure.mempool.DagAwaitingParentConfig
 import io.constellationnetwork.dag.l0.infrastructure.snapshot.event.GlobalSnapshotEvent
@@ -81,20 +82,22 @@ object GlobalSnapshotConsensusStateCreator {
     private val dagAwaitingParentConfig = DagAwaitingParentConfig.default
     private val maxAwaitingParentReactivationPerRound = 128
 
-    /** Track every auditable parent-round Tier-1 signer from actual local snapshot proofs and audit one deterministic target. After three
-      * consecutive local misses, reuse the existing B1 vote path only when the observed signer population cannot safely support one more
-      * committee seat.
+    /** Track every auditable parent-round Tier-1 signer from actual local snapshot proofs and audit one deterministic target. Reuse the
+      * existing B1 vote path only after the round-count and elapsed-time miss floors, on the existing membership-change cadence, and when
+      * the observed signer population is below the current committee's finality floor.
       *
-      * The local proof subset is evidence for vote emission only. It never enters the outcome, artifact, committee hash, or state proof. A
-      * Both the proof subset and next-seat headroom remain local vote-emission evidence. A membership change still requires the normal
-      * Core-quorum EvictionCertificate to be embedded in and accepted with the Proposal.
+      * The local proof subset, monotonic time, and resulting headroom decision are evidence for local vote emission only. They never enter
+      * the outcome, artifact, committee hash, or state proof. A membership change still requires the normal Core-quorum EvictionCertificate
+      * to be embedded in and accepted with the Proposal.
       */
     private def auditTier1FinalityParticipation(
       key: GlobalSnapshotKey,
       lastOutcome: GlobalConsensusOutcome,
       currentCore: Set[PeerId],
       currentTier1: Set[PeerId],
-      resources: ConsensusResources[GlobalSnapshotArtifact, GlobalConsensusKind]
+      resources: ConsensusResources[GlobalSnapshotArtifact, GlobalConsensusKind],
+      observedAt: FiniteDuration,
+      cadenceAllowed: Boolean
     ): F[Unit] = {
       val parentEvidence = lastOutcome.controllerEvidence.flatMap(_.get(lastOutcome.key))
       val locallyObservedParentSigners =
@@ -123,6 +126,10 @@ object GlobalSnapshotConsensusStateCreator {
             locallyObservedParentSigners,
             consensusConfig.quorumThresholdFraction
           )
+          val requiredMissDuration = FinalityParticipationAuditor.minimumMissDuration(
+            consensusConfig.timeTriggerInterval,
+            TierTransitions.DemotionConsecutiveMisses
+          )
           val recordHeadroom =
             (Metrics[F].updateGauge(
               "dag_consensus_tier1_finality_audit_current_committee_size",
@@ -131,6 +138,14 @@ object GlobalSnapshotConsensusStateCreator {
               Metrics[F].updateGauge(
                 "dag_consensus_tier1_finality_audit_observed_current_committee_signers",
                 finalityHeadroom.observedCurrentCommitteeSigners.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_current_finality_floor",
+                finalityHeadroom.currentFinalityFloor.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_current_finality_margin",
+                finalityHeadroom.currentMargin.toLong
               ) >>
               Metrics[F].updateGauge(
                 "dag_consensus_tier1_finality_audit_next_committee_size",
@@ -143,6 +158,14 @@ object GlobalSnapshotConsensusStateCreator {
               Metrics[F].updateGauge(
                 "dag_consensus_tier1_finality_audit_finality_margin",
                 finalityHeadroom.margin.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_membership_hold",
+                if (finalityHeadroom.holdsMembership) 1L else 0L
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_cadence_allowed",
+                if (cadenceAllowed) 1L else 0L
               ) >>
               Metrics[F].updateGauge(
                 "dag_consensus_tier1_finality_audit_silent_eviction_allowed",
@@ -158,12 +181,14 @@ object GlobalSnapshotConsensusStateCreator {
               locallyObservedParentSigners,
               lastOutcome.key.value.value,
               lastOutcome.finished.snapshotHash,
+              observedAt,
+              requiredMissDuration,
               inBootstrap,
               previous
             )
             (observation.history, observation.decision)
           }.flatMap {
-            case Some(audit) if FinalityParticipationAuditor.shouldEmitSilentEvictionVote(audit, finalityHeadroom) =>
+            case Some(audit) if FinalityParticipationAuditor.shouldEmitSilentEvictionVote(audit, finalityHeadroom, cadenceAllowed) =>
               val alreadyVoted = resources.evictionVotes.get(audit.target).exists(_.contains(selfId))
               val emit =
                 if (alreadyVoted) Sync[F].unit
@@ -184,36 +209,20 @@ object GlobalSnapshotConsensusStateCreator {
                   "signatureObserved" -> "false",
                   "consecutiveMisses" -> audit.consecutiveMisses.toString,
                   "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString,
+                  "consecutiveMissDurationMs" -> audit.consecutiveMissDuration.toMillis.toString,
+                  "requiredMissDurationMs" -> audit.requiredMissDuration.toMillis.toString,
                   "currentCommitteeSize" -> finalityHeadroom.currentCommitteeSize.toString,
                   "observedCurrentCommitteeSigners" -> finalityHeadroom.observedCurrentCommitteeSigners.toString,
+                  "currentFinalityFloor" -> finalityHeadroom.currentFinalityFloor.toString,
+                  "currentFinalityMargin" -> finalityHeadroom.currentMargin.toString,
                   "nextFinalityFloor" -> finalityHeadroom.nextFinalityFloor.toString,
-                  "finalityMargin" -> finalityHeadroom.margin.toString,
+                  "nextSeatFinalityMargin" -> finalityHeadroom.nextSeatMargin.toString,
+                  "cadenceAllowed" -> cadenceAllowed.toString,
                   "alreadyVoted" -> alreadyVoted.toString
                 ) >>
                 Metrics[F].incrementCounter(
                   "dag_consensus_tier1_finality_audit_total",
                   Seq(outcomeLabel -> (if (alreadyVoted) "already_voted" else "vote_emitted"))
-                )
-
-            case Some(audit) if audit.shouldVote =>
-              ConsensusLog.info(
-                logger,
-                Facilitator,
-                key.show,
-                "n/a",
-                Eviction,
-                "stage" -> "tier1_finality_audit_headroom_preserved",
-                "target" -> ConsensusLog.pid(audit.target),
-                "consecutiveMisses" -> audit.consecutiveMisses.toString,
-                "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString,
-                "currentCommitteeSize" -> finalityHeadroom.currentCommitteeSize.toString,
-                "observedCurrentCommitteeSigners" -> finalityHeadroom.observedCurrentCommitteeSigners.toString,
-                "nextFinalityFloor" -> finalityHeadroom.nextFinalityFloor.toString,
-                "finalityMargin" -> finalityHeadroom.margin.toString
-              ) >>
-                Metrics[F].incrementCounter(
-                  "dag_consensus_tier1_finality_audit_total",
-                  Seq(outcomeLabel -> "headroom_preserved")
                 )
 
             case Some(audit) if audit.signatureObserved =>
@@ -223,24 +232,38 @@ object GlobalSnapshotConsensusStateCreator {
               )
 
             case Some(audit) =>
+              val outcome =
+                if (!audit.roundHysteresisSatisfied) "round_hysteresis_wait"
+                else if (!audit.durationHysteresisSatisfied) "duration_hysteresis_wait"
+                else if (finalityHeadroom.holdsMembership) "membership_hold"
+                else if (finalityHeadroom.allowsExpansion) "headroom_preserved"
+                else if (!cadenceAllowed) "off_cadence"
+                else "vote_suppressed"
+
               ConsensusLog.info(
                 logger,
                 Facilitator,
                 key.show,
                 "n/a",
                 Eviction,
-                "stage" -> "tier1_finality_audit_hysteresis",
+                "stage" -> "tier1_finality_audit_suppressed",
+                "outcome" -> outcome,
                 "target" -> ConsensusLog.pid(audit.target),
                 "consecutiveMisses" -> audit.consecutiveMisses.toString,
                 "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString,
+                "consecutiveMissDurationMs" -> audit.consecutiveMissDuration.toMillis.toString,
+                "requiredMissDurationMs" -> audit.requiredMissDuration.toMillis.toString,
                 "currentCommitteeSize" -> finalityHeadroom.currentCommitteeSize.toString,
                 "observedCurrentCommitteeSigners" -> finalityHeadroom.observedCurrentCommitteeSigners.toString,
+                "currentFinalityFloor" -> finalityHeadroom.currentFinalityFloor.toString,
+                "currentFinalityMargin" -> finalityHeadroom.currentMargin.toString,
                 "nextFinalityFloor" -> finalityHeadroom.nextFinalityFloor.toString,
-                "finalityMargin" -> finalityHeadroom.margin.toString
+                "nextSeatFinalityMargin" -> finalityHeadroom.nextSeatMargin.toString,
+                "cadenceAllowed" -> cadenceAllowed.toString
               ) >>
                 Metrics[F].incrementCounter(
                   "dag_consensus_tier1_finality_audit_total",
-                  Seq(outcomeLabel -> "hysteresis_wait")
+                  Seq(outcomeLabel -> outcome)
                 )
 
             case None => Sync[F].unit
@@ -724,7 +747,9 @@ object GlobalSnapshotConsensusStateCreator {
             lastOutcome,
             committees.core.toSet,
             committees.tier1.toSet,
-            resources
+            resources,
+            time,
+            expansionAllowedThisRound
           ).handleErrorWith { error =>
             logger.warn(error)(s"Tier-1 finality audit failed for key=$key; continuing round") >>
               Metrics[F].incrementCounter(

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
@@ -82,10 +82,12 @@ object GlobalSnapshotConsensusStateCreator {
     private val maxAwaitingParentReactivationPerRound = 128
 
     /** Track every auditable parent-round Tier-1 signer from actual local snapshot proofs and audit one deterministic target. After three
-      * consecutive local misses, reuse the existing B1 vote path.
+      * consecutive local misses, reuse the existing B1 vote path only when the observed signer population cannot safely support one more
+      * committee seat.
       *
       * The local proof subset is evidence for vote emission only. It never enters the outcome, artifact, committee hash, or state proof. A
-      * membership change still requires the normal Core-quorum EvictionCertificate to be embedded in and accepted with the Proposal.
+      * Both the proof subset and next-seat headroom remain local vote-emission evidence. A membership change still requires the normal
+      * Core-quorum EvictionCertificate to be embedded in and accepted with the Proposal.
       */
     private def auditTier1FinalityParticipation(
       key: GlobalSnapshotKey,
@@ -115,7 +117,39 @@ object GlobalSnapshotConsensusStateCreator {
               .whenA(!inBootstrap && currentCore.contains(selfId))
 
         case Some(evidence) =>
-          tier1FinalityMissHistoryRef.modify { previous =>
+          val currentCommittee = currentCore ++ currentTier1
+          val finalityHeadroom = FinalityHeadroom.evaluate(
+            currentCommittee,
+            locallyObservedParentSigners,
+            consensusConfig.quorumThresholdFraction
+          )
+          val recordHeadroom =
+            (Metrics[F].updateGauge(
+              "dag_consensus_tier1_finality_audit_current_committee_size",
+              finalityHeadroom.currentCommitteeSize.toLong
+            ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_observed_current_committee_signers",
+                finalityHeadroom.observedCurrentCommitteeSigners.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_next_committee_size",
+                finalityHeadroom.nextCommitteeSize.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_next_finality_floor",
+                finalityHeadroom.nextFinalityFloor.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_finality_margin",
+                finalityHeadroom.margin.toLong
+              ) >>
+              Metrics[F].updateGauge(
+                "dag_consensus_tier1_finality_audit_silent_eviction_allowed",
+                if (finalityHeadroom.allowsSilentEviction) 1L else 0L
+              )).whenA(currentCore.contains(selfId) && !inBootstrap)
+
+          recordHeadroom >> tier1FinalityMissHistoryRef.modify { previous =>
             val observation = FinalityParticipationAuditor.observe(
               selfId,
               currentCore,
@@ -129,7 +163,7 @@ object GlobalSnapshotConsensusStateCreator {
             )
             (observation.history, observation.decision)
           }.flatMap {
-            case Some(audit) if audit.shouldVote =>
+            case Some(audit) if FinalityParticipationAuditor.shouldEmitSilentEvictionVote(audit, finalityHeadroom) =>
               val alreadyVoted = resources.evictionVotes.get(audit.target).exists(_.contains(selfId))
               val emit =
                 if (alreadyVoted) Sync[F].unit
@@ -150,11 +184,36 @@ object GlobalSnapshotConsensusStateCreator {
                   "signatureObserved" -> "false",
                   "consecutiveMisses" -> audit.consecutiveMisses.toString,
                   "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString,
+                  "currentCommitteeSize" -> finalityHeadroom.currentCommitteeSize.toString,
+                  "observedCurrentCommitteeSigners" -> finalityHeadroom.observedCurrentCommitteeSigners.toString,
+                  "nextFinalityFloor" -> finalityHeadroom.nextFinalityFloor.toString,
+                  "finalityMargin" -> finalityHeadroom.margin.toString,
                   "alreadyVoted" -> alreadyVoted.toString
                 ) >>
                 Metrics[F].incrementCounter(
                   "dag_consensus_tier1_finality_audit_total",
                   Seq(outcomeLabel -> (if (alreadyVoted) "already_voted" else "vote_emitted"))
+                )
+
+            case Some(audit) if audit.shouldVote =>
+              ConsensusLog.info(
+                logger,
+                Facilitator,
+                key.show,
+                "n/a",
+                Eviction,
+                "stage" -> "tier1_finality_audit_headroom_preserved",
+                "target" -> ConsensusLog.pid(audit.target),
+                "consecutiveMisses" -> audit.consecutiveMisses.toString,
+                "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString,
+                "currentCommitteeSize" -> finalityHeadroom.currentCommitteeSize.toString,
+                "observedCurrentCommitteeSigners" -> finalityHeadroom.observedCurrentCommitteeSigners.toString,
+                "nextFinalityFloor" -> finalityHeadroom.nextFinalityFloor.toString,
+                "finalityMargin" -> finalityHeadroom.margin.toString
+              ) >>
+                Metrics[F].incrementCounter(
+                  "dag_consensus_tier1_finality_audit_total",
+                  Seq(outcomeLabel -> "headroom_preserved")
                 )
 
             case Some(audit) if audit.signatureObserved =>
@@ -173,7 +232,11 @@ object GlobalSnapshotConsensusStateCreator {
                 "stage" -> "tier1_finality_audit_hysteresis",
                 "target" -> ConsensusLog.pid(audit.target),
                 "consecutiveMisses" -> audit.consecutiveMisses.toString,
-                "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString
+                "requiredConsecutiveMisses" -> audit.requiredConsecutiveMisses.toString,
+                "currentCommitteeSize" -> finalityHeadroom.currentCommitteeSize.toString,
+                "observedCurrentCommitteeSigners" -> finalityHeadroom.observedCurrentCommitteeSigners.toString,
+                "nextFinalityFloor" -> finalityHeadroom.nextFinalityFloor.toString,
+                "finalityMargin" -> finalityHeadroom.margin.toString
               ) >>
                 Metrics[F].incrementCounter(
                   "dag_consensus_tier1_finality_audit_total",
@@ -332,7 +395,7 @@ object GlobalSnapshotConsensusStateCreator {
         // the committee. Excluded from the round NON-BYPASSABLY: re-admission requires a
         // consensus-witnessed AdmissionCertificate embedded in a Proposal (cleared at
         // round-finish in the advancer). Deterministic: derived from consensus-agreed lastOutcome.
-        probationPeers = lastOutcome.readmissionCountdown.filter(_._2 > 0).keySet
+        probationPeers = ReadmissionMaintenance.probationPeers(lastOutcome.readmissionCountdown)
 
         _ <- logger
           .debug(
@@ -347,10 +410,15 @@ object GlobalSnapshotConsensusStateCreator {
           .debug(
             s"Readmission probation for key=$key: ${probationPeers.size} probation peers" +
               (if (probationPeers.nonEmpty)
-                 s" [${lastOutcome.readmissionCountdown.filter(_._2 > 0).map(kv => s"${kv._1.value.value.take(8)}:${kv._2}").mkString(",")}]"
+                 s" [${lastOutcome.readmissionCountdown.map(kv => s"${kv._1.value.value.take(8)}:${kv._2}").mkString(",")}]"
                else "")
           )
           .whenA(probationPeers.nonEmpty)
+        _ <- Metrics[F].updateGauge("dag_consensus_readmission_probation_size", probationPeers.size.toLong)
+        _ <- Metrics[F].updateGauge(
+          "dag_consensus_readmission_probation_ready_size",
+          lastOutcome.readmissionCountdown.count { case (_, countdown) => countdown == 0 }.toLong
+        )
 
         // Per-peer quality gauges (Prometheus). With v19 cleanup, the quality-degradation
         // override in CommitteeBuilder demotes peers with cumulative ratio < minRatio to Tier 1,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/schema.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/schema.scala
@@ -275,7 +275,7 @@ object schema {
               quality = peerQuality.getOrElse(pid, (0, 0)),
               removalPenalty = removalPenalties.getOrElse(pid, 0),
               cumulativeMissCount = cumulativeMissCounts.getOrElse(pid, 0L),
-              readmissionCountdown = readmissionCountdown.getOrElse(pid, 0),
+              readmissionCountdown = ReadmissionMaintenance.persistenceValue(readmissionCountdown, pid),
               deferralCountdown = deferralCountdown.getOrElse(pid, 0),
               // v16: Option-wrap so absent peers / pre-v16 readers see no key under
               // dropNullValues=true. Some(0) would render as "0" and break byte-stable

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/ControllerEvidencePeerHistorySuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/ControllerEvidencePeerHistorySuite.scala
@@ -102,7 +102,8 @@ object ControllerEvidencePeerHistorySuite extends MutableIOSuite {
     peerQuality: SortedMap[PeerId, (Int, Int)],
     activeAdmissionScores: SortedMap[PeerId, Int],
     peerTiers: SortedMap[PeerId, Int],
-    recentRoundEndTimes: SortedMap[SnapshotOrdinal, Long]
+    recentRoundEndTimes: SortedMap[SnapshotOrdinal, Long],
+    readmissionCountdown: SortedMap[PeerId, Int] = SortedMap.empty
   ): GlobalConsensusOutcome =
     GlobalConsensusOutcome(
       key = ord(14L),
@@ -113,6 +114,7 @@ object ControllerEvidencePeerHistorySuite extends MutableIOSuite {
       finished = finished,
       peerQuality = peerQuality,
       recentProofSizes = recentProofSizes,
+      readmissionCountdown = readmissionCountdown,
       recentSigners = recentSigners,
       peerTiers = peerTiers,
       activeAdmissionScores = activeAdmissionScores,
@@ -194,6 +196,34 @@ object ControllerEvidencePeerHistorySuite extends MutableIOSuite {
         // ...but the signed peerHistory payloads are identical, structurally and byte-for-byte.
         expect.same(signedA, signedB) &&
         expect.same(signedA.asJson.printWith(printer), signedB.asJson.printWith(printer))
+  }
+
+  test("sticky zero probation survives sidecar packing without entering signed artifact bytes") { res =>
+    implicit val (js, h, sp) = res
+
+    for {
+      finished <- mkFinished
+      outcome = mkOutcome(
+        finished,
+        peerQuality = SortedMap(a -> (5, 5), b -> (5, 5), c -> (1, 5)),
+        activeAdmissionScores = SortedMap(a -> 150, b -> 150, c -> 60),
+        peerTiers = SortedMap(a -> 2, b -> 2, c -> 1),
+        recentRoundEndTimes = SortedMap(ord(14L) -> 1700000000000L),
+        readmissionCountdown = SortedMap(c -> 0)
+      )
+      operational = outcome.toOperationalState
+      decoded = decode[ConsensusOperationalState](operational.asJson.noSpaces)
+      seededReadmission = decoded.toOption
+        .map(state =>
+          SortedMap.from(state.perPeer.collect {
+            case (pid, record) if record.readmissionCountdown > 0 => pid -> record.readmissionCountdown
+          })
+        )
+        .getOrElse(SortedMap.empty[PeerId, Int])
+    } yield
+      expect.same(Some(1), operational.perPeer.get(c).map(_.readmissionCountdown)) &&
+        expect.same(SortedMap(c -> 1), seededReadmission) &&
+        expect(outcome.signedArtifactPeerHistory.perPeer.isEmpty)
   }
 
   test("divergent carried perPeer state yields byte-identical signedArtifactPeerHistory for the same evidence") { res =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityHeadroom.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityHeadroom.scala
@@ -3,7 +3,7 @@ package io.constellationnetwork.node.shared.infrastructure.consensus
 import io.constellationnetwork.node.shared.infrastructure.consensus.state.QuorumPolicy
 import io.constellationnetwork.schema.peer.PeerId
 
-/** Exact next-seat finality-headroom calculation shared by admission and Tier-1 silence eviction.
+/** Exact current-seat and next-seat finality-headroom calculation shared by admission and Tier-1 silence eviction.
   *
   * Finalized proof subsets are node-local, so this result may only control local vote emission. It must never be validated from a Proposal
   * or copied into deterministic state. Admission and eviction remain authoritative only after their existing Core-quorum certificates are
@@ -14,14 +14,34 @@ object FinalityHeadroom {
   final case class Evaluation(
     currentCommitteeSize: Int,
     observedCurrentCommitteeSigners: Int,
+    currentFinalityFloor: Int,
     nextCommitteeSize: Int,
     nextFinalityFloor: Int
   ) {
-    val margin: Int = observedCurrentCommitteeSigners - nextFinalityFloor
-    val allowsExpansion: Boolean = margin >= 0
+    val currentMargin: Int = observedCurrentCommitteeSigners - currentFinalityFloor
+    val nextSeatMargin: Int = observedCurrentCommitteeSigners - nextFinalityFloor
 
-    /** A silent seat should be removed only when the observed signer population cannot safely support one additional seat. */
-    val allowsSilentEviction: Boolean = !allowsExpansion
+    // Retain the original accessor for admission callers and dashboards. It is the
+    // next-seat margin, not the current-committee margin.
+    val margin: Int = nextSeatMargin
+
+    val allowsExpansion: Boolean = nextSeatMargin >= 0
+
+    /** Remove a silent seat only when the observed signer population is below the floor of the committee already seated.
+      *
+      * This deliberately leaves a protocol-derived neutral zone when the current committee can finalize but the next seat is not yet
+      * supported:
+      *
+      * {{{
+      * currentFloor <= observedSigners < nextFloor
+      * }}}
+      *
+      * Neither admission nor silent eviction is allowed in that zone. Using `!allowsExpansion` here would make adjacent floor steps
+      * oscillate between admitting and evicting the same seat.
+      */
+    val allowsSilentEviction: Boolean = currentMargin < 0
+
+    val holdsMembership: Boolean = !allowsExpansion && !allowsSilentEviction
   }
 
   /** Evaluate the protocol-derived invariant:
@@ -35,12 +55,15 @@ object FinalityHeadroom {
     locallyObservedParentSigners: Set[PeerId],
     quorumThresholdFraction: Double
   ): Evaluation = {
+    val currentCommitteeSize = currentCommittee.size
+    val currentFinalityFloor = math.max(1, QuorumPolicy.fromFraction(currentCommitteeSize, quorumThresholdFraction))
     val nextCommitteeSize = currentCommittee.size + 1
     val nextFinalityFloor = math.max(1, QuorumPolicy.fromFraction(nextCommitteeSize, quorumThresholdFraction))
 
     Evaluation(
-      currentCommitteeSize = currentCommittee.size,
+      currentCommitteeSize = currentCommitteeSize,
       observedCurrentCommitteeSigners = locallyObservedParentSigners.intersect(currentCommittee).size,
+      currentFinalityFloor = currentFinalityFloor,
       nextCommitteeSize = nextCommitteeSize,
       nextFinalityFloor = nextFinalityFloor
     )

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityHeadroom.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityHeadroom.scala
@@ -1,0 +1,48 @@
+package io.constellationnetwork.node.shared.infrastructure.consensus
+
+import io.constellationnetwork.node.shared.infrastructure.consensus.state.QuorumPolicy
+import io.constellationnetwork.schema.peer.PeerId
+
+/** Exact next-seat finality-headroom calculation shared by admission and Tier-1 silence eviction.
+  *
+  * Finalized proof subsets are node-local, so this result may only control local vote emission. It must never be validated from a Proposal
+  * or copied into deterministic state. Admission and eviction remain authoritative only after their existing Core-quorum certificates are
+  * accepted.
+  */
+object FinalityHeadroom {
+
+  final case class Evaluation(
+    currentCommitteeSize: Int,
+    observedCurrentCommitteeSigners: Int,
+    nextCommitteeSize: Int,
+    nextFinalityFloor: Int
+  ) {
+    val margin: Int = observedCurrentCommitteeSigners - nextFinalityFloor
+    val allowsExpansion: Boolean = margin >= 0
+
+    /** A silent seat should be removed only when the observed signer population cannot safely support one additional seat. */
+    val allowsSilentEviction: Boolean = !allowsExpansion
+  }
+
+  /** Evaluate the protocol-derived invariant:
+    *
+    * {{{
+    * observed current-committee parent signers >= finality floor(current committee size + 1)
+    * }}}
+    */
+  def evaluate(
+    currentCommittee: Set[PeerId],
+    locallyObservedParentSigners: Set[PeerId],
+    quorumThresholdFraction: Double
+  ): Evaluation = {
+    val nextCommitteeSize = currentCommittee.size + 1
+    val nextFinalityFloor = math.max(1, QuorumPolicy.fromFraction(nextCommitteeSize, quorumThresholdFraction))
+
+    Evaluation(
+      currentCommitteeSize = currentCommittee.size,
+      observedCurrentCommitteeSigners = locallyObservedParentSigners.intersect(currentCommittee).size,
+      nextCommitteeSize = nextCommitteeSize,
+      nextFinalityFloor = nextFinalityFloor
+    )
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditor.scala
@@ -2,6 +2,8 @@ package io.constellationnetwork.node.shared.infrastructure.consensus
 
 import cats.Order
 
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.hash.Hash
 
@@ -22,30 +24,51 @@ object FinalityParticipationAuditor {
 
   final case class MissHistory(
     lastObservedParent: Option[ObservedParent],
-    consecutiveMisses: Map[PeerId, Int]
+    consecutiveMisses: Map[PeerId, Int],
+    missStartedAt: Map[PeerId, FiniteDuration]
   )
 
   object MissHistory {
-    val empty: MissHistory = MissHistory(None, Map.empty)
+    val empty: MissHistory = MissHistory(None, Map.empty, Map.empty)
   }
 
   final case class Decision(
     target: PeerId,
     signatureObserved: Boolean,
     consecutiveMisses: Int,
-    requiredConsecutiveMisses: Int
+    requiredConsecutiveMisses: Int,
+    consecutiveMissDuration: FiniteDuration,
+    requiredMissDuration: FiniteDuration
   ) {
-    def shouldVote: Boolean = !signatureObserved && consecutiveMisses >= requiredConsecutiveMisses
+    def roundHysteresisSatisfied: Boolean = consecutiveMisses >= requiredConsecutiveMisses
+    def durationHysteresisSatisfied: Boolean = consecutiveMissDuration >= requiredMissDuration
+    def shouldVote: Boolean = !signatureObserved && roundHysteresisSatisfied && durationHysteresisSatisfied
   }
 
   final case class Observation(history: MissHistory, decision: Option[Decision])
 
-  /** Combine the three-round proof-miss hysteresis with the exact next-seat finality-headroom invariant.
+  /** Combine proof-miss hysteresis, the exact current-seat finality deficit, and the existing membership-change cadence.
     *
     * This remains a local vote-emission decision. A Core quorum of existing EvictionVotes is still required before membership changes.
     */
-  def shouldEmitSilentEvictionVote(decision: Decision, headroom: FinalityHeadroom.Evaluation): Boolean =
-    decision.shouldVote && headroom.allowsSilentEviction
+  def shouldEmitSilentEvictionVote(
+    decision: Decision,
+    headroom: FinalityHeadroom.Evaluation,
+    cadenceAllowed: Boolean
+  ): Boolean =
+    decision.shouldVote && headroom.allowsSilentEviction && cadenceAllowed
+
+  /** Preserve the intended elapsed-time meaning of an N-round miss window when EventTrigger accelerates rounds.
+    *
+    * N observations span N-1 intervals from the first miss through the Nth miss. Reusing `timeTriggerInterval` gives the local auditor a
+    * stable lower bound without adding configuration. This is local abstention policy only; differing clocks or timing configuration cannot
+    * mutate membership without the existing Core-quorum certificate.
+    */
+  def minimumMissDuration(timeTriggerInterval: FiniteDuration, requiredConsecutiveMisses: Int): FiniteDuration = {
+    val intervals = math.max(0, requiredConsecutiveMisses - 1).toLong
+    if (timeTriggerInterval <= Duration.Zero) Duration.Zero
+    else timeTriggerInterval * intervals
+  }
 
   def selectTarget(
     currentTier1: Set[PeerId],
@@ -76,6 +99,8 @@ object FinalityParticipationAuditor {
     locallyObservedParentSigners: Set[PeerId],
     parentOrdinal: Long,
     entropy: Hash,
+    observedAt: FiniteDuration,
+    requiredMissDuration: FiniteDuration,
     inBootstrap: Boolean,
     previous: MissHistory,
     requiredConsecutiveMisses: Int = TierTransitions.DemotionConsecutiveMisses
@@ -86,34 +111,51 @@ object FinalityParticipationAuditor {
     else {
       val auditable = currentTier1.intersect(parentRoundCommittee)
       val observedParent = ObservedParent(parentOrdinal, entropy)
-      val nextMisses =
+      val (nextMisses, nextMissStartedAt) =
         if (previous.lastObservedParent.contains(observedParent))
-          auditable.iterator.map(pid => pid -> previous.consecutiveMisses.getOrElse(pid, 0)).toMap
+          (
+            auditable.iterator.map(pid => pid -> previous.consecutiveMisses.getOrElse(pid, 0)).toMap,
+            previous.missStartedAt.view.filterKeys(auditable.contains).toMap
+          )
         else {
-          val previousConsecutiveMisses = previous.lastObservedParent match {
-            case Some(parent) if parent.ordinal < Long.MaxValue && parent.ordinal + 1L == parentOrdinal =>
-              previous.consecutiveMisses
-            case _ => Map.empty[PeerId, Int]
+          val isConsecutive = previous.lastObservedParent.exists { parent =>
+            parent.ordinal < Long.MaxValue && parent.ordinal + 1L == parentOrdinal
           }
-          auditable.iterator.map { pid =>
-            val misses =
+          val previousConsecutiveMisses =
+            if (isConsecutive) previous.consecutiveMisses else Map.empty[PeerId, Int]
+          val previousMissStartedAt =
+            if (isConsecutive) previous.missStartedAt else Map.empty[PeerId, FiniteDuration]
+          val misses = auditable.iterator.map { pid =>
+            val count =
               if (locallyObservedParentSigners.contains(pid)) 0
               else math.min(required, previousConsecutiveMisses.getOrElse(pid, 0) + 1)
-            pid -> misses
+            pid -> count
           }.toMap
+          val startedAt = auditable.iterator.flatMap { pid =>
+            if (locallyObservedParentSigners.contains(pid)) None
+            else Some(pid -> previousMissStartedAt.getOrElse(pid, observedAt))
+          }.toMap
+
+          (misses, startedAt)
         }
-      val nextHistory = MissHistory(Some(observedParent), nextMisses)
+      val nextHistory = MissHistory(Some(observedParent), nextMisses, nextMissStartedAt)
       val decision = Option
         .when(currentCore.contains(selfId)) {
           selectTarget(currentTier1, parentRoundCommittee, entropy)
         }
         .flatten
         .map { target =>
+          val missDuration = nextMissStartedAt
+            .get(target)
+            .fold(Duration.Zero: FiniteDuration)(startedAt => (observedAt - startedAt).max(Duration.Zero))
+
           Decision(
             target = target,
             signatureObserved = locallyObservedParentSigners.contains(target),
             consecutiveMisses = nextMisses.getOrElse(target, 0),
-            requiredConsecutiveMisses = required
+            requiredConsecutiveMisses = required,
+            consecutiveMissDuration = missDuration,
+            requiredMissDuration = requiredMissDuration.max(Duration.Zero)
           )
         }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditor.scala
@@ -40,6 +40,13 @@ object FinalityParticipationAuditor {
 
   final case class Observation(history: MissHistory, decision: Option[Decision])
 
+  /** Combine the three-round proof-miss hysteresis with the exact next-seat finality-headroom invariant.
+    *
+    * This remains a local vote-emission decision. A Core quorum of existing EvictionVotes is still required before membership changes.
+    */
+  def shouldEmitSilentEvictionVote(decision: Decision, headroom: FinalityHeadroom.Evaluation): Boolean =
+    decision.shouldVote && headroom.allowsSilentEviction
+
   def selectTarget(
     currentTier1: Set[PeerId],
     parentRoundCommittee: Set[PeerId],

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/OpenAdmissionPolicy.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/OpenAdmissionPolicy.scala
@@ -1,6 +1,5 @@
 package io.constellationnetwork.node.shared.infrastructure.consensus
 
-import io.constellationnetwork.node.shared.infrastructure.consensus.state.QuorumPolicy
 import io.constellationnetwork.schema.peer.PeerId
 
 /** Local vote-emission policy for open Ready-at-tip admission.
@@ -26,16 +25,7 @@ object OpenAdmissionPolicy {
   def penaltyBlocksCertificate(target: PeerId, probation: Set[PeerId], activePenaltyPeers: Set[PeerId]): Boolean =
     activePenaltyPeers.contains(target) && !probation.contains(target)
 
-  final case class Headroom(
-    observedCurrentCommitteeSigners: Int,
-    nextCommitteeSize: Int,
-    nextFinalityFloor: Int
-  ) {
-    val margin: Int = observedCurrentCommitteeSigners - nextFinalityFloor
-    val allowsExpansion: Boolean = margin >= 0
-  }
-
-  final case class Decision(cadenceAllowed: Boolean, headroom: Option[Headroom]) {
+  final case class Decision(cadenceAllowed: Boolean, headroom: Option[FinalityHeadroom.Evaluation]) {
     val allowsOpenAdmission: Boolean = cadenceAllowed && headroom.forall(_.allowsExpansion)
   }
 
@@ -62,16 +52,8 @@ object OpenAdmissionPolicy {
     headroomGateActive: Boolean
   ): Decision = {
     val headroomEvidence = locallyObservedParentSigners.filter(_ => headroomGateActive)
-    val headroom = headroomEvidence.fold(Option.empty[Headroom]) { observedSigners =>
-      val nextCommitteeSize = currentCommittee.size + 1
-      val nextFinalityFloor = math.max(1, QuorumPolicy.fromFraction(nextCommitteeSize, quorumThresholdFraction))
-      Some(
-        Headroom(
-          observedCurrentCommitteeSigners = observedSigners.intersect(currentCommittee).size,
-          nextCommitteeSize = nextCommitteeSize,
-          nextFinalityFloor = nextFinalityFloor
-        )
-      )
+    val headroom = headroomEvidence.fold(Option.empty[FinalityHeadroom.Evaluation]) { observedSigners =>
+      Some(FinalityHeadroom.evaluate(currentCommittee, observedSigners, quorumThresholdFraction))
     }
 
     Decision(cadenceAllowed, headroom)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/AdmissionCertificateSelector.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/AdmissionCertificateSelector.scala
@@ -2,6 +2,7 @@ package io.constellationnetwork.node.shared.infrastructure.consensus.state
 
 import io.constellationnetwork.node.shared.infrastructure.consensus.FacilitatorSelector
 import io.constellationnetwork.node.shared.infrastructure.consensus.declaration.AdmissionCertificate
+import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.hash.Hash
 
 /** Deterministic cap for the assembled `AdmissionCertificate`s a leader attaches to an outgoing Proposal.
@@ -37,9 +38,10 @@ object AdmissionCertificateSelector {
     Selection(kept, dropped)
   }
 
-  /** Proposal-construction policy: cap certificates by the same parent-entropy rendezvous ranking used for open nominations, with the
-    * certificate's existing ordering as the final tie-break. This prevents a permanent lowest-PeerId preference when probation and open
-    * certificates compete for a one-certificate proposal budget.
+  /** Proposal-construction policy: prioritize the existing penalty/probation recovery lane, then cap certificates within each priority by
+    * the same parent-entropy rendezvous ranking used for open nominations, with the certificate's existing ordering as the final tie-break.
+    * Recovery priority prevents an open Ready-at-tip certificate from consuming the only proposal slot while an already-evicted peer has a
+    * quorum certificate waiting. Rendezvous ordering still prevents a permanent lowest-PeerId preference among peers in the same lane.
     *
     * The apply-site defense remains on [[select]], intentionally. Validation rejects over-cap proposals, so apply selection is unreachable
     * for valid traffic; preserving its legacy ordering avoids turning that version-stability safety net into construction policy.
@@ -47,14 +49,21 @@ object AdmissionCertificateSelector {
   def selectForProposal(
     assembled: Iterable[AdmissionCertificate],
     activeAdmissionMaxExpansionPerRound: Int,
-    entropy: Hash
+    entropy: Hash,
+    probation: Set[PeerId] = Set.empty
   ): Selection = {
     val cap = math.max(0, activeAdmissionMaxExpansionPerRound)
     val targetOrdering = FacilitatorSelector.orderByScore(entropy).toOrdering
     val ranked = assembled.toList.sortWith { (left, right) =>
-      val targetComparison = targetOrdering.compare(left.targetPeer, right.targetPeer)
-      if (targetComparison != 0) targetComparison < 0
-      else AdmissionCertificate.ordering.compare(left, right) < 0
+      val leftIsProbation = probation.contains(left.targetPeer)
+      val rightIsProbation = probation.contains(right.targetPeer)
+
+      if (leftIsProbation != rightIsProbation) leftIsProbation
+      else {
+        val targetComparison = targetOrdering.compare(left.targetPeer, right.targetPeer)
+        if (targetComparison != 0) targetComparison < 0
+        else AdmissionCertificate.ordering.compare(left, right) < 0
+      }
     }
     val (kept, dropped) = ranked.splitAt(cap)
     Selection(kept, dropped)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusEngineContext.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusEngineContext.scala
@@ -86,7 +86,7 @@ final case class ConsensusEngineContext[F[_], Event, Key, Artifact, Context, Sta
   // rejected at build time and the advancer validates the cert's tip at proposal-acceptance time.
   lastSnapshotHashOf: Outcome => Hash,
   // Set of peers currently on B2 probation per the carried outcome. A peer is on probation while
-  // its `readmissionCountdown` is positive — it was previously evicted via B1 and is awaiting a
+  // its `readmissionCountdown` map entry exists, including at sticky zero — it was previously evicted via B1 and is awaiting a
   // quorum-witnessed `AdmissionCertificate` from the cluster before it can re-enter the committee.
   // Recovery (`StateTransitions.initFromDownload`) must respect this set
   // and decline to facilitate while self is still in probation. Otherwise a recovering peer would

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateAdvancer.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ConsensusStateAdvancer.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.node.shared.config.types.ConsensusConfig
 import io.constellationnetwork.node.shared.domain.cluster.storage.ClusterStorage
 import io.constellationnetwork.node.shared.infrastructure.consensus.{ConsensusResources, PeerDeclarations}
 import io.constellationnetwork.schema.peer.{PeerId, Responsive, Unresponsive}
+import io.constellationnetwork.security.signature.Signed
 
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -72,6 +73,19 @@ trait ConsensusStateAdvancer[F[_], Key, Artifact, Context, Status, Outcome, Kind
   def isBootstrapActive(lastOutcome: Outcome): Boolean = false
 
   def advanceStatus(resources: ConsensusResources[Artifact, Kind]): StateT[F, ConsensusState[Key, Status, Outcome, Kind], F[Unit]]
+
+  /** Align layer-specific application storage when recovery accepts a newer consensus outcome than the snapshot originally handed to
+    * `InitializeFromDownload`.
+    *
+    * The consensus-outcome endpoint retains only its latest outcome. A fast chain can therefore advance between download convergence and
+    * initialization, causing recovery to accept outcome `N+1` while application snapshot storage is still at `N`. Starting consensus from
+    * that torn handoff makes the first persisted `N+2` snapshot fail strict contiguity forever. Layers whose recovery path can accept a
+    * newer outcome override this hook to install that outcome's artifact and context before consensus starts. Layers without that
+    * recovery-storage stack implement an inert hook and preserve their existing download behavior.
+    *
+    * This is node-local recovery state only. It does not alter artifact bytes, state proofs, committee derivation, or proposal validation.
+    */
+  def synchronizeDownloadedOutcome(artifact: Signed[Artifact], context: Context): F[Unit]
 
   def logger(implicit async: Async[F]): SelfAwareStructuredLogger[F] =
     Slf4jLogger.getLoggerFromName[F](this.getClass.getName)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ReadmissionMaintenance.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ReadmissionMaintenance.scala
@@ -17,6 +17,24 @@ import io.constellationnetwork.schema.peer.PeerId
   */
 object ReadmissionMaintenance {
 
+  /** Every map entry is a probation member, including an entry whose countdown has reached zero.
+    *
+    * The countdown is timing/observability state; map membership is the authority. Keeping this definition here prevents emission, proposal
+    * validation, state creation, and certificate selection from independently reintroducing the former `> 0` auto-clear bug.
+    */
+  def probationPeers(readmissionCountdown: scala.collection.Map[PeerId, Int]): Set[PeerId] =
+    readmissionCountdown.keySet.toSet
+
+  /** Encode map membership through the existing integer field in the node-local operational sidecar.
+    *
+    * `PerPeerOperationalRecord.readmissionCountdown` predates sticky zero and has no separate presence bit. Persisting a live zero as zero
+    * makes startup's sparse-map reconstruction indistinguishable from "not on probation". A value of one is therefore the persistence
+    * sentinel for a live zero entry; after restart the normal maintenance step returns it to zero. This does not enter signed artifact
+    * peerHistory, whose `perPeer` map is intentionally empty.
+    */
+  def persistenceValue(readmissionCountdown: scala.collection.Map[PeerId, Int], peerId: PeerId): Int =
+    readmissionCountdown.get(peerId).fold(0)(countdown => math.max(1, countdown))
+
   /** Apply one round of probation maintenance.
     *
     *   1. Decrement every active counter by 1, clamped at 0. 2. Seed entries for peers in `justUnpenalized` at `probationRounds` (only if

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitions.scala
@@ -1429,19 +1429,32 @@ class StateTransitions[F[_]: Async: Random: Metrics, Event, Key: Eq: Show: TypeT
           val keyMatch = outcomeKey.get(o) === key
           val artifactMatch = outcomeArtifact.get(o) === artifact
           val contextMatch = outcomeContext.get(o) === context
-          if (keyMatch && artifactMatch && contextMatch) (o, isRecovery).pure[F]
-          else {
-            // If the peer returned a DIFFERENT outcome (cluster has moved on past our downloaded
-            // ordinal), accept it and treat as recovery — skip the 43s deferral so we join
-            // the cluster at its current tip instead of targeting a stale ordinal.
-            //
-            // Lower-ordinal outcomes cannot reach here: ConsensusRoutes returns Conflict() when
-            // the peer's key > requested key, and None when key doesn't match. Only the exact
-            // key match returns Some(outcome). This branch is defensive against future API changes.
-            val keyMismatch = outcomeKey.get(o) =!= key
-            if (keyMismatch)
-              (o, true).pure[F]
-            else
+          StateTransitions.downloadOutcomeDisposition(keyMatch, artifactMatch, contextMatch, isRecovery) match {
+            case StateTransitions.DownloadOutcomeDisposition.AcceptExact(isRecoveryEffective) =>
+              (o, isRecoveryEffective).pure[F]
+
+            // If the specific-outcome endpoint reports Conflict, fetchOutcomeFromCluster falls
+            // back to the peer's latest outcome. That can legitimately be N+1 after download
+            // converged at N. Accepting it into consensus without also moving layer storage to
+            // N+1 creates a torn handoff: consensus next emits N+2 while application storage
+            // still requires N+1. Align the layer before installing the newer outcome.
+            case StateTransitions.DownloadOutcomeDisposition.AcceptAndAlignApplicationStorage =>
+              ctx.advancer
+                .synchronizeDownloadedOutcome(outcomeArtifact.get(o), outcomeContext.get(o)) >>
+                ConsensusLog.info(
+                  log,
+                  Category.Lifecycle,
+                  outcomeKey.get(o).show,
+                  "n/a",
+                  LogEvent.DownloadInitStart,
+                  "stage" -> "newer_outcome_storage_aligned",
+                  "requestedKey" -> key.show,
+                  "acceptedKey" -> outcomeKey.get(o).show
+                ) >>
+                Metrics[F].incrementCounter("dag_consensus_download_newer_outcome_storage_aligned_total") >>
+                (o, true).pure[F]
+
+            case StateTransitions.DownloadOutcomeDisposition.Reject =>
               new Throwable(
                 s"[DownloadInit] Outcome validation failed after retries for key=$key: " +
                   s"keyMatch=$keyMatch, artifactMatch=$artifactMatch, contextMatch=$contextMatch"
@@ -1481,7 +1494,7 @@ class StateTransitions[F[_]: Async: Random: Metrics, Event, Key: Eq: Show: TypeT
       // split-brain. The marker is still written so a future deterministic-across-committee
       // reintroduction can reuse it without new plumbing. See
       // `ConsensusEngineContext.recoveredAtKeyRef` for full rationale.
-      _ <- ctx.recoveredAtKeyRef.set(Some(key))
+      _ <- ctx.recoveredAtKeyRef.set(Some(outcomeKey.get(outcome)))
       _ <- storage
         .trySetInitialConsensusOutcome(outcome)
         .ifM(
@@ -1882,6 +1895,29 @@ class StateTransitions[F[_]: Async: Random: Metrics, Event, Key: Eq: Show: TypeT
 }
 
 object StateTransitions {
+
+  private[consensus] sealed trait DownloadOutcomeDisposition
+
+  private[consensus] object DownloadOutcomeDisposition {
+    final case class AcceptExact(isRecoveryEffective: Boolean) extends DownloadOutcomeDisposition
+    case object AcceptAndAlignApplicationStorage extends DownloadOutcomeDisposition
+    case object Reject extends DownloadOutcomeDisposition
+  }
+
+  /** Classify the handoff independently of layer storage effects so the critical alignment rule is regression-tested.
+    *
+    * A different key is the latest-outcome fallback used when the requested outcome has already been evicted. It is accepted only with an
+    * application-storage alignment. A same-key artifact or context mismatch remains invalid.
+    */
+  private[consensus] def downloadOutcomeDisposition(
+    keyMatches: Boolean,
+    artifactMatches: Boolean,
+    contextMatches: Boolean,
+    isRecovery: Boolean
+  ): DownloadOutcomeDisposition =
+    if (keyMatches && artifactMatches && contextMatches) DownloadOutcomeDisposition.AcceptExact(isRecovery)
+    else if (!keyMatches) DownloadOutcomeDisposition.AcceptAndAlignApplicationStorage
+    else DownloadOutcomeDisposition.Reject
 
   private[consensus] sealed trait ReadyPromotionPeerAlignment
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitions.scala
@@ -1450,7 +1450,8 @@ class StateTransitions[F[_]: Async: Random: Metrics, Event, Key: Eq: Show: TypeT
         }
       // B2 readmission gate: refuse to facilitate while self is on probation per the carried
       // outcome. A peer that was B1-evicted during isolation comes back
-      // via recovery with a downloaded snapshot containing `readmissionCountdown[selfId] > 0`. The
+      // via recovery with a downloaded snapshot containing a `readmissionCountdown[selfId]` entry,
+      // including a sticky entry whose countdown reached zero. The
       // cluster's state creator excludes probation peers from `state.facilitators`; if we
       // ignore that and emit Facility/Proposal/Signature anyway, our declarations land in nobody's
       // expected committee and the round wedges at `progress=1/5` until the whole 90s phase

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
@@ -159,7 +159,14 @@ object LastNGlobalSnapshotStorage {
           case Some((current, _)) if isNextSnapshot(current, snapshot.signed.value) => ((snapshot, state).some, Applicative[F].unit)
           case s @ Some((current, _)) if current.hash === snapshot.hash             => (s, Applicative[F].unit)
           case other =>
-            (other, MonadThrow[F].raiseError[Unit](new Throwable("Failure during setting new global snapshot!")))
+            val current = other.map { case (value, _) => s"ordinal=${value.ordinal},hash=${value.hash}" }.getOrElse("empty")
+            val incoming = s"ordinal=${snapshot.ordinal},hash=${snapshot.hash}"
+            (
+              other,
+              MonadThrow[F].raiseError[Unit](
+                new Throwable(s"Failure during setting new global snapshot: non-contiguous update current=[$current] incoming=[$incoming]")
+              )
+            )
         }.flatten
 
         _ <- incrementalSnapshotsR.modify { incrementalSnapshots =>
@@ -175,8 +182,17 @@ object LastNGlobalSnapshotStorage {
               (trimmed, Applicative[F].unit)
             case Some((_, latest)) if latest.hash === snapshot.hash =>
               (incrementalSnapshots, Applicative[F].unit)
-            case _ =>
-              (incrementalSnapshots, MonadThrow[F].raiseError[Unit](new Throwable("Failure during putting new global snapshot!")))
+            case other =>
+              val current = other.map { case (_, value) => s"ordinal=${value.ordinal},hash=${value.hash}" }.getOrElse("empty")
+              val incoming = s"ordinal=${snapshot.ordinal},hash=${snapshot.hash}"
+              (
+                incrementalSnapshots,
+                MonadThrow[F].raiseError[Unit](
+                  new Throwable(
+                    s"Failure during putting new global snapshot: non-contiguous update current=[$current] incoming=[$incoming]"
+                  )
+                )
+              )
           }
         }.flatten
       } yield ()

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/AdmissionCertificateSelectorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/AdmissionCertificateSelectorSuite.scala
@@ -20,7 +20,7 @@ import weaver.FunSuite
   *   - the cap is `math.max(0, activeAdmissionMaxExpansionPerRound)` -- EXACTLY the limit `validateProposalAcs` enforces via
   *     `acs_too_many`, so a capped proposal can never be rejected for size
   *   - selection is deterministic under input-ordering permutations (two leaders building from the same assembled set must agree)
-  *   - kept certs are the lexicographically-first targets by `PeerId` value, per `AdmissionCertificate.ordering`
+  *   - the apply defense keeps lexicographic ordering while proposal construction uses entropy and prioritizes probation recovery
   */
 object AdmissionCertificateSelectorSuite extends FunSuite {
 
@@ -129,6 +129,17 @@ object AdmissionCertificateSelectorSuite extends FunSuite {
     expect(selections.nonEmpty) &&
     forEach(selections)(selection => expect.same(selections.head, selection)) &&
     expect(selections.head.kept != List(certA))
+  }
+
+  test("proposal selection prioritizes probation recovery over open expansion") {
+    val entropy = Hash.fromBytes("probation-priority".getBytes("UTF-8"))
+    val probation = Set(certD.targetPeer)
+    val selections = all.permutations
+      .map(AdmissionCertificateSelector.selectForProposal(_, 1, entropy, probation))
+      .toList
+
+    expect(selections.nonEmpty) &&
+    forEach(selections)(selection => expect.same(List(certD), selection.kept))
   }
 
   test("apply defense keeps its version-stable legacy ordering") {

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditorSuite.scala
@@ -64,6 +64,29 @@ object FinalityParticipationAuditorSuite extends FunSuite {
     expect(third.decision.exists(d => d.consecutiveMisses == TierTransitions.DemotionConsecutiveMisses && d.shouldVote))
   }
 
+  test("three misses do not emit an eviction vote while next-seat finality headroom remains") {
+    val first = observe("parent-1", 1L, core)
+    val second = observe("parent-2", 2L, core, first.history)
+    val third = observe("parent-3", 3L, core, second.history)
+    val committee = core ++ tier1
+    val headroom = FinalityHeadroom.evaluate(committee, committee.take(6), 2.0 / 3.0)
+
+    expect(third.decision.exists(_.shouldVote)) &&
+    expect(headroom.allowsExpansion) &&
+    expect(third.decision.forall(d => !FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom)))
+  }
+
+  test("three misses emit an eviction vote when next-seat finality headroom is absent") {
+    val first = observe("parent-1", 1L, core)
+    val second = observe("parent-2", 2L, core, first.history)
+    val third = observe("parent-3", 3L, core, second.history)
+    val committee = core ++ tier1
+    val headroom = FinalityHeadroom.evaluate(committee, committee.take(5), 2.0 / 3.0)
+
+    expect(!headroom.allowsExpansion) &&
+    expect(third.decision.exists(d => FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom)))
+  }
+
   test("any observed proof resets that peer while other Tier-1 streaks continue") {
     val first = observe("parent-1", 1L, core)
     val second = observe("parent-2", 2L, core + peer('4'), first.history)

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditorSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditorSuite.scala
@@ -1,5 +1,7 @@
 package io.constellationnetwork.node.shared.infrastructure.consensus
 
+import scala.concurrent.duration._
+
 import io.constellationnetwork.schema.peer.PeerId
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
@@ -22,7 +24,9 @@ object FinalityParticipationAuditorSuite extends FunSuite {
     signers: Set[PeerId],
     previous: FinalityParticipationAuditor.MissHistory = FinalityParticipationAuditor.MissHistory.empty,
     observer: PeerId = self,
-    inBootstrap: Boolean = false
+    inBootstrap: Boolean = false,
+    observedAt: FiniteDuration = Duration.Zero,
+    minimumMissDuration: FiniteDuration = 86.seconds
   ): FinalityParticipationAuditor.Observation =
     FinalityParticipationAuditor.observe(
       observer,
@@ -32,6 +36,8 @@ object FinalityParticipationAuditorSuite extends FunSuite {
       signers,
       ordinal,
       entropy(parent),
+      if (observedAt == Duration.Zero) (ordinal * 43L).seconds else observedAt,
+      minimumMissDuration,
       inBootstrap,
       previous
     )
@@ -73,10 +79,10 @@ object FinalityParticipationAuditorSuite extends FunSuite {
 
     expect(third.decision.exists(_.shouldVote)) &&
     expect(headroom.allowsExpansion) &&
-    expect(third.decision.forall(d => !FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom)))
+    expect(third.decision.forall(d => !FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom, cadenceAllowed = true)))
   }
 
-  test("three misses emit an eviction vote when next-seat finality headroom is absent") {
+  test("three misses hold membership in the current-floor to next-floor dead band") {
     val first = observe("parent-1", 1L, core)
     val second = observe("parent-2", 2L, core, first.history)
     val third = observe("parent-3", 3L, core, second.history)
@@ -84,7 +90,37 @@ object FinalityParticipationAuditorSuite extends FunSuite {
     val headroom = FinalityHeadroom.evaluate(committee, committee.take(5), 2.0 / 3.0)
 
     expect(!headroom.allowsExpansion) &&
-    expect(third.decision.exists(d => FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom)))
+    expect(headroom.holdsMembership) &&
+    expect(third.decision.forall(d => !FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom, cadenceAllowed = true)))
+  }
+
+  test("three elapsed misses emit an eviction vote only for a current-floor deficit and on cadence") {
+    val first = observe("parent-1", 1L, core)
+    val second = observe("parent-2", 2L, core, first.history)
+    val third = observe("parent-3", 3L, core, second.history)
+    val committee = core ++ tier1
+    val headroom = FinalityHeadroom.evaluate(committee, committee.take(4), 2.0 / 3.0)
+
+    expect(headroom.allowsSilentEviction) &&
+    expect(third.decision.exists(d => FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom, cadenceAllowed = true))) &&
+    expect(third.decision.forall(d => !FinalityParticipationAuditor.shouldEmitSilentEvictionVote(d, headroom, cadenceAllowed = false)))
+  }
+
+  test("fast event rounds satisfy the miss count but not the elapsed-time floor") {
+    val first = observe("parent-1", 1L, core, observedAt = 1.second)
+    val second = observe("parent-2", 2L, core, first.history, observedAt = 8.seconds)
+    val third = observe("parent-3", 3L, core, second.history, observedAt = 15.seconds)
+    val afterElapsedFloor = observe("parent-3", 3L, core, third.history, observedAt = 87.seconds)
+
+    expect(third.decision.exists(_.roundHysteresisSatisfied)) &&
+    expect(third.decision.exists(d => !d.durationHysteresisSatisfied && !d.shouldVote)) &&
+    expect(afterElapsedFloor.decision.exists(d => d.durationHysteresisSatisfied && d.shouldVote)) &&
+    expect.same(third.history.consecutiveMisses, afterElapsedFloor.history.consecutiveMisses)
+  }
+
+  test("minimum elapsed miss duration reuses the configured idle round interval") {
+    expect.same(86.seconds, FinalityParticipationAuditor.minimumMissDuration(43.seconds, 3)) &&
+    expect.same(Duration.Zero, FinalityParticipationAuditor.minimumMissDuration(43.seconds, 1))
   }
 
   test("any observed proof resets that peer while other Tier-1 streaks continue") {
@@ -93,6 +129,7 @@ object FinalityParticipationAuditorSuite extends FunSuite {
     val third = observe("parent-3", 3L, core, second.history)
 
     expect.same(Some(0), second.history.consecutiveMisses.get(peer('4'))) &&
+    expect(!second.history.missStartedAt.contains(peer('4'))) &&
     expect.same(Some(2), second.history.consecutiveMisses.get(peer('5'))) &&
     expect.same(Some(1), third.history.consecutiveMisses.get(peer('4'))) &&
     expect.same(Some(3), third.history.consecutiveMisses.get(peer('5')))
@@ -121,6 +158,7 @@ object FinalityParticipationAuditorSuite extends FunSuite {
     expect.same(FinalityParticipationAuditor.MissHistory.empty, bootstrap.history) &&
     expect.same(None, bootstrap.decision) &&
     expect(afterRestart.history.consecutiveMisses.values.forall(_ == 1)) &&
+    expect(afterRestart.history.missStartedAt.values.forall(_ == 129.seconds)) &&
     expect(afterRestart.decision.forall(!_.shouldVote))
   }
 
@@ -130,6 +168,7 @@ object FinalityParticipationAuditorSuite extends FunSuite {
     val alternateSameOrdinal = observe("alternate-parent-3", 3L, core, afterGap.history)
 
     expect(afterGap.history.consecutiveMisses.values.forall(_ == 1)) &&
+    expect(afterGap.history.missStartedAt.values.forall(_ == 129.seconds)) &&
     expect(alternateSameOrdinal.history.consecutiveMisses.values.forall(_ == 1)) &&
     expect(alternateSameOrdinal.decision.forall(!_.shouldVote))
   }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/OpenAdmissionPolicySuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/OpenAdmissionPolicySuite.scala
@@ -49,6 +49,32 @@ object OpenAdmissionPolicySuite extends FunSuite {
     expect(!decision.allowsOpenAdmission)
   }
 
+  test("Tier-1 silence eviction is suppressed while the signer set supports one more seat") {
+    val headroom = FinalityHeadroom.evaluate(
+      currentCommittee = committee,
+      locallyObservedParentSigners = committee.take(5),
+      quorumThresholdFraction = 2.0 / 3.0
+    )
+
+    expect.same(6, headroom.currentCommitteeSize) &&
+    expect.same(5, headroom.observedCurrentCommitteeSigners) &&
+    expect.same(5, headroom.nextFinalityFloor) &&
+    expect(headroom.allowsExpansion) &&
+    expect(!headroom.allowsSilentEviction)
+  }
+
+  test("Tier-1 silence eviction is allowed only when next-seat finality headroom is absent") {
+    val headroom = FinalityHeadroom.evaluate(
+      currentCommittee = committee,
+      locallyObservedParentSigners = committee.take(4),
+      quorumThresholdFraction = 2.0 / 3.0
+    )
+
+    expect.same(-1, headroom.margin) &&
+    expect(!headroom.allowsExpansion) &&
+    expect(headroom.allowsSilentEviction)
+  }
+
   test("off-cadence rounds suppress open admission even with sufficient headroom") {
     val decision = OpenAdmissionPolicy.evaluate(
       cadenceAllowed = false,

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/OpenAdmissionPolicySuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/OpenAdmissionPolicySuite.scala
@@ -8,6 +8,7 @@ import weaver.FunSuite
 object OpenAdmissionPolicySuite extends FunSuite {
 
   private def peer(c: Char): PeerId = PeerId(Hex(c.toString * 128))
+  private def peer(index: Int): PeerId = PeerId(Hex(f"$index%0128x"))
 
   private val committee = Set(peer('1'), peer('2'), peer('3'), peer('4'), peer('5'), peer('6'))
 
@@ -58,12 +59,15 @@ object OpenAdmissionPolicySuite extends FunSuite {
 
     expect.same(6, headroom.currentCommitteeSize) &&
     expect.same(5, headroom.observedCurrentCommitteeSigners) &&
+    expect.same(4, headroom.currentFinalityFloor) &&
     expect.same(5, headroom.nextFinalityFloor) &&
+    expect.same(1, headroom.currentMargin) &&
     expect(headroom.allowsExpansion) &&
-    expect(!headroom.allowsSilentEviction)
+    expect(!headroom.allowsSilentEviction) &&
+    expect(!headroom.holdsMembership)
   }
 
-  test("Tier-1 silence eviction is allowed only when next-seat finality headroom is absent") {
+  test("current-floor to next-floor gap is a neutral membership dead band") {
     val headroom = FinalityHeadroom.evaluate(
       currentCommittee = committee,
       locallyObservedParentSigners = committee.take(4),
@@ -71,8 +75,51 @@ object OpenAdmissionPolicySuite extends FunSuite {
     )
 
     expect.same(-1, headroom.margin) &&
+    expect.same(0, headroom.currentMargin) &&
     expect(!headroom.allowsExpansion) &&
-    expect(headroom.allowsSilentEviction)
+    expect(!headroom.allowsSilentEviction) &&
+    expect(headroom.holdsMembership)
+  }
+
+  test("Tier-1 silence eviction requires a deficit against the current committee floor") {
+    val headroom = FinalityHeadroom.evaluate(
+      currentCommittee = committee,
+      locallyObservedParentSigners = committee.take(3),
+      quorumThresholdFraction = 2.0 / 3.0
+    )
+
+    expect.same(-1, headroom.currentMargin) &&
+    expect(!headroom.allowsExpansion) &&
+    expect(headroom.allowsSilentEviction) &&
+    expect(!headroom.holdsMembership)
+  }
+
+  test("a floor step holds the admitted seat instead of oscillating membership") {
+    val peers = (1 to 21).map(peer).toList
+    val signers = peers.take(14).toSet
+    val beforeAdmission = FinalityHeadroom.evaluate(peers.take(20).toSet, signers, 2.0 / 3.0)
+    val afterAdmission = FinalityHeadroom.evaluate(peers.toSet, signers, 2.0 / 3.0)
+
+    expect.same(14, beforeAdmission.currentFinalityFloor) &&
+    expect.same(14, beforeAdmission.nextFinalityFloor) &&
+    expect(beforeAdmission.allowsExpansion) &&
+    expect.same(14, afterAdmission.currentFinalityFloor) &&
+    expect.same(15, afterAdmission.nextFinalityFloor) &&
+    expect(afterAdmission.holdsMembership) &&
+    expect(!afterAdmission.allowsSilentEviction)
+  }
+
+  test("expand, hold, and evict form an exact disjoint policy for every observed signer count") {
+    val decisions = (1 to 100).flatMap { size =>
+      val peers = (1 to size).map(peer).toList
+      (0 to size).map { signerCount =>
+        FinalityHeadroom.evaluate(peers.toSet, peers.take(signerCount).toSet, 2.0 / 3.0)
+      }
+    }
+
+    expect(decisions.forall { decision =>
+      List(decision.allowsExpansion, decision.holdsMembership, decision.allowsSilentEviction).count(identity) == 1
+    })
   }
 
   test("off-cadence rounds suppress open admission even with sufficient headroom") {

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ReadmissionMaintenanceSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/ReadmissionMaintenanceSuite.scala
@@ -57,6 +57,20 @@ object ReadmissionMaintenanceSuite extends FunSuite {
     )
   }
 
+  test("probation membership includes sticky zero-countdown entries") {
+    val countdown = SortedMap(pA -> 0, pB -> 1)
+
+    expect.same(Set(pA, pB), ReadmissionMaintenance.probationPeers(countdown))
+  }
+
+  test("operational persistence distinguishes sticky zero from absent membership") {
+    val countdown = SortedMap(pA -> 0, pB -> 3)
+
+    expect.same(1, ReadmissionMaintenance.persistenceValue(countdown, pA)) &&
+    expect.same(3, ReadmissionMaintenance.persistenceValue(countdown, pB)) &&
+    expect.same(0, ReadmissionMaintenance.persistenceValue(countdown, pC))
+  }
+
   test("justUnpenalized seeds new entries at probationRounds") {
     val initial = SortedMap(pA -> 5)
     val afterSeed = ReadmissionMaintenance.step(initial, Set(pB), Set.empty, 8)

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitionsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/StateTransitionsSuite.scala
@@ -10,6 +10,53 @@ object StateTransitionsSuite extends SimpleIOSuite {
   private def pid(name: String): PeerId =
     PeerId(Hex(name.getBytes("UTF-8").map(b => f"$b%02x").mkString))
 
+  pureTest("exact downloaded outcomes preserve the caller's recovery mode") {
+    val normal = StateTransitions.downloadOutcomeDisposition(
+      keyMatches = true,
+      artifactMatches = true,
+      contextMatches = true,
+      isRecovery = false
+    )
+    val recovery = StateTransitions.downloadOutcomeDisposition(
+      keyMatches = true,
+      artifactMatches = true,
+      contextMatches = true,
+      isRecovery = true
+    )
+
+    expect.same(StateTransitions.DownloadOutcomeDisposition.AcceptExact(false), normal) &&
+    expect.same(StateTransitions.DownloadOutcomeDisposition.AcceptExact(true), recovery)
+  }
+
+  pureTest("a newer downloaded outcome requires application-storage alignment") {
+    val disposition = StateTransitions.downloadOutcomeDisposition(
+      keyMatches = false,
+      artifactMatches = false,
+      contextMatches = false,
+      isRecovery = true
+    )
+
+    expect.same(StateTransitions.DownloadOutcomeDisposition.AcceptAndAlignApplicationStorage, disposition)
+  }
+
+  pureTest("a same-key artifact or context mismatch is rejected") {
+    val artifactMismatch = StateTransitions.downloadOutcomeDisposition(
+      keyMatches = true,
+      artifactMatches = false,
+      contextMatches = true,
+      isRecovery = true
+    )
+    val contextMismatch = StateTransitions.downloadOutcomeDisposition(
+      keyMatches = true,
+      artifactMatches = true,
+      contextMatches = false,
+      isRecovery = true
+    )
+
+    expect.same(StateTransitions.DownloadOutcomeDisposition.Reject, artifactMismatch) &&
+    expect.same(StateTransitions.DownloadOutcomeDisposition.Reject, contextMismatch)
+  }
+
   pureTest("view-change leader pool uses Core when Core is populated") {
     val core = List(pid("core-1"), pid("core-2"))
     val nonCore = pid("non-core")


### PR DESCRIPTION
## Context

Follow-up to #1558 after the IntegrationNet rc.4 activation and load test.

The load test showed that peer health and signing membership had become decoupled: most of the cluster remained Ready while the Core + Tier-1 signing/reward committee contracted sharply. The initial stabilization fixed the immediate retention/readmission defects, but review identified three remaining churn risks:

- admission and silent eviction were boolean complements, allowing adjacent-size oscillation at finality-floor boundaries;
- proactive silent eviction could run every round while open admission ran only once every five rounds; and
- a three-round miss streak compressed to seconds under EventTrigger load.

The same investigation also found an independent recovery handoff defect. One node converged application storage at ordinal 5,880,534, accepted consensus outcome 5,880,535, then attempted to persist 5,880,536 against the stale application head. The nearby DownloadDaemon cancellation happened after successful convergence and was not the cause.

## Changes

### Broad Tier-1 membership and readmission

- Preserve selected parent signing leases as Tier 1 instead of deleting seats solely because they fell below the Core score threshold.
- Keep countdown-zero peers in probation until an accepted AdmissionCertificate clears membership.
- Prioritize certified probation recovery over open expansion when both compete for the bounded proposal budget.
- Keep entropy ranking at proposal construction while retaining legacy certificate ordering at state application for version-stable defense in depth.
- Keep Currency L0 on its bounded active-set policy while sharing the readmission and certificate-safety corrections.

### Headroom and eviction stability

Use an exact, protocol-derived three-state policy for observed signer count S and finality floor F:

```text
expand: S >= F(n + 1)
hold:   F(n) <= S < F(n + 1)
evict:  S < F(n)
```

- The neutral hold band prevents the observed class of boundary oscillation.
- Proactive Tier-1 silent-audit votes now use the existing five-round expansion cadence.
- Penalty/probation readmission and certified Core stall eviction remain separate every-round recovery lanes.
- Silent eviction still requires three consecutive local proof misses, and those misses must now span at least `(DemotionConsecutiveMisses - 1) * timeTriggerInterval` (86 seconds with IntegrationNet's current values).
- Proof subsets, monotonic time, and cadence only control local vote emission. Membership still changes solely through existing Core-quorum certificates.

### Recovery handoff

- Classify exact, newer-key, and invalid same-key outcome handoffs explicitly.
- Before Global L0 accepts a newer consensus outcome, align Last-N storage, LastSnapshot storage, snapshot head, MPT state, and already-committed mempool events to the accepted artifact/context.
- Record the accepted key rather than the stale requested key in the recovery marker.
- Include current and incoming ordinal/hash in non-contiguous storage errors.
- Document the recovery trace and rollout checks in ADR-0031 and the v4.1 runbook.

## Compatibility

- No new snapshot, state-proof, consensus-message, or deterministic-configuration schema.
- No new configuration value or activation ordinal.
- No change to GlobalSnapshotStateProof calculation or metagraph snapshot validation.
- Snapshot membership/reward contents can change as intended because healthy Tier-1 peers are retained and readmitted.
- Deploy one jar across the full Global-L0 cluster; mixed behavior is not the rollout plan.

## Verification

- `nodeShared/test`: 1,056 passed, 0 failed
- `dagL0/test`: 133 passed, 0 failed, 2 ignored
- `currencyL0/test`: 37 passed, 0 failed
- `scalafmtCheckAll`: passed

The rollout runbook documents the new headroom, audit, and recovery metrics and the conditions that should stop deployment.
