### PR TITLE
chore: add pre-push Scala format guard

### DIFF
--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+
+git -C "$repository_root" config core.hooksPath .githooks
+printf 'Installed tessellation Git hooks from .githooks/\n'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+cd "$repository_root"
+
+printf 'Checking Scala formatting before push...\n'
+
+if ! sbt --error scalafmtCheckAll; then
+  printf '\nScala formatting is not clean. Run `sbt scalafmtAll`, commit the result, and push again.\n' >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,18 @@
 
 For IntelliJ scalafmt integration, see [JetBrains documentation](https://www.jetbrains.com/help/idea/work-with-scala-formatter.html).
 
+### Git Hooks
+
+Install the repository hooks once after cloning:
+
+```sh
+./.githooks/install
+```
+
+The pre-push hook runs `scalafmtCheckAll`, the same formatting gate that CI runs
+first. If it fails, run `sbt scalafmtAll`, commit the formatting change, and push
+again. Git's standard `--no-verify` option remains available for exceptional cases.
+
 ## Code Contributions
 
 ### Repository Fork
@@ -59,7 +71,7 @@ git push -u origin 747-update-contrib
 ### Style Guide
 
 - Follow existing code style in the repository
-- Run `sbt runLinter` before committing (scalafmt + scalafix)
+- Run `sbt runLinter` before committing (Scalafix imports, then Scalafmt)
 
 ### Commands
 

--- a/build.sbt
+++ b/build.sbt
@@ -691,4 +691,4 @@ lazy val sdk = (project in file("modules/sdk"))
     ).flatten,
   )
 
-addCommandAlias("runLinter", ";scalafixAll --rules OrganizeImports")
+addCommandAlias("runLinter", ";scalafixAll --rules OrganizeImports;scalafmtAll")


### PR DESCRIPTION
## Summary

- add an installable tracked pre-push hook that runs `scalafmtCheckAll`
- document the one-time `./.githooks/install` setup
- make `sbt runLinter` explicitly run both Scalafix import organization and Scalafmt

## Why

The direct-sender emergency patch reached `release/integrationnet` with one unformatted test. Both the Scala and Release workflows failed immediately on `scalafmtCheckAll`; no compiler or behavioral test had failed. This fast local gate prevents that class of avoidable CI/release failure before Git sends a branch.

The hook intentionally checks only Scalafmt so it stays fast and matches CI's first fail-fast gate. Full tests and Scalafix remain CI responsibilities; `sbt runLinter` is the local auto-fix command. Git's standard `--no-verify` escape hatch remains available.

## Verification

- hook installer sets `core.hooksPath=.githooks`
- both shell files pass `bash -n`
- a real `git push` invoked the hook, `scalafmtCheckAll` passed, and the push proceeded
