### PR TITLE
fix: reject fee transactions that overflow balances instead of minting supply

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManager.scala
@@ -14,7 +14,6 @@ import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.schema.transaction.RewardTransaction
 import io.constellationnetwork.security.signature.Signed
 
-import eu.timepit.refined.types.numeric.NonNegLong
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -75,36 +74,59 @@ class BalanceOpsManager[F[_]: Async](
     maybeTxs match {
       case None => (balances, maybeTxs).pure[F]
       case Some(txs) =>
-        val feeReferredAddresses = txs.flatMap(tx => Set(tx.value.source, tx.value.destination))
-        val feeReferredBalances = feeReferredAddresses.foldLeft(SortedMap.empty[Address, Long]) {
-          case (acc, address) =>
-            acc.updated(address, balances.getOrElse(address, Balance.empty).value.value)
-        }
-        val updatedFeeReferredBalances = txs
-          .foldLeft(feeReferredBalances) {
-            case (balances, tx) =>
-              balances
-                .updatedWith(tx.source)(existing => (existing.getOrElse(Balance.empty.value.value) - tx.amount.value.value).some)
-                .updatedWith(tx.destination)(existing => (existing.getOrElse(Balance.empty.value.value) + tx.amount.value.value).some)
-          }
+        val (updatedBalances, acceptedTxs, rejectedTxs) = BalanceOpsManager.applyFeeTransactions(balances, txs)
 
-        updatedFeeReferredBalances.toList
-          .foldLeftM(SortedMap.empty[Address, Balance]) {
-            case (acc, (address, balance)) =>
-              NonNegLong
-                .from(balance)
-                .map(Balance(_))
-                .map(acc.updated(address, _))
-                .leftMap(e => new ArithmeticException(s"Unexpected state when applying fee transactions: $e"))
-                .liftTo[F]
-          }
-          .map { updates =>
-            (balances ++ updates, txs.some)
-          }
+        rejectedTxs.traverse_ { signedTx =>
+          logger.warn(
+            s"Rejected fee transaction from ${signedTx.value.source} to ${signedTx.value.destination} of " +
+              s"${signedTx.value.amount.value.value}: source balance insufficient or destination balance overflow"
+          )
+        }
+          .as((updatedBalances, acceptedTxs.some))
     }
 }
 
 object BalanceOpsManager {
+
+  /** Applies fee transactions sequentially, dropping any transaction whose source cannot cover it.
+    *
+    * Every debit and credit goes through `Balance.minus`/`Balance.plus`, which reject underflow and overflow. Accumulating raw `Long`s and
+    * checking only the final per-address total allowed a group of transactions to wrap a source balance past `Long.MinValue` back to a
+    * non-negative value, crediting destinations with supply that was never debited from anywhere.
+    *
+    * Unaffordable transactions are dropped rather than failing the snapshot: fee transactions are user-supplied, so raising here would let
+    * anyone halt a metagraph.
+    *
+    * @return
+    *   the updated balances, the accepted transactions, and the rejected ones in iteration order
+    */
+  def applyFeeTransactions(
+    balances: SortedMap[Address, Balance],
+    txs: SortedSet[Signed[FeeTransaction]]
+  ): (SortedMap[Address, Balance], SortedSet[Signed[FeeTransaction]], List[Signed[FeeTransaction]]) = {
+    val (feeReferredBalances, rejected) =
+      txs.foldLeft((SortedMap.empty[Address, Balance], List.empty[Signed[FeeTransaction]])) {
+        case ((acc, rejected), signedTx) =>
+          val tx = signedTx.value
+
+          def balanceOf(address: Address, current: SortedMap[Address, Balance]): Balance =
+            current.getOrElse(address, balances.getOrElse(address, Balance.empty))
+
+          val applied = for {
+            debited <- balanceOf(tx.source, acc).minus(tx.amount)
+            afterDebit = acc.updated(tx.source, debited)
+            credited <- balanceOf(tx.destination, afterDebit).plus(tx.amount)
+          } yield afterDebit.updated(tx.destination, credited)
+
+          applied match {
+            case Right(updated) => (updated, rejected)
+            case Left(_)        => (acc, signedTx :: rejected)
+          }
+      }
+
+    (balances ++ feeReferredBalances, txs -- rejected, rejected.reverse)
+  }
+
   def make[F[_]: Async](
     feeTransactionValidator: FeeTransactionValidator[F]
   ): BalanceOpsManager[F] =

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManagerFeeTxsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManagerFeeTxsSuite.scala
@@ -1,0 +1,177 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot.managers.currency
+
+import cats.data.NonEmptySet
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.currency.dataApplication.FeeTransaction
+import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.currency.BalanceOpsManager.applyFeeTransactions
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object BalanceOpsManagerFeeTxsSuite extends SimpleIOSuite with Checkers {
+
+  private val payer = Address("DAG011jH7FMDvKpdb7wewrMWwYtkwq56nHquAHdi")
+  private val payeeA = Address("DAG06z64ifT2HzXoHfMexRfrcnpYFEwMqjFiPKze")
+  private val payeeB = Address("DAG07tqNLYW8jHU9emXcRTT3CfgCUoumwcLghopd")
+  private val payeeC = Address("DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM")
+  private val payeeD = Address("DAG0eQr94qUQSUhmYGNXt6CoBKWu5K6htvRMGC6M")
+
+  /** 4_611_686_018_427_387_904 — four of these sum to exactly 2^64, wrapping a Long back to zero. */
+  private val twoPow62 = 4611686018427387904L
+
+  private def proofOf(seed: Int): NonEmptySet[SignatureProof] = {
+    val hex = (seed.toString * 128).take(128)
+    NonEmptySet.one(SignatureProof(Id(Hex(hex)), Signature(Hex(hex))))
+  }
+
+  private def feeTx(source: Address, destination: Address, amount: Long, seed: Int): Signed[FeeTransaction] =
+    Signed(
+      FeeTransaction(source, destination, Amount(NonNegLong.unsafeFrom(amount)), Hash.empty),
+      proofOf(seed)
+    )
+
+  private def balancesOf(entries: (Address, Long)*): SortedMap[Address, Balance] =
+    SortedMap.from(entries.map { case (a, v) => a -> Balance(NonNegLong.unsafeFrom(v)) })
+
+  private def totalSupply(balances: SortedMap[Address, Balance]): BigInt =
+    balances.values.foldLeft(BigInt(0))((acc, b) => acc + BigInt(b.value.value))
+
+  pureTest("rejects a batch that overflows the source balance and creates no supply") {
+    // Four transfers of 2^62 out of an account holding nothing. Under wrapping arithmetic the source
+    // walks 0 -> -2^62 -> Long.MinValue -> +2^62 -> 0, ending non-negative, so a guard that only
+    // inspects the final total sees nothing wrong while every destination gains 2^62 from nowhere.
+    val txs = SortedSet(
+      feeTx(payer, payeeA, twoPow62, 1),
+      feeTx(payer, payeeB, twoPow62, 2),
+      feeTx(payer, payeeC, twoPow62, 3),
+      feeTx(payer, payeeD, twoPow62, 4)
+    )
+    val before = balancesOf(payer -> 0L)
+
+    val (after, accepted, rejected) = applyFeeTransactions(before, txs)
+
+    expect.all(
+      accepted.isEmpty,
+      rejected.size == 4,
+      after.get(payeeA).forall(_ == Balance.empty),
+      after.get(payeeB).forall(_ == Balance.empty),
+      after.get(payeeC).forall(_ == Balance.empty),
+      after.get(payeeD).forall(_ == Balance.empty),
+      after.getOrElse(payer, Balance.empty) == Balance.empty,
+      totalSupply(after) == BigInt(0)
+    )
+  }
+
+  pureTest("rejects a single fee transaction the source cannot afford") {
+    val txs = SortedSet(feeTx(payer, payeeA, 101L, 1))
+    val before = balancesOf(payer -> 100L)
+
+    val (after, accepted, rejected) = applyFeeTransactions(before, txs)
+
+    expect.all(
+      accepted.isEmpty,
+      rejected.size == 1,
+      after.getOrElse(payer, Balance.empty).value.value == 100L,
+      after.get(payeeA).forall(_ == Balance.empty)
+    )
+  }
+
+  pureTest("applies an affordable fee transaction") {
+    val txs = SortedSet(feeTx(payer, payeeA, 40L, 1))
+    val before = balancesOf(payer -> 100L, payeeA -> 5L)
+
+    val (after, accepted, rejected) = applyFeeTransactions(before, txs)
+
+    expect.all(
+      accepted.size == 1,
+      rejected.isEmpty,
+      after(payer).value.value == 60L,
+      after(payeeA).value.value == 45L,
+      totalSupply(after) == totalSupply(before)
+    )
+  }
+
+  pureTest("debits between transactions instead of validating against a stale balance") {
+    // Each transaction is affordable against the starting balance of 100, but not against the
+    // balance left after the previous one. Only the first may be accepted.
+    val txs = SortedSet(
+      feeTx(payer, payeeA, 60L, 1),
+      feeTx(payer, payeeB, 60L, 2)
+    )
+    val before = balancesOf(payer -> 100L)
+
+    val (after, accepted, rejected) = applyFeeTransactions(before, txs)
+
+    expect.all(
+      accepted.size == 1,
+      rejected.size == 1,
+      after(payer).value.value == 40L,
+      totalSupply(after) == totalSupply(before)
+    )
+  }
+
+  pureTest("rejects a transfer that would overflow the destination balance") {
+    val txs = SortedSet(feeTx(payer, payeeA, 10L, 1))
+    val before = balancesOf(payer -> 10L, payeeA -> (Long.MaxValue - 5L))
+
+    val (after, accepted, rejected) = applyFeeTransactions(before, txs)
+
+    expect.all(
+      accepted.isEmpty,
+      rejected.size == 1,
+      after(payeeA).value.value == Long.MaxValue - 5L,
+      totalSupply(after) == totalSupply(before)
+    )
+  }
+
+  pureTest("accepts the affordable prefix of a batch and rejects the rest") {
+    val txs = SortedSet(
+      feeTx(payer, payeeA, 30L, 1),
+      feeTx(payer, payeeB, 40L, 2),
+      feeTx(payer, payeeC, 90L, 3)
+    )
+    val before = balancesOf(payer -> 100L)
+
+    val (after, accepted, rejected) = applyFeeTransactions(before, txs)
+
+    expect.all(
+      accepted.size == 2,
+      rejected.size == 1,
+      rejected.head.value.amount.value.value == 90L,
+      after(payer).value.value == 30L,
+      totalSupply(after) == totalSupply(before)
+    )
+  }
+
+  test("never changes total supply, for any batch of fee transactions") {
+    val gen = for {
+      startingBalance <- Gen.oneOf(0L, 1L, 100L, Long.MaxValue / 2, Long.MaxValue)
+      amounts <- Gen.listOfN(4, Gen.oneOf(0L, 1L, 100L, twoPow62, Long.MaxValue))
+    } yield (startingBalance, amounts)
+
+    forall(gen) {
+      case (startingBalance, amounts) =>
+        val destinations = List(payeeA, payeeB, payeeC, payeeD)
+        val txs = SortedSet.from(amounts.zip(destinations).zipWithIndex.map {
+          case ((amount, destination), i) => feeTx(payer, destination, amount, i + 1)
+        })
+        val before = balancesOf(payer -> startingBalance)
+
+        val (after, _, _) = applyFeeTransactions(before, txs)
+
+        expect.eql(totalSupply(before), totalSupply(after))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`BalanceOpsManager.acceptFeeTxs` unwrapped the balance map from `Balance` to raw `Long` and applied every fee transaction in a fold, checking the result only once at the end through `NonNegLong.from`. Both the debit and the credit could wrap silently, and the single end-of-fold guard rejected a negative result while accepting one that had wrapped back around to non-negative.

## The problem

A group of large fee transactions from an address without sufficient balance can drive the running total past `Long.MinValue` and back into positive territory. Because only the final per-address total is validated, every intermediate balance is invisible to the guard, the end state is a set of valid `NonNegLong` values, and destinations end up credited with supply that was never debited from anywhere.

Worth stressing for review: **a corrected end-state guard would not catch this.** The final state is entirely valid. The check has to happen per transaction.

## The fix

Fee transactions are applied one at a time through `Balance.minus` and `Balance.plus`, the domain's existing checked operations, which reject underflow and overflow. Every intermediate balance is now validated rather than only the final total.

Transactions the source cannot cover are **dropped, not raised on**. Fee transactions are user-supplied, so raising here would let anyone permanently halt a metagraph by submitting a single unaffordable transaction — the snapshot would fail and the transaction would be retried indefinitely.

The logic moved to `BalanceOpsManager.applyFeeTransactions` so it can be unit tested directly.

## Compatibility

Behaviour is **identical** for any batch of affordable fee transactions: same balances, same accepted set. Only the overflow path changes. Normal metagraph traffic is unaffected, so this can roll out to nodes progressively without a coordinated flag day.

## Tests

`BalanceOpsManagerFeeTxsSuite`, 7 tests:

- rejects a batch that overflows the source balance and creates no supply
- rejects a single fee transaction the source cannot afford
- applies an affordable fee transaction
- debits between transactions instead of validating against a stale balance
- rejects a transfer that would overflow the destination balance
- accepts the affordable prefix of a batch and rejects the rest
- property: total supply never changes, for any batch

I verified these fail against the pre-fix implementation: restoring the old logic makes 6 of the 7 fail, and all 7 pass on the new. Full `nodeShared/test` suite passes (1070 tests).

## Not covered here — follow-ups

1. **`FeeTransactionValidator` has no balance check.** It validates only the signature and `source != destination`. Acceptance is now safe on its own, but the validator should reject unaffordable transactions earlier. Left out because plumbing balances into it changes its signature and every call site — too much for a targeted patch.
2. **`Order[FeeTransaction]` is `Order.by(_.amount)`.** Source, destination and `dataUpdateRef` do not participate in ordering, so `SortedSet` iteration order is externally influenceable and two transactions with equal amount collapse to a value-level tie broken only by proofs. Not exploitable for minting after this fix, but it should be a total order over all fields. Changing it alters snapshot content, so it needs its own coordinated change.
3. **This patch is forward-looking only.** It prevents further occurrences; it does not reconcile balances that already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
