### PR TITLE
fix(node-shared): gate data application acceptance behind activation ordinals

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -98,7 +98,13 @@ object Services {
 
       dataApplicationAcceptanceManager = (maybeDataApplication, storages.calculatedStateStorage).mapN {
         case (service, storage) =>
-          DataApplicationSnapshotAcceptanceManager.make[F](service, l0NodeContext, storage)
+          DataApplicationSnapshotAcceptanceManager.make[F](
+            service,
+            l0NodeContext,
+            storage,
+            sharedCfg.fieldsAddedOrdinals.fixingDataApplicationFeeValidation
+              .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue)
+          )
       }
 
       feeCalculator = FeeCalculator.make(cfg.shared.feeConfigs)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
@@ -121,8 +121,16 @@ object StateChannelSnapshotService {
       )(implicit hasher: Hasher[F]): F[Unit] = for {
         _ <- dataApplicationSnapshotAcceptanceManager.traverse { manager =>
           snapshotStorage.head.map { lastSnapshot =>
-            lastSnapshot.flatMap { case (value, _) => value.dataApplication }
-          }.flatMap(manager.consumeSignedMajorityArtifact(_, signedArtifact))
+            // Both come from the same previous snapshot the artifact was built on, so the activation gate
+            // resolves here exactly as it did when the artifact was created.
+            (
+              lastSnapshot.flatMap { case (value, _) => value.dataApplication },
+              lastSnapshot.flatMap { case (value, _) => value.globalSyncView }
+            )
+          }.flatMap {
+            case (lastDataApplication, lastGlobalSyncView) =>
+              manager.consumeSignedMajorityArtifact(lastDataApplication, signedArtifact, lastGlobalSyncView)
+          }
         }
         _ <- snapshotStorage
           .prepend(signedArtifact, context.snapshotInfo)

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -85,6 +85,8 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
                 Map.empty,
                 Map.empty,
                 Map.empty,
+                Map.empty,
+                Map.empty,
                 Map.empty
               ),
               Dev,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -138,7 +138,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       context: AllowSpendBlockAcceptanceContext[IO],
       snapshotOrdinal: SnapshotOrdinal,
       shouldValidateCollateral: Boolean = true,
