### PR TITLE
fix: allow healthy validators to replace persistently non-participating nodes

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -356,11 +356,10 @@ object GlobalSnapshotConsensus {
           mptStore,
           facilitatorSelector,
           peerHistorySidecar,
-          HealthDerivedMembershipPolicy.RetainSigningLeases,
+          HealthDerivedMembershipPolicy.CertifiedEvictionOnly,
           onUnsignedRecoverySuccessor,
           (key: GlobalSnapshotKey) =>
             consensusStorage.getRoundAttemptId.flatMap { expectedAttemptId =>
-              consensusQueue.offer(ConsensusCommand.RestartAfterSoftReset(key, expectedAttemptId))
             }
         )
 
@@ -389,7 +388,7 @@ object GlobalSnapshotConsensus {
           rawEvictionVoter,
           consensusQueue,
           tier1FinalityMissHistoryRef,
-          HealthDerivedMembershipPolicy.RetainSigningLeases
+          HealthDerivedMembershipPolicy.CertifiedEvictionOnly
         )
 
       stateRemover =
@@ -509,7 +508,7 @@ object GlobalSnapshotConsensus {
           effectiveConsensusConfig,
           facilitatorSelector,
           peerQualityTracker,
-          HealthDerivedMembershipPolicy.RetainSigningLeases,
+          HealthDerivedMembershipPolicy.CertifiedEvictionOnly,
           viewChangeVoter,
           timeoutVoter,
           rawEvictionVoter,

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -360,6 +360,7 @@ object GlobalSnapshotConsensus {
           onUnsignedRecoverySuccessor,
           (key: GlobalSnapshotKey) =>
             consensusStorage.getRoundAttemptId.flatMap { expectedAttemptId =>
+              consensusQueue.offer(ConsensusCommand.RestartAfterSoftReset(key, expectedAttemptId))
             }
         )
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateAdvancer.scala
@@ -3140,12 +3140,15 @@ object GlobalSnapshotConsensusStateAdvancer {
           if (evictedTargets.isEmpty) state.facilitators
           else Facilitators(state.facilitators.value.filterNot(evictedTargets.contains))
         // GL0 retain mode signs the same canonical round-start membership that proposal
-        // construction hashed. The mutable active set reflects node-local withdrawal timing and
-        // must not enter MajoritySignature.facilitatorsHash. Legacy automatic-removal policy keeps
-        // the post-eviction active set.
-        val signatureFacilitators = membershipPolicy.canonicalFacilitators(
+        // construction hashed unless the Proposal carried a validated eviction certificate. The
+        // mutable active set reflects node-local withdrawal timing and must not enter
+        // MajoritySignature.facilitatorsHash; a certified target is consensus evidence rather
+        // than a local withdrawal. Legacy automatic-removal policy also keeps the post-eviction
+        // active set.
+        val signatureFacilitators = membershipPolicy.canonicalFacilitatorsAfterCertifiedEviction(
           postEvictionFacilitators.value,
-          state.roundStartFacilitators.value
+          state.roundStartFacilitators.value,
+          evictedTargets
         )
         val postEvictionRemoved =
           if (evictedTargets.isEmpty) state.removedFacilitators

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
@@ -85,7 +85,7 @@ object GlobalSnapshotConsensusStateCreator {
 
     /** Track every auditable parent-round Tier-1 signer from actual local snapshot proofs and audit one deterministic target. Reuse the
       * existing B1 vote path only after the round-count and elapsed-time miss floors, on the existing membership-change cadence, and when
-      * the observed signer population is below the current committee's finality floor.
+      * the observed signer population is either below the current finality floor or trapped below the next-seat floor.
       *
       * The local proof subset, monotonic time, and resulting headroom decision are evidence for local vote emission only. They never enter
       * the outcome, artifact, committee hash, or state proof. A membership change still requires the normal Core-quorum EvictionCertificate
@@ -96,6 +96,8 @@ object GlobalSnapshotConsensusStateCreator {
       lastOutcome: GlobalConsensusOutcome,
       currentCore: Set[PeerId],
       currentTier1: Set[PeerId],
+      roundStartFacilitators: List[PeerId],
+      gossipFacilitators: List[PeerId],
       resources: ConsensusResources[GlobalSnapshotArtifact, GlobalConsensusKind],
       observedAt: FiniteDuration,
       cadenceAllowed: Boolean
@@ -193,7 +195,15 @@ object GlobalSnapshotConsensusStateCreator {
               val alreadyVoted = resources.evictionVotes.get(audit.target).exists(_.contains(selfId))
               val emit =
                 if (alreadyVoted) Sync[F].unit
-                else evictionVoter.emitEvictionVote(key, audit.target, EvictionReason.Silent)
+                else
+                  evictionVoter.emitEvictionVoteForRound(
+                    key,
+                    audit.target,
+                    EvictionReason.Silent,
+                    roundStartFacilitators,
+                    gossipFacilitators,
+                    lastOutcome.finished.snapshotHash
+                  )
 
               emit >>
                 // Queue assembly before the first Facility is sent. Every honest Core voter
@@ -975,12 +985,14 @@ object GlobalSnapshotConsensusStateCreator {
         // the state. The retained post-commit effect below may be replayed after delivery fails or
         // is cancelled, so it must contain only the exact Facility self-store and gossip delivery.
         _ <-
-          if (membershipPolicy.allowsAutomaticRemoval)
+          if (membershipPolicy.acceptsEvictionCertificates)
             auditTier1FinalityParticipation(
               key,
               lastOutcome,
               committees.core.toSet,
               committees.tier1.toSet,
+              state.roundStartFacilitators.value,
+              state.facilitators.value,
               resources,
               time,
               expansionAllowedThisRound

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityHeadroom.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityHeadroom.scala
@@ -42,6 +42,14 @@ object FinalityHeadroom {
     val allowsSilentEviction: Boolean = currentMargin < 0
 
     val holdsMembership: Boolean = !allowsExpansion && !allowsSilentEviction
+
+    /** The current committee still finalizes, but its observed signer set cannot support another seat.
+      *
+      * A persistently silent Tier-1 seat may be replaced from this state only through the existing Core-quorum eviction-certificate path.
+      * This flag never mutates membership by itself and deliberately remains distinct from `allowsSilentEviction`, which describes an
+      * already-finality-deficient committee.
+      */
+    val allowsCertifiedReplacement: Boolean = holdsMembership
   }
 
   /** Evaluate the protocol-derived invariant for the largest admission batch the proposal may carry:

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/FinalityParticipationAuditor.scala
@@ -47,16 +47,18 @@ object FinalityParticipationAuditor {
 
   final case class Observation(history: MissHistory, decision: Option[Decision])
 
-  /** Combine proof-miss hysteresis, the exact current-seat finality deficit, and the existing membership-change cadence.
+  /** Combine proof-miss hysteresis, exact finality headroom, and the existing membership-change cadence.
     *
-    * This remains a local vote-emission decision. A Core quorum of existing EvictionVotes is still required before membership changes.
+    * A vote is useful both when the current committee has already fallen below its floor and in the membership HOLD where the current
+    * committee still finalizes but cannot add a replacement seat. This remains a local vote-emission decision. A Core quorum of existing
+    * EvictionVotes is still required before membership changes.
     */
   def shouldEmitSilentEvictionVote(
     decision: Decision,
     headroom: FinalityHeadroom.Evaluation,
     cadenceAllowed: Boolean
   ): Boolean =
-    decision.shouldVote && headroom.allowsSilentEviction && cadenceAllowed
+    decision.shouldVote && (headroom.allowsSilentEviction || headroom.allowsCertifiedReplacement) && cadenceAllowed
 
   /** Preserve the intended elapsed-time meaning of an N-round miss window when EventTrigger accelerates rounds.
     *

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/EvictionVoter.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/EvictionVoter.scala
@@ -21,6 +21,19 @@ trait EvictionVoter[F[_], Key] {
     target: PeerId,
     reason: EvictionReason
   ): F[Unit]
+
+  /** Emit during round creation, before the new [[io.constellationnetwork.node.shared.infrastructure.consensus.state.ConsensusState]] is
+    * visible in storage. The default preserves compatibility with voters that do not need explicit round context; the gossiping voter
+    * overrides it so the vote is bound to the same frozen committee and parent hash as the state being created.
+    */
+  def emitEvictionVoteForRound(
+    key: Key,
+    target: PeerId,
+    reason: EvictionReason,
+    roundStartFacilitators: List[PeerId],
+    gossipFacilitators: List[PeerId],
+    lastSnapshotHash: Hash
+  ): F[Unit] = emitEvictionVote(key, target, reason)
 }
 
 object EvictionVoter {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/EvictionVoter.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/EvictionVoter.scala
@@ -4,6 +4,7 @@ import cats.Applicative
 
 import io.constellationnetwork.node.shared.infrastructure.consensus.declaration.EvictionReason
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
 
 /** Emits (signs, stores locally, gossips) an `EvictionVote` on behalf of this node.
   *

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/GossipingEvictionVoter.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/engine/GossipingEvictionVoter.scala
@@ -64,34 +64,58 @@ class GossipingEvictionVoter[F[
           "target" -> ConsensusLog.pid(target)
         )
       case Some(state) =>
-        HasherSelector[F].withCurrent { implicit hasher =>
-          // Canonical committee hash for vote content so every voter signs the
-          // same hash value — EvictionCertificateBuilder matches votes by this
-          // field. Using mutable state.facilitators would block cert assembly
-          // when different voters captured different withdrawal timings.
-          state.roundStartFacilitators.value.hash.flatMap { facilitatorsHash =>
-            val lastSnapshotHash = lastSnapshotHashOf(state.lastOutcome)
-            val vote = EvictionVote(target, reason, facilitatorsHash, lastSnapshotHash)
-            vote.sign(keyPair).flatMap { signedVote =>
-              // Spread to live peers only — gossip delivery target, not vote content.
-              val targets = state.facilitators.value.toSet - selfId
-              storage.addEvictionVote(selfId, key, signedVote) >>
-                gossip.spreadDirect(ConsensusPeerEvictionVote[Key](key, signedVote), targets) >>
-                ConsensusLog
-                  .info(
-                    logger,
-                    Category.Phase,
-                    key.toString,
-                    "n/a",
-                    LogEvent.Eviction,
-                    "emitted" -> "eviction_vote",
-                    "target" -> ConsensusLog.pid(target),
-                    "reason" -> reason.toString,
-                    "targets" -> targets.size.toString
-                  )
-                  .void
-            }
-          }
+        signStoreAndGossip(
+          key,
+          target,
+          reason,
+          state.roundStartFacilitators.value,
+          state.facilitators.value,
+          lastSnapshotHashOf(state.lastOutcome)
+        )
+    }
+
+  override def emitEvictionVoteForRound(
+    key: Key,
+    target: PeerId,
+    reason: EvictionReason,
+    roundStartFacilitators: List[PeerId],
+    gossipFacilitators: List[PeerId],
+    lastSnapshotHash: Hash
+  ): F[Unit] =
+    signStoreAndGossip(key, target, reason, roundStartFacilitators, gossipFacilitators, lastSnapshotHash)
+
+  private def signStoreAndGossip(
+    key: Key,
+    target: PeerId,
+    reason: EvictionReason,
+    roundStartFacilitators: List[PeerId],
+    gossipFacilitators: List[PeerId],
+    lastSnapshotHash: Hash
+  ): F[Unit] =
+    HasherSelector[F].withCurrent { implicit hasher =>
+      // Canonical committee hash for vote content so every voter signs the same hash value.
+      // The explicit context path is used during round creation, before storage exposes state.
+      roundStartFacilitators.hash.flatMap { facilitatorsHash =>
+        val vote = EvictionVote(target, reason, facilitatorsHash, lastSnapshotHash)
+        vote.sign(keyPair).flatMap { signedVote =>
+          // Spread to live peers only — gossip delivery target, not vote content.
+          val targets = gossipFacilitators.toSet - selfId
+          storage.addEvictionVote(selfId, key, signedVote) >>
+            gossip.spreadDirect(ConsensusPeerEvictionVote[Key](key, signedVote), targets) >>
+            ConsensusLog
+              .info(
+                logger,
+                Category.Phase,
+                key.toString,
+                "n/a",
+                LogEvent.Eviction,
+                "emitted" -> "eviction_vote",
+                "target" -> ConsensusLog.pid(target),
+                "reason" -> reason.toString,
+                "targets" -> targets.size.toString
+              )
+              .void
         }
+      }
     }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/HealthDerivedMembershipPolicy.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/consensus/state/HealthDerivedMembershipPolicy.scala
@@ -6,27 +6,25 @@ import io.constellationnetwork.node.shared.infrastructure.consensus.ActiveFacili
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.peer.PeerId
 
-/** Layer policy for membership changes derived from transient health observations.
+/** Layer policy for membership changes derived from transient health observations or quorum-certified evidence.
   *
-  * Global L0's conservative bridge creates no new health-derived removal debt. It retains leases not already excluded by carried debt or
-  * administrative policy. Local Facility arrival, eviction votes, and timeout voters may still drive progress within a round, but they
-  * cannot create a new reason to delete a peer from the next round's signing committee. Currency L0 retains the legacy automatic removal
-  * behavior.
+  * Global L0 never removes a signing lease from node-local Facility arrival, withdrawal timing, or timeout observations. Its certified
+  * policy may separately accept an EvictionCertificate after the Proposal path validates the target, tip, committee hash, Core witness
+  * pool, quorum, and signatures. Currency L0 retains the legacy automatic-removal behavior.
   *
   * This policy changes behavior only. It is not serialized, hashed, or copied into consensus state.
   */
 sealed trait HealthDerivedMembershipPolicy extends Product with Serializable {
 
   def allowsAutomaticRemoval: Boolean
+  def acceptsEvictionCertificates: Boolean
 
   /** Filter both newly observed and outcome-carried Facility removals through the layer policy. */
   final def persistentFacilityRemovals(healthDerivedPeers: Set[PeerId]): Set[PeerId] =
     if (allowsAutomaticRemoval) healthDerivedPeers else Set.empty
 
   final def acceptedEvictionTargets(certifiedTargets: Set[PeerId]): Set[PeerId] =
-    if (allowsAutomaticRemoval) certifiedTargets else Set.empty
-
-  final def acceptsEvictionCertificates: Boolean = allowsAutomaticRemoval
+    if (acceptsEvictionCertificates) certifiedTargets else Set.empty
 
   /** Canonical facilitator source at a certified-view or signature boundary.
     *
@@ -35,6 +33,15 @@ sealed trait HealthDerivedMembershipPolicy extends Product with Serializable {
     */
   final def canonicalFacilitators(activeFacilitators: List[PeerId], roundStartFacilitators: List[PeerId]): List[PeerId] =
     if (allowsAutomaticRemoval) activeFacilitators else roundStartFacilitators
+
+  /** Apply a Proposal's already-validated eviction certificates without allowing node-local health observations to affect membership. */
+  final def canonicalFacilitatorsAfterCertifiedEviction(
+    activeFacilitators: List[PeerId],
+    roundStartFacilitators: List[PeerId],
+    certifiedTargets: Set[PeerId]
+  ): List[PeerId] =
+    if (certifiedTargets.nonEmpty && acceptsEvictionCertificates) activeFacilitators
+    else canonicalFacilitators(activeFacilitators, roundStartFacilitators)
 
   /** Leader pool after a certified VCC/TC. GL0 must not narrow frozen Core with node-local withdrawal observations. */
   def certifiedViewChangeLeaderPool(
@@ -74,6 +81,7 @@ object HealthDerivedMembershipPolicy {
     */
   case object RetainSigningLeases extends HealthDerivedMembershipPolicy {
     val allowsAutomaticRemoval: Boolean = false
+    val acceptsEvictionCertificates: Boolean = false
 
     def certifiedViewChangeLeaderPool(
       coreFacilitators: List[PeerId],
@@ -104,9 +112,47 @@ object HealthDerivedMembershipPolicy {
     }
   }
 
+  /** Global L0 policy: retain leases across node-local health observations, but accept an explicitly certified Tier-1 replacement.
+    *
+    * Timeout and Facility-removal behavior is identical to `RetainSigningLeases`. The only removal authority added here is an
+    * EvictionCertificate whose target, tip binding, facilitator hash, Core witness pool, quorum, and signatures are validated by the normal
+    * Proposal path.
+    */
+  case object CertifiedEvictionOnly extends HealthDerivedMembershipPolicy {
+    val allowsAutomaticRemoval: Boolean = false
+    val acceptsEvictionCertificates: Boolean = true
+
+    def certifiedViewChangeLeaderPool(
+      coreFacilitators: List[PeerId],
+      activeFacilitators: List[PeerId],
+      roundStartFacilitators: List[PeerId]
+    ): List[PeerId] = leaderPool(coreFacilitators, roundStartFacilitators)
+
+    def timeoutMembership(
+      facilitators: List[PeerId],
+      coreFacilitators: List[PeerId],
+      roundStartFacilitators: List[PeerId],
+      timeoutVoters: Set[PeerId],
+      shrinkFloor: Int
+    ): TimeoutMembership = {
+      val canonical = canonicalFacilitators(facilitators, roundStartFacilitators)
+      TimeoutMembership(
+        facilitators = canonical,
+        coreFacilitators = coreFacilitators,
+        leaderPool = certifiedViewChangeLeaderPool(coreFacilitators, facilitators, roundStartFacilitators),
+        evaluatedActive = canonical,
+        shrinkApplied = false,
+        shrinkEvaluated = false,
+        exclusionCount = 0,
+        recentSignerPoolSize = 0
+      )
+    }
+  }
+
   /** Exact rc.6 behavior retained for Currency L0. */
   case object LegacyAutomaticRemoval extends HealthDerivedMembershipPolicy {
     val allowsAutomaticRemoval: Boolean = true
+    val acceptsEvictionCertificates: Boolean = true
 
     def certifiedViewChangeLeaderPool(
       coreFacilitators: List[PeerId],


### PR DESCRIPTION
## What I observed

While testing RC10, I found a case where the consensus committee had four validator seats, but only three validators were consistently completing rounds.

Three participants were still enough to finalize snapshots, so consensus did not stop. However, four participants were needed before the committee could safely add a fifth validator.

This left the network in an unusual middle state:

- snapshots continued to finalize
- the non-participating validator kept its committee seat
- its address continued to appear in snapshot rewards
- healthy validators waiting outside the committee could not be admitted and
- committee growth and rotation could not continue.

The network was still running, but it had no safe way to replace the validator that was no longer participating.

## What RC11 improved

RC11 added important improvements to validator admission and follower recovery.

It now performs stronger checks to confirm that a candidate is aligned with the current consensus round and snapshot before admission. It also improves how a newly admitted validator catches up and becomes an active participant.

Those changes address the most likely cause of the behavior I originally saw on RC10: a newly admitted validator failing to become a reliable participant. RC11 looked noticeably healthier in both the live network data and local testing.

The remaining issue is what happens if a validator is admitted correctly but later stops participating.

That could be caused by a crashed process, a network or P2P failure, a hung consensus component, a software malfunction, or another operational problem. RC11 made the original situation less likely, but it did not change the membership policy used after a validator becomes persistently non-participating.

I was able to reproduce that remaining condition using untouched official RC11 on an isolated seven-validator network.

## What this change does

This change adds a safe replacement path for a Tier-1 validator that repeatedly fails to provide the expected consensus participation.

It intentionally does not try to classify every possible node malfunction. Instead, it acts on something the other validators can objectively observe and verify: the validator has persistently failed to participate in consensus.

Before the validator can be removed:

1. It must miss the required number of consecutive rounds.
2. The existing minimum amount of time must pass.
3. The existing membership-change schedule must allow the action.
4. Core validators must independently sign votes identifying the same validator.
5. The existing eviction-certificate process must collect the required Core quorum.
6. The proposal must validate the validator identity, snapshot, committee, voters, quorum, and signatures.

Only after those checks succeed can the non-participating validator’s seat be removed.

Once that seat is removed, the remaining committee can admit a healthy waiting validator through the normal admission process.

## Why this complements RC11

RC11 improves the process of admitting a validator and helping it become an active participant.

This change covers the other side of the lifecycle: what the network can safely do if an admitted validator later stops participating and prevents another validator from joining.

Together, the two changes provide:

- stronger checks before admission
- better recovery for newly admitted validators
- a safe response when a Tier-1 validator remains non-participating
- an opportunity for a healthy waiting validator to join and
- a path for the removed validator to return after it has recovered.

A removed validator is not permanently banned. If it is repaired, catches up to the current snapshot, and passes the existing health and probation checks, it can safely rejoin later.

## Safety

This change does not lower consensus or finality requirements.

It also does not:

- allow one validator to remove another by itself
- remove a validator based only on one node’s local health information
- count waiting validators as consensus participants
- create, assume, or bypass signatures
- bypass the existing admission process or
- bypass eviction-certificate validation.

Removal requires signed agreement from the required Core-validator quorum.

## Test results

I compared the behavior on an isolated seven-validator network.

With untouched RC11:

- the committee remained at four seats with three completing validators from rounds 32 through 45
- snapshots continued to finalize
- no validator was removed or admitted
- the non-participating validator remained in the reward set (the bad validator continued to get rewards) and
- healthy waiting validators remained outside the committee.

With this change:

- all three Core validators independently produced signed eviction votes after the required miss and time limits
- the required two-validator Core quorum formed an eviction certificate
- snapshot 36 recorded the removal
- the removed validator left the reward set
- a healthy waiting validator was admitted at round 40 and
- after the failed validator was repaired and caught up, the existing probation process safely re-admitted it at round 44.

I also ran the focused test coverage locally. All 48 tests passed, along with compilation, assembly, Scala formatting, and source-diff validation.


This work is based on official RC11 commit.