### PR TITLE
fix(node-shared): gate data application acceptance behind activation ordinals

### DIFF
--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -333,6 +333,23 @@ fields-added-ordinals {
     integrationnet: 5880000,
     dev: 0
   }
+  # At/after this global ordinal every fee transaction in a data envelope is validated and a data block whose
+  # fees cannot be applied is rejected. Activate only after every Currency L1 and ML0 node is upgraded, and
+  # never at an ordinal already present in signed history. testnet and integrationnet are placeholders.
+  fixing-data-application-fee-validation {
+    mainnet: 6818000,
+    testnet: 9999999,
+    integrationnet: 9999999,
+    dev: 0
+  }
+  # At/after this global ordinal an allow spend stops crediting its destination at block acceptance.
+  # testnet and integrationnet are placeholders.
+  fixing-allow-spend-destination-credit {
+    mainnet: 6818000,
+    testnet: 9999999,
+    integrationnet: 9999999,
+    dev: 0
+  }
 }
 
 validation-error-storage {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -55,10 +55,23 @@ object types {
     // the `fields-added-ordinals.dust-sweeps` HOCON block, so the jar hash plus the environment is the determinism fence (the
     // conf is packaged into the assembly jar and peers only connect to matching jar hashes). Default empty: an environment with
     // no entry never sweeps. See `DustSweep` and `GlobalSnapshotDustSweep`.
-    dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] = Map.empty
+    dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] = Map.empty,
+    // At/after this global ordinal every fee transaction in a data envelope is validated, and a data block whose
+    // fees cannot be applied is rejected. Deliberately NOT feeTransactionSecurity: that gate is already open on
+    // integrationnet at 5880000, so widening what it controls would change how signed history there replays.
+    fixingDataApplicationFeeValidation: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+    // At/after this global ordinal an allow spend no longer credits its destination at block acceptance; the
+    // destination is credited only when a SpendAction consumes the allowance.
+    fixingAllowSpendDestinationCredit: Map[AppEnvironment, SnapshotOrdinal] = Map.empty
   ) {
     def feeTransactionSecurityFor(environment: AppEnvironment): SnapshotOrdinal =
       feeTransactionSecurity.getOrElse(environment, SnapshotOrdinal.MaxValue)
+
+    def fixingDataApplicationFeeValidationFor(environment: AppEnvironment): SnapshotOrdinal =
+      fixingDataApplicationFeeValidation.getOrElse(environment, SnapshotOrdinal.MinValue)
+
+    def fixingAllowSpendDestinationCreditFor(environment: AppEnvironment): SnapshotOrdinal =
+      fixingAllowSpendDestinationCredit.getOrElse(environment, SnapshotOrdinal.MinValue)
   }
 
   /** A single ordinal-gated GSI dust sweep (state deflation).

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogic.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogic.scala
@@ -19,7 +19,8 @@ trait AllowSpendBlockAcceptanceLogic[F[_]] {
     txChains: Map[Address, AllowSpendNel],
     context: AllowSpendBlockAcceptanceContext[F],
     contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
-    shouldPerformMetagraphSpecificValidations: Boolean
+    shouldPerformMetagraphSpecificValidations: Boolean,
+    creditDestination: Boolean
   )(implicit hasher: Hasher[F]): EitherT[F, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]
 
 }
@@ -34,12 +35,13 @@ object AllowSpendBlockAcceptanceLogic {
         txChains: Map[Address, AllowSpendNel],
         context: AllowSpendBlockAcceptanceContext[F],
         contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
-        shouldPerformMetagraphSpecificValidations: Boolean
+        shouldPerformMetagraphSpecificValidations: Boolean,
+        creditDestination: Boolean
       )(implicit hasher: Hasher[F]): EitherT[F, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate] =
         for {
           _ <- processSignatures(signedBlock, context, shouldPerformMetagraphSpecificValidations)
           contextUpdate1 <- processLastTxRefs(txChains, context, contextUpdate)
-          contextUpdate2 <- processBalances(signedBlock, context, contextUpdate1)
+          contextUpdate2 <- processBalances(signedBlock, context, contextUpdate1, creditDestination)
         } yield contextUpdate2
 
       def processLastTxRefs(
@@ -106,10 +108,17 @@ object AllowSpendBlockAcceptanceLogic {
             contextUpdate.copy(lastTxRefs = lastTxRefsUpdate)
           }
 
+      // An allow spend escrows the amount at the source until a SpendAction consumes it; the destination is
+      // credited by updateGlobalBalancesBySpendTransactions at that point, not here. Crediting it here as well
+      // hands the destination a balance no snapshot ever recorded, which it can then spend into further allow
+      // spend blocks until recomputation disagrees and the snapshot fails to build.
+      // TokenLockBlockAcceptanceLogic.processBalances, the other escrow, only debits.
+      // creditDestination retains the old behaviour below the activation ordinal so replay stays byte-identical.
       private def processBalances(
         block: Signed[AllowSpendBlock],
         context: AllowSpendBlockAcceptanceContext[F],
-        contextUpdate: AllowSpendBlockAcceptanceContextUpdate
+        contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
+        creditDestination: Boolean
       ): EitherT[F, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate] = {
         val minusFn: Amount => Balance => Either[BalanceArithmeticError, Balance] = a => _.minus(a)
         val plusFn: Amount => Balance => Either[BalanceArithmeticError, Balance] = a => _.plus(a)
@@ -117,9 +126,9 @@ object AllowSpendBlockAcceptanceLogic {
         val sortedTxs = block.transactions.toNonEmptyList
         val minusAmountOps = sortedTxs.groupMap(_.source)(tx => minusFn(tx.amount))
         val minusFeeOps = sortedTxs.groupMap(_.source)(tx => minusFn(tx.fee))
-        val plusAmountOps = sortedTxs.groupMap(_.destination)(tx => plusFn(tx.amount))
-
-        val allOps = minusAmountOps |+| minusFeeOps |+| plusAmountOps
+        val allOps =
+          if (creditDestination) minusAmountOps |+| minusFeeOps |+| sortedTxs.groupMap(_.destination)(tx => plusFn(tx.amount))
+          else minusAmountOps |+| minusFeeOps
 
         allOps
           .foldLeft(contextUpdate.balances.asRight[AddressBalanceOutOfRange].toEitherT[F]) { (acc, addressAndOps) =>

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/package.scala
@@ -182,6 +182,9 @@ object Errors {
   case object InvalidFeeTransactionSignature extends DataApplicationValidationError {
     val message = "Fee transaction signature validation failed"
   }
+  case object SameSourceAndDestinationAddress extends DataApplicationValidationError {
+    val message = "Fee transaction source and destination should differ"
+  }
   case object InvalidSignature extends DataApplicationValidationError {
     val message = "Invalid signature in data transactions"
   }

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/DataTransactionsValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/DataTransactionsValidator.scala
@@ -9,7 +9,7 @@ import io.constellationnetwork.currency.dataApplication.DataUpdate.getDataUpdate
 import io.constellationnetwork.currency.dataApplication.Errors.MissingDataUpdateTransaction
 import io.constellationnetwork.currency.dataApplication.FeeTransaction.getByDataUpdate
 import io.constellationnetwork.currency.dataApplication._
-import io.constellationnetwork.currency.validations.FeeTransactionValidator.validateFeeTransaction
+import io.constellationnetwork.currency.validations.FeeTransactionValidator.{validateAllFeeTransactions, validateFeeTransaction}
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
@@ -28,13 +28,26 @@ object DataTransactionsValidator {
     ) => F[ValidatedNec[DataApplicationValidationError, Unit]],
     feeValidationOrdinal: SnapshotOrdinal,
     globalSnapshotOrdinal: SnapshotOrdinal,
-    feeTransactionSecurityActivationOrdinal: SnapshotOrdinal
+    feeTransactionSecurityActivationOrdinal: SnapshotOrdinal,
+    validateEveryFeeTransaction: Boolean
   ): F[ValidatedNec[DataApplicationValidationError, Unit]] = {
 
     val dataUpdates = dataTransactions.collect {
       case Signed(dataUpdate: DataUpdate, proofs) => Signed(dataUpdate, proofs)
     }
     NonEmptyList.fromList(dataUpdates) match {
+      case Some(value) if validateEveryFeeTransaction =>
+        for {
+          // Only the metagraph's own fee policy stays per-data-update. The signature, hash and balance
+          // checks live in validateAllFeeTransactions, which sees every fee transaction in the envelope
+          // rather than the one getByDataUpdate happens to return.
+          perDataUpdateValidation <- value.traverse { dataUpdate =>
+            getByDataUpdate(dataTransactions, dataUpdate.value, dataApplication.serializeUpdate)
+              .flatMap(maybeFeeTransaction => validateFee(feeValidationOrdinal)(dataUpdate, maybeFeeTransaction))
+          }.map(_.reduce)
+          allFeeTransactionsValidation <- validateAllFeeTransactions(dataTransactions, balances, dataApplication)
+        } yield perDataUpdateValidation.productR(allFeeTransactionsValidation)
+
       case Some(value) =>
         value.traverse { dataUpdate =>
           for {
@@ -53,6 +66,7 @@ object DataTransactionsValidator {
               .productR(feeAgainstDataUpdateValidation)
         }
           .map(_.reduce)
+
       case None =>
         MissingDataUpdateTransaction
           .asInstanceOf[DataApplicationValidationError]
@@ -81,7 +95,9 @@ object DataTransactionsValidator {
         dataApplication.validateFee,
         gsOrdinal,
         gsOrdinal,
-        feeTransactionSecurityActivationOrdinal
+        feeTransactionSecurityActivationOrdinal,
+        // L1 is an admission check and never replays signed history, so it always runs the current rules.
+        validateEveryFeeTransaction = true
       )
     } yield dataUpdatesValidation.productR(dataTransactionsValidation)
 
@@ -92,7 +108,8 @@ object DataTransactionsValidator {
     currencySnapshotOrdinal: SnapshotOrdinal,
     parentGlobalSnapshotOrdinal: SnapshotOrdinal,
     currentState: DataState[DataOnChainState, DataCalculatedState],
-    feeTransactionSecurityActivationOrdinal: SnapshotOrdinal
+    feeTransactionSecurityActivationOrdinal: SnapshotOrdinal,
+    validateEveryFeeTransaction: Boolean
   ): F[ValidatedNec[DataApplicationValidationError, Unit]] =
     for {
       dataUpdates <- OptionT
@@ -106,7 +123,8 @@ object DataTransactionsValidator {
         dataApplication.validateFee,
         currencySnapshotOrdinal,
         parentGlobalSnapshotOrdinal,
-        feeTransactionSecurityActivationOrdinal
+        feeTransactionSecurityActivationOrdinal,
+        validateEveryFeeTransaction
       )
     } yield dataUpdatesValidation.productR(dataTransactionsValidation)
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/FeeTransactionValidator.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/validations/FeeTransactionValidator.scala
@@ -15,7 +15,7 @@ import io.constellationnetwork.ext.cats.syntax.validated._
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -96,5 +96,95 @@ object FeeTransactionValidator {
           hashMatchValidation <- validateFeeTransactionHashMatch(feeTransaction, dataTransactions, dataApplication)
         } yield sourceWalletValidation.productR(hashMatchValidation).productR(balanceValidation)
     }
+
+  private def validateFeeTransactionRefPresent(
+    feeTransaction: Signed[FeeTransaction],
+    dataUpdateHashes: Set[Hash]
+  ): ValidatedNec[DataApplicationValidationError, Unit] =
+    if (dataUpdateHashes.contains(feeTransaction.value.dataUpdateRef)) ().validNec[DataApplicationValidationError]
+    else
+      MissingDataUpdateOfFeeTransaction
+        .asInstanceOf[DataApplicationValidationError]
+        .invalidNec[Unit]
+
+  // Acceptance applies every fee transaction in the envelope, so every one of them has to be validated here.
+  // Walking the data updates instead reaches a fee transaction only through getByDataUpdate, which returns an
+  // Option -- a fee transaction referencing no data update present in the envelope is skipped entirely and
+  // reaches acceptance unchecked.
+  def validateAllFeeTransactions[F[_]: Async: JsonSerializer: SecurityProvider](
+    dataTransactions: DataTransactions,
+    balances: Map[Address, Balance],
+    dataApplication: BaseDataApplicationService[F]
+  ): F[ValidatedNec[DataApplicationValidationError, Unit]] = {
+    val feeTransactions = dataTransactions.collect {
+      case Signed(feeTransaction: FeeTransaction, proofs) => Signed(feeTransaction, proofs)
+    }
+
+    // Hashed once for the whole envelope. Checking each fee transaction against the data updates one at a
+    // time re-serializes them per fee transaction, which a sender controls: n fee transactions all pointing
+    // at a dataUpdateRef that is not there costs every validating node n * m serializations. Envelopes
+    // carrying no fee transactions still serialize nothing, which is the common case.
+    val dataUpdateHashes: F[Set[Hash]] =
+      if (feeTransactions.isEmpty) Set.empty[Hash].pure[F]
+      else
+        dataTransactions.collect { case Signed(dataUpdate: DataUpdate, _) => dataUpdate }
+          .traverse(dataUpdate => dataApplication.serializeUpdate(dataUpdate).flatMap(Hash.fromBytesForSync(_)))
+          .map(_.toSet)
+
+    dataUpdateHashes.flatMap { hashes =>
+      feeTransactions.traverse { feeTransaction =>
+        validateFeeTransactionSignatures(feeTransaction)
+          .map(_.errorMap[DataApplicationValidationError](_ => InvalidFeeTransactionSignature).void)
+          .map(
+            _.productR(validateDifferentAddresses(feeTransaction))
+              .productR(validateFeeTransactionRefPresent(feeTransaction, hashes))
+          )
+      }.map {
+        _.foldLeft(().validNec[DataApplicationValidationError])(_.productR(_))
+          .productR(validateSourcesHaveEnoughBalance(feeTransactions, balances))
+      }
+    }
+  }
+
+  // node-shared's FeeTransactionValidator runs on the same transactions immediately before acceptance and
+  // enforces source != destination. Anything it rejects but this layer accepts is a user-supplied value that
+  // reaches acceptance and is dropped there, after combine has already applied the data update it paid for.
+  private def validateDifferentAddresses(
+    feeTransaction: Signed[FeeTransaction]
+  ): ValidatedNec[DataApplicationValidationError, Unit] =
+    if (feeTransaction.value.source =!= feeTransaction.value.destination) ().validNec[DataApplicationValidationError]
+    else SameSourceAndDestinationAddress.asInstanceOf[DataApplicationValidationError].invalidNec[Unit]
+
+  // A single source may fund several fee transactions in one envelope. Checking each against the same
+  // starting balance lets the group overspend it, so the group is summed with the checked Amount.plus.
+  //
+  // This is deliberately stricter than the per-block fold in DataApplicationSnapshotAcceptanceManager, which
+  // can pay a fee transaction out of a credit an earlier one in the same block produced. The two do not need
+  // to agree: this runs per envelope and the fold there runs per block in amount-ascending order. Rejecting
+  // an envelope this layer cannot prove affordable costs the sender a resubmission; accepting one it cannot
+  // is the failure that matters.
+  private def validateSourcesHaveEnoughBalance(
+    feeTransactions: List[Signed[FeeTransaction]],
+    balances: Map[Address, Balance]
+  ): ValidatedNec[DataApplicationValidationError, Unit] =
+    feeTransactions
+      .groupBy(_.value.source)
+      .toList
+      .traverse {
+        case (source, txs) =>
+          val notEnoughBalance = SourceWalletNotEnoughBalance.asInstanceOf[DataApplicationValidationError]
+
+          val totalOrError = txs.foldLeft(Amount.empty.asRight[DataApplicationValidationError]) { (acc, tx) =>
+            acc.flatMap(_.plus(tx.value.amount).leftMap(_ => notEnoughBalance))
+          }
+
+          totalOrError.flatMap { total =>
+            val available = Balance.toAmount(balances.getOrElse(source, Balance.empty))
+
+            if (available < total) notEnoughBalance.asLeft[Unit]
+            else ().asRight[DataApplicationValidationError]
+          }.toValidatedNec
+      }
+      .void
 
 }


### PR DESCRIPTION
Develop counterpart of #1573.

## Summary

Aligns the data application acceptance path with the validation node-shared already performs immediately before acceptance, so the two layers reach the same verdict on the same transactions.

Every behaviour change is routed through `FieldsAddedOrdinals` entries. Snapshots signed below the activation ordinal continue to replay under the rules they were produced with, so rejoin, download and consensus validation recreate them unchanged, and a rolling upgrade does not split consensus.

## Why new config keys rather than `fee-transaction-security`

`fee-transaction-security` is already open on integrationnet at `5880000`. Widening what that gate controls would change how signed history between `5880000` and now replays on that network, which is exactly the failure the gate exists to prevent. Two new entries are used instead:

- `fixing-data-application-fee-validation`
- `fixing-allow-spend-destination-credit`

## Gate inputs

Both gates read an ordinal carried by the history being replayed, not the node's live view of the global chain:

- currency side: the previous snapshot's `globalSyncView` ordinal, already threaded as `parentGlobalSnapshotOrdinal`
- global side: the ordinal of the snapshot being built

A node replaying an old ordinal therefore evaluates the gate exactly as the node that produced it did.

## Notable

`validateFeeTxs` in `BalanceOpsManager` is gated as well. Below activation it keeps raising. The drop changes which artifact acceptance produces from the same events, and below activation the data application layer is on its legacy validator, which checks neither `source != destination` nor signature exclusivity, so such a transaction still reaches acceptance. A patched node dropping it while an unpatched node raises would split the rollout window.

## Activation

Mainnet activates at global ordinal **6818000**, at/after. `testnet` and `integrationnet` are placeholders (`9999999`) and must be pinned before those networks upgrade. `dev` is `0`, so a fresh network runs the current rules from genesis.

Roll the binary out to every Currency L1 and ML0 node before the activation ordinal is reached.

## Verification

- `compile` and `Test/compile` clean across all modules (Java 21).
- 26 tests pass in the touched suites: `FeeTransactionValidatorSuite`, `AllowSpendBlockAcceptanceLogicSuite`, and the node-shared snapshot manager suites.
- `scalafmtAll` clean.

## Not covered

The activation gates themselves have no unit test - reaching them needs a stubbed `BaseDataApplicationL0Service`, `L0NodeContext` and `CalculatedStateLocalFileSystemStorage`.