-      lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+      lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+      creditDestination: Boolean = false
     )(implicit hasher: Hasher[IO]): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] = ???
 
     override def acceptBlocksIteratively(
@@ -146,7 +147,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       context: AllowSpendBlockAcceptanceContext[IO],
       snapshotOrdinal: SnapshotOrdinal,
       shouldValidateCollateral: Boolean = true,
-      lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+      lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+      creditDestination: Boolean = false
     )(implicit hasher: Hasher[IO]): IO[AllowSpendBlockAcceptanceResult] =
       AllowSpendBlockAcceptanceResult(
         AllowSpendBlockAcceptanceContextUpdate.empty,
@@ -324,7 +326,20 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     val snapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[IO] =
       GlobalSnapshotAcceptanceManager
         .make[IO](
-          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+          FieldsAddedOrdinals(
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty
+          ),
           MetagraphsSyncConfig(PosInt(100)),
           Dev,
           bam,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -111,7 +111,20 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
 
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
-        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+        FieldsAddedOrdinals(
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty
+        ),
         Dev,
         LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -322,7 +322,20 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
 
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
-        FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+        FieldsAddedOrdinals(
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty
+        ),
         Dev,
         LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
@@ -371,7 +384,20 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
-          FieldsAddedOrdinals(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty),
+          FieldsAddedOrdinals(
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty,
+            Map.empty
+          ),
           MetagraphsSyncConfig(PosInt(100)),
           Dev,
           blockAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -169,6 +169,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                     Map.empty,
                     Map.empty,
                     Map.empty,
+                    Map.empty,
+                    Map.empty,
                     Map.empty
                   ),
                   Dev,
@@ -212,6 +214,8 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
               globalSnapshotAcceptanceManager = GlobalSnapshotAcceptanceManager.make(
                 FieldsAddedOrdinals(
+                  Map.empty,
+                  Map.empty,
                   Map.empty,
                   Map.empty,
                   Map.empty,

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -197,6 +197,18 @@ fields-added-ordinals {
     integrationnet: 9999999,
     dev: 0
   }
+  fixing-allow-spend-destination-credit {
+    mainnet: 9999999,
+    testnet: 9999999,
+    integrationnet: 9999999,
+    dev: 0
+  }
+  fixing-data-application-fee-validation {
+    mainnet: 9999999,
+    testnet: 9999999,
+    integrationnet: 9999999,
+    dev: 0
+  }
 }
 
 validation-error-storage {

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -197,14 +197,20 @@ fields-added-ordinals {
     integrationnet: 9999999,
     dev: 0
   }
+  # At/after this global ordinal an allow spend stops crediting its destination at block acceptance; the
+  # destination is credited only when a SpendAction consumes the allowance. testnet and integrationnet are
+  # placeholders and must be pinned before those networks upgrade.
   fixing-allow-spend-destination-credit {
-    mainnet: 9999999,
+    mainnet: 6818000,
     testnet: 9999999,
     integrationnet: 9999999,
     dev: 0
   }
+  # At/after this global ordinal every fee transaction in a data envelope is validated and a data block whose
+  # fees cannot be applied is rejected. Activate only after every Currency L1 and ML0 node is upgraded, and
+  # never at an ordinal already present in signed history. testnet and integrationnet are placeholders.
   fixing-data-application-fee-validation {
-    mainnet: 9999999,
+    mainnet: 6818000,
     testnet: 9999999,
     integrationnet: 9999999,
     dev: 0

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -36,7 +36,9 @@ object types {
     updatingCombineFunctionSpendActions: Map[AppEnvironment, SnapshotOrdinal],
     fixingAllowSpendExpiration: Map[AppEnvironment, SnapshotOrdinal],
     fixingAllowSpendAndTokenLockValidation: Map[AppEnvironment, SnapshotOrdinal],
-    removingProcessedDelegatedStakeWithdrawals: Map[AppEnvironment, SnapshotOrdinal]
+    removingProcessedDelegatedStakeWithdrawals: Map[AppEnvironment, SnapshotOrdinal],
+    fixingAllowSpendDestinationCredit: Map[AppEnvironment, SnapshotOrdinal],
+    fixingDataApplicationFeeValidation: Map[AppEnvironment, SnapshotOrdinal]
   )
 
   case class MetagraphsSyncConfig(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogic.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogic.scala
@@ -19,7 +19,8 @@ trait AllowSpendBlockAcceptanceLogic[F[_]] {
     txChains: Map[Address, AllowSpendNel],
     context: AllowSpendBlockAcceptanceContext[F],
     contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
-    shouldValidateCollateral: Boolean
+    shouldValidateCollateral: Boolean,
+    creditDestination: Boolean
   )(implicit hasher: Hasher[F]): EitherT[F, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]
 
 }
@@ -34,12 +35,13 @@ object AllowSpendBlockAcceptanceLogic {
         txChains: Map[Address, AllowSpendNel],
         context: AllowSpendBlockAcceptanceContext[F],
         contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
-        shouldValidateCollateral: Boolean
+        shouldValidateCollateral: Boolean,
+        creditDestination: Boolean
       )(implicit hasher: Hasher[F]): EitherT[F, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate] =
         for {
           _ <- processSignatures(signedBlock, context, shouldValidateCollateral)
           contextUpdate1 <- processLastTxRefs(txChains, context, contextUpdate)
-          contextUpdate2 <- processBalances(signedBlock, context, contextUpdate1)
+          contextUpdate2 <- processBalances(signedBlock, context, contextUpdate1, creditDestination)
         } yield contextUpdate2
 
       def processLastTxRefs(
@@ -106,10 +108,17 @@ object AllowSpendBlockAcceptanceLogic {
             contextUpdate.copy(lastTxRefs = lastTxRefsUpdate)
           }
 
+      // An allow spend escrows the amount at the source until a SpendAction consumes it; the destination is
+      // credited by updateGlobalBalancesBySpendTransactions at that point, not here. Crediting it here as
+      // well hands the destination a balance no snapshot ever recorded, which it can then spend into further
+      // allow spend blocks until recomputation disagrees and the snapshot fails to build.
+      // TokenLockBlockAcceptanceLogic.processBalances, the other escrow, only debits.
+      // creditDestination retains the old behaviour below the activation ordinal so replay stays byte-identical.
       private def processBalances(
         block: Signed[AllowSpendBlock],
         context: AllowSpendBlockAcceptanceContext[F],
-        contextUpdate: AllowSpendBlockAcceptanceContextUpdate
+        contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
+        creditDestination: Boolean
       ): EitherT[F, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate] = {
         val minusFn: Amount => Balance => Either[BalanceArithmeticError, Balance] = a => _.minus(a)
         val plusFn: Amount => Balance => Either[BalanceArithmeticError, Balance] = a => _.plus(a)
@@ -117,9 +126,10 @@ object AllowSpendBlockAcceptanceLogic {
         val sortedTxs = block.transactions.toNonEmptyList
         val minusAmountOps = sortedTxs.groupMap(_.source)(tx => minusFn(tx.amount))
         val minusFeeOps = sortedTxs.groupMap(_.source)(tx => minusFn(tx.fee))
-        val plusAmountOps = sortedTxs.groupMap(_.destination)(tx => plusFn(tx.amount))
 
-        val allOps = minusAmountOps |+| minusFeeOps |+| plusAmountOps
+        val allOps =
+          if (creditDestination) minusAmountOps |+| minusFeeOps |+| sortedTxs.groupMap(_.destination)(tx => plusFn(tx.amount))
+          else minusAmountOps |+| minusFeeOps
 
         allOps
           .foldLeft(contextUpdate.balances.asRight[AddressBalanceOutOfRange].toEitherT[F]) { (acc, addressAndOps) =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceManager.scala
@@ -22,7 +22,8 @@ trait AllowSpendBlockAcceptanceManager[F[_]] {
     context: AllowSpendBlockAcceptanceContext[F],
     snapshotOrdinal: SnapshotOrdinal,
     shouldValidateCollateral: Boolean = true,
-    lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+    lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+    creditDestination: Boolean = false
   )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult]
 
   def acceptBlock(
@@ -30,7 +31,8 @@ trait AllowSpendBlockAcceptanceManager[F[_]] {
     context: AllowSpendBlockAcceptanceContext[F],
     snapshotOrdinal: SnapshotOrdinal,
     shouldValidateCollateral: Boolean = true,
-    lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+    lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+    creditDestination: Boolean = false
   )(implicit hasher: Hasher[F]): F[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]]
 
 }
@@ -53,7 +55,8 @@ object AllowSpendBlockAcceptanceManager {
         context: AllowSpendBlockAcceptanceContext[F],
         snapshotOrdinal: SnapshotOrdinal,
         shouldValidateCollateral: Boolean = true,
-        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+        creditDestination: Boolean = false
       )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult] = {
 
         def go(
@@ -66,7 +69,7 @@ object AllowSpendBlockAcceptanceManager {
                 blockAndTxChains match {
                   case (block, txChains) =>
                     logic
-                      .acceptBlock(block, txChains, context, acc.contextUpdate, shouldValidateCollateral)
+                      .acceptBlock(block, txChains, context, acc.contextUpdate, shouldValidateCollateral, creditDestination)
                       .map {
                         case contextUpdate =>
                           acc
@@ -123,7 +126,8 @@ object AllowSpendBlockAcceptanceManager {
         context: AllowSpendBlockAcceptanceContext[F],
         snapshotOrdinal: SnapshotOrdinal,
         shouldValidateCollateral: Boolean = true,
-        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+        creditDestination: Boolean = false
       )(implicit hasher: Hasher[F]): F[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
         blockValidator.validate(block, snapshotOrdinal, AllowSpendBlockValidationParams.default, lastGlobalSnapshotEpochProgress).flatMap {
           _.toEither
@@ -131,7 +135,14 @@ object AllowSpendBlockAcceptanceManager {
             .toEitherT[F]
             .flatMap {
               case (block, txChains) =>
-                logic.acceptBlock(block, txChains, context, AllowSpendBlockAcceptanceContextUpdate.empty, shouldValidateCollateral)
+                logic.acceptBlock(
+                  block,
+                  txChains,
+                  context,
+                  AllowSpendBlockAcceptanceContextUpdate.empty,
+                  shouldValidateCollateral,
+                  creditDestination
+                )
             }
             .leftSemiflatTap(reason => logNotAcceptedBlock((block, reason)))
             .semiflatTap(_ => logAcceptedBlock(block))

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -986,7 +986,7 @@ object CurrencySnapshotAcceptanceManager {
       // is a live read of the node's own global head, so a node replaying an old snapshot today would evaluate
       // the gate against today's head and apply the current rule to old history. lastGlobalSyncViewOrdinal is
       // carried by the previous currency snapshot, so it is the same on every node and at every replay.
-      val creditDestination = lastGlobalSyncViewOrdinal <= fixingAllowSpendDestinationCredit
+      val creditDestination = lastGlobalSyncViewOrdinal < fixingAllowSpendDestinationCredit
       if (lastUnsyncGlobalSnapshotOrdinal > fixingAllowSpendAndTokenLockValidation) {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
           blocksForAcceptance,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -279,6 +279,14 @@ object CurrencySnapshotAcceptanceManager {
         .getOrElse(environment, SnapshotOrdinal.MinValue)
       fixingAllowSpendDestinationCredit = fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
         .getOrElse(environment, SnapshotOrdinal.MinValue)
+      fixingDataApplicationFeeValidation = fieldsAddedOrdinals.fixingDataApplicationFeeValidation
+        .getOrElse(environment, SnapshotOrdinal.MinValue)
+      // Same gate, same deterministic ordinal, as the data application layer one level up. Below it that layer
+      // runs the legacy validator, which checks neither source != destination nor signature exclusivity, so a
+      // transaction failing only those still reaches acceptance. Dropping it here while an unpatched node
+      // raises would make the two produce different artifacts from the same events during the rollout window.
+      validateEveryFeeTransaction =
+        maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >= fixingDataApplicationFeeValidation
 
       acceptanceBlocksResult <- acceptBlocks(
         blocksForAcceptance,
@@ -306,7 +314,7 @@ object CurrencySnapshotAcceptanceManager {
         rewards
       )
 
-      validatedFeeTxs <- validateFeeTxs(feeTransactionsForAcceptance)
+      validatedFeeTxs <- validateFeeTxs(feeTransactionsForAcceptance, validateEveryFeeTransaction)
 
       (updatedBalancesByFeeTransactions, acceptedFeeTxs) <- acceptFeeTxs(
         updatedBalancesByRewards,
@@ -1039,28 +1047,45 @@ object CurrencySnapshotAcceptanceManager {
       (finalBalances, acceptedTxs).pure
     }
 
-    // Drops the transactions that fail validation rather than raising, for the same reason applyFeeTransactions
-    // drops unaffordable ones: fee transactions are user-supplied, and raising here fails the snapshot on a
-    // value an attacker chose. A self-addressed fee transaction, or one carrying a second signature, passes the
-    // data-application validators and is rejected only here.
+    // At or above the activation ordinal, drops the transactions that fail validation rather than raising, for
+    // the same reason applyFeeTransactions drops unaffordable ones: fee transactions are user-supplied, and
+    // raising fails the snapshot on a value an attacker chose. A self-addressed fee transaction, or one
+    // carrying a second signature, passes the data-application validators and is rejected only here.
+    //
+    // Below the activation ordinal it keeps raising. The drop changes which artifact this method produces from
+    // the same events, and the data application layer is on its legacy rules down there -- it checks neither
+    // source != destination nor signature exclusivity -- so such a transaction still reaches acceptance. A
+    // patched node dropping it while an unpatched node raises would split the rollout window.
     private def validateFeeTxs(
-      maybeTxs: Option[SortedSet[Signed[FeeTransaction]]]
+      maybeTxs: Option[SortedSet[Signed[FeeTransaction]]],
+      dropInvalid: Boolean
     ): F[Option[SortedSet[Signed[FeeTransaction]]]] =
-      maybeTxs.traverse { txs =>
-        txs.toList.traverseFilter { signedTx =>
-          feeTransactionValidator.validate(signedTx).flatMap {
+      if (!dropInvalid)
+        NonEmptyList.fromList(maybeTxs.toList.flatMap(_.toList)).fold(maybeTxs.pure[F]) { nonEmptyTxs =>
+          feeTransactionValidator.validate(nonEmptyTxs).flatMap {
             case Validated.Valid(_) =>
-              signedTx.some.pure[F]
+              maybeTxs.pure[F]
             case Validated.Invalid(errors) =>
-              logger
-                .warn(
-                  s"Dropped fee transaction from ${signedTx.value.source.show} to ${signedTx.value.destination.show} of " +
-                    s"${signedTx.value.amount.value.value}: ${errors.toList.mkString(", ")}"
-                )
-                .as(none[Signed[FeeTransaction]])
+              new Exception(s"FeeTransaction validation failed: ${errors.toList.mkString(", ")}")
+                .raiseError[F, Option[SortedSet[Signed[FeeTransaction]]]]
           }
-        }.map(SortedSet.from(_))
-      }
+        }
+      else
+        maybeTxs.traverse { txs =>
+          txs.toList.traverseFilter { signedTx =>
+            feeTransactionValidator.validate(signedTx).flatMap {
+              case Validated.Valid(_) =>
+                signedTx.some.pure[F]
+              case Validated.Invalid(errors) =>
+                logger
+                  .warn(
+                    s"Dropped fee transaction from ${signedTx.value.source.show} to ${signedTx.value.destination.show} of " +
+                      s"${signedTx.value.amount.value.value}: ${errors.toList.mkString(", ")}"
+                  )
+                  .as(none[Signed[FeeTransaction]])
+            }
+          }.map(SortedSet.from(_))
+        }
 
     private def acceptFeeTxs(
       balances: SortedMap[Address, Balance],

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotAcceptanceManager.scala
@@ -277,6 +277,8 @@ object CurrencySnapshotAcceptanceManager {
         .getOrElse(environment, SnapshotOrdinal.MinValue)
       fixingAllowSpendAndTokenLockValidation = fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation
         .getOrElse(environment, SnapshotOrdinal.MinValue)
+      fixingAllowSpendDestinationCredit = fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
+        .getOrElse(environment, SnapshotOrdinal.MinValue)
 
       acceptanceBlocksResult <- acceptBlocks(
         blocksForAcceptance,
@@ -304,11 +306,11 @@ object CurrencySnapshotAcceptanceManager {
         rewards
       )
 
-      _ <- validateFeeTxs(feeTransactionsForAcceptance)
+      validatedFeeTxs <- validateFeeTxs(feeTransactionsForAcceptance)
 
       (updatedBalancesByFeeTransactions, acceptedFeeTxs) <- acceptFeeTxs(
         updatedBalancesByRewards,
-        feeTransactionsForAcceptance
+        validatedFeeTxs
       )
 
       acceptedSharedArtifacts = acceptSharedArtifacts(sharedArtifactsForAcceptance)
@@ -415,7 +417,9 @@ object CurrencySnapshotAcceptanceManager {
         initialAllowSpendRef,
         shouldValidateCollateral,
         lastUnsyncGlobalSnapshot.ordinal,
+        maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue),
         fixingAllowSpendAndTokenLockValidation,
+        fixingAllowSpendDestinationCredit,
         lastGlobalSnapshotEpochProgress
       )
 
@@ -967,7 +971,9 @@ object CurrencySnapshotAcceptanceManager {
       initialTxRef: AllowSpendReference,
       shouldValidateCollateral: Boolean,
       lastUnsyncGlobalSnapshotOrdinal: SnapshotOrdinal,
+      lastGlobalSyncViewOrdinal: SnapshotOrdinal,
       fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal,
+      fixingAllowSpendDestinationCredit: SnapshotOrdinal,
       lastSyncGlobalSnapshotEpochProgress: EpochProgress
     )(implicit hasher: Hasher[F]) = {
       val context = AllowSpendBlockAcceptanceContext.fromStaticData(
@@ -976,13 +982,19 @@ object CurrencySnapshotAcceptanceManager {
         collateral,
         initialTxRef
       )
+      // Deliberately not lastUnsyncGlobalSnapshotOrdinal, which the sibling gate on the line below uses: that
+      // is a live read of the node's own global head, so a node replaying an old snapshot today would evaluate
+      // the gate against today's head and apply the current rule to old history. lastGlobalSyncViewOrdinal is
+      // carried by the previous currency snapshot, so it is the same on every node and at every replay.
+      val creditDestination = lastGlobalSyncViewOrdinal <= fixingAllowSpendDestinationCredit
       if (lastUnsyncGlobalSnapshotOrdinal > fixingAllowSpendAndTokenLockValidation) {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
           blocksForAcceptance,
           context,
           snapshotOrdinal,
           shouldValidateCollateral,
-          lastSyncGlobalSnapshotEpochProgress.some
+          lastSyncGlobalSnapshotEpochProgress.some,
+          creditDestination
         )
       } else {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
@@ -990,7 +1002,8 @@ object CurrencySnapshotAcceptanceManager {
           context,
           snapshotOrdinal,
           shouldValidateCollateral,
-          none
+          none,
+          creditDestination
         )
       }
     }
@@ -1026,17 +1039,27 @@ object CurrencySnapshotAcceptanceManager {
       (finalBalances, acceptedTxs).pure
     }
 
+    // Drops the transactions that fail validation rather than raising, for the same reason applyFeeTransactions
+    // drops unaffordable ones: fee transactions are user-supplied, and raising here fails the snapshot on a
+    // value an attacker chose. A self-addressed fee transaction, or one carrying a second signature, passes the
+    // data-application validators and is rejected only here.
     private def validateFeeTxs(
       maybeTxs: Option[SortedSet[Signed[FeeTransaction]]]
-    ): F[Unit] =
-      NonEmptyList.fromList(maybeTxs.toList.flatMap(_.toList)).fold(().pure[F]) { nonEmptyTxs =>
-        feeTransactionValidator.validate(nonEmptyTxs).flatMap {
-          case Validated.Valid(_) =>
-            ().pure[F]
-          case Validated.Invalid(errors) =>
-            new Exception(s"FeeTransaction validation failed: ${errors.toList.mkString(", ")}")
-              .raiseError[F, Unit]
-        }
+    ): F[Option[SortedSet[Signed[FeeTransaction]]]] =
+      maybeTxs.traverse { txs =>
+        txs.toList.traverseFilter { signedTx =>
+          feeTransactionValidator.validate(signedTx).flatMap {
+            case Validated.Valid(_) =>
+              signedTx.some.pure[F]
+            case Validated.Invalid(errors) =>
+              logger
+                .warn(
+                  s"Dropped fee transaction from ${signedTx.value.source.show} to ${signedTx.value.destination.show} of " +
+                    s"${signedTx.value.amount.value.value}: ${errors.toList.mkString(", ")}"
+                )
+                .as(none[Signed[FeeTransaction]])
+          }
+        }.map(SortedSet.from(_))
       }
 
     private def acceptFeeTxs(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
@@ -164,7 +164,7 @@ object CurrencySnapshotCreator {
             }
 
           dataApplicationAcceptanceResult <- dataApplicationSnapshotAcceptanceManager.flatTraverse(
-            _.accept(maybeLastDataApplication, dataBlocks, lastArtifact.ordinal, currentOrdinal)
+            _.accept(maybeLastDataApplication, dataBlocks, lastArtifact.ordinal, currentOrdinal, lastArtifact.globalSyncView)
           )
 
           customArtifacts = maybeCustomArtifacts.map { customArtifactFn =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
@@ -160,7 +160,7 @@ object DataApplicationSnapshotAcceptanceManager {
       // None on snapshots older than tessellation-3-migration, which are exactly the ones that must replay
       // under the legacy rules.
       val validateEveryFeeTransaction =
-        lastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) > fixingDataApplicationFeeValidation
+        lastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >= fixingDataApplicationFeeValidation
 
       val newDataState: OptionT[F, DataApplicationAcceptanceResult] = for {
         lastOnChainState <- OptionT.fromOption(maybeLastDataApplication.map(_.onChainState)).flatMapF { lastDataApplication =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/DataApplicationSnapshotAcceptanceManager.scala
@@ -6,7 +6,7 @@ import cats.data.{NonEmptyList, OptionT}
 import cats.effect.Async
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedSet
+import scala.collection.immutable.{SortedMap, SortedSet}
 import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate.getDataUpdates
@@ -15,12 +15,15 @@ import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationBlock
 import io.constellationnetwork.currency.dataApplication.storage.CalculatedStateLocalFileSystemStorage
 import io.constellationnetwork.currency.schema.currency.DataApplicationPart
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
 import io.constellationnetwork.currency.validations.DataTransactionsValidator.validateDataTransactionsL0
 import io.constellationnetwork.ext.cats.syntax.partialPrevious.catsSyntaxPartialPrevious
 import io.constellationnetwork.node.shared.domain.block.processing.{BlockNotAcceptedReason, DataBlockNotAccepted}
 import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotArtifact
 import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.{SharedArtifact, TokenUnlock}
+import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, SecurityProvider}
@@ -32,12 +35,14 @@ trait DataApplicationSnapshotAcceptanceManager[F[_]] {
     maybeLastDataApplication: Option[DataApplicationPart],
     dataBlocks: List[Signed[DataApplicationBlock]],
     lastOrdinal: SnapshotOrdinal,
-    currentOrdinal: SnapshotOrdinal
+    currentOrdinal: SnapshotOrdinal,
+    lastGlobalSyncView: Option[GlobalSyncView]
   ): F[Option[DataApplicationAcceptanceResult]]
 
   def consumeSignedMajorityArtifact(
     maybeLastDataApplication: Option[DataApplicationPart],
-    artifact: Signed[CurrencySnapshotArtifact]
+    artifact: Signed[CurrencySnapshotArtifact],
+    lastGlobalSyncView: Option[GlobalSyncView]
   ): F[Unit]
 }
 
@@ -65,9 +70,31 @@ object DataApplicationSnapshotAcceptanceManager {
   def make[F[_]: Async: Hasher: SecurityProvider](
     service: BaseDataApplicationL0Service[F],
     nodeContext: L0NodeContext[F],
-    calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F]
+    calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F],
+    fixingDataApplicationFeeValidation: SnapshotOrdinal
   ): DataApplicationSnapshotAcceptanceManager[F] = new DataApplicationSnapshotAcceptanceManager[F] {
     private val logger = Slf4jLogger.getLogger
+
+    // Same arithmetic and same iteration order as CurrencySnapshotAcceptanceManager.applyFeeTransactions, which
+    // folds over a SortedSet, so both layers reach the same verdict on the same transactions. The one difference
+    // is deliberate: acceptance drops the individual transaction it cannot apply, while here the whole block is
+    // rejected, because letting the block through would apply its data updates without charging for them.
+    private def applyFeeTransactions(
+      balances: SortedMap[Address, Balance],
+      feeTransactions: List[Signed[FeeTransaction]]
+    ): Either[Throwable, SortedMap[Address, Balance]] =
+      SortedSet.from(feeTransactions).foldLeft(balances.asRight[Throwable]) { (acc, tx) =>
+        acc.flatMap { current =>
+          (for {
+            debitedSource <- current.getOrElse(tx.source, Balance.empty).minus(tx.amount)
+            withSource = current.updated(tx.source, debitedSource)
+            creditedDestination <- withSource.getOrElse(tx.destination, Balance.empty).plus(tx.amount)
+          } yield withSource.updated(tx.destination, creditedDestination)).leftMap { e =>
+            val details = s"source: ${tx.source.show}, destination: ${tx.destination.show}, amount: ${tx.amount.value.value}"
+            new ArithmeticException(s"Cannot apply fee transaction: $e, $details")
+          }
+        }
+      }
 
     def expectCalculatedStateOrdinal(
       expectedOrdinal: SnapshotOrdinal
@@ -92,7 +119,8 @@ object DataApplicationSnapshotAcceptanceManager {
 
     def consumeSignedMajorityArtifact(
       maybeLastDataApplication: Option[DataApplicationPart],
-      artifact: Signed[CurrencySnapshotArtifact]
+      artifact: Signed[CurrencySnapshotArtifact],
+      lastGlobalSyncView: Option[GlobalSyncView]
     ): F[Unit] = {
       implicit val context: L0NodeContext[F] = nodeContext
 
@@ -103,7 +131,7 @@ object DataApplicationSnapshotAcceptanceManager {
             .liftF(da.blocks.traverse(service.deserializeBlock).map(_.flatMap(_.toOption)))
             .flatMapF { dataBlocks =>
               artifact.ordinal.partialPrevious.flatTraverse(lastOrdinal =>
-                accept(maybeLastDataApplication, dataBlocks, lastOrdinal, artifact.ordinal)
+                accept(maybeLastDataApplication, dataBlocks, lastOrdinal, artifact.ordinal, lastGlobalSyncView)
               )
             }
             .map(_.calculatedState)
@@ -119,9 +147,20 @@ object DataApplicationSnapshotAcceptanceManager {
       maybeLastDataApplication: Option[DataApplicationPart],
       dataBlocks: List[Signed[DataApplicationBlock]],
       lastOrdinal: SnapshotOrdinal,
-      currentOrdinal: SnapshotOrdinal
+      currentOrdinal: SnapshotOrdinal,
+      lastGlobalSyncView: Option[GlobalSyncView]
     ): F[Option[DataApplicationAcceptanceResult]] = {
       implicit val context: L0NodeContext[F] = nodeContext
+
+      // Snapshot acceptance is re-executed verbatim whenever a signed snapshot is replayed -- rejoin, download
+      // and consensus validation all recreate the artifact and compare it to the recorded one. The gate has to
+      // read a value carried by the history being replayed, not the node's live view of the global chain, or a
+      // node replaying an old ordinal today evaluates it against today's head and diverges. globalSyncView is a
+      // field of the previous currency snapshot, so it is identical on every node and at every replay. It is
+      // None on snapshots older than tessellation-3-migration, which are exactly the ones that must replay
+      // under the legacy rules.
+      val validateEveryFeeTransaction =
+        lastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) > fixingDataApplicationFeeValidation
 
       val newDataState: OptionT[F, DataApplicationAcceptanceResult] = for {
         lastOnChainState <- OptionT.fromOption(maybeLastDataApplication.map(_.onChainState)).flatMapF { lastDataApplication =>
@@ -153,6 +192,7 @@ object DataApplicationSnapshotAcceptanceManager {
         dataState = DataState(lastOnChainState, lastCalculatedState)
         initialResult = (
           dataState,
+          balances,
           List.empty[Signed[FeeTransaction]],
           List.empty[Signed[DataApplicationBlock]],
           List.empty[(Signed[DataApplicationBlock], DataBlockNotAccepted)]
@@ -165,19 +205,42 @@ object DataApplicationSnapshotAcceptanceManager {
             .getOrElse(Nil)
 
           if (blocksToProcess.isEmpty) {
-            val (oldState, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks) = initialResult
+            val (oldState, oldBalances, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks) = initialResult
             // No blocks to process - call combine with empty updates
             service.combine(oldState, List.empty).map { newState =>
-              (newState, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks)
+              (newState, oldBalances, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks)
             }
           } else {
             logger.info(s"Starting to process blocks: ${blocksToProcess.map(_.roundId)}") >>
               blocksToProcess.foldLeftM(initialResult) {
-                case ((currentState, accFeeTransactions, accAcceptedBlocks, accNotAcceptedBlocks), dataBlock) =>
+                case ((currentState, currentBalances, accFeeTransactions, accAcceptedBlocks, accNotAcceptedBlocks), dataBlock) =>
                   val dataTransactions = dataBlock.value.dataTransactions
 
+                  // At or above the activation ordinal the validator reads currentBalances rather than the
+                  // snapshot balances: fee transactions accepted by an earlier block in this same snapshot
+                  // have already been debited, so a later block cannot spend a balance that is no longer
+                  // there. Below it, currentBalances is never advanced and equals the snapshot balances, so
+                  // the validator sees exactly what it saw before.
+                  // The traverse validates each envelope on its own, so the per-source sum inside
+                  // validateAllFeeTransactions covers one envelope rather than the whole block: two envelopes
+                  // from the same source can each clear here while jointly exceeding its balance. The
+                  // applyFeeTransactions fold below runs over the block's fee transactions with checked
+                  // arithmetic and rejects the block in that case.
+                  val validationBalances = if (validateEveryFeeTransaction) currentBalances else balances
+
                   val dataTransactionsValidations =
-                    dataTransactions.traverse(validateDataTransactionsL0(_, service, balances, currentOrdinal, dataState)).map(_.reduce)
+                    dataTransactions
+                      .traverse(
+                        validateDataTransactionsL0(
+                          _,
+                          service,
+                          validationBalances,
+                          currentOrdinal,
+                          dataState,
+                          validateEveryFeeTransaction
+                        )
+                      )
+                      .map(_.reduce)
 
                   dataTransactionsValidations.flatTap { validation =>
                     if (validation.isValid)
@@ -190,23 +253,47 @@ object DataApplicationSnapshotAcceptanceManager {
                       val dataUpdates = getDataUpdates(dataTransactionsAsList)
                       val feeTransactions = getFeeTransactions(dataTransactionsAsList)
 
-                      for {
-                        _ <- logger.info(s"Block ${dataBlock.value.roundId} is valid")
-                        result <- service.combine(currentState, dataUpdates).map { newState =>
-                          (
-                            newState,
-                            accFeeTransactions ++ feeTransactions,
-                            accAcceptedBlocks :+ dataBlock,
-                            accNotAcceptedBlocks
-                          )
-                        }
-                        _ <- logger.info(s"SharedArtifacts produced: ${result._1.sharedArtifacts}")
-                      } yield result
+                      // Below the activation ordinal the block is never rejected for arithmetic and the
+                      // running balance is left untouched, which is the pre-fix behaviour.
+                      val feeApplication =
+                        if (validateEveryFeeTransaction) applyFeeTransactions(currentBalances, feeTransactions)
+                        else currentBalances.asRight[Throwable]
+
+                      feeApplication match {
+                        case Left(err) =>
+                          logger
+                            .warn(s"Block ${dataBlock.value.roundId} not accepted: ${err.getMessage}")
+                            .as(
+                              (
+                                currentState,
+                                currentBalances,
+                                accFeeTransactions,
+                                accAcceptedBlocks,
+                                accNotAcceptedBlocks :+ (dataBlock, DataBlockNotAccepted(err.getMessage))
+                              )
+                            )
+
+                        case Right(updatedBalances) =>
+                          for {
+                            _ <- logger.info(s"Block ${dataBlock.value.roundId} is valid")
+                            result <- service.combine(currentState, dataUpdates).map { newState =>
+                              (
+                                newState,
+                                updatedBalances,
+                                accFeeTransactions ++ feeTransactions,
+                                accAcceptedBlocks :+ dataBlock,
+                                accNotAcceptedBlocks
+                              )
+                            }
+                            _ <- logger.info(s"SharedArtifacts produced: ${result._1.sharedArtifacts}")
+                          } yield result
+                      }
 
                     case Invalid(err) =>
                       Async[F].pure(
                         (
                           currentState,
+                          currentBalances,
                           accFeeTransactions,
                           accAcceptedBlocks,
                           accNotAcceptedBlocks :+ (dataBlock, DataBlockNotAccepted(err.toString))
@@ -217,6 +304,7 @@ object DataApplicationSnapshotAcceptanceManager {
                       Async[F].pure(
                         (
                           currentState,
+                          currentBalances,
                           accFeeTransactions,
                           accAcceptedBlocks,
                           accNotAcceptedBlocks :+ (dataBlock, DataBlockNotAccepted(err.getMessage))
@@ -227,7 +315,7 @@ object DataApplicationSnapshotAcceptanceManager {
           }
         }
 
-        (newDataState, validatedFeeTransactions, validatedBlocks, notAcceptedBlocks) = processingResult
+        (newDataState, _, validatedFeeTransactions, validatedBlocks, notAcceptedBlocks) = processingResult
 
         serializedOnChainState <- OptionT.liftF(
           service.serializeState(newDataState.onChain)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
@@ -1194,7 +1194,7 @@ object GlobalSnapshotAcceptanceManager {
         collateral,
         AllowSpendReference.empty
       )
-      val creditDestination = snapshotOrdinal <= fixingAllowSpendDestinationCredit
+      val creditDestination = snapshotOrdinal < fixingAllowSpendDestinationCredit
       if (snapshotOrdinal > fixingAllowSpendAndTokenLockValidation) {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
           blocksForAcceptance,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotAcceptanceManager.scala
@@ -175,6 +175,9 @@ object GlobalSnapshotAcceptanceManager {
       val fixingAllowSpendAndTokenLockValidation = fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation
         .getOrElse(environment, SnapshotOrdinal.MinValue)
 
+      val fixingAllowSpendDestinationCredit = fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
+        .getOrElse(environment, SnapshotOrdinal.MinValue)
+
       val removingProcessedDelegatedStakeWithdrawalsOrdinal = fieldsAddedOrdinals.removingProcessedDelegatedStakeWithdrawals
         .getOrElse(environment, SnapshotOrdinal.MinValue)
 
@@ -335,6 +338,7 @@ object GlobalSnapshotAcceptanceManager {
           lastSnapshotContext,
           ordinal,
           fixingAllowSpendAndTokenLockValidation,
+          fixingAllowSpendDestinationCredit,
           epochProgress
         )
 
@@ -1181,6 +1185,7 @@ object GlobalSnapshotAcceptanceManager {
       lastSnapshotContext: GlobalSnapshotInfo,
       snapshotOrdinal: SnapshotOrdinal,
       fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal,
+      fixingAllowSpendDestinationCredit: SnapshotOrdinal,
       epochProgress: EpochProgress
     )(implicit hasher: Hasher[F]) = {
       val context = AllowSpendBlockAcceptanceContext.fromStaticData(
@@ -1189,13 +1194,15 @@ object GlobalSnapshotAcceptanceManager {
         collateral,
         AllowSpendReference.empty
       )
+      val creditDestination = snapshotOrdinal <= fixingAllowSpendDestinationCredit
       if (snapshotOrdinal > fixingAllowSpendAndTokenLockValidation) {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
           blocksForAcceptance,
           context,
           snapshotOrdinal,
           shouldValidateCollateral = true,
-          epochProgress.some
+          epochProgress.some,
+          creditDestination
         )
       } else {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
@@ -1203,7 +1210,8 @@ object GlobalSnapshotAcceptanceManager {
           context,
           snapshotOrdinal,
           shouldValidateCollateral = true,
-          none
+          none,
+          creditDestination
         )
       }
     }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogicSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogicSuite.scala
@@ -1,0 +1,161 @@
+package io.constellationnetwork.node.shared.domain.swap.block
+
+import java.util.UUID
+
+import cats.data.NonEmptySet
+import cats.effect.{IO, Resource}
+
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
+import weaver.MutableIOSuite
+
+object AllowSpendBlockAcceptanceLogicSuite extends MutableIOSuite {
+
+  type Res = (Hasher[IO], SecurityProvider[IO])
+
+  def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h = Hasher.forJson[IO]
+  } yield (h, sp)
+
+  private val source = Address("DAG011jH7FMDvKpdb7wewrMWwYtkwq56nHquAHdi")
+  private val destination = Address("DAG06z64ifT2HzXoHfMexRfrcnpYFEwMqjFiPKze")
+  private val onward = Address("DAG07tqNLYW8jHU9emXcRTT3CfgCUoumwcLghopd")
+
+  private def balance(value: Long): Balance = Balance(NonNegLong.unsafeFrom(value))
+
+  private def proofOf(seed: Int): NonEmptySet[SignatureProof] = {
+    val hex = (seed.toString * 128).take(128)
+    NonEmptySet.one(SignatureProof(Id(Hex(hex)), Signature(Hex(hex))))
+  }
+
+  private def blockOf(from: Address, to: Address, amount: Long, fee: Long, seed: Int): Signed[AllowSpendBlock] = {
+    val allowSpend = Signed(
+      AllowSpend(
+        from,
+        to,
+        None,
+        SwapAmount(PosLong.unsafeFrom(amount)),
+        AllowSpendFee(NonNegLong.unsafeFrom(fee)),
+        AllowSpendReference.empty,
+        EpochProgress(NonNegLong.unsafeFrom(100L)),
+        List.empty
+      ),
+      proofOf(seed)
+    )
+
+    val roundId = RoundId(UUID.fromString(s"00000000-0000-0000-0000-00000000000$seed"))
+
+    Signed(AllowSpendBlock(roundId, NonEmptySet.one(allowSpend)), proofOf(seed))
+  }
+
+  private def contextOf(entries: (Address, Long)*): AllowSpendBlockAcceptanceContext[IO] =
+    AllowSpendBlockAcceptanceContext.fromStaticData[IO](
+      entries.map { case (address, value) => address -> balance(value) }.toMap,
+      Map.empty,
+      Amount.empty,
+      AllowSpendReference.empty
+    )
+
+  // txChains is empty so processLastTxRefs is a no-op, and collateral validation is skipped; what is
+  // left is processBalances.
+  private def accept(
+    signedBlock: Signed[AllowSpendBlock],
+    context: AllowSpendBlockAcceptanceContext[IO],
+    contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
+    creditDestination: Boolean
+  )(
+    implicit h: Hasher[IO],
+    sp: SecurityProvider[IO]
+  ): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
+    AllowSpendBlockAcceptanceLogic
+      .make[IO]
+      .acceptBlock(signedBlock, Map.empty, context, contextUpdate, shouldValidateCollateral = false, creditDestination)
+      .value
+
+  test("escrows at the source without crediting the destination") { res =>
+    implicit val (h, sp) = res
+
+    accept(
+      blockOf(source, destination, 10L, 1L, 1),
+      contextOf(source -> 100L),
+      AllowSpendBlockAcceptanceContextUpdate.empty,
+      creditDestination = false
+    ).map {
+      case Right(update) =>
+        expect.all(
+          update.balances.get(source).contains(balance(89L)),
+          update.balances.get(destination).isEmpty
+        )
+      case Left(reason) => failure(s"expected acceptance, got $reason")
+    }
+  }
+
+  test("credits the destination below the activation ordinal") { res =>
+    implicit val (h, sp) = res
+
+    accept(
+      blockOf(source, destination, 10L, 1L, 1),
+      contextOf(source -> 100L),
+      AllowSpendBlockAcceptanceContextUpdate.empty,
+      creditDestination = true
+    ).map {
+      case Right(update) =>
+        expect.all(
+          update.balances.get(source).contains(balance(89L)),
+          update.balances.get(destination).contains(balance(10L))
+        )
+      case Left(reason) => failure(s"expected acceptance, got $reason")
+    }
+  }
+
+  // AllowSpendBlockAcceptanceManager threads contextUpdate across blocks, so under the old behaviour a
+  // destination credited by the first block funds an allow spend of its own in the second, out of a
+  // balance no snapshot ever recorded for it.
+  test("a destination cannot fund a second block once the credit is dropped") { res =>
+    implicit val (h, sp) = res
+
+    val context = contextOf(source -> 101L)
+
+    for {
+      first <- accept(blockOf(source, destination, 100L, 1L, 1), context, AllowSpendBlockAcceptanceContextUpdate.empty, false)
+      firstUpdate = first.getOrElse(AllowSpendBlockAcceptanceContextUpdate.empty)
+      second <- accept(blockOf(destination, onward, 100L, 0L, 2), context, firstUpdate, false)
+    } yield
+      expect.all(
+        first.exists(_.balances.get(source).contains(balance(0L))),
+        first.exists(_.balances.get(destination).isEmpty),
+        second.swap.exists(_.isInstanceOf[AddressBalanceOutOfRange])
+      )
+  }
+
+  test("a destination funds a second block under the old behaviour") { res =>
+    implicit val (h, sp) = res
+
+    val context = contextOf(source -> 101L)
+
+    for {
+      first <- accept(blockOf(source, destination, 100L, 1L, 1), context, AllowSpendBlockAcceptanceContextUpdate.empty, true)
+      firstUpdate = first.getOrElse(AllowSpendBlockAcceptanceContextUpdate.empty)
+      second <- accept(blockOf(destination, onward, 100L, 0L, 2), context, firstUpdate, true)
+    } yield
+      expect.all(
+        first.exists(_.balances.get(destination).contains(balance(100L))),
+        second.exists(_.balances.get(onward).contains(balance(100L)))
+      )
+  }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -177,6 +177,12 @@ object Errors {
   case object SourceWalletNotSignTheTransaction extends DataApplicationValidationError {
     val message = "Source wallet should sign the transaction"
   }
+  case object FeeTransactionNotSignedExclusivelyBySource extends DataApplicationValidationError {
+    val message = "Fee transaction should be signed exclusively by the source wallet"
+  }
+  case object SameSourceAndDestinationAddress extends DataApplicationValidationError {
+    val message = "Fee transaction source and destination should differ"
+  }
   case object InvalidSignature extends DataApplicationValidationError {
     val message = "Invalid signature in data transactions"
   }

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/DataTransactionsValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/DataTransactionsValidator.scala
@@ -9,7 +9,7 @@ import io.constellationnetwork.currency.dataApplication.DataUpdate.getDataUpdate
 import io.constellationnetwork.currency.dataApplication.Errors.MissingDataUpdateTransaction
 import io.constellationnetwork.currency.dataApplication.FeeTransaction.getByDataUpdate
 import io.constellationnetwork.currency.dataApplication._
-import io.constellationnetwork.currency.validations.FeeTransactionValidator.validateFeeTransaction
+import io.constellationnetwork.currency.validations.FeeTransactionValidator.{validateAllFeeTransactions, validateFeeTransaction}
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
@@ -25,13 +25,26 @@ object DataTransactionsValidator {
       Signed[DataUpdate],
       Option[Signed[FeeTransaction]]
     ) => F[ValidatedNec[DataApplicationValidationError, Unit]],
-    gsOrdinal: SnapshotOrdinal
+    gsOrdinal: SnapshotOrdinal,
+    validateEveryFeeTransaction: Boolean
   ): F[ValidatedNec[DataApplicationValidationError, Unit]] = {
 
     val dataUpdates = dataTransactions.collect {
       case Signed(dataUpdate: DataUpdate, proofs) => Signed(dataUpdate, proofs)
     }
     NonEmptyList.fromList(dataUpdates) match {
+      case Some(value) if validateEveryFeeTransaction =>
+        for {
+          // Only the metagraph's own fee policy is per-data-update on this path. The signature, hash and
+          // balance checks live in validateAllFeeTransactions, which sees every fee transaction in the
+          // envelope rather than the one getByDataUpdate happens to return.
+          perDataUpdateValidation <- value.traverse { dataUpdate =>
+            getByDataUpdate(dataTransactions, dataUpdate.value, dataApplication.serializeUpdate)
+              .flatMap(maybeFeeTransaction => validateFee(gsOrdinal)(dataUpdate, maybeFeeTransaction))
+          }.map(_.reduce)
+          allFeeTransactionsValidation <- validateAllFeeTransactions(dataTransactions, balances, dataApplication)
+        } yield perDataUpdateValidation.productR(allFeeTransactionsValidation)
+
       case Some(value) =>
         value.traverse { dataUpdate =>
           for {
@@ -43,6 +56,7 @@ object DataTransactionsValidator {
               .productR(feeAgainstDataUpdateValidation)
         }
           .map(_.reduce)
+
       case None =>
         MissingDataUpdateTransaction
           .asInstanceOf[DataApplicationValidationError]
@@ -52,6 +66,7 @@ object DataTransactionsValidator {
 
   }
 
+  // L1 is an admission check and never replays signed history, so it always runs the current rules.
   def validateDataTransactionsL1[F[_]: Async: L1NodeContext: SecurityProvider](
     dataTransactions: DataTransactions,
     dataApplication: BaseDataApplicationL1Service[F],
@@ -68,16 +83,20 @@ object DataTransactionsValidator {
         balances,
         dataApplication,
         dataApplication.validateFee,
-        gsOrdinal
+        gsOrdinal,
+        validateEveryFeeTransaction = true
       )
     } yield dataUpdatesValidation.productR(dataTransactionsValidation)
 
+  // L0 runs inside snapshot acceptance, which is re-executed verbatim when a signed snapshot is replayed,
+  // so the caller decides which rules apply from an ordinal recorded in the history being replayed.
   def validateDataTransactionsL0[F[_]: Async: L0NodeContext: SecurityProvider](
     dataTransactions: DataTransactions,
     dataApplication: BaseDataApplicationL0Service[F],
     balances: Map[Address, Balance],
     gsOrdinal: SnapshotOrdinal,
-    currentState: DataState[DataOnChainState, DataCalculatedState]
+    currentState: DataState[DataOnChainState, DataCalculatedState],
+    validateEveryFeeTransaction: Boolean
   ): F[ValidatedNec[DataApplicationValidationError, Unit]] =
     for {
       dataUpdates <- OptionT
@@ -89,7 +108,8 @@ object DataTransactionsValidator {
         balances,
         dataApplication,
         dataApplication.validateFee,
-        gsOrdinal
+        gsOrdinal,
+        validateEveryFeeTransaction
       )
     } yield dataUpdatesValidation.productR(dataTransactionsValidation)
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/FeeTransactionValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/FeeTransactionValidator.scala
@@ -8,7 +8,7 @@ import io.constellationnetwork.currency.dataApplication.DataTransaction.DataTran
 import io.constellationnetwork.currency.dataApplication.Errors._
 import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -67,6 +67,8 @@ object FeeTransactionValidator {
         }
       }
 
+  // Legacy path, kept for replay below the activation ordinal. It reaches a fee transaction only through
+  // getByDataUpdate, so it sees at most one per data update; validateAllFeeTransactions is the current path.
   def validateFeeTransaction[F[_]: Async: SecurityProvider](
     maybeFeeTransaction: Option[Signed[FeeTransaction]],
     dataTransactions: DataTransactions,
@@ -82,5 +84,113 @@ object FeeTransactionValidator {
           hashMatchValidation <- validateFeeTransactionHashMatch(feeTransaction, dataTransactions, dataApplication)
         } yield sourceWalletValidation.productR(hashMatchValidation).productR(balanceValidation)
     }
+
+  private def validateFeeTransactionRefPresent(
+    feeTransaction: Signed[FeeTransaction],
+    dataUpdateHashes: Set[Hash]
+  ): ValidatedNec[DataApplicationValidationError, Unit] =
+    if (dataUpdateHashes.contains(feeTransaction.value.dataUpdateRef)) ().validNec[DataApplicationValidationError]
+    else
+      MissingDataUpdateOfFeeTransaction
+        .asInstanceOf[DataApplicationValidationError]
+        .invalidNec[Unit]
+
+  // node-shared's FeeTransactionValidator runs on the same transactions immediately before acceptance and
+  // enforces both exclusivity and source != destination. Anything it rejects but this layer accepts is a
+  // user-supplied value that reaches acceptance and is dropped there, after combine has already applied the
+  // data update it was paying for.
+  private def validateFeeTransactionAddresses[F[_]: Async: SecurityProvider](
+    feeTransaction: Signed[FeeTransaction]
+  ): F[ValidatedNec[DataApplicationValidationError, Unit]] = {
+    val tx = feeTransaction.value
+
+    feeTransaction.proofs
+      .map(_.id)
+      .toList
+      .traverse(_.toAddress[F])
+      .map { proofAddresses =>
+        // Exclusivity only makes sense as a complaint once the source has signed at all; reporting both
+        // when it has not just duplicates SourceWalletNotSignTheTransaction.
+        val signedBySource =
+          if (!proofAddresses.contains(tx.source))
+            SourceWalletNotSignTheTransaction.asInstanceOf[DataApplicationValidationError].invalidNec[Unit]
+          else if (!proofAddresses.forall(_ === tx.source))
+            FeeTransactionNotSignedExclusivelyBySource.asInstanceOf[DataApplicationValidationError].invalidNec[Unit]
+          else ().validNec[DataApplicationValidationError]
+
+        val differentAddresses =
+          if (tx.source =!= tx.destination) ().validNec[DataApplicationValidationError]
+          else SameSourceAndDestinationAddress.asInstanceOf[DataApplicationValidationError].invalidNec[Unit]
+
+        signedBySource.productR(differentAddresses)
+      }
+  }
+
+  // Acceptance applies every fee transaction in the envelope, so every one of them has to be validated
+  // here. Walking the data updates instead reaches a fee transaction only through getByDataUpdate, which
+  // returns an Option -- a fee transaction referencing no data update present in the envelope is skipped
+  // entirely and reaches acceptance unchecked.
+  def validateAllFeeTransactions[F[_]: Async: SecurityProvider](
+    dataTransactions: DataTransactions,
+    balances: Map[Address, Balance],
+    dataApplication: BaseDataApplicationService[F]
+  ): F[ValidatedNec[DataApplicationValidationError, Unit]] = {
+    val feeTransactions = dataTransactions.collect {
+      case Signed(feeTransaction: FeeTransaction, proofs) => Signed(feeTransaction, proofs)
+    }
+
+    // Hashed once for the whole envelope. Checking each fee transaction against the data updates one at a
+    // time re-serializes them per fee transaction, which a sender controls: n fee transactions all pointing
+    // at a dataUpdateRef that is not there costs every validating node n * m serializations. Envelopes
+    // carrying no fee transactions still serialize nothing, which is the common case.
+    val dataUpdateHashes: F[Set[Hash]] =
+      if (feeTransactions.isEmpty) Set.empty[Hash].pure[F]
+      else
+        dataTransactions.collect { case Signed(dataUpdate: DataUpdate, _) => dataUpdate }
+          .traverse(dataUpdate => dataApplication.serializeUpdate(dataUpdate).map(Hash.fromBytes))
+          .map(_.toSet)
+
+    dataUpdateHashes.flatMap { hashes =>
+      feeTransactions.traverse { feeTransaction =>
+        validateFeeTransactionAddresses(feeTransaction).map(_.productR(validateFeeTransactionRefPresent(feeTransaction, hashes)))
+      }.map {
+        _.foldLeft(().validNec[DataApplicationValidationError])(_.productR(_))
+          .productR(validateSourcesHaveEnoughBalance(feeTransactions, balances))
+      }
+    }
+  }
+
+  // A single source may fund several fee transactions in one envelope. Checking each against the same
+  // starting balance lets the group overspend it, so the group is summed with the checked Amount.plus.
+  //
+  // This is deliberately stricter than DataApplicationSnapshotAcceptanceManager.applyFeeTransactions, which
+  // folds sequentially and so can pay a fee transaction out of a credit an earlier one in the same block
+  // produced. The two do not need to agree: this runs per envelope, applyFeeTransactions runs per block over
+  // the block's whole SortedSet, and the fold order there is amount-ascending rather than envelope order.
+  // Rejecting an envelope this layer cannot prove affordable costs the sender a resubmission; accepting one
+  // it cannot is the failure that matters.
+  private def validateSourcesHaveEnoughBalance(
+    feeTransactions: List[Signed[FeeTransaction]],
+    balances: Map[Address, Balance]
+  ): ValidatedNec[DataApplicationValidationError, Unit] =
+    feeTransactions
+      .groupBy(_.value.source)
+      .toList
+      .traverse {
+        case (source, txs) =>
+          val notEnoughBalance = SourceWalletNotEnoughBalance.asInstanceOf[DataApplicationValidationError]
+
+          val totalOrError = txs.foldLeft(Amount.empty.asRight[DataApplicationValidationError]) { (acc, tx) =>
+            acc.flatMap(_.plus(tx.value.amount).leftMap(_ => notEnoughBalance))
+          }
+
+          totalOrError.flatMap { total =>
+            val available = Balance.toAmount(balances.getOrElse(source, Balance.empty))
+
+            if (available < total) notEnoughBalance.asLeft[Unit]
+            else ().asRight[DataApplicationValidationError]
+          }.toValidatedNec
+      }
+      .void
 
 }

--- a/modules/shared/src/test/scala/io/constellationnetwork/currency/validations/FeeTransactionValidatorSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/currency/validations/FeeTransactionValidatorSuite.scala
@@ -1,0 +1,160 @@
+package io.constellationnetwork.currency.validations
+
+import cats.data.{NonEmptyList, ValidatedNec}
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.DataTransaction.DataTransactions
+import io.constellationnetwork.currency.dataApplication.Errors._
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationBlock
+import io.constellationnetwork.currency.validations.FeeTransactionValidator.validateAllFeeTransactions
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.signature.Signed
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.{Decoder, Encoder}
+import org.http4s.{EntityDecoder, EntityEncoder}
+import weaver.MutableIOSuite
+
+object FeeTransactionValidatorSuite extends MutableIOSuite {
+
+  type Res = (JsonSerializer[IO], Hasher[IO], SecurityProvider[IO])
+
+  def sharedResource: Resource[IO, Res] =
+    for {
+      implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+      h = Hasher.forJson[IO]
+      sp <- SecurityProvider.forAsync[IO]
+    } yield (j, h, sp)
+
+  @derive(decoder, encoder)
+  case class SampleDataUpdate(value: String) extends DataUpdate
+
+  def mkDataApplication(implicit j: JsonSerializer[IO]): BaseDataApplicationService[IO] =
+    new BaseDataApplicationService[IO] {
+      def serializeUpdate(update: DataUpdate): IO[Array[Byte]] = update match {
+        case sample: SampleDataUpdate => j.serialize(sample)
+        case other                    => IO.raiseError(new IllegalArgumentException(s"Unexpected data update: $other"))
+      }
+
+      def serializeState(state: DataOnChainState): IO[Array[Byte]] = ???
+      def deserializeState(bytes: Array[Byte]): IO[Either[Throwable, DataOnChainState]] = ???
+      def deserializeUpdate(bytes: Array[Byte]): IO[Either[Throwable, DataUpdate]] = ???
+      def serializeBlock(block: Signed[DataApplicationBlock]): IO[Array[Byte]] = ???
+      def deserializeBlock(bytes: Array[Byte]): IO[Either[Throwable, Signed[DataApplicationBlock]]] = ???
+      def serializeCalculatedState(state: DataCalculatedState): IO[Array[Byte]] = ???
+      def deserializeCalculatedState(bytes: Array[Byte]): IO[Either[Throwable, DataCalculatedState]] = ???
+      def dataEncoder: Encoder[DataUpdate] = ???
+      def dataDecoder: Decoder[DataUpdate] = ???
+      def signedDataEntityEncoder: EntityEncoder[IO, Signed[DataUpdate]] = ???
+      def signedDataEntityDecoder: EntityDecoder[IO, Signed[DataUpdate]] = ???
+      def calculatedStateEncoder: Encoder[DataCalculatedState] = ???
+      def calculatedStateDecoder: Decoder[DataCalculatedState] = ???
+    }
+
+  // One data update plus `amounts.size` fee transactions, all signed by the same source. When
+  // refMatchesDataUpdate is false the fee transactions point at a hash no data update in the envelope
+  // serializes to, which is what getByDataUpdate silently skips.
+  def mkEnvelope(
+    amounts: List[Amount],
+    refMatchesDataUpdate: Boolean = true,
+    selfAddressed: Boolean = false,
+    coSigned: Boolean = false
+  )(implicit j: JsonSerializer[IO], h: Hasher[IO], sp: SecurityProvider[IO]): IO[(Address, DataTransactions)] =
+    for {
+      sourceKeyPair <- KeyPairGenerator.makeKeyPair[IO]
+      source = sourceKeyPair.getPublic.toAddress
+      otherKeyPair <- KeyPairGenerator.makeKeyPair[IO]
+      destination = if (selfAddressed) source else otherKeyPair.getPublic.toAddress
+      update = SampleDataUpdate("sample")
+      signedUpdate <- Signed.forAsyncHasher(update, sourceKeyPair)
+      serializedUpdate <- j.serialize(update)
+      dataUpdateRef = if (refMatchesDataUpdate) Hash.fromBytes(serializedUpdate) else Hash.empty
+      feeTransactions <- amounts.traverse { amount =>
+        Signed
+          .forAsyncHasher(FeeTransaction(source, destination, amount, dataUpdateRef), sourceKeyPair)
+          .flatMap(signed => if (coSigned) signed.signAlsoWith(otherKeyPair) else signed.pure[IO])
+      }
+    } yield (source, NonEmptyList[Signed[DataTransaction]](signedUpdate, feeTransactions))
+
+  def errorsOf(result: ValidatedNec[DataApplicationValidationError, Unit]): List[DataApplicationValidationError] =
+    result.fold(_.toList, _ => List.empty)
+
+  // The amount of each of the four fee transactions minted on mainnet at metagraph ordinal 731261. Their
+  // total is exactly 2^64, so an unchecked sum wraps to 0 and clears any balance check.
+  val exploitAmount: Amount = Amount(NonNegLong(4611686018427387904L))
+
+  test("a fee transaction referencing no data update in the envelope is rejected") { res =>
+    implicit val (j, h, sp) = res
+
+    for {
+      (source, dataTransactions) <- mkEnvelope(List(Amount(NonNegLong(60L))), refMatchesDataUpdate = false)
+      balances = Map(source -> Balance(NonNegLong(100L)))
+      result <- validateAllFeeTransactions[IO](dataTransactions, balances, mkDataApplication)
+    } yield expect(errorsOf(result).contains(MissingDataUpdateOfFeeTransaction))
+  }
+
+  test("fee transactions from one source whose total overflows Long are rejected rather than wrapping") { res =>
+    implicit val (j, h, sp) = res
+
+    for {
+      (_, dataTransactions) <- mkEnvelope(List.fill(4)(exploitAmount), refMatchesDataUpdate = true)
+      result <- validateAllFeeTransactions[IO](dataTransactions, Map.empty[Address, Balance], mkDataApplication)
+    } yield expect(errorsOf(result).contains(SourceWalletNotEnoughBalance))
+  }
+
+  test("fee transactions that each fit the source balance but jointly exceed it are rejected") { res =>
+    implicit val (j, h, sp) = res
+
+    val affordableAlone = Amount(NonNegLong(60L))
+
+    for {
+      (source, dataTransactions) <- mkEnvelope(List(affordableAlone, affordableAlone), refMatchesDataUpdate = true)
+      balances = Map(source -> Balance(NonNegLong(100L)))
+      result <- validateAllFeeTransactions[IO](dataTransactions, balances, mkDataApplication)
+    } yield expect(errorsOf(result).contains(SourceWalletNotEnoughBalance))
+  }
+
+  test("a funded fee transaction referencing a data update in the envelope is valid") { res =>
+    implicit val (j, h, sp) = res
+
+    for {
+      (source, dataTransactions) <- mkEnvelope(List(Amount(NonNegLong(60L))), refMatchesDataUpdate = true)
+      balances = Map(source -> Balance(NonNegLong(100L)))
+      result <- validateAllFeeTransactions[IO](dataTransactions, balances, mkDataApplication)
+    } yield expect(result.isValid)
+  }
+
+  // The two below are rejected by node-shared's FeeTransactionValidator at acceptance. If this layer lets
+  // them through, the block is accepted, combine applies the data update, and the fee is dropped at
+  // acceptance -- the update happens for free.
+  test("a fee transaction sending to its own source is rejected") { res =>
+    implicit val (j, h, sp) = res
+
+    for {
+      (source, dataTransactions) <- mkEnvelope(List(Amount(NonNegLong(60L))), selfAddressed = true)
+      balances = Map(source -> Balance(NonNegLong(100L)))
+      result <- validateAllFeeTransactions[IO](dataTransactions, balances, mkDataApplication)
+    } yield expect(errorsOf(result).contains(SameSourceAndDestinationAddress))
+  }
+
+  test("a fee transaction carrying a signature other than the source's is rejected") { res =>
+    implicit val (j, h, sp) = res
+
+    for {
+      (source, dataTransactions) <- mkEnvelope(List(Amount(NonNegLong(60L))), coSigned = true)
+      balances = Map(source -> Balance(NonNegLong(100L)))
+      result <- validateAllFeeTransactions[IO](dataTransactions, balances, mkDataApplication)
+    } yield expect(errorsOf(result).contains(FeeTransactionNotSignedExclusivelyBySource))
+  }
+}


### PR DESCRIPTION
## Summary

Aligns the data application acceptance path with the validation node-shared already performs immediately before acceptance, so the two layers reach the same verdict on the same transactions.

All behaviour changes are routed through `FieldsAddedOrdinals` entries. Snapshots signed before the activation ordinal continue to replay under the rules they were produced with, so rejoin, download and consensus validation recreate them unchanged, and a rolling upgrade does not split consensus.

## Changes

- `fixing-data-application-fee-validation` gates the data application acceptance changes. Below it, the previous code path runs unmodified.
- `fixing-allow-spend-destination-credit` gates the allow-spend destination credit change on the currency side.
- Both gates read the previous snapshot's `globalSyncView` rather than the node's live view of the global chain, so they evaluate identically on every node and at every replay. `None`, on snapshots older than `tessellation-3-migration`, resolves to the legacy path.
- L1 is an admission check and never replays signed history, so it always runs the current rules.
- `fixingAllowSpendDestinationCredit` and `fixingDataApplicationFeeValidation` are required config keys, consistent with the other ten entries in the block: a config that omits them fails to load rather than resolving to an unintended default.

## Notable

`validateFeeTxs` in `CurrencySnapshotAcceptanceManager` is gated as well. Below activation it keeps raising. The drop changes which artifact acceptance produces from the same events, and below activation the data application layer is on its legacy validator, which checks neither `source != destination` nor signature exclusivity, so such a transaction still reaches acceptance. A patched node dropping it while an unpatched node raises would split the rollout window.

## Activation

Both gates activate at global ordinal **6818000 on mainnet**, and the comparison is at/after, so 6818000 is the first ordinal on the new path. Roll the binary out to every Currency L1 and ML0 node before that ordinal is reached.

`testnet` and `integrationnet` are still placeholders (`9999999`) and must be pinned before those networks upgrade. `dev` is `0`, so a fresh network runs the current rules from genesis.

## Verification

- `compile` and `Test/compile` clean across all modules.
- Touched suites pass: `FeeTransactionValidatorSuite` (6), node-shared snapshot and allow-spend suites (12).
- `scalafmtAll` clean.
- The legacy branch was restored from `origin/release/mainnet` rather than reimplemented; `diff` against that revision shows it is unchanged apart from one widened import.

## Not covered

The activation gate itself has no unit test - reaching it needs a stubbed `BaseDataApplicationL0Service`, `L0NodeContext` and `CalculatedStateLocalFileSystemStorage`.
