### PR TITLE
fix(node-shared): authorize Pacaswap fee-transaction balance deductions

### DIFF
--- a/docker/snapshot-streaming/snapshot-streaming-state-proof.patch
+++ b/docker/snapshot-streaming/snapshot-streaming-state-proof.patch
@@ -95,3 +95,31 @@ index 17fb788..2dc2f06 100644
                } else {
                  validator.validate(snapshot, snapshotInfo)
                }
+diff --git a/src/main/scala/org/constellation/snapshotstreaming/TessellationServices.scala b/src/main/scala/org/constellation/snapshotstreaming/TessellationServices.scala
+index 2e0472c..80bee59 100644
+--- a/src/main/scala/org/constellation/snapshotstreaming/TessellationServices.scala
++++ b/src/main/scala/org/constellation/snapshotstreaming/TessellationServices.scala
+@@ -51,6 +51,8 @@ object TessellationServices {
+       _ <- Async[F].unit
+       nodeConfig = Configuration.nodeSharedConfig(env, configuration)
+       tessellation3Migration = configuration.fieldsAddedOrdinals.tessellation3Migration.getOrElse(env, SnapshotOrdinal.MinValue)
++      fixingAllowSpendDestinationCredit =
++        configuration.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit.getOrElse(env, SnapshotOrdinal.MinValue)
+       txHasher = Hasher.forKryo
+       validators = hasherSelector.withCurrent { implicit hasher =>
+         SharedValidators.make[F](
+@@ -107,7 +109,7 @@ object TessellationServices {
+                 validationErrorStorage
+               )
+             val currencySnapshotValidator = CurrencySnapshotValidator
+-              .make[F](currencySnapshotCreator, SignedValidator.make[F], None, None)
++              .make[F](currencySnapshotCreator, SignedValidator.make[F], None, None, fixingAllowSpendDestinationCredit)
+             CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
+           }
+         }
+@@ -157,4 +159,5 @@ object TessellationServices {
+           configuration.fieldsAddedOrdinals.setSumFix.getOrElse(env, SnapshotOrdinal.MinValue),
+           mptStore,
+           configuration.incrementalDelegatedStakingStartingOrdinal.getOrElse(env, SnapshotOrdinal.MinValue),
++          fixingAllowSpendDestinationCredit
+         )

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -143,7 +143,9 @@ object Services {
         creator,
         signedValidator,
         maybeRewards,
-        maybeDataApplication
+        maybeDataApplication,
+        sharedCfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
+          .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue)
       )
 
       addressService = AddressService.make[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](cfg.shared.addresses, storages.snapshot)

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/BalanceAdjustmentLoaderSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/BalanceAdjustmentLoaderSuite.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.currency.l0.snapshot.services
 
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.node.shared.infrastructure.BalanceAdjustmentLoader
 import io.constellationnetwork.node.shared.infrastructure.snapshot.CurrencyBalanceAdjustments
@@ -10,6 +10,7 @@ import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.generators.addressGen
+import io.constellationnetwork.security.hash.Hash
 
 import eu.timepit.refined.types.numeric.NonNegLong
 import org.scalacheck.{Arbitrary, Gen}
@@ -18,11 +19,19 @@ import weaver.scalacheck.Checkers
 
 object BalanceAdjustmentLoaderSuite extends SimpleIOSuite with Checkers {
 
+  private val adjustmentReasonGen = Gen.oneOf(
+    "SpendTransactionNotApplied",
+    "SpendTransactionSourceNotApplied",
+    "SpendTransactionDestinationNotApplied",
+    "TokenUnlockBugDeduction",
+    "FeeTransactionBugDeduction"
+  )
+
   // Generator for JsonAdjustment
   val jsonAdjustmentIncreaseGen: Gen[BalanceAdjustmentLoader.JsonAdjustment] = for {
     address <- addressGen
     amount <- Gen.chooseNum(1L, 1000000L)
-    reason <- Gen.alphaNumStr.filter(_.nonEmpty)
+    reason <- adjustmentReasonGen
     reference <- Gen.listOfN(Gen.chooseNum(1, 3).sample.getOrElse(1), Gen.alphaNumStr.filter(_.nonEmpty))
   } yield
     BalanceAdjustmentLoader.JsonAdjustment(
@@ -36,7 +45,7 @@ object BalanceAdjustmentLoaderSuite extends SimpleIOSuite with Checkers {
   val jsonAdjustmentDecreaseGen: Gen[BalanceAdjustmentLoader.JsonAdjustment] = for {
     address <- addressGen
     amount <- Gen.chooseNum(1L, 1000000L)
-    reason <- Gen.alphaNumStr.filter(_.nonEmpty)
+    reason <- adjustmentReasonGen
     reference <- Gen.listOfN(Gen.chooseNum(1, 3).sample.getOrElse(1), Gen.alphaNumStr.filter(_.nonEmpty))
   } yield
     BalanceAdjustmentLoader.JsonAdjustment(
@@ -194,9 +203,9 @@ object BalanceAdjustmentLoaderSuite extends SimpleIOSuite with Checkers {
       result match {
         case Right(adjustmentEntries) =>
           adjustmentEntries.get(jsonCurrencyAdj.currencyId) match {
-            case Some(adjustmentAtOrdinal) =>
+            case Some(adjustmentsAtOrdinal) =>
               val expectedOrdinal = jsonCurrencyAdj.snapshotOrdinal
-              expect(adjustmentAtOrdinal.snapshotOrdinal == expectedOrdinal)
+              expect(adjustmentsAtOrdinal.exists(_.snapshotOrdinal == expectedOrdinal))
             case None =>
               failure(s"Should have entry for currency ${jsonCurrencyAdj.currencyId}")
           }
@@ -251,6 +260,46 @@ object BalanceAdjustmentLoaderSuite extends SimpleIOSuite with Checkers {
           expect(error.contains("Missing required adjustments"))
         case Right(_) =>
           failure("Should have failed validation when required adjustments are missing")
+      }
+    }
+  }
+
+  test("exact matching compares metadata while legacy entries preserve historical tuple matching") {
+    forall(jsonAdjustmentIncreaseGen) { jsonAdj =>
+      val currencyId = jsonAdj.address
+      val ordinal = SnapshotOrdinal.unsafeApply(123L)
+      val exactJson = BalanceAdjustmentLoader.JsonCurrencyAdjustments(
+        currencyId,
+        ordinal,
+        List(jsonAdj),
+        enforceExactMatch = true.some
+      )
+      val legacyJson = exactJson.copy(enforceExactMatch = false.some)
+
+      val result = for {
+        authorized <- BalanceAdjustmentLoader.convertSingleBalanceAdjustment(jsonAdj)
+        exactEntry <- BalanceAdjustmentLoader
+          .convertToAdjustmentEntries(List(exactJson))
+          .flatMap(_.get(currencyId).flatMap(_.headOption).toRight("missing exact entry"))
+        legacyEntry <- BalanceAdjustmentLoader
+          .convertToAdjustmentEntries(List(legacyJson))
+          .flatMap(_.get(currencyId).flatMap(_.headOption).toRight("missing legacy entry"))
+      } yield {
+        val changedMetadata = authorized.copy(reference = SortedSet(Hash("different-reference")))
+        val balances = SortedMap.empty[Address, io.constellationnetwork.schema.balance.Balance]
+
+        (
+          exactEntry.exactMatchRequired,
+          exactEntry.balanceAdjustFunction(balances, Set(changedMetadata)),
+          legacyEntry.exactMatchRequired,
+          legacyEntry.balanceAdjustFunction(balances, Set(changedMetadata))
+        )
+      }
+
+      result match {
+        case Left(error) => failure(error)
+        case Right((exactRequired, exactResult, legacyRequired, legacyResult)) =>
+          expect.all(exactRequired, exactResult.isLeft, !legacyRequired, legacyResult.isRight)
       }
     }
   }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctions.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctions.scala
@@ -583,7 +583,8 @@ object GlobalSnapshotConsensusFunctions {
               lastDeprecatedTips,
               rewardsWithFacilitators(lastFacilitators),
               StateChannelValidationType.Full,
-              getGlobalSnapshotByOrdinal
+              getGlobalSnapshotByOrdinal,
+              AllowSpendBlockAcceptanceMode.live
             )
         acceptEndMs <- Async[F].monotonic.map(_.toMillis)
         balanceDiagnostics = {

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -1,7 +1,9 @@
 package io.constellationnetwork.dag.l0.infrastructure.snapshot
 
+import java.util.UUID
+
 import cats.data.Validated.Valid
-import cats.data.{NonEmptyList, NonEmptySet}
+import cats.data.{NonEmptyList, NonEmptySet, ValidatedNec}
 import cats.effect._
 import cats.effect.std.Supervisor
 import cats.implicits.none
@@ -17,7 +19,7 @@ import io.constellationnetwork.dag.l0.domain.snapshot.programs.{
   UpdateNodeParametersCutter
 }
 import io.constellationnetwork.dag.l0.infrastructure.rewards.RewardsService
-import io.constellationnetwork.dag.l0.infrastructure.snapshot.event.{GlobalSnapshotEvent, StateChannelEvent}
+import io.constellationnetwork.dag.l0.infrastructure.snapshot.event.{AllowSpendEvent, GlobalSnapshotEvent, StateChannelEvent}
 import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.env.AppEnvironment.Dev
 import io.constellationnetwork.ext.cats.effect.ResourceIO
@@ -38,6 +40,7 @@ import io.constellationnetwork.node.shared.domain.rewards.Rewards
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelAcceptanceResult
 import io.constellationnetwork.node.shared.domain.statechannel.StateChannelAcceptanceResult.CurrencySnapshotWithState
+import io.constellationnetwork.node.shared.domain.swap.AllowSpendChainValidator.AllowSpendNel
 import io.constellationnetwork.node.shared.domain.swap.SpendActionValidator
 import io.constellationnetwork.node.shared.domain.swap.block._
 import io.constellationnetwork.node.shared.domain.tokenlock.block._
@@ -50,27 +53,32 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.glob
   GlobalSnapshotAcceptanceManager,
   GlobalSnapshotStateChannelEventsProcessor
 }
-import io.constellationnetwork.node.shared.logger.Slf4jLoggerBundle
+import io.constellationnetwork.node.shared.logger.{LoggerBundle, Slf4jLoggerBundle}
+import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
 import io.constellationnetwork.schema.node.RewardFraction
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.schema.tokenLock.TokenLockBlock
 import io.constellationnetwork.schema.{GlobalStateProofSelector, _}
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
 import io.constellationnetwork.security.key.ops.PublicKeyOps
 import io.constellationnetwork.security.mpt.producer.InMemoryMerklePatriciaProducer
 import io.constellationnetwork.security.signature.Signed.forAsyncHasher
 import io.constellationnetwork.security.signature.SignedValidator.SignedValidationErrorOr
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
 import io.constellationnetwork.security.signature.{Signed, SignedValidator}
 import io.constellationnetwork.statechannel.{StateChannelOutput, StateChannelSnapshotBinary, StateChannelValidationType}
 import io.constellationnetwork.syntax.sortedCollection._
 
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
+import eu.timepit.refined.types.numeric.{NonNegLong, PosInt, PosLong}
 import io.circe.{Encoder, Json}
 import weaver.MutableIOSuite
 import weaver.scalacheck.Checkers
@@ -258,6 +266,36 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
 
   val collateral: Amount = Amount.empty
 
+  private val exploitSource = Address("DAG011jH7FMDvKpdb7wewrMWwYtkwq56nHquAHdi")
+  private val exploitDestination = Address("DAG06z64ifT2HzXoHfMexRfrcnpYFEwMqjFiPKze")
+  private val exploitOnward = Address("DAG07tqNLYW8jHU9emXcRTT3CfgCUoumwcLghopd")
+
+  private def exploitProof(id: Id, seed: Int): NonEmptySet[SignatureProof] = {
+    val hex = (seed.toString * 128).take(128)
+    NonEmptySet.one(SignatureProof(id, Signature(Hex(hex))))
+  }
+
+  private def exploitBlock(from: Address, to: Address, amount: Long, fee: Long, signerId: Id, seed: Int): Signed[AllowSpendBlock] = {
+    val allowSpend = Signed(
+      AllowSpend(
+        from,
+        to,
+        None,
+        SwapAmount(PosLong.unsafeFrom(amount)),
+        AllowSpendFee(NonNegLong.unsafeFrom(fee)),
+        AllowSpendReference.empty,
+        EpochProgress(NonNegLong.unsafeFrom(100L)),
+        List.empty
+      ),
+      exploitProof(signerId, seed)
+    )
+
+    Signed(
+      AllowSpendBlock(RoundId(UUID.fromString(s"00000000-0000-0000-0000-00000000000$seed")), NonEmptySet.one(allowSpend)),
+      exploitProof(signerId, seed)
+    )
+  }
+
   val classicRewards: Rewards[F, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotEvent] =
     (_, _, _, _, _, _) => IO(SortedSet.empty)
 
@@ -306,7 +344,59 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       )
   }
 
+  // Extracted so a test can build the acceptance manager directly with a recording allow-spend manager.
+  def mkGlobalSnapshotAcceptanceManager(
+    allowSpendBlockAcceptanceManager: AllowSpendBlockAcceptanceManager[IO],
+    mptStore: MptStore[IO, GlobalStateKey],
+    dbLogger: LoggerBundle[IO]
+  )(
+    implicit j: JsonSerializer[IO],
+    sp: SecurityProvider[IO],
+    h: Hasher[IO],
+    m: Metrics[IO]
+  ): GlobalSnapshotAcceptanceManager[IO] = {
+    implicit val hs = HasherSelector.forSyncAlwaysCurrent(h)
+
+    val spendActionValidator = SpendActionValidator.make[IO]
+    val pricingUpdateValidator = PricingUpdateValidator.make[IO](None, NonNegLong(0))
+    val priceStateUpdater = PriceStateUpdater.make(Dev, delegatedRewardsConfigProvider)
+
+    GlobalSnapshotAcceptanceManager
+      .make[IO](
+        FieldsAddedOrdinals(
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map.empty
+        ),
+        MetagraphsSyncConfig(PosInt(100)),
+        Dev,
+        bam,
+        allowSpendBlockAcceptanceManager,
+        tlbam,
+        scProcessor,
+        updateNodeParametersAcceptanceManager,
+        updateDelegatedStakeAcceptanceManager,
+        updateNodeCollateralAcceptanceManager,
+        spendActionValidator,
+        pricingUpdateValidator,
+        priceStateUpdater,
+        collateral,
+        EpochProgress(NonNegLong(136080L)),
+        mptStore,
+        dbLogger
+      )
+  }
+
   def mkGlobalSnapshotConsensusFunctions(
+    allowSpendBlockAcceptanceManager: AllowSpendBlockAcceptanceManager[IO] = asbam
+  )(
     implicit j: JsonSerializer[IO],
     sp: SecurityProvider[IO],
     h: Hasher[IO],
@@ -334,37 +424,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
         GlobalStateKey.toHex[IO]
       )
       dbLogger <- Slf4jLoggerBundle.makeUnsafe[IO]
-      snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
-        .make[IO](
-          FieldsAddedOrdinals(
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty
-          ),
-          MetagraphsSyncConfig(PosInt(100)),
-          Dev,
-          bam,
-          asbam,
-          tlbam,
-          scProcessor,
-          updateNodeParametersAcceptanceManager,
-          updateDelegatedStakeAcceptanceManager,
-          updateNodeCollateralAcceptanceManager,
-          spendActionValidator,
-          pricingUpdateValidator,
-          priceStateUpdater,
-          collateral,
-          EpochProgress(NonNegLong(136080L)),
-          mptStore,
-          dbLogger
-        )
+      snapshotAcceptanceManager = mkGlobalSnapshotAcceptanceManager(allowSpendBlockAcceptanceManager, mptStore, dbLogger)
       rewardsInfoStorage <- RewardsInfoStorage.make
       rewardsInfoCalculator = RewardsInfoCalculator.make(delegatorRewards)
       rewardsService = RewardsService[IO](classicRewards, delegatorRewards, rewardsInfoCalculator, rewardsInfoStorage)
@@ -388,6 +448,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
   }
 
   def getTestData(
+    allowSpendBlockAcceptanceManager: AllowSpendBlockAcceptanceManager[IO] = asbam
+  )(
     implicit sp: SecurityProvider[F],
     j: JsonSerializer[F],
     h: Hasher[IO],
@@ -396,7 +458,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[F]
 
-      gscf <- mkGlobalSnapshotConsensusFunctions
+      gscf <- mkGlobalSnapshotConsensusFunctions(allowSpendBlockAcceptanceManager)
       facilitators = Set.empty[PeerId]
 
       genesis = GlobalSnapshot.mkGenesis(Map.empty, EpochProgress.MinValue)
@@ -412,7 +474,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     implicit val (_, j, h, sp, m) = res
 
     for {
-      (gscf, facilitators, signedLastArtifact, signedGenesis, scEvent) <- getTestData
+      (gscf, facilitators, signedLastArtifact, signedGenesis, scEvent) <- getTestData()
 
       (artifact, _, _) <- gscf.createProposalArtifact(
         SnapshotOrdinal.MinValue,
@@ -443,7 +505,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
     implicit val (_, j, h, sp, m) = res
 
     for {
-      (gscf, facilitators, signedLastArtifact, signedGenesis, scEvent) <- getTestData
+      (gscf, facilitators, signedLastArtifact, signedGenesis, scEvent) <- getTestData()
 
       (artifact, _, _) <- gscf.createProposalArtifact(
         SnapshotOrdinal.MinValue,
@@ -706,6 +768,193 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
 //    }
 //  }
 
+  test("createProposalArtifact - live global consensus always uses escrow allow-spend semantics") { res =>
+    implicit val (_, j, h, sp, m) = res
+
+    for {
+      observedCreditDestination <- Ref.of[IO, List[Boolean]](List.empty)
+      recordingManager = new AllowSpendBlockAcceptanceManager[IO] {
+        def acceptBlock(
+          block: Signed[swap.AllowSpendBlock],
+          context: AllowSpendBlockAcceptanceContext[IO],
+          snapshotOrdinal: SnapshotOrdinal,
+          shouldPerformMetagraphSpecificValidations: Boolean,
+          lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+          creditDestination: Boolean
+        )(implicit hasher: Hasher[IO]): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
+          IO.raiseError(new IllegalStateException("acceptBlock should not be called directly"))
+
+        def acceptBlocksIteratively(
+          blocks: List[Signed[swap.AllowSpendBlock]],
+          context: AllowSpendBlockAcceptanceContext[IO],
+          snapshotOrdinal: SnapshotOrdinal,
+          shouldPerformMetagraphSpecificValidations: Boolean,
+          lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+          creditDestination: Boolean
+        )(implicit hasher: Hasher[IO]): IO[AllowSpendBlockAcceptanceResult] =
+          observedCreditDestination.update(creditDestination :: _) >>
+            AllowSpendBlockAcceptanceResult(
+              AllowSpendBlockAcceptanceContextUpdate.empty,
+              List.empty,
+              List.empty
+            ).pure[IO]
+      }
+      (gscf, facilitators, signedLastArtifact, signedGenesis, scEvent) <- getTestData(recordingManager)
+      _ <- gscf.createProposalArtifact(
+        SnapshotOrdinal.MinValue,
+        signedLastArtifact,
+        signedGenesis.value.info.toGlobalSnapshotInfo,
+        h,
+        EventTrigger,
+        Set(scEvent),
+        facilitators,
+        _ => None.pure[IO]
+      )
+      observed <- observedCreditDestination.get
+    } yield expect.same(List(false), observed)
+  }
+
+  test("live global consensus rejects the two-block phantom-funding chain") { res =>
+    implicit val (_, j, h, sp, m) = res
+
+    val blockValidator = new AllowSpendBlockValidator[IO] {
+      def validate(
+        signedBlock: Signed[AllowSpendBlock],
+        snapshotOrdinal: SnapshotOrdinal,
+        params: AllowSpendBlockValidationParams,
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+      )(implicit hasher: Hasher[IO]): IO[
+        ValidatedNec[AllowSpendBlockValidationError, (Signed[AllowSpendBlock], Map[Address, AllowSpendNel])]
+      ] = IO.pure(Valid((signedBlock, Map.empty)))
+    }
+    val iterativeManager = AllowSpendBlockAcceptanceManager.make[IO](AllowSpendBlockAcceptanceLogic.make[IO], blockValidator)
+
+    for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      signerId = keyPair.getPublic.toId
+      first = exploitBlock(exploitSource, exploitDestination, 100L, 1L, signerId, 1)
+      phantomSecond = exploitBlock(exploitDestination, exploitOnward, 100L, 0L, signerId, 2)
+      genesis = GlobalSnapshot.mkGenesis(
+        Map(exploitSource -> Balance(NonNegLong.unsafeFrom(101L))),
+        EpochProgress.MinValue
+      )
+      signedGenesis <- Signed.forAsyncHasher[IO, GlobalSnapshot](genesis, keyPair)
+      lastArtifact <- GlobalIncrementalSnapshot.fromGlobalSnapshot[IO](signedGenesis.value)
+      signedLastArtifact <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](lastArtifact, keyPair)
+      consensusFunctions <- mkGlobalSnapshotConsensusFunctions(iterativeManager)
+      (artifact, _, _) <- consensusFunctions.createProposalArtifact(
+        SnapshotOrdinal.MinValue,
+        signedLastArtifact,
+        signedGenesis.value.info.toGlobalSnapshotInfo,
+        h,
+        EventTrigger,
+        Set(AllowSpendEvent(first), AllowSpendEvent(phantomSecond)),
+        Set.empty,
+        _ => None.pure[IO]
+      )
+      maliciousArtifact = artifact.copy(allowSpendBlocks = Some(SortedSet(first, phantomSecond)))
+      validation <- consensusFunctions.validateArtifact(
+        signedLastArtifact,
+        signedGenesis.value.info.toGlobalSnapshotInfo,
+        EventTrigger,
+        maliciousArtifact,
+        Set.empty,
+        _ => None.pure[IO]
+      )
+    } yield
+      expect.all(
+        artifact.allowSpendBlocks.contains(SortedSet(first)),
+        !artifact.allowSpendBlocks.exists(_.contains(phantomSecond)),
+        validation.isLeft
+      )
+  }
+
+  test("global historical recreation falls back from escrow to legacy below activation") { res =>
+    implicit val (_, j, h, sp, m) = res
+    implicit val hs = HasherSelector.forSyncAlwaysCurrent(h)
+
+    for {
+      observedCreditDestination <- Ref.of[IO, List[Boolean]](List.empty)
+      recordingManager = new AllowSpendBlockAcceptanceManager[IO] {
+        def acceptBlock(
+          block: Signed[swap.AllowSpendBlock],
+          context: AllowSpendBlockAcceptanceContext[IO],
+          snapshotOrdinal: SnapshotOrdinal,
+          shouldPerformMetagraphSpecificValidations: Boolean,
+          lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+          creditDestination: Boolean
+        )(implicit hasher: Hasher[IO]): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
+          IO.raiseError(new IllegalStateException("acceptBlock should not be called directly"))
+
+        def acceptBlocksIteratively(
+          blocks: List[Signed[swap.AllowSpendBlock]],
+          context: AllowSpendBlockAcceptanceContext[IO],
+          snapshotOrdinal: SnapshotOrdinal,
+          shouldPerformMetagraphSpecificValidations: Boolean,
+          lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+          creditDestination: Boolean
+        )(implicit hasher: Hasher[IO]): IO[AllowSpendBlockAcceptanceResult] =
+          observedCreditDestination.update(creditDestination :: _) >>
+            (if (!creditDestination) IO.raiseError(new ArithmeticException("escrow recreation failed"))
+             else
+               asbam.acceptBlocksIteratively(
+                 blocks,
+                 context,
+                 snapshotOrdinal,
+                 shouldPerformMetagraphSpecificValidations,
+                 lastGlobalSnapshotEpochProgress,
+                 creditDestination
+               )(hasher))
+      }
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      genesis = GlobalSnapshot.mkGenesis(Map.empty, EpochProgress.MinValue)
+      signedGenesis <- Signed.forAsyncHasher[IO, GlobalSnapshot](genesis, keyPair)
+      lastArtifact <- GlobalIncrementalSnapshot.fromGlobalSnapshot[IO](signedGenesis.value)
+      signedLastArtifact <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](lastArtifact, keyPair)
+      consensusFunctions <- mkGlobalSnapshotConsensusFunctions()
+      (artifact, _, _) <- consensusFunctions.createProposalArtifact(
+        SnapshotOrdinal.MinValue,
+        signedLastArtifact,
+        signedGenesis.value.info.toGlobalSnapshotInfo,
+        h,
+        EventTrigger,
+        Set.empty,
+        Set.empty,
+        _ => None.pure[IO]
+      )
+      signedArtifact <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](artifact, keyPair)
+      _ <- observedCreditDestination.set(List.empty)
+      mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
+      mptStore <- MptStore.make[IO, GlobalStateKey](mptProducer, GlobalStateKey.toHex[IO])
+      dbLogger <- Slf4jLoggerBundle.makeUnsafe[IO]
+      acceptanceManager = mkGlobalSnapshotAcceptanceManager(recordingManager, mptStore, dbLogger)
+      contextFunctions = GlobalSnapshotContextFunctions.make[IO](
+        acceptanceManager,
+        updateDelegatedStakeAcceptanceManager,
+        EpochProgress(NonNegLong.unsafeFrom(1L)),
+        SnapshotOrdinal.MinValue,
+        SnapshotOrdinal.MinValue,
+        mptStore,
+        SnapshotOrdinal.MinValue,
+        SnapshotOrdinal.unsafeApply(100L)
+      )
+      recreated <- contextFunctions.createContext(
+        signedGenesis.value.info.toGlobalSnapshotInfo,
+        signedLastArtifact,
+        signedArtifact,
+        _ => None.pure[IO]
+      )
+      observed <- observedCreditDestination.get
+    } yield
+      // Escrow is attempted first and, because it fails below the activation ordinal, recreation falls back to
+      // LegacyCreditDestination -- the observed order is exactly [Escrow, LegacyCreditDestination].
+      // The mainnet version of this test also asserts that a corrupted state proof makes createContext fail.
+      // That assertion is deliberately absent here: this branch skips per-ordinal state-proof validation for
+      // followers (see the note in GlobalSnapshotContextFunctions), so a bad proof is not an error on this path.
+      expect.same(List(false, true), observed.reverse) &&
+        expect(recreated.balances == signedGenesis.value.info.toGlobalSnapshotInfo.balances)
+  }
+
   test("createProposalArtifact - deterministic: two independent calls with same inputs produce identical artifacts") { res =>
     implicit val (_, j, h, sp, m) = res
 
@@ -725,8 +974,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
 
       // Build two independent consensus function instances (each with its own MptStore)
       // to ensure no shared mutable state affects the output
-      gscf1 <- mkGlobalSnapshotConsensusFunctions
-      gscf2 <- mkGlobalSnapshotConsensusFunctions
+      gscf1 <- mkGlobalSnapshotConsensusFunctions()
+      gscf2 <- mkGlobalSnapshotConsensusFunctions()
 
       (artifact1, ctx1, _) <- gscf1.createProposalArtifact(
         SnapshotOrdinal.MinValue,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -157,7 +157,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
           validationErrorStorage
         )
       currencySnapshotValidator = CurrencySnapshotValidator
-        .make[IO](creator, validators.signedValidator, None, None)
+        .make[IO](creator, validators.signedValidator, None, None, SnapshotOrdinal.MinValue)
       mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
       mptStore <- MptStore.make[IO, GlobalStateKey](
         mptProducer,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -375,7 +375,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
             validationErrorStorage
           )
       currencySnapshotValidator = CurrencySnapshotValidator
-        .make[IO](currencySnapshotCreator, validators.signedValidator, None, None)
+        .make[IO](currencySnapshotCreator, validators.signedValidator, None, None, SnapshotOrdinal.MinValue)
 
       mptProducer <- InMemoryMerklePatriciaProducer.make[IO]()
       mptStore <- MptStore.make[IO, GlobalStateKey](
@@ -457,6 +457,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
         SnapshotOrdinal.MinValue,
         SnapshotOrdinal.MinValue,
         mptStore,
+        SnapshotOrdinal.MinValue,
         SnapshotOrdinal.MinValue
       )
       lastNSnapshotStorage =

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -215,7 +215,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                   validationErrorStorage
                 )
               currencySnapshotValidator = CurrencySnapshotValidator
-                .make[IO](currencySnapshotCreator, validators.signedValidator, None, None)
+                .make[IO](currencySnapshotCreator, validators.signedValidator, None, None, SnapshotOrdinal.MinValue)
 
               mptProducer <- InMemoryMerklePatriciaProducer.make[IO]().asResource
               mptStore <- MptStore
@@ -312,6 +312,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                   SnapshotOrdinal.MinValue,
                   SnapshotOrdinal.MinValue,
                   mptStore,
+                  SnapshotOrdinal.MinValue,
                   SnapshotOrdinal.MinValue
                 )
               }

--- a/modules/node-shared/src/main/resources/adjustments.json
+++ b/modules/node-shared/src/main/resources/adjustments.json
@@ -4980,5 +4980,152 @@
         ]
       }
     ]
+  },
+  {
+    "currencyId": "DAG7X5idd4aLfp4XC6WQdG1eDfR3LGPVEwtUUB2W",
+    "snapshotOrdinal": 731647,
+    "enforceExactMatch": true,
+    "adjustments": [
+      {
+        "address": "DAG1kEmLAgnCVBURHrL4AMsfn9TZdk4QCYQ8tUu3",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -4611686018427387904,
+        "reference": [
+          "3b6284b71a7b0f709af4455e504c06f8df05cefbc83be062ec2c552a7d293ff5",
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG4w5mUqNNxQNS4hgdpx3E8FGgiu2UCRsJxHwhX",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -4611686018427387904,
+        "reference": [
+          "c1db013c80c0ea526a7774034b471b8d5b6f071bf697df656dfa3b85a786be00",
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG7ZjENTP4T36PPSp3skJdTHtQbcuLfpEaAFWdn",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -4611686018427387904,
+        "reference": [
+          "be02914f5df9580640d8541538a3be1c00ca9fb5b6b0870d83d59a8e99bfc7b0",
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG8uqhyGtFABWSS5KeVB2ia1R4vXop5AeijXeoU",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -4611686018427387904,
+        "reference": [
+          "d50e8ee719b37f425b0e52d83fd8196f40460fe5b487071321b8deb8339ab131",
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG7X5idd4aLfp4XC6WQdG1eDfR3LGPVEwtUUB2W",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -355312351884858115,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG6zZakMJrrf25FSvPZAi8QA9wVDdmvFkPvTbKu",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -67978819470437886,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG3sGFqKZ974eoCQeZN3jyhsVakPaEZ9usvvCw7",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -26323732835282059,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG7iLJFTAF1sESqM95TJ3W41ibFN29kMYEBiPzb",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -15984111479123286,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG6pvRsWjTzmPSGgNZUu6MGgsQDNQHdnzNGNhzf",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -14691064551766330,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG4jWvjPdpvUqbpUXUobcQG6Js7XGfzZzhvxFmS",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -9266944704388053,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG8Eyr6SGvLorNU4rQspeUXZLZi3wt84CwbV1Ep",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -1997061245659082,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG4fVZch1qTY2ccA5eHkxe2RMTFsnNDU6Zu6mUU",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -1100000000000000,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG4kfRPpcPSh4cMn8ZgdMuTEfdu3yz4veZFrv3L",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -979882653723803,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG0xNaGuUfhorbRKqjsaDt6BP8eqWW3ZMRo1nRp",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -543508489720562,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG5434oVLFRRTqVSsTv4Y1qvyoMBkb4Tey21YuZ",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -292412009465784,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG7uHRz6stwzsEnSHB2w1VxVHsCq7PDuDhTbjNP",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -99773645951861,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      },
+      {
+        "address": "DAG1DD2bM1hpFyWwa8UNgh3wMLGAe5JDSwpoUS9M",
+        "reason": "FeeTransactionBugDeduction",
+        "deduct": -76610032383686,
+        "reference": [
+          "0200028940b285045a40b3f2176b3dcd33f2a94821d24ecfa12ab6db1103e358"
+        ]
+      }
+    ]
   }
 ]

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -333,6 +333,16 @@ fields-added-ordinals {
     integrationnet: 5880000,
     dev: 0
   }
+  # Checked arithmetic in acceptFeeTxs. Set to the global ordinal of the mint so everything at or below
+  # it replays through the original wrapping path and reproduces the state that was actually signed,
+  # while everything above uses the corrected arithmetic. This gate is deliberately set inside signed
+  # history: the point is to preserve that history, not to change it.
+  fixing-fee-transaction-balance-overflow {
+    mainnet: 6814499,
+    testnet: 3255000,
+    integrationnet: 5905000,
+    dev: 0
+  }
   # At/after this global ordinal every fee transaction in a data envelope is validated and a data block whose
   # fees cannot be applied is rejected. Activate only after every Currency L1 and ML0 node is upgraded, and
   # never at an ordinal already present in signed history. testnet and integrationnet are placeholders.
@@ -342,8 +352,10 @@ fields-added-ordinals {
     integrationnet: 9999999,
     dev: 0
   }
-  # At/after this global ordinal an allow spend stops crediting its destination at block acceptance.
-  # testnet and integrationnet are placeholders.
+  # Historical boundary for allow-spend destination-credit behavior. Live Currency and Global L0 consensus
+  # always use escrow semantics; this boundary is used only to recreate signed history. Currency history uses
+  # its parent global-sync view and Global history uses its own signed snapshot ordinal. Testnet and integrationnet
+  # are placeholders and must be pinned before those networks upgrade.
   fixing-allow-spend-destination-credit {
     mainnet: 6818000,
     testnet: 9999999,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -51,6 +51,10 @@ object types {
     delegatedRewardsFullCommittee: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
     // At/after this global ordinal, fee transactions require cryptographic authorization by their source wallet.
     feeTransactionSecurity: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+    // At/after this global ordinal, acceptFeeTxs applies fee transactions through checked Balance arithmetic. Below it, the
+    // original wrapping fold is replayed so already-signed history re-derives byte-identically -- the fix changes what a
+    // snapshot contains, so an ungated rollout diverges any node syncing from genesis. Mainnet activates at the mint ordinal.
+    fixingFeeTransactionBalanceOverflow: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
     // Ordinal-gated GSI dust sweeps (state deflation), per environment, keyed by the ordinal each sweep fires at. Loaded from
     // the `fields-added-ordinals.dust-sweeps` HOCON block, so the jar hash plus the environment is the determinism fence (the
     // conf is packaged into the assembly jar and peers only connect to matching jar hashes). Default empty: an environment with

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogic.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogic.scala
@@ -113,7 +113,8 @@ object AllowSpendBlockAcceptanceLogic {
       // hands the destination a balance no snapshot ever recorded, which it can then spend into further allow
       // spend blocks until recomputation disagrees and the snapshot fails to build.
       // TokenLockBlockAcceptanceLogic.processBalances, the other escrow, only debits.
-      // creditDestination retains the old behaviour below the activation ordinal so replay stays byte-identical.
+      // creditDestination exists only for signed historical recreation. Live Currency and Global L0
+      // creation and validation always pass false.
       private def processBalances(
         block: Signed[AllowSpendBlock],
         context: AllowSpendBlockAcceptanceContext[F],

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/ext/pureconfig/pureconfig.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/ext/pureconfig/pureconfig.scala
@@ -69,7 +69,7 @@ package object pureconfig {
   implicit val envToOrdinalToDustSweepReader: ConfigReader[Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]] =
     genericMapReader(catchReadError(AppEnvironment.withName))
   implicit val fieldsAddedOrdinalsReader: ConfigReader[FieldsAddedOrdinals] =
-    ConfigReader.forProduct19(
+    ConfigReader.forProduct20(
       "tessellation-3-migration",
       "tessellation-301-migration",
       "check-sync-global-snapshot-field",
@@ -84,6 +84,7 @@ package object pureconfig {
       "sub-trie-roots",
       "delegated-rewards-full-committee",
       "fee-transaction-security",
+      "fixing-fee-transaction-balance-overflow",
       "dust-sweeps",
       "fixing-data-application-fee-validation",
       "fixing-allow-spend-destination-credit",

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/BalanceAdjustmentLoader.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/BalanceAdjustmentLoader.scala
@@ -2,7 +2,7 @@ package io.constellationnetwork.node.shared.infrastructure
 
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{SortedMap, SortedSet}
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
@@ -15,8 +15,9 @@ import io.constellationnetwork.node.shared.infrastructure.snapshot.CurrencyBalan
 }
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.artifact.BalanceAdjustment
+import io.constellationnetwork.schema.artifact._
 import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.security.hash.Hash
 
 import derevo.cats.{eqv, show}
 import derevo.circe.magnolia.{decoder, encoder}
@@ -39,7 +40,8 @@ object BalanceAdjustmentLoader {
   case class JsonCurrencyAdjustments(
     currencyId: Address,
     snapshotOrdinal: SnapshotOrdinal,
-    adjustments: List[JsonAdjustment]
+    adjustments: List[JsonAdjustment],
+    enforceExactMatch: Option[Boolean] = None
   )
 
   /** Helper method to create a balance adjustment function for a specific currency */
@@ -54,10 +56,27 @@ object BalanceAdjustmentLoader {
       )
   }
 
-  /** Load adjustments and create BalanceAdjustmentAtOrdinal entries for integration with metagraphsBalancesAdjustments */
+  /** Exact authorization is opt-in so tightening a newly added incident block does not change how historical adjustment blocks replay. */
+  def createExactBalanceAdjustmentFunction(
+    authorizedAdjustments: Set[BalanceAdjustment]
+  ): (SortedMap[Address, Balance], Set[BalanceAdjustment]) => Either[String, SortedMap[Address, Balance]] = {
+    (currentBalances, balanceAdjustments) =>
+      CurrencyBalanceAdjustments.applyAndValidateExactBalanceAdjustments(
+        currentBalances,
+        balanceAdjustments,
+        authorizedAdjustments
+      )
+  }
+
+  /** Load adjustments and create BalanceAdjustmentAtOrdinal entries for integration with metagraphsBalancesAdjustments.
+    *
+    * A metagraph may hold several blocks, one per ordinal at which it adjusts balances, so entries are grouped rather than keyed uniquely.
+    * Keying uniquely meant the last block in the file silently retired every earlier block for the same currency, which both broke replay
+    * of those ordinals and made a follow-up adjustment impossible to schedule.
+    */
   def loadAndCreateAdjustmentEntries(
     resourcePath: String
-  ): Either[String, Map[Address, BalanceAdjustmentAtOrdinal]] =
+  ): Either[String, Map[Address, List[BalanceAdjustmentAtOrdinal]]] =
     for {
       jsonString <- readResourceFile(resourcePath)
       jsonAdjustments <- parseJsonToModel(jsonString)
@@ -66,11 +85,11 @@ object BalanceAdjustmentLoader {
 
   def convertToAdjustmentEntries(
     jsonAdjustments: List[JsonCurrencyAdjustments]
-  ): Either[String, Map[Address, BalanceAdjustmentAtOrdinal]] = {
+  ): Either[String, Map[Address, List[BalanceAdjustmentAtOrdinal]]] = {
 
     val convertedEntries = jsonAdjustments.map { currencyAdj =>
       val convertedAdjustments = currencyAdj.adjustments.map { adj =>
-        convertSingleAdjustment(adj)
+        convertSingleBalanceAdjustment(adj)
       }
 
       // Separate successful conversions from errors for this currency
@@ -81,10 +100,19 @@ object BalanceAdjustmentLoader {
       } else {
         val snapshotOrdinal = currencyAdj.snapshotOrdinal
 
+        val authorizedAdjustments = adjustments.toSet
+        val exactMatchRequired = currencyAdj.enforceExactMatch.contains(true)
+        val balanceAdjustFunction =
+          if (exactMatchRequired)
+            createExactBalanceAdjustmentFunction(authorizedAdjustments)
+          else
+            createBalanceAdjustmentFunction(authorizedAdjustments.map(toRequiredAdjustment))
+
         val adjustmentEntry = BalanceAdjustmentAtOrdinal(
-          snapshotOrdinal,
-          Mainnet,
-          createBalanceAdjustmentFunction(adjustments.toSet)
+          snapshotOrdinal = snapshotOrdinal,
+          environment = Mainnet,
+          exactMatchRequired = exactMatchRequired,
+          balanceAdjustFunction = balanceAdjustFunction
         )
 
         Right((currencyAdj.currencyId, adjustmentEntry))
@@ -97,7 +125,7 @@ object BalanceAdjustmentLoader {
     if (currencyErrors.nonEmpty) {
       Left(currencyErrors.mkString("; "))
     } else {
-      Right(successfulEntries.toMap)
+      Right(successfulEntries.groupMap(_._1)(_._2))
     }
   }
 
@@ -161,6 +189,37 @@ object BalanceAdjustmentLoader {
         address = jsonAdj.address,
         adjustment = adjustmentType
       )
+
+  def convertSingleBalanceAdjustment(jsonAdj: JsonAdjustment): Either[String, BalanceAdjustment] =
+    for {
+      reason <- parseAdjustmentReason(jsonAdj.reason)
+      adjustmentType <- parseAdjustmentType(jsonAdj.deduct, jsonAdj.increase)
+    } yield
+      adjustmentType match {
+        case AdjustmentType.Increase(amount) =>
+          BalanceAdjustment(jsonAdj.address, reason, SortedSet.from(jsonAdj.reference.map(Hash(_))), amount.some, none)
+        case AdjustmentType.Decrease(amount) =>
+          BalanceAdjustment(jsonAdj.address, reason, SortedSet.from(jsonAdj.reference.map(Hash(_))), none, amount.some)
+      }
+
+  def parseAdjustmentReason(reason: String): Either[String, BalanceAdjustmentReason] =
+    reason match {
+      case "SpendTransactionNotApplied"            => SpendTransactionNotApplied.asRight
+      case "SpendTransactionSourceNotApplied"      => SpendTransactionSourceNotApplied.asRight
+      case "SpendTransactionDestinationNotApplied" => SpendTransactionDestinationNotApplied.asRight
+      case "TokenUnlockBugDeduction"               => TokenUnlockBugDeduction.asRight
+      case "FeeTransactionBugDeduction"            => FeeTransactionBugDeduction.asRight
+      case other                                   => Left(s"Unknown balance adjustment reason: $other")
+    }
+
+  private def toRequiredAdjustment(adjustment: BalanceAdjustment): RequiredAdjustment = {
+    val adjustmentType = adjustment.increase
+      .map(AdjustmentType.Increase(_))
+      .orElse(adjustment.deduct.map(AdjustmentType.Decrease(_)))
+      .getOrElse(throw new IllegalArgumentException("Balance adjustment must contain an increase or deduction"))
+
+    RequiredAdjustment(adjustment.address, adjustmentType)
+  }
 
   def parseAdjustmentType(
     deduct: Option[Long],

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/AllowSpendBlockAcceptanceMode.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/AllowSpendBlockAcceptanceMode.scala
@@ -1,0 +1,34 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot
+
+import cats.syntax.order._
+
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+/** Selects the allow-spend balance semantics used while building or recreating a snapshot.
+  *
+  * Live consensus must always use the Escrow mode. LegacyCreditDestination exists only to reproduce signed historical snapshots created
+  * before allow-spends were correctly treated as escrows.
+  */
+sealed abstract class AllowSpendBlockAcceptanceMode(val creditDestination: Boolean)
+
+object AllowSpendBlockAcceptanceMode {
+  private[snapshot] case object LegacyCreditDestination extends AllowSpendBlockAcceptanceMode(true)
+  case object Escrow extends AllowSpendBlockAcceptanceMode(false)
+
+  val live: AllowSpendBlockAcceptanceMode = Escrow
+
+  def currencyHistoricalRecreationModes(
+    lastGlobalSyncView: Option[GlobalSyncView],
+    escrowStartingOrdinal: SnapshotOrdinal
+  ): List[AllowSpendBlockAcceptanceMode] =
+    if (lastGlobalSyncView.exists(_.ordinal >= escrowStartingOrdinal)) List(Escrow)
+    else List(Escrow, LegacyCreditDestination)
+
+  def globalHistoricalRecreationModes(
+    snapshotOrdinal: SnapshotOrdinal,
+    escrowStartingOrdinal: SnapshotOrdinal
+  ): List[AllowSpendBlockAcceptanceMode] =
+    if (snapshotOrdinal >= escrowStartingOrdinal) List(Escrow)
+    else List(Escrow, LegacyCreditDestination)
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyBalanceAdjustments.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyBalanceAdjustments.scala
@@ -37,10 +37,11 @@ object CurrencyBalanceAdjustments {
   case class BalanceAdjustmentAtOrdinal(
     snapshotOrdinal: SnapshotOrdinal,
     environment: AppEnvironment,
+    exactMatchRequired: Boolean,
     balanceAdjustFunction: (SortedMap[Address, Balance], Set[BalanceAdjustment]) => Either[String, SortedMap[Address, Balance]]
   )
 
-  val metagraphsBalancesAdjustments: Map[Address, BalanceAdjustmentAtOrdinal] =
+  val metagraphsBalancesAdjustments: Map[Address, List[BalanceAdjustmentAtOrdinal]] =
     BalanceAdjustmentLoader.loadAndCreateAdjustmentEntries(
       "/adjustments.json"
     ) match {
@@ -61,7 +62,8 @@ object CurrencyBalanceAdjustments {
       updatedBalances <- applyBalanceAdjustments(currentBalances, balanceAdjustments)
     } yield updatedBalances
 
-  /** Validates that all required adjustments are present in the balance adjustments set
+  /** Legacy validation retained for historical adjustment blocks. It checks that every required address/direction/amount tuple is present,
+    * but deliberately ignores metadata and extras because tightening already-signed history can change replay results.
     */
   def validateRequiredAdjustments(
     balanceAdjustments: Set[BalanceAdjustment],
@@ -76,6 +78,37 @@ object CurrencyBalanceAdjustments {
     if (missingAdjustments.nonEmpty) {
       val missingDescription = missingAdjustments.map(describeRequiredAdjustment).mkString(", ")
       Left(s"Missing required adjustments: $missingDescription")
+    } else {
+      Right(())
+    }
+  }
+
+  /** Validates the complete artifact values for a newly authorized adjustment block, then applies them.
+    *
+    * Equality includes address, reason, reference set, increase and deduction. This prevents a metagraph from satisfying an authorized
+    * deduction while attaching an unauthorized increase, repeating it with different metadata, or adding another artifact.
+    */
+  def applyAndValidateExactBalanceAdjustments(
+    currentBalances: SortedMap[Address, Balance],
+    balanceAdjustments: Set[BalanceAdjustment],
+    authorizedAdjustments: Set[BalanceAdjustment]
+  ): Either[String, SortedMap[Address, Balance]] =
+    for {
+      _ <- validateExactBalanceAdjustments(balanceAdjustments, authorizedAdjustments)
+      updatedBalances <- applyBalanceAdjustments(currentBalances, balanceAdjustments)
+    } yield updatedBalances
+
+  def validateExactBalanceAdjustments(
+    balanceAdjustments: Set[BalanceAdjustment],
+    authorizedAdjustments: Set[BalanceAdjustment]
+  ): Either[String, Unit] = {
+    val missingAdjustments = authorizedAdjustments -- balanceAdjustments
+    val unauthorizedAdjustments = balanceAdjustments -- authorizedAdjustments
+
+    if (missingAdjustments.nonEmpty) {
+      Left(s"Missing required adjustments: ${missingAdjustments.mkString(", ")}")
+    } else if (unauthorizedAdjustments.nonEmpty) {
+      Left(s"Unauthorized balance adjustments not present in the authorized set: ${unauthorizedAdjustments.mkString(", ")}")
     } else {
       Right(())
     }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreator.scala
@@ -72,7 +72,8 @@ trait CurrencySnapshotCreator[F[_]] {
     maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]],
     // v20: see ConsensusFunctions for full rationale -- packed by caller from
     // the consensus-agreed previous round outcome.
-    peerHistory: Option[ConsensusOperationalState] = None
+    peerHistory: Option[ConsensusOperationalState] = None,
+    allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
   )(implicit hasher: Hasher[F]): F[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]
 }
 
@@ -108,7 +109,8 @@ object CurrencySnapshotCreator {
       getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
       shouldPerformMetagraphSpecificValidations: Boolean,
       maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]],
-      peerHistory: Option[ConsensusOperationalState] = None
+      peerHistory: Option[ConsensusOperationalState] = None,
+      allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
     )(implicit hasher: Hasher[F]): F[CurrencySnapshotCreationResult[CurrencySnapshotEvent]] = {
       val maxArtifactSize = maxProposalSizeInBytes(facilitators)
 
@@ -227,7 +229,8 @@ object CurrencySnapshotCreator {
                 getGlobalSnapshotByOrdinal,
                 lastArtifact.globalSyncView,
                 shouldPerformMetagraphSpecificValidations,
-                lastArtifact.proofs
+                lastArtifact.proofs,
+                allowSpendBlockAcceptanceMode
               )
 
           rejectedBlockEvents = currencySnapshotAcceptanceResult.block.notAccepted.collect {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotValidator.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotValidator.scala
@@ -64,7 +64,8 @@ object CurrencySnapshotValidator {
     currencySnapshotCreator: CurrencySnapshotCreator[F],
     signedValidator: SignedValidator[F],
     maybeRewards: Option[Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
-    maybeDataApplication: Option[BaseDataApplicationService[F]]
+    maybeDataApplication: Option[BaseDataApplicationService[F]],
+    fixingAllowSpendDestinationCredit: SnapshotOrdinal
   ): CurrencySnapshotValidator[F] = new CurrencySnapshotValidator[F] {
     def validateSignedSnapshot(
       lastArtifact: Signed[CurrencySnapshotArtifact],
@@ -72,23 +73,31 @@ object CurrencySnapshotValidator {
       artifact: Signed[CurrencySnapshotArtifact],
       getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
     )(implicit hasher: Hasher[F]): F[CurrencySnapshotValidationErrorOr[(Signed[CurrencyIncrementalSnapshot], CurrencySnapshotContext)]] =
-      validateSigned(artifact).flatMap { signedV =>
-        val facilitators = artifact.proofs.map(_.id).map(PeerId.fromId).toSortedSet
+      validateSigned(artifact).flatMap {
+        case Validated.Invalid(errors) =>
+          Async[F].pure[CurrencySnapshotValidationErrorOr[(Signed[CurrencyIncrementalSnapshot], CurrencySnapshotContext)]](
+            Validated.Invalid(errors)
+          )
+        case Validated.Valid(validatedArtifact) =>
+          val facilitators = artifact.proofs.map(_.id).map(PeerId.fromId).toSortedSet
+          val historicalModes = AllowSpendBlockAcceptanceMode.currencyHistoricalRecreationModes(
+            lastArtifact.globalSyncView,
+            fixingAllowSpendDestinationCredit
+          )
 
-        validateSnapshot(
-          lastArtifact,
-          lastContext,
-          artifact,
-          facilitators,
-          getGlobalSnapshotByOrdinal,
-          // Chain-replay path: no live consensus state to consult, so re-feed the
-          // artifact's own claim as the recreation input. The signature-validation
-          // above already binds the value to the signing facilitators -- if it
-          // were tampered with, this would have failed first.
-          artifact.value.peerHistory
-        ).map { snapshotV =>
-          signedV.product(snapshotV.map { case (_, info) => info })
-        }
+          validateSnapshotWithModes(
+            lastArtifact,
+            lastContext,
+            artifact,
+            facilitators,
+            getGlobalSnapshotByOrdinal,
+            // Chain-replay path: no live consensus state to consult, so re-feed the
+            // artifact's own claim as the recreation input. The signature-validation
+            // above already binds the value to the signing facilitators -- if it
+            // were tampered with, this would have failed first.
+            artifact.value.peerHistory,
+            historicalModes
+          ).map(_.map { case (_, info) => (validatedArtifact, info) })
       }
 
     def validateSnapshot(
@@ -98,6 +107,25 @@ object CurrencySnapshotValidator {
       facilitators: Set[PeerId],
       getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
       peerHistory: Option[ConsensusOperationalState] = None
+    )(implicit hasher: Hasher[F]): F[CurrencySnapshotValidationErrorOr[(CurrencyIncrementalSnapshot, CurrencySnapshotContext)]] =
+      validateSnapshotWithModes(
+        lastArtifact,
+        lastContext,
+        artifact,
+        facilitators,
+        getGlobalSnapshotByOrdinal,
+        peerHistory,
+        List(AllowSpendBlockAcceptanceMode.live)
+      )
+
+    private def validateSnapshotWithModes(
+      lastArtifact: Signed[CurrencySnapshotArtifact],
+      lastContext: CurrencySnapshotContext,
+      artifact: CurrencySnapshotArtifact,
+      facilitators: Set[PeerId],
+      getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
+      peerHistory: Option[ConsensusOperationalState],
+      allowSpendRecreationModes: List[AllowSpendBlockAcceptanceMode]
     )(implicit hasher: Hasher[F]): F[CurrencySnapshotValidationErrorOr[(CurrencyIncrementalSnapshot, CurrencySnapshotContext)]] = for {
       contentV <- validateRecreateContent(
         lastArtifact,
@@ -105,7 +133,8 @@ object CurrencySnapshotValidator {
         artifact,
         facilitators,
         getGlobalSnapshotByOrdinal,
-        peerHistory
+        peerHistory,
+        allowSpendRecreationModes
       )
       blocksV <- contentV.map(validateNotAcceptedEvents).pure[F]
     } yield
@@ -138,7 +167,8 @@ object CurrencySnapshotValidator {
       expected: CurrencySnapshotArtifact,
       facilitators: Set[PeerId],
       getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
-      peerHistory: Option[ConsensusOperationalState]
+      peerHistory: Option[ConsensusOperationalState],
+      allowSpendRecreationModes: List[AllowSpendBlockAcceptanceMode]
     )(implicit hasher: Hasher[F]): F[CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]] = {
       def dataApplicationBlocks = maybeDataApplication.flatTraverse { service =>
         expected.dataApplication.map(_.blocks).traverse {
@@ -173,7 +203,10 @@ object CurrencySnapshotValidator {
         }
       })
 
-      def recreateFn(trigger: ConsensusTrigger) =
+      def recreateFn(
+        trigger: ConsensusTrigger,
+        allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
+      ): F[CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]] =
         mkEvents.flatMap { events =>
           def usingHasher = (lastArtifactHasher: Hasher[F]) =>
             currencySnapshotCreator
@@ -191,10 +224,13 @@ object CurrencySnapshotValidator {
                 getGlobalSnapshotByOrdinal,
                 shouldPerformMetagraphSpecificValidations = false,
                 Some((_: Signed[CurrencyIncrementalSnapshot]) => expected.artifacts),
-                peerHistory
+                peerHistory,
+                allowSpendBlockAcceptanceMode
               )
 
-          def check(result: F[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]) =
+          def check(
+            result: F[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]
+          ): F[CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]] =
             // Rewrite if implementation not provided
             result.map { creationResult =>
               maybeDataApplication match {
@@ -223,8 +259,30 @@ object CurrencySnapshotValidator {
           check(usingHasher(Hasher.forJson[F]))
         }
 
-      recreateFn(TimeTrigger).flatMap { tV =>
-        recreateFn(EventTrigger).map(_.orElse(tV))
+      def recreateWithModes(
+        trigger: ConsensusTrigger,
+        modes: List[AllowSpendBlockAcceptanceMode]
+      ): F[CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]] =
+        modes match {
+          case Nil =>
+            new IllegalStateException("No allow-spend acceptance mode available for snapshot recreation")
+              .raiseError[F, CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]]
+          case mode :: remaining =>
+            recreateFn(trigger, mode).attempt.flatMap {
+              case Right(valid @ Validated.Valid(_)) =>
+                Async[F].pure[CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]](valid)
+              case Right(invalid @ Validated.Invalid(_)) =>
+                if (remaining.nonEmpty) recreateWithModes(trigger, remaining)
+                else
+                  Async[F].pure[CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]](invalid)
+              case Left(error) =>
+                if (remaining.nonEmpty) recreateWithModes(trigger, remaining)
+                else error.raiseError[F, CurrencySnapshotValidationErrorOr[CurrencySnapshotCreationResult[CurrencySnapshotEvent]]]
+            }
+        }
+
+      recreateWithModes(TimeTrigger, allowSpendRecreationModes).flatMap { tV =>
+        recreateWithModes(EventTrigger, allowSpendRecreationModes).map(_.orElse(tV))
       }
     }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotContextFunctions.scala
@@ -12,6 +12,7 @@ import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.domain.block.processing._
 import io.constellationnetwork.node.shared.domain.delegatedStake.UpdateDelegatedStakeAcceptanceManager
 import io.constellationnetwork.node.shared.domain.snapshot.SnapshotContextFunctions
+import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockNotAcceptedReason
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.TimeTrigger
 import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.global.GlobalSnapshotAcceptanceManager
 import io.constellationnetwork.schema.ID.Id
@@ -50,7 +51,8 @@ object GlobalSnapshotContextFunctions {
     tessellation3MigrationStartingOrdinal: SnapshotOrdinal,
     setSumFixOrdinal: SnapshotOrdinal,
     mptStore: MptStore[F, GlobalStateKey],
-    incrementalDelegatedStakingStartingOrdinal: SnapshotOrdinal
+    incrementalDelegatedStakingStartingOrdinal: SnapshotOrdinal,
+    fixingAllowSpendDestinationCredit: SnapshotOrdinal
   )(
     implicit globalStateProofSelector: GlobalStateProofSelector
   ) =
@@ -146,6 +148,59 @@ object GlobalSnapshotContextFunctions {
         lastArtifact: Signed[GlobalIncrementalSnapshot],
         signedArtifact: Signed[GlobalIncrementalSnapshot],
         getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
+      )(implicit hasher: Hasher[F]): F[GlobalSnapshotInfo] = {
+        val modes = AllowSpendBlockAcceptanceMode.globalHistoricalRecreationModes(
+          signedArtifact.ordinal,
+          fixingAllowSpendDestinationCredit
+        )
+
+        // Only the attempts that still have a mode to fall back to treat a divergence as "wrong mode". The final
+        // mode falls through to the follower-divergence handling below, so when a single mode applies -- at or
+        // above the activation ordinal -- this function behaves exactly as it did before allow-spend modes existed.
+        def attempt(remaining: List[AllowSpendBlockAcceptanceMode]): F[GlobalSnapshotInfo] =
+          remaining match {
+            case mode :: Nil =>
+              createContextWithMode(
+                context,
+                lastArtifact,
+                signedArtifact,
+                getGlobalSnapshotByOrdinal,
+                mode,
+                enforceModeAgreement = false
+              )
+            case mode :: rest =>
+              createContextWithMode(
+                context,
+                lastArtifact,
+                signedArtifact,
+                getGlobalSnapshotByOrdinal,
+                mode,
+                enforceModeAgreement = true
+              ).handleErrorWith { error =>
+                // While a fallback mode remains, ANY failure means this mode did not reproduce the signed
+                // snapshot rather than that this node has forked -- both the soft divergence signalled by
+                // AllowSpendModeMismatchError and a hard failure such as the balance underflow escrow
+                // semantics produce on pre-activation snapshots. Matches the mainnet fix, which likewise
+                // falls back on any raised error. The final mode never reaches here, so a genuine failure
+                // there still surfaces unchanged.
+                logger.debug(error)(s"Retrying global snapshot recreation with allow-spend mode=${rest.head}") >>
+                  attempt(rest)
+              }
+            case Nil =>
+              new IllegalStateException("No allow-spend acceptance mode available for global snapshot recreation")
+                .raiseError[F, GlobalSnapshotInfo]
+          }
+
+        attempt(modes)
+      }
+
+      private def createContextWithMode(
+        context: GlobalSnapshotInfo,
+        lastArtifact: Signed[GlobalIncrementalSnapshot],
+        signedArtifact: Signed[GlobalIncrementalSnapshot],
+        getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
+        allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode,
+        enforceModeAgreement: Boolean
       )(implicit hasher: Hasher[F]): F[GlobalSnapshotInfo] = for {
         lastActiveTips <- HasherSelector[F].forOrdinal(lastArtifact.ordinal)(implicit hasher => lastArtifact.activeTips)
 
@@ -227,7 +282,7 @@ object GlobalSnapshotContextFunctions {
 
         (
           acceptanceResult,
-          _,
+          allowSpendBlockAcceptanceResult,
           _,
           _,
           _,
@@ -323,26 +378,39 @@ object GlobalSnapshotContextFunctions {
                   }
                 },
             StateChannelValidationType.Historical,
-            getGlobalSnapshotByOrdinal
+            getGlobalSnapshotByOrdinal,
+            allowSpendBlockAcceptanceMode
           )
 
         // Followers (currency-l0, dag-l1, currency-l1) AND dag-l0 recovery/replay reconstruct the global context
         // by RE-RUNNING acceptance over the already-L0-validated signedArtifact. Items the local reconstruction
-        // rejects (blocks / state-channels / rewards that the signed snapshot included) mean this node computed a
-        // DIFFERENT GlobalSnapshotInfo than the canonical one -- its global state has diverged. This was previously
-        // three benign-looking warnings ("Continuing since validated"), which masked real forks. We now surface it
-        // as a single loud, greppable signal. Full per-ordinal MPT re-validation stays skipped here (too expensive
-        // -- ~2 min for 800K entries; the MPT is synced once during initial download). By default we still continue
-        // (followers trust the L0 majority and re-sync via the caller's download path); set
-        // CL_RAISE_ON_FOLLOWER_DIVERGENCE=true to instead halt so the caller's recovery re-syncs the correct state.
+        // rejects (blocks / allow-spend blocks / state-channels / rewards that the signed snapshot included) mean
+        // this node computed a DIFFERENT GlobalSnapshotInfo than the canonical one -- its global state has
+        // diverged. This was previously three benign-looking warnings ("Continuing since validated"), which masked
+        // real forks. We now surface it as a single loud, greppable signal. Full per-ordinal MPT re-validation
+        // stays skipped here (too expensive -- ~2 min for 800K entries; the MPT is synced once during initial
+        // download). By default we still continue (followers trust the L0 majority and re-sync via the caller's
+        // download path); set CL_RAISE_ON_FOLLOWER_DIVERGENCE=true to instead halt so the caller's recovery
+        // re-syncs the correct state.
         diffRewards = acceptedRewardTxs -- signedArtifact.rewards
-        diverged = acceptanceResult.notAccepted.nonEmpty || returnedSCEvents.nonEmpty || diffRewards.nonEmpty
+        diverged = acceptanceResult.notAccepted.nonEmpty || allowSpendBlockAcceptanceResult.notAccepted.nonEmpty ||
+          returnedSCEvents.nonEmpty || diffRewards.nonEmpty
+
+        // While another allow-spend mode is still available, a divergence means this mode did not reproduce the
+        // signed snapshot rather than that this node has forked. Signal that internally so createContext can try
+        // the next mode; the retry there is the only handler, so it never escapes and never reaches an operator.
+        // On the final mode this is skipped and the handling below runs unchanged.
+        _ <- AllowSpendModeMismatchError(signedArtifact.ordinal)
+          .raiseError[F, Unit]
+          .whenA(enforceModeAgreement && diverged)
+
         _ <- (
           logger.error(
             s"[FOLLOWER-STATE-DIVERGENCE] ordinal=${signedArtifact.ordinal.show}: local reconstruction diverged from " +
               s"the L0-validated snapshot (this node may be on a forked global state and should re-sync). " +
               s"blocksNotAccepted=${acceptanceResult.notAccepted.size} " +
               s"[${acceptanceResult.notAccepted.map { case (_, reason) => reason }.mkString("; ")}] " +
+              s"allowSpendBlocksNotAccepted=${allowSpendBlockAcceptanceResult.notAccepted.size} " +
               s"stateChannelsReturned=${returnedSCEvents.size} [${returnedSCEvents.toList.map(_.address).mkString(",")}] " +
               s"rewardsDiff=${diffRewards.size}"
           ) >>
@@ -356,6 +424,13 @@ object GlobalSnapshotContextFunctions {
 
   @derive(eqv, show)
   case class CannotApplyBlocksError(reasons: List[BlockNotAcceptedReason]) extends NoStackTrace {
+
+    override def getMessage: String =
+      s"Cannot build global snapshot ${reasons.show}"
+  }
+
+  @derive(eqv, show)
+  case class CannotApplyAllowSpendBlocksError(reasons: List[AllowSpendBlockNotAcceptedReason]) extends NoStackTrace {
 
     override def getMessage: String =
       s"Cannot build global snapshot ${reasons.show}"
@@ -381,5 +456,14 @@ object GlobalSnapshotContextFunctions {
 
     override def getMessage: String =
       s"Follower reconstruction diverged from the L0-validated snapshot at ordinal=${ordinal.value}"
+  }
+
+  // Internal to createContext's allow-spend mode selection: raised by an attempt that still has another mode to
+  // fall back to, and caught by that retry. It never escapes, so it is never a signal to an operator -- a genuine
+  // divergence on the final mode is reported by GlobalStateDivergenceError above.
+  case class AllowSpendModeMismatchError(ordinal: SnapshotOrdinal) extends NoStackTrace {
+
+    override def getMessage: String =
+      s"Allow-spend acceptance mode did not reproduce the signed snapshot at ordinal=${ordinal.value}"
   }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManager.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.schema.transaction.RewardTransaction
 import io.constellationnetwork.security.signature.Signed
 
+import eu.timepit.refined.types.numeric.NonNegLong
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -69,12 +70,15 @@ class BalanceOpsManager[F[_]: Async](
 
   def acceptFeeTxs(
     balances: SortedMap[Address, Balance],
-    maybeTxs: Option[SortedSet[Signed[FeeTransaction]]]
+    maybeTxs: Option[SortedSet[Signed[FeeTransaction]]],
+    checkedArithmetic: Boolean
   ): F[(SortedMap[Address, Balance], Option[SortedSet[Signed[FeeTransaction]]])] =
     maybeTxs match {
       case None => (balances, maybeTxs).pure[F]
       case Some(txs) =>
-        val (updatedBalances, acceptedTxs, rejectedTxs) = BalanceOpsManager.applyFeeTransactions(balances, txs)
+        val (updatedBalances, acceptedTxs, rejectedTxs) =
+          if (checkedArithmetic) BalanceOpsManager.applyFeeTransactions(balances, txs)
+          else BalanceOpsManager.applyFeeTransactionsUnchecked(balances, txs)
 
         rejectedTxs.traverse_ { signedTx =>
           logger.warn(
@@ -100,6 +104,28 @@ object BalanceOpsManager {
     * @return
     *   the updated balances, the accepted transactions, and the rejected ones in iteration order
     */
+  /** The pre-fix wrapping implementation, kept so global ordinals at or below the activation still replay to the state that was actually
+    * signed. Selected via fixingFeeTransactionBalanceOverflow.
+    */
+  def applyFeeTransactionsUnchecked(
+    balances: SortedMap[Address, Balance],
+    txs: SortedSet[Signed[FeeTransaction]]
+  ): (SortedMap[Address, Balance], SortedSet[Signed[FeeTransaction]], List[Signed[FeeTransaction]]) = {
+    val feeReferredAddresses = txs.flatMap(tx => Set(tx.value.source, tx.value.destination))
+    val feeReferredBalances = feeReferredAddresses.foldLeft(SortedMap.empty[Address, Long]) {
+      case (acc, address) => acc.updated(address, balances.getOrElse(address, Balance.empty).value.value)
+    }
+    val updated = txs.foldLeft(feeReferredBalances) {
+      case (acc, tx) =>
+        acc
+          .updatedWith(tx.value.source)(existing => (existing.getOrElse(0L) - tx.value.amount.value.value).some)
+          .updatedWith(tx.value.destination)(existing => (existing.getOrElse(0L) + tx.value.amount.value.value).some)
+    }
+    val asBalances = updated.map { case (a, v) => a -> Balance(NonNegLong.unsafeFrom(v)) }
+
+    (balances ++ asBalances, txs, List.empty)
+  }
+
   def applyFeeTransactions(
     balances: SortedMap[Address, Balance],
     txs: SortedSet[Signed[FeeTransaction]]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BlockAcceptanceOpsManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BlockAcceptanceOpsManager.scala
@@ -104,7 +104,8 @@ class BlockAcceptanceOpsManager[F[_]: Async: Parallel](
     shouldPerformMetagraphSpecificValidations: Boolean,
     lastUnsyncGlobalSnapshotOrdinal: SnapshotOrdinal,
     fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal,
-    lastSyncGlobalSnapshotEpochProgress: EpochProgress
+    lastSyncGlobalSnapshotEpochProgress: EpochProgress,
+    creditDestination: Boolean
   )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult] = {
     val context = AllowSpendBlockAcceptanceContext.fromStaticData(
       lastSnapshotContext.snapshotInfo.balances,
@@ -124,7 +125,8 @@ class BlockAcceptanceOpsManager[F[_]: Async: Parallel](
       context,
       snapshotOrdinal,
       shouldPerformMetagraphSpecificValidations,
-      maybeEpochProgress
+      maybeEpochProgress,
+      creditDestination
     )
   }
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
@@ -21,7 +21,11 @@ import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockAcce
 import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
 import io.constellationnetwork.node.shared.domain.transaction.FeeTransactionValidator
 import io.constellationnetwork.node.shared.infrastructure.snapshot.CurrencyBalanceAdjustments.metagraphsBalancesAdjustments
-import io.constellationnetwork.node.shared.infrastructure.snapshot.{CurrencyMessageValidator, GlobalSnapshotSyncValidator}
+import io.constellationnetwork.node.shared.infrastructure.snapshot.{
+  AllowSpendBlockAcceptanceMode,
+  CurrencyMessageValidator,
+  GlobalSnapshotSyncValidator
+}
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact._
@@ -59,7 +63,8 @@ trait CurrencySnapshotAcceptanceManager[F[_]] {
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     lastGlobalSyncView: Option[GlobalSyncView],
     shouldPerformMetagraphSpecificValidations: Boolean,
-    lastArtifactProofs: NonEmptySet[SignatureProof]
+    lastArtifactProofs: NonEmptySet[SignatureProof],
+    allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
   )(implicit hasher: Hasher[F]): F[CurrencySnapshotAcceptanceResult]
 
   def acceptRewardTxs(
@@ -175,7 +180,8 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     maybeLastGlobalSyncView: Option[GlobalSyncView],
     shouldPerformMetagraphSpecificValidations: Boolean,
-    lastArtifactProofs: NonEmptySet[SignatureProof]
+    lastArtifactProofs: NonEmptySet[SignatureProof],
+    allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
   )(implicit hasher: Hasher[F]): F[CurrencySnapshotAcceptanceResult] = for {
     initialTxRef <- TransactionReference.emptyCurrency(lastSnapshotContext.address)
     tokenLockInitialTxRef <- TokenLockReference.emptyCurrency(lastSnapshotContext.address)
@@ -238,9 +244,14 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
       )
     )
 
+    // Gated on the GLOBAL ordinal, like every other FieldsAddedOrdinals entry -- the currency ordinal is
+    // only used for balance adjustments. At or below the activation the original wrapping path runs, so
+    // history replays to the state that was actually signed.
     (updatedBalancesByFeeTransactions, acceptedFeeTxs) <- balanceOps.acceptFeeTxs(
       updatedBalancesByRewards,
-      feeTransactionsForAcceptance
+      feeTransactionsForAcceptance,
+      maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >
+        fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow.getOrElse(environment, SnapshotOrdinal.MaxValue)
     )
 
     acceptedSharedArtifacts = sharedArtifactsForAcceptance
@@ -346,7 +357,8 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
         shouldPerformMetagraphSpecificValidations,
         lastUnsyncGlobalSnapshot.ordinal,
         fixingAllowSpendAndTokenLockValidation,
-        lastGlobalSnapshotEpochProgress
+        lastGlobalSnapshotEpochProgress,
+        allowSpendBlockAcceptanceMode.creditDestination
       )
     ).parMapN((tokenLock, allowSpend) => (tokenLock, allowSpend))
 
@@ -508,9 +520,13 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
     }
 
     updatedBalancesByInvalidAddressChecks <-
-      metagraphsBalancesAdjustments
-        .get(lastSnapshotContext.address)
-        .fold[F[SortedMap[Address, Balance]]] {
+      // A metagraph may be authorized at several ordinals, so select the block matching this one
+      // rather than assuming a single entry. Keying uniquely meant the last block in the resource
+      // silently retired every earlier block for the same currency: replaying one of those ordinals
+      // applied no adjustment and diverged without raising, and a follow-up adjustment could not be
+      // scheduled at all.
+      metagraphsBalancesAdjustments.get(lastSnapshotContext.address) match {
+        case None =>
           if (balanceAdjustments.nonEmpty) {
             val unauthorizedError = new RuntimeException(
               s"Metagraph $metagraphId not authorized to perform balance updates on ordinal $snapshotOrdinal"
@@ -519,16 +535,16 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
           } else {
             updatedBalancesBySpendTransactions.pure[F]
           }
-        } { info =>
-          if (info.snapshotOrdinal === snapshotOrdinal && info.environment === environment) {
-            info.balanceAdjustFunction(updatedBalancesBySpendTransactions, balanceAdjustments) match {
-              case Right(balances) => balances.pure[F]
-              case Left(error)     => Async[F].raiseError(new RuntimeException(s"Balance adjustment failed: $error"))
+        case Some(infos) =>
+          infos
+            .find(info => info.snapshotOrdinal === snapshotOrdinal && info.environment === environment)
+            .fold(updatedBalancesBySpendTransactions.pure[F]) { info =>
+              info.balanceAdjustFunction(updatedBalancesBySpendTransactions, balanceAdjustments) match {
+                case Right(balances) => balances.pure[F]
+                case Left(error)     => Async[F].raiseError(new RuntimeException(s"Balance adjustment failed: $error"))
+              }
             }
-          } else {
-            updatedBalancesBySpendTransactions.pure[F]
-          }
-        }
+      }
 
     csi = CurrencySnapshotInfo(
       if (snapshotOrdinalToCheckFields < tessellation3MigrationStartingOrdinal)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/BlockAcceptanceCoordinatorManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/BlockAcceptanceCoordinatorManager.scala
@@ -34,7 +34,8 @@ trait BlockAcceptanceCoordinatorManager[F[_]] {
     lastSnapshotContext: GlobalSnapshotInfo,
     snapshotOrdinal: SnapshotOrdinal,
     fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal,
-    epochProgress: EpochProgress
+    epochProgress: EpochProgress,
+    creditDestination: Boolean
   )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult]
 
   def acceptTokenLockBlocks(
@@ -80,7 +81,8 @@ object BlockAcceptanceCoordinatorManager {
       lastSnapshotContext: GlobalSnapshotInfo,
       snapshotOrdinal: SnapshotOrdinal,
       fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal,
-      epochProgress: EpochProgress
+      epochProgress: EpochProgress,
+      creditDestination: Boolean
     )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult] = {
       val context = AllowSpendBlockAcceptanceContext.fromStaticData(
         lastSnapshotContext.balances,
@@ -94,7 +96,8 @@ object BlockAcceptanceCoordinatorManager {
           context,
           snapshotOrdinal,
           shouldPerformMetagraphSpecificValidations = true,
-          epochProgress.some
+          epochProgress.some,
+          creditDestination
         )
       } else {
         allowSpendBlockAcceptanceManager.acceptBlocksIteratively(
@@ -102,7 +105,8 @@ object BlockAcceptanceCoordinatorManager {
           context,
           snapshotOrdinal,
           shouldPerformMetagraphSpecificValidations = true,
-          none
+          none,
+          creditDestination
         )
       }
     }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -131,7 +131,8 @@ trait GlobalSnapshotAcceptanceManager[F[_]] {
     lastDeprecatedTips: SortedSet[DeprecatedTip],
     calculateRewardsFn: RewardsInput => F[DelegatedRewardsResult],
     validationType: StateChannelValidationType,
-    getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
+    getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
+    allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
   ): F[
     (
       BlockAcceptanceResult,
@@ -385,7 +386,8 @@ object GlobalSnapshotAcceptanceManager {
         allowSpendBlocksForAcceptance: List[Signed[AllowSpendBlock]],
         tokenLockBlocksForAcceptance: List[Signed[TokenLockBlock]],
         lastSnapshotContext: GlobalSnapshotInfo,
-        fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal
+        fixingAllowSpendAndTokenLockValidation: SnapshotOrdinal,
+        allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
       )(implicit hasher: Hasher[F]): F[(AllowSpendBlockAcceptanceResult, TokenLockBlockAcceptanceResult)] =
         for {
           allowSpend <- blockAcceptanceCoordinatorManager.acceptAllowSpendBlocks(
@@ -393,7 +395,8 @@ object GlobalSnapshotAcceptanceManager {
             lastSnapshotContext,
             ordinal,
             fixingAllowSpendAndTokenLockValidation,
-            epochProgress
+            epochProgress,
+            allowSpendBlockAcceptanceMode.creditDestination
           )
           tokenLock <- blockAcceptanceCoordinatorManager.acceptTokenLockBlocks(
             tokenLockBlocksForAcceptance,
@@ -623,7 +626,8 @@ object GlobalSnapshotAcceptanceManager {
         lastDeprecatedTips: SortedSet[DeprecatedTip],
         calculateRewardsFn: RewardsInput => F[DelegatedRewardsResult],
         validationType: StateChannelValidationType,
-        getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]]
+        getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
+        allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
       ): F[
         (
           BlockAcceptanceResult,
@@ -687,7 +691,8 @@ object GlobalSnapshotAcceptanceManager {
                 allowSpendBlocksForAcceptance,
                 tokenLockBlocksForAcceptance,
                 lastSnapshotContext,
-                fixingAllowSpendAndTokenLockValidation
+                fixingAllowSpendAndTokenLockValidation,
+                allowSpendBlockAcceptanceMode
               )
 
             acceptedGlobalAllowSpends = allowSpendBlockAcceptanceResult.accepted.flatMap(_.value.transactions.toList)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -160,7 +160,9 @@ object SharedServices {
         ),
         validators.signedValidator,
         None,
-        None
+        None,
+        cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
+          .getOrElse(cfg.environment, SnapshotOrdinal.MinValue)
       )
       currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(
         currencySnapshotValidator
@@ -210,7 +212,8 @@ object SharedServices {
         cfg.fieldsAddedOrdinals.tessellation3Migration.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
         cfg.fieldsAddedOrdinals.setSumFix.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
         storages.mptStore,
-        cfg.incrementalDelegatedStakingStartingOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MinValue)
+        cfg.incrementalDelegatedStakingStartingOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
+        cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit.getOrElse(cfg.environment, SnapshotOrdinal.MinValue)
       )
     } yield
       new SharedServices[F, A](

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogicSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceLogicSuite.scala
@@ -1,0 +1,230 @@
+package io.constellationnetwork.node.shared.domain.swap.block
+
+import java.util.UUID
+
+import cats.data.Validated.Valid
+import cats.data.{EitherT, NonEmptySet, ValidatedNec}
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all._
+
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.domain.swap.AllowSpendChainValidator.AllowSpendNel
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
+import weaver.MutableIOSuite
+
+object AllowSpendBlockAcceptanceLogicSuite extends MutableIOSuite {
+
+  type Res = (Hasher[IO], SecurityProvider[IO])
+
+  def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO].asResource
+    h = Hasher.forJson[IO]
+  } yield (h, sp)
+
+  private val source = Address("DAG011jH7FMDvKpdb7wewrMWwYtkwq56nHquAHdi")
+  private val destination = Address("DAG06z64ifT2HzXoHfMexRfrcnpYFEwMqjFiPKze")
+  private val onward = Address("DAG07tqNLYW8jHU9emXcRTT3CfgCUoumwcLghopd")
+
+  private def balance(value: Long): Balance = Balance(NonNegLong.unsafeFrom(value))
+
+  private def proofOf(seed: Int): NonEmptySet[SignatureProof] = {
+    val hex = (seed.toString * 128).take(128)
+    NonEmptySet.one(SignatureProof(Id(Hex(hex)), Signature(Hex(hex))))
+  }
+
+  private def blockOf(from: Address, to: Address, amount: Long, fee: Long, seed: Int): Signed[AllowSpendBlock] = {
+    val allowSpend = Signed(
+      AllowSpend(
+        from,
+        to,
+        None,
+        SwapAmount(PosLong.unsafeFrom(amount)),
+        AllowSpendFee(NonNegLong.unsafeFrom(fee)),
+        AllowSpendReference.empty,
+        EpochProgress(NonNegLong.unsafeFrom(100L)),
+        List.empty
+      ),
+      proofOf(seed)
+    )
+
+    val roundId = RoundId(UUID.fromString(s"00000000-0000-0000-0000-00000000000$seed"))
+
+    Signed(AllowSpendBlock(roundId, NonEmptySet.one(allowSpend)), proofOf(seed))
+  }
+
+  private def contextOf(entries: (Address, Long)*): AllowSpendBlockAcceptanceContext[IO] =
+    AllowSpendBlockAcceptanceContext.fromStaticData[IO](
+      entries.map { case (address, value) => address -> balance(value) }.toMap,
+      Map.empty,
+      Amount.empty,
+      AllowSpendReference.empty
+    )
+
+  // txChains is empty so processLastTxRefs is a no-op, and collateral validation is skipped; what is
+  // left is processBalances.
+  private def accept(
+    signedBlock: Signed[AllowSpendBlock],
+    context: AllowSpendBlockAcceptanceContext[IO],
+    contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
+    creditDestination: Boolean
+  )(
+    implicit h: Hasher[IO],
+    sp: SecurityProvider[IO]
+  ): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
+    AllowSpendBlockAcceptanceLogic
+      .make[IO]
+      .acceptBlock(signedBlock, Map.empty, context, contextUpdate, shouldPerformMetagraphSpecificValidations = false, creditDestination)
+      .value
+
+  test("escrows at the source without crediting the destination") { res =>
+    implicit val (h, sp) = res
+
+    accept(
+      blockOf(source, destination, 10L, 1L, 1),
+      contextOf(source -> 100L),
+      AllowSpendBlockAcceptanceContextUpdate.empty,
+      creditDestination = false
+    ).map {
+      case Right(update) =>
+        expect.all(
+          update.balances.get(source).contains(balance(89L)),
+          update.balances.get(destination).isEmpty
+        )
+      case Left(reason) => failure(s"expected acceptance, got $reason")
+    }
+  }
+
+  test("credits the destination only when legacy behavior is explicitly selected") { res =>
+    implicit val (h, sp) = res
+
+    accept(
+      blockOf(source, destination, 10L, 1L, 1),
+      contextOf(source -> 100L),
+      AllowSpendBlockAcceptanceContextUpdate.empty,
+      creditDestination = true
+    ).map {
+      case Right(update) =>
+        expect.all(
+          update.balances.get(source).contains(balance(89L)),
+          update.balances.get(destination).contains(balance(10L))
+        )
+      case Left(reason) => failure(s"expected acceptance, got $reason")
+    }
+  }
+
+  // AllowSpendBlockAcceptanceManager threads contextUpdate across blocks, so under the old behaviour a
+  // destination credited by the first block funds an allow spend of its own in the second, out of a
+  // balance no snapshot ever recorded for it.
+  test("a destination cannot fund a second block once the credit is dropped") { res =>
+    implicit val (h, sp) = res
+
+    val context = contextOf(source -> 101L)
+
+    for {
+      first <- accept(blockOf(source, destination, 100L, 1L, 1), context, AllowSpendBlockAcceptanceContextUpdate.empty, false)
+      firstUpdate = first.getOrElse(AllowSpendBlockAcceptanceContextUpdate.empty)
+      second <- accept(blockOf(destination, onward, 100L, 0L, 2), context, firstUpdate, false)
+    } yield
+      expect.all(
+        first.exists(_.balances.get(source).contains(balance(0L))),
+        first.exists(_.balances.get(destination).isEmpty),
+        second.swap.exists(_.isInstanceOf[AddressBalanceOutOfRange])
+      )
+  }
+
+  test("a destination funds a second block under the old behaviour") { res =>
+    implicit val (h, sp) = res
+
+    val context = contextOf(source -> 101L)
+
+    for {
+      first <- accept(blockOf(source, destination, 100L, 1L, 1), context, AllowSpendBlockAcceptanceContextUpdate.empty, true)
+      firstUpdate = first.getOrElse(AllowSpendBlockAcceptanceContextUpdate.empty)
+      second <- accept(blockOf(destination, onward, 100L, 0L, 2), context, firstUpdate, true)
+    } yield
+      expect.all(
+        first.exists(_.balances.get(destination).contains(balance(100L))),
+        second.exists(_.balances.get(onward).contains(balance(100L)))
+      )
+  }
+
+  test("iterative acceptance retries phantom-funded blocks only under legacy semantics") { res =>
+    implicit val (h, sp) = res
+
+    val first = blockOf(source, destination, 100L, 1L, 1)
+    val second = blockOf(destination, onward, 100L, 0L, 2)
+    val context = contextOf(source -> 101L)
+
+    val validator = new AllowSpendBlockValidator[IO] {
+      def validate(
+        signedBlock: Signed[AllowSpendBlock],
+        snapshotOrdinal: io.constellationnetwork.schema.SnapshotOrdinal,
+        params: AllowSpendBlockValidationParams,
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+      )(implicit hasher: Hasher[IO]): IO[
+        ValidatedNec[AllowSpendBlockValidationError, (Signed[AllowSpendBlock], Map[Address, AllowSpendNel])]
+      ] = IO.pure(Valid((signedBlock, Map.empty)))
+    }
+
+    for {
+      attempts <- Ref.of[IO, List[RoundId]](List.empty)
+      underlying = AllowSpendBlockAcceptanceLogic.make[IO]
+      recordingLogic = new AllowSpendBlockAcceptanceLogic[IO] {
+        def acceptBlock(
+          block: Signed[AllowSpendBlock],
+          txChains: Map[Address, AllowSpendNel],
+          context: AllowSpendBlockAcceptanceContext[IO],
+          contextUpdate: AllowSpendBlockAcceptanceContextUpdate,
+          shouldPerformMetagraphSpecificValidations: Boolean,
+          creditDestination: Boolean
+        )(implicit hasher: Hasher[IO]): EitherT[IO, AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate] =
+          EitherT.liftF[IO, AllowSpendBlockNotAcceptedReason, Unit](attempts.update(block.value.roundId :: _)) >>
+            underlying.acceptBlock(block, txChains, context, contextUpdate, shouldPerformMetagraphSpecificValidations, creditDestination)(
+              hasher
+            )
+      }
+      manager = AllowSpendBlockAcceptanceManager.make[IO](recordingLogic, validator)
+      legacy <- manager.acceptBlocksIteratively(
+        List(first, second),
+        context,
+        io.constellationnetwork.schema.SnapshotOrdinal.MinValue,
+        shouldPerformMetagraphSpecificValidations = false,
+        None,
+        creditDestination = true
+      )
+      legacyAttempts <- attempts.get
+      _ <- attempts.set(List.empty)
+      escrow <- manager.acceptBlocksIteratively(
+        List(first, second),
+        context,
+        io.constellationnetwork.schema.SnapshotOrdinal.MinValue,
+        shouldPerformMetagraphSpecificValidations = false,
+        None,
+        creditDestination = false
+      )
+      escrowAttempts <- attempts.get
+    } yield
+      expect.all(
+        legacy.accepted.toSet == Set(first, second),
+        legacy.notAccepted.isEmpty,
+        legacyAttempts.count(_ == second.value.roundId) == 2,
+        escrow.accepted == List(first),
+        escrow.notAccepted.map(_._1) == List(second),
+        escrowAttempts.count(_ == second.value.roundId) == 2
+      )
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyBalanceAdjustmentsResourceSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencyBalanceAdjustmentsResourceSuite.scala
@@ -1,0 +1,261 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot
+
+import cats.syntax.all._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.env.AppEnvironment.Mainnet
+import io.constellationnetwork.node.shared.infrastructure.BalanceAdjustmentLoader
+import io.constellationnetwork.node.shared.infrastructure.snapshot.CurrencyBalanceAdjustments.{
+  AdjustmentType,
+  RequiredAdjustment,
+  metagraphsBalancesAdjustments
+}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.{BalanceAdjustment, FeeTransactionBugDeduction, TokenUnlockBugDeduction}
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.security.hash.Hash
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
+import weaver.SimpleIOSuite
+
+object CurrencyBalanceAdjustmentsResourceSuite extends SimpleIOSuite {
+
+  private val pacaswap = Address("DAG7X5idd4aLfp4XC6WQdG1eDfR3LGPVEwtUUB2W")
+
+  private val adjustmentOrdinal = SnapshotOrdinal.unsafeApply(731647L)
+
+  /** 2^62, the amount each of the four fee transactions in metagraph snapshot 731261 credited. */
+  private val minted = 4611686018427387904L
+
+  /** Balances observed when the metagraph was stopped. Two wallets still hold the full 2^62, two were partially spent, so the deduction has
+    * to zero the exact and the drained case alike.
+    */
+  private val mintedWallets: List[(Address, Long)] = List(
+    Address("DAG1kEmLAgnCVBURHrL4AMsfn9TZdk4QCYQ8tUu3") -> minted,
+    Address("DAG7ZjENTP4T36PPSp3skJdTHtQbcuLfpEaAFWdn") -> minted,
+    Address("DAG4w5mUqNNxQNS4hgdpx3E8FGgiu2UCRsJxHwhX") -> 4573023841357253629L,
+    Address("DAG8uqhyGtFABWSS5KeVB2ia1R4vXop5AeijXeoU") -> 4111686018427387904L
+  )
+
+  /** The pool address. Phantom PACA the attacker swapped in piled up here on top of the reserve the pool held before the mint, and the
+    * deduction takes that pile back off.
+    */
+  private val poolBalance = 360351876219858115L
+  private val poolSurplus = 355312351884858115L
+
+  /** Two of the ten addresses that bought phantom PACA out of the pool with real DAG, as (held, deducted). The deduction lands short of
+    * zero on purpose: each keeps what their DAG would have bought at the pre-attack price, on top of any genuine pre-mint balance.
+    */
+  private val buyers: List[(Address, Long, Long)] = List(
+    (Address("DAG6zZakMJrrf25FSvPZAi8QA9wVDdmvFkPvTbKu"), 68023006936021839L, 67978819470437886L),
+    (Address("DAG1DD2bM1hpFyWwa8UNgh3wMLGAe5JDSwpoUS9M"), 77579706235110L, 76610032383686L)
+  )
+
+  /** An address no adjustment names, which has to come out of the fix byte for byte. */
+  private val bystander = Address("DAG62QdFnvW8xX3uGmo6F3yB2CT5i25hZoVmN6za") -> 4200000000L
+
+  /** The incident block, located by currency and ordinal, so the tests read the same block the loader will serve at runtime.
+    */
+  private val incidentAdjustmentBlock =
+    (for {
+      jsonString <- BalanceAdjustmentLoader.readResourceFile("/adjustments.json")
+      parsed <- BalanceAdjustmentLoader.parseJsonToModel(jsonString)
+      block <- parsed
+        .find(block => block.currencyId == pacaswap && block.snapshotOrdinal == adjustmentOrdinal)
+        .toRight("PacaSwap incident adjustment block not found")
+    } yield block)
+      .fold(error => throw new RuntimeException(error), identity)
+
+  /** Read straight out of the shipped resource, including reason and reference, so this is the complete artifact set the metagraph must
+    * emit at 731647 for the snapshot to be accepted. Exact matching compares address, reason, reference set and amounts, so the test
+    * artifacts have to carry the real references, not placeholders.
+    */
+  private val allDeductions: Set[BalanceAdjustment] =
+    incidentAdjustmentBlock.adjustments
+      .traverse(BalanceAdjustmentLoader.convertSingleBalanceAdjustment)
+      .map(_.toSet)
+      .fold(error => throw new RuntimeException(error), identity)
+
+  private val requiredAdjustments: Set[RequiredAdjustment] =
+    incidentAdjustmentBlock.adjustments
+      .traverse(BalanceAdjustmentLoader.convertSingleAdjustment)
+      .map(_.toSet)
+      .fold(error => throw new RuntimeException(error), identity)
+
+  private def deduction(address: Address, amount: Long): BalanceAdjustment =
+    BalanceAdjustment(
+      address,
+      FeeTransactionBugDeduction,
+      SortedSet(Hash.empty),
+      none,
+      Amount(NonNegLong.unsafeFrom(amount)).some
+    )
+
+  private def authorizedDeduction(address: Address, amount: Long): BalanceAdjustment =
+    allDeductions
+      .find(adjustment => adjustment.address == address && adjustment.deduct.exists(_.value.value == amount))
+      .getOrElse(throw new RuntimeException(s"Authorized deduction not found for $address: $amount"))
+
+  private lazy val entryAt731647 =
+    metagraphsBalancesAdjustments(pacaswap).find(_.snapshotOrdinal == adjustmentOrdinal).get
+
+  private val balances: SortedMap[Address, Balance] =
+    SortedMap.from(
+      (mintedWallets ++ buyers.map { case (a, held, _) => a -> held } :+ (pacaswap -> poolBalance) :+ bystander).map {
+        case (address, value) => address -> Balance(NonNegLong.unsafeFrom(value))
+      }
+    )
+
+  // The incident block must remain registered alongside every historical PacaSwap block, and only this
+  // newly scheduled block should opt into exact artifact authorization.
+  pureTest("the active Pacaswap entry is the fee-transaction deduction at the first restart ordinal") {
+    val entry = metagraphsBalancesAdjustments.get(pacaswap)
+
+    expect.all(
+      entry.isDefined,
+      entry.exists(_.exists(_.snapshotOrdinal == adjustmentOrdinal)),
+      entry.exists(_.exists(_.environment == Mainnet)),
+      entry.exists(_.exists(entry => entry.snapshotOrdinal == adjustmentOrdinal && entry.exactMatchRequired))
+    )
+  }
+
+  pureTest("the live block covers the mint, the pool and the buyers, once each") {
+    expect.all(
+      requiredAdjustments.size == 17,
+      requiredAdjustments.map(_.address).size == 17,
+      requiredAdjustments.forall { required =>
+        required.adjustment match {
+          case AdjustmentType.Decrease(_) => true
+          case AdjustmentType.Increase(_) => false
+        }
+      },
+      mintedWallets.forall {
+        case (address, _) =>
+          requiredAdjustments.contains(
+            RequiredAdjustment(address, AdjustmentType.Decrease(Amount(NonNegLong.unsafeFrom(minted))))
+          )
+      },
+      requiredAdjustments.contains(
+        RequiredAdjustment(pacaswap, AdjustmentType.Decrease(Amount(NonNegLong.unsafeFrom(poolSurplus))))
+      )
+    )
+  }
+
+  pureTest("the entry zeroes the minted wallets and takes the surplus off the pool") {
+    val result = entryAt731647.balanceAdjustFunction(balances, allDeductions)
+
+    result match {
+      case Left(error) => failure(s"expected the adjustment to apply, got: $error")
+      case Right(updated) =>
+        expect.all(
+          mintedWallets.forall { case (address, _) => updated.get(address).contains(Balance.empty) },
+          updated.get(pacaswap).contains(Balance(NonNegLong.unsafeFrom(poolBalance - poolSurplus))),
+          updated.get(bystander._1).contains(Balance(NonNegLong.unsafeFrom(bystander._2)))
+        )
+    }
+  }
+
+  pureTest("buyers keep the PACA they held before the mint") {
+    val result = entryAt731647.balanceAdjustFunction(balances, allDeductions)
+
+    result match {
+      case Left(error) => failure(s"expected the adjustment to apply, got: $error")
+      case Right(updated) =>
+        expect(buyers.forall {
+          case (address, held, deduct) =>
+            updated.get(address).contains(Balance(NonNegLong.unsafeFrom(held - deduct)))
+        })
+    }
+  }
+
+  // If the metagraph fails to emit the full artifact set at 731647 the snapshot must not be produced,
+  // rather than being accepted with a partial deduction.
+  pureTest("the entry rejects an incomplete adjustment set") {
+    val partial = allDeductions - authorizedDeduction(mintedWallets.head._1, minted)
+    val result = entryAt731647.balanceAdjustFunction(balances, partial)
+
+    expect(result.isLeft)
+  }
+
+  // Amounts are matched exactly, so a rounded or rescaled figure on either side of the pair is
+  // indistinguishable from a missing artifact.
+  pureTest("the entry rejects an adjustment whose amount is off by one") {
+    val authorizedPoolDeduction = authorizedDeduction(pacaswap, poolSurplus)
+    val skewed = allDeductions - authorizedPoolDeduction + authorizedPoolDeduction.copy(
+      deduct = Amount(NonNegLong.unsafeFrom(poolSurplus - 1L)).some
+    )
+    val result = entryAt731647.balanceAdjustFunction(balances, skewed)
+
+    expect(result.isLeft)
+  }
+
+  pureTest("every historical adjustment block for a currency stays live, not just the last") {
+    // convertToAdjustmentEntries used to end in .toMap, so the last block in the resource silently
+    // retired every earlier block for the same currency. Replaying one of those ordinals then applied
+    // no adjustment and diverged without raising, and a follow-up block could not be scheduled.
+    val blocks = metagraphsBalancesAdjustments.getOrElse(pacaswap, List.empty)
+    val ordinals = blocks.map(_.snapshotOrdinal.value.value).toSet
+
+    expect.all(
+      blocks.size >= 4,
+      ordinals.contains(109991L),
+      ordinals.contains(145000L),
+      ordinals.contains(472325L),
+      ordinals.contains(adjustmentOrdinal.value.value),
+      ordinals.size == blocks.size
+    )
+  }
+
+  pureTest("the entry rejects an adjustment that is not in the authorized set") {
+    // validateRequiredAdjustments used to check only that the required set was a subset of what the
+    // metagraph emitted, so a metagraph could emit the authorized deductions plus arbitrary extras and
+    // every one of them would be applied. The resource is the authorization boundary, so the emitted
+    // set has to match it exactly.
+    // An address nowhere in the authorized set, with a deduction nobody approved.
+    val extra = deduction(Address("DAG6zZakMJrrf25FSvPZAi8QA9wVDdmvFkPvTbKu"), 999999999L)
+
+    val result = entryAt731647.balanceAdjustFunction(balances, allDeductions + extra)
+
+    expect(result.isLeft) &&
+    expect(result.left.exists(_.toLowerCase.contains("unauthorized")))
+  }
+
+  pureTest("the entry rejects a matching deduction with an unauthorized increase") {
+    val authorized = authorizedDeduction(pacaswap, poolSurplus)
+    val withIncrease = authorized.copy(increase = Amount(NonNegLong.unsafeFrom(1L)).some)
+
+    val result = entryAt731647.balanceAdjustFunction(balances, allDeductions - authorized + withIncrease)
+
+    expect(result.isLeft)
+  }
+
+  pureTest("the entry rejects changed reason or reference metadata") {
+    val authorized = authorizedDeduction(pacaswap, poolSurplus)
+    val wrongReason = authorized.copy(reason = TokenUnlockBugDeduction)
+    val wrongReference = authorized.copy(reference = authorized.reference + Hash("unauthorized-reference"))
+
+    expect.all(
+      entryAt731647.balanceAdjustFunction(balances, allDeductions - authorized + wrongReason).isLeft,
+      entryAt731647.balanceAdjustFunction(balances, allDeductions - authorized + wrongReference).isLeft
+    )
+  }
+
+  pureTest("the entry rejects a duplicate deduction distinguished only by metadata") {
+    val authorized = authorizedDeduction(pacaswap, poolSurplus)
+    val duplicate = authorized.copy(reference = authorized.reference + Hash("unauthorized-reference"))
+
+    val result = entryAt731647.balanceAdjustFunction(balances, allDeductions + duplicate)
+
+    expect(result.isLeft)
+  }
+
+  pureTest("historical blocks keep legacy subset validation so already-signed replay is unchanged") {
+    val historical = metagraphsBalancesAdjustments(pacaswap).filter(_.snapshotOrdinal =!= adjustmentOrdinal)
+
+    expect(historical.nonEmpty) &&
+    expect(historical.forall(!_.exactMatchRequired))
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreatorAllowSpendModeSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotCreatorAllowSpendModeSuite.scala
@@ -1,0 +1,278 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot
+
+import java.util.UUID
+
+import cats.data.NonEmptySet
+import cats.effect.{IO, Ref}
+import cats.syntax.all._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.currency.dataApplication.FeeTransaction
+import io.constellationnetwork.currency.schema.currency._
+import io.constellationnetwork.currency.schema.globalSnapshotSync.{GlobalSnapshotSync, GlobalSyncView}
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.config.types.SnapshotSizeConfig
+import io.constellationnetwork.node.shared.domain.block.processing._
+import io.constellationnetwork.node.shared.domain.rewards.Rewards
+import io.constellationnetwork.node.shared.domain.swap.block.{
+  AllowSpendBlockAcceptanceContext,
+  AllowSpendBlockAcceptanceContextUpdate,
+  AllowSpendBlockAcceptanceLogic
+}
+import io.constellationnetwork.node.shared.infrastructure.consensus.ValidationErrorStorage
+import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.EventTrigger
+import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.currency.{
+  CurrencySnapshotAcceptanceManager,
+  CurrencySnapshotAcceptanceResult
+}
+import io.constellationnetwork.node.shared.snapshot.currency._
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.SharedArtifact
+import io.constellationnetwork.schema.balance.{Amount, Balance}
+import io.constellationnetwork.schema.currencyMessage.CurrencyMessage
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.round.RoundId
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.schema.tokenLock.TokenLockBlock
+import io.constellationnetwork.schema.transaction.{RewardTransaction, Transaction, TransactionReference}
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
+import weaver.SimpleIOSuite
+
+object CurrencySnapshotCreatorAllowSpendModeSuite extends SimpleIOSuite {
+
+  private case object StopAfterAllowSpendAcceptance extends RuntimeException
+  private case class Observed(mode: AllowSpendBlockAcceptanceMode, firstAccepted: Boolean, phantomSecondAccepted: Boolean)
+
+  private val source = Address("DAG011jH7FMDvKpdb7wewrMWwYtkwq56nHquAHdi")
+  private val destination = Address("DAG06z64ifT2HzXoHfMexRfrcnpYFEwMqjFiPKze")
+  private val onward = Address("DAG07tqNLYW8jHU9emXcRTT3CfgCUoumwcLghopd")
+
+  private def balance(value: Long): Balance = Balance(NonNegLong.unsafeFrom(value))
+
+  private def proofOf(seed: Int): NonEmptySet[SignatureProof] = {
+    val hex = (seed.toString * 128).take(128)
+    NonEmptySet.one(SignatureProof(Id(Hex(hex)), Signature(Hex(hex))))
+  }
+
+  private def blockOf(from: Address, to: Address, amount: Long, fee: Long, seed: Int): Signed[AllowSpendBlock] = {
+    val allowSpend = Signed(
+      AllowSpend(
+        from,
+        to,
+        None,
+        SwapAmount(PosLong.unsafeFrom(amount)),
+        AllowSpendFee(NonNegLong.unsafeFrom(fee)),
+        AllowSpendReference.empty,
+        EpochProgress(NonNegLong.unsafeFrom(100L)),
+        List.empty
+      ),
+      proofOf(seed)
+    )
+
+    Signed(
+      AllowSpendBlock(RoundId(UUID.fromString(s"00000000-0000-0000-0000-00000000000$seed")), NonEmptySet.one(allowSpend)),
+      proofOf(seed)
+    )
+  }
+
+  private val firstBlock = blockOf(source, destination, 100L, 1L, 1)
+  private val phantomSecondBlock = blockOf(destination, onward, 100L, 0L, 2)
+
+  private def emptyInfo: CurrencySnapshotInfo =
+    CurrencySnapshotInfo(
+      SortedMap.empty[Address, TransactionReference],
+      SortedMap(source -> balance(101L)),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None
+    )
+
+  private def emptyStateProof: CurrencySnapshotStateProof =
+    CurrencySnapshotStateProof(Hash.empty, Hash.empty, None, None, None, None, None, None, None)
+
+  private def parentArtifact: Signed[CurrencyIncrementalSnapshot] =
+    Signed(
+      CurrencyIncrementalSnapshot(
+        SnapshotOrdinal(10L),
+        Height.MinValue,
+        SubHeight.MinValue,
+        Hash.empty,
+        SortedSet.empty,
+        SortedSet.empty,
+        SnapshotTips(SortedSet.empty, SortedSet.empty),
+        emptyStateProof,
+        EpochProgress.MinValue,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(GlobalSyncView(SnapshotOrdinal(6815490L), Hash.empty, EpochProgress.MinValue))
+      ),
+      proofOf(9)
+    )
+
+  private def recordingAcceptanceManager(
+    observed: Ref[IO, Option[Observed]]
+  )(implicit securityProvider: SecurityProvider[IO]): CurrencySnapshotAcceptanceManager[IO] =
+    new CurrencySnapshotAcceptanceManager[IO] {
+      def accept(
+        blocksForAcceptance: List[Signed[Block]],
+        tokenLockBlocksForAcceptance: List[Signed[TokenLockBlock]],
+        allowSpendBlocksForAcceptance: List[Signed[AllowSpendBlock]],
+        messagesForAcceptance: List[Signed[CurrencyMessage]],
+        feeTransactionsForAcceptance: Option[SortedSet[Signed[FeeTransaction]]],
+        globalSnapshotSyncsForAcceptance: List[Signed[GlobalSnapshotSync]],
+        sharedArtifactsForAcceptance: SortedSet[SharedArtifact],
+        lastSnapshotContext: CurrencySnapshotContext,
+        snapshotOrdinal: SnapshotOrdinal,
+        epochProgress: EpochProgress,
+        lastActiveTips: SortedSet[ActiveTip],
+        lastDeprecatedTips: SortedSet[DeprecatedTip],
+        calculateRewardsFn: SortedSet[Signed[Transaction]] => IO[SortedSet[RewardTransaction]],
+        facilitators: Set[PeerId],
+        getGlobalSnapshotByOrdinal: SnapshotOrdinal => IO[Option[Hashed[GlobalIncrementalSnapshot]]],
+        lastGlobalSyncView: Option[GlobalSyncView],
+        shouldPerformMetagraphSpecificValidations: Boolean,
+        lastArtifactProofs: NonEmptySet[SignatureProof],
+        allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
+      )(implicit hasher: Hasher[IO]): IO[CurrencySnapshotAcceptanceResult] = {
+        val logic = AllowSpendBlockAcceptanceLogic.make[IO]
+        val context = AllowSpendBlockAcceptanceContext.fromStaticData[IO](
+          lastSnapshotContext.snapshotInfo.balances,
+          Map.empty,
+          Amount.empty,
+          AllowSpendReference.empty
+        )
+
+        for {
+          first <- logic
+            .acceptBlock(
+              firstBlock,
+              Map.empty,
+              context,
+              AllowSpendBlockAcceptanceContextUpdate.empty,
+              shouldPerformMetagraphSpecificValidations = false,
+              allowSpendBlockAcceptanceMode.creditDestination
+            )
+            .value
+          firstUpdate = first.getOrElse(AllowSpendBlockAcceptanceContextUpdate.empty)
+          second <- logic
+            .acceptBlock(
+              phantomSecondBlock,
+              Map.empty,
+              context,
+              firstUpdate,
+              shouldPerformMetagraphSpecificValidations = false,
+              allowSpendBlockAcceptanceMode.creditDestination
+            )
+            .value
+          _ <- observed.set(Some(Observed(allowSpendBlockAcceptanceMode, first.isRight, second.isRight)))
+          result <- StopAfterAllowSpendAcceptance.raiseError[IO, CurrencySnapshotAcceptanceResult]
+        } yield result
+      }
+
+      def acceptRewardTxs(
+        baseBalances: SortedMap[Address, Balance],
+        newUpdatedBalance: Map[Address, Balance],
+        rewards: SortedSet[RewardTransaction]
+      ): IO[(SortedMap[Address, Balance], SortedSet[RewardTransaction])] =
+        (baseBalances, SortedSet.empty[RewardTransaction]).pure[IO]
+    }
+
+  test("live creator uses escrow semantics even when the signed parent global view predates activation") {
+    SecurityProvider.forAsync[IO].use { implicit securityProvider =>
+      JsonSerializer.forAsync[IO].flatMap { implicit jsonSerializer =>
+        implicit val hasher: Hasher[IO] = Hasher.forJson[IO]
+
+        for {
+          observed <- Ref.of[IO, Option[Observed]](None)
+          validationStorage <- ValidationErrorStorage.make[IO, CurrencySnapshotEvent, BlockRejectionReason](
+            10,
+            _ => List.empty[Hash].pure[IO]
+          )
+          creator = CurrencySnapshotCreator.make[IO](
+            SnapshotOrdinal.MinValue,
+            recordingAcceptanceManager(observed),
+            None,
+            SnapshotSizeConfig(203L, 512000L),
+            CurrencyEventsCutter.make[IO](None),
+            validationStorage
+          )
+          _ <- creator
+            .createProposalArtifact(
+              parentArtifact.ordinal,
+              parentArtifact,
+              CurrencySnapshotContext(source, emptyInfo),
+              hasher,
+              EventTrigger,
+              Set(AllowSpendBlockEvent(firstBlock), AllowSpendBlockEvent(phantomSecondBlock)),
+              None: Option[Rewards[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
+              Set.empty,
+              None,
+              None,
+              _ => none[Hashed[GlobalIncrementalSnapshot]].pure[IO],
+              shouldPerformMetagraphSpecificValidations = false,
+              None,
+              None,
+              AllowSpendBlockAcceptanceMode.live
+            )
+            .attempt
+          result <- observed.get
+        } yield expect(result.contains(Observed(AllowSpendBlockAcceptanceMode.Escrow, firstAccepted = true, phantomSecondAccepted = false)))
+      }
+    }
+  }
+
+  test("historical recreation allows legacy only below activation") {
+    val activation = SnapshotOrdinal.unsafeApply(100L)
+    val below = GlobalSyncView(SnapshotOrdinal.unsafeApply(99L), Hash.empty, EpochProgress.MinValue)
+    val at = GlobalSyncView(activation, Hash.empty, EpochProgress.MinValue)
+    val above = GlobalSyncView(SnapshotOrdinal.unsafeApply(101L), Hash.empty, EpochProgress.MinValue)
+
+    IO.pure(
+      expect.all(
+        AllowSpendBlockAcceptanceMode.live == AllowSpendBlockAcceptanceMode.Escrow,
+        AllowSpendBlockAcceptanceMode.currencyHistoricalRecreationModes(Some(below), activation) == List(
+          AllowSpendBlockAcceptanceMode.Escrow,
+          AllowSpendBlockAcceptanceMode.LegacyCreditDestination
+        ),
+        AllowSpendBlockAcceptanceMode.currencyHistoricalRecreationModes(None, activation) == List(
+          AllowSpendBlockAcceptanceMode.Escrow,
+          AllowSpendBlockAcceptanceMode.LegacyCreditDestination
+        ),
+        AllowSpendBlockAcceptanceMode.currencyHistoricalRecreationModes(Some(at), activation) == List(
+          AllowSpendBlockAcceptanceMode.Escrow
+        ),
+        AllowSpendBlockAcceptanceMode.globalHistoricalRecreationModes(below.ordinal, activation) == List(
+          AllowSpendBlockAcceptanceMode.Escrow,
+          AllowSpendBlockAcceptanceMode.LegacyCreditDestination
+        ),
+        AllowSpendBlockAcceptanceMode.globalHistoricalRecreationModes(at.ordinal, activation) == List(
+          AllowSpendBlockAcceptanceMode.Escrow
+        ),
+        AllowSpendBlockAcceptanceMode.globalHistoricalRecreationModes(above.ordinal, activation) == List(
+          AllowSpendBlockAcceptanceMode.Escrow
+        )
+      )
+    )
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotValidatorAllowSpendModeSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/CurrencySnapshotValidatorAllowSpendModeSuite.scala
@@ -1,0 +1,288 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot
+
+import cats.data.NonEmptySet
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.currency.dataApplication.FeeTransaction
+import io.constellationnetwork.currency.schema.currency._
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.kryo.KryoSerializer
+import io.constellationnetwork.node.shared.domain.rewards.Rewards
+import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
+import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.currency.{
+  CurrencySnapshotAcceptanceManager,
+  CurrencySnapshotAcceptanceResult
+}
+import io.constellationnetwork.node.shared.nodeSharedKryoRegistrar
+import io.constellationnetwork.node.shared.snapshot.currency._
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.SharedArtifact
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.schema.transaction.TransactionReference
+import io.constellationnetwork.schema.{ConsensusOperationalState, _}
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import eu.timepit.refined.auto._
+import weaver.MutableIOSuite
+
+object CurrencySnapshotValidatorAllowSpendModeSuite extends MutableIOSuite {
+
+  type Res = (KryoSerializer[IO], JsonSerializer[IO], Hasher[IO], SecurityProvider[IO])
+
+  def sharedResource: Resource[IO, Res] =
+    for {
+      kryo <- KryoSerializer.forAsync[IO](nodeSharedKryoRegistrar)
+      json <- JsonSerializer.forAsync[IO].asResource
+      securityProvider <- SecurityProvider.forAsync[IO]
+    } yield {
+      implicit val jsonSerializer: JsonSerializer[IO] = json
+      (kryo, json, Hasher.forJson[IO], securityProvider)
+    }
+
+  private val address = Address("DAG011jH7FMDvKpdb7wewrMWwYtkwq56nHquAHdi")
+  private val activation = SnapshotOrdinal.unsafeApply(100L)
+
+  private def proofOf(seed: Int): NonEmptySet[SignatureProof] = {
+    val hex = (seed.toString * 128).take(128)
+    NonEmptySet.one(SignatureProof(Id(Hex(hex)), Signature(Hex(hex))))
+  }
+
+  private def info: CurrencySnapshotInfo =
+    CurrencySnapshotInfo(
+      SortedMap.empty[Address, TransactionReference],
+      SortedMap.empty[Address, Balance],
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None
+    )
+
+  private def stateProof: CurrencySnapshotStateProof =
+    CurrencySnapshotStateProof(Hash.empty, Hash.empty, None, None, None, None, None, None, None)
+
+  private def artifact(ordinal: SnapshotOrdinal, globalViewOrdinal: SnapshotOrdinal, parentHash: Hash): CurrencyIncrementalSnapshot =
+    CurrencyIncrementalSnapshot(
+      ordinal,
+      Height.MinValue,
+      SubHeight.MinValue,
+      parentHash,
+      SortedSet.empty,
+      SortedSet.empty,
+      SnapshotTips(SortedSet.empty, SortedSet.empty),
+      stateProof,
+      EpochProgress.MinValue,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some(GlobalSyncView(globalViewOrdinal, Hash.empty, EpochProgress.MinValue))
+    )
+
+  private def parent(globalViewOrdinal: SnapshotOrdinal): Signed[CurrencyIncrementalSnapshot] =
+    Signed(artifact(SnapshotOrdinal(10L), globalViewOrdinal, Hash.empty), proofOf(9))
+
+  private def recordingCreator(
+    calls: Ref[IO, List[AllowSpendBlockAcceptanceMode]],
+    resultFor: AllowSpendBlockAcceptanceMode => CurrencyIncrementalSnapshot
+  ): CurrencySnapshotCreator[IO] =
+    new CurrencySnapshotCreator[IO] {
+      def createProposalArtifact(
+        lastKey: SnapshotOrdinal,
+        lastArtifact: Signed[CurrencySnapshotArtifact],
+        lastContext: CurrencySnapshotContext,
+        lastArtifactHasher: Hasher[IO],
+        trigger: ConsensusTrigger,
+        events: Set[CurrencySnapshotEvent],
+        rewards: Option[Rewards[IO, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
+        facilitators: Set[PeerId],
+        feeTransactionFn: Option[() => SortedSet[Signed[FeeTransaction]]],
+        artifactsFn: Option[() => SortedSet[SharedArtifact]],
+        getGlobalSnapshotByOrdinal: SnapshotOrdinal => IO[Option[Hashed[GlobalIncrementalSnapshot]]],
+        shouldPerformMetagraphSpecificValidations: Boolean,
+        maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]],
+        peerHistory: Option[ConsensusOperationalState],
+        allowSpendBlockAcceptanceMode: AllowSpendBlockAcceptanceMode
+      )(implicit hasher: Hasher[IO]): IO[CurrencySnapshotCreationResult[CurrencySnapshotEvent]] =
+        calls
+          .update(_ :+ allowSpendBlockAcceptanceMode)
+          .as(
+            CurrencySnapshotCreationResult(
+              resultFor(allowSpendBlockAcceptanceMode),
+              lastContext,
+              Set.empty,
+              Set.empty
+            )
+          )
+    }
+
+  private def validator(
+    calls: Ref[IO, List[AllowSpendBlockAcceptanceMode]],
+    resultFor: AllowSpendBlockAcceptanceMode => CurrencyIncrementalSnapshot
+  )(implicit kryo: KryoSerializer[IO], json: JsonSerializer[IO], securityProvider: SecurityProvider[IO]): CurrencySnapshotValidator[IO] =
+    CurrencySnapshotValidator.make[IO](
+      recordingCreator(calls, resultFor),
+      io.constellationnetwork.security.signature.SignedValidator.make[IO],
+      None,
+      None,
+      activation
+    )
+
+  private def distinctCalls(calls: List[AllowSpendBlockAcceptanceMode]): List[AllowSpendBlockAcceptanceMode] =
+    calls.foldLeft(List.empty[AllowSpendBlockAcceptanceMode]) { (acc, mode) =>
+      if (acc.contains(mode)) acc else acc :+ mode
+    }
+
+  test("live artifact validation never attempts legacy semantics") { res =>
+    implicit val (kryo, json, hasher, securityProvider) = res
+    val oldParent = parent(SnapshotOrdinal.unsafeApply(99L))
+    val expected = artifact(oldParent.ordinal.next, SnapshotOrdinal.unsafeApply(99L), Hash.empty)
+
+    for {
+      calls <- Ref.of[IO, List[AllowSpendBlockAcceptanceMode]](List.empty)
+      snapshotValidator = validator(calls, _ => expected)
+      result <- snapshotValidator
+        .validateSnapshot(
+          oldParent,
+          CurrencySnapshotContext(address, info),
+          expected,
+          Set.empty,
+          _ => none[Hashed[GlobalIncrementalSnapshot]].pure[IO]
+        )
+      observed <- calls.get
+    } yield
+      expect.all(
+        distinctCalls(observed) == List(AllowSpendBlockAcceptanceMode.Escrow),
+        result.isValid
+      )
+  }
+
+  test("signed historical replay below activation can reproduce legacy semantics") { res =>
+    implicit val (kryo, json, hasher, securityProvider) = res
+    val oldParent = parent(SnapshotOrdinal.unsafeApply(99L))
+    val expected = artifact(oldParent.ordinal.next, SnapshotOrdinal.unsafeApply(99L), Hash.empty)
+    val mismatch = expected.copy(lastSnapshotHash = Hash("escrow"))
+
+    for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      signedExpected <- Signed.forAsyncHasher(expected, keyPair)
+      calls <- Ref.of[IO, List[AllowSpendBlockAcceptanceMode]](List.empty)
+      snapshotValidator = validator(
+        calls,
+        {
+          case AllowSpendBlockAcceptanceMode.LegacyCreditDestination => expected
+          case AllowSpendBlockAcceptanceMode.Escrow                  => mismatch
+        }
+      )
+      result <- snapshotValidator
+        .validateSignedSnapshot(
+          oldParent,
+          CurrencySnapshotContext(address, info),
+          signedExpected,
+          _ => none[Hashed[GlobalIncrementalSnapshot]].pure[IO]
+        )
+      observed <- calls.get
+    } yield
+      expect.all(
+        distinctCalls(observed) == List(
+          AllowSpendBlockAcceptanceMode.Escrow,
+          AllowSpendBlockAcceptanceMode.LegacyCreditDestination
+        ),
+        result.isValid
+      )
+  }
+
+  test("signed replay below activation uses escrow first for a new artifact") { res =>
+    implicit val (kryo, json, hasher, securityProvider) = res
+    val oldParent = parent(SnapshotOrdinal.unsafeApply(99L))
+    val expected = artifact(oldParent.ordinal.next, SnapshotOrdinal.unsafeApply(99L), Hash.empty)
+    val legacyMismatch = expected.copy(lastSnapshotHash = Hash("legacy"))
+
+    for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      signedExpected <- Signed.forAsyncHasher(expected, keyPair)
+      calls <- Ref.of[IO, List[AllowSpendBlockAcceptanceMode]](List.empty)
+      snapshotValidator = validator(
+        calls,
+        {
+          case AllowSpendBlockAcceptanceMode.LegacyCreditDestination => legacyMismatch
+          case AllowSpendBlockAcceptanceMode.Escrow                  => expected
+        }
+      )
+      result <- snapshotValidator
+        .validateSignedSnapshot(
+          oldParent,
+          CurrencySnapshotContext(address, info),
+          signedExpected,
+          _ => none[Hashed[GlobalIncrementalSnapshot]].pure[IO]
+        )
+      observed <- calls.get
+    } yield
+      expect(
+        distinctCalls(observed) == List(AllowSpendBlockAcceptanceMode.Escrow)
+      ) && expect(result.isValid)
+  }
+
+  test("signed replay at activation never attempts legacy semantics") { res =>
+    implicit val (kryo, json, hasher, securityProvider) = res
+    val activatedParent = parent(activation)
+    val expectedLegacy = artifact(activatedParent.ordinal.next, activation, Hash.empty)
+    val escrowMismatch = expectedLegacy.copy(lastSnapshotHash = Hash("escrow"))
+
+    for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      signedExpected <- Signed.forAsyncHasher(expectedLegacy, keyPair)
+      calls <- Ref.of[IO, List[AllowSpendBlockAcceptanceMode]](List.empty)
+      snapshotValidator = validator(calls, _ => escrowMismatch)
+      result <- snapshotValidator.validateSignedSnapshot(
+        activatedParent,
+        CurrencySnapshotContext(address, info),
+        signedExpected,
+        _ => none[Hashed[GlobalIncrementalSnapshot]].pure[IO]
+      )
+      observed <- calls.get
+    } yield
+      expect.all(
+        distinctCalls(observed) == List(AllowSpendBlockAcceptanceMode.Escrow),
+        result.isInvalid
+      )
+  }
+
+  test("invalid signed historical artifact is rejected before any replay mode is attempted") { res =>
+    implicit val (kryo, json, hasher, securityProvider) = res
+    val oldParent = parent(SnapshotOrdinal.unsafeApply(99L))
+    val expected = artifact(oldParent.ordinal.next, SnapshotOrdinal.unsafeApply(99L), Hash.empty)
+    val invalidSignedExpected = Signed(expected, proofOf(1))
+
+    for {
+      calls <- Ref.of[IO, List[AllowSpendBlockAcceptanceMode]](List.empty)
+      snapshotValidator = validator(calls, _ => expected)
+      result <- snapshotValidator.validateSignedSnapshot(
+        oldParent,
+        CurrencySnapshotContext(address, info),
+        invalidSignedExpected,
+        _ => none[Hashed[GlobalIncrementalSnapshot]].pure[IO]
+      )
+      observed <- calls.get
+    } yield expect.all(result.isInvalid, observed.isEmpty)
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManagerSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManagerSuite.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.infrastructure.snapshot.AllowSpendBlockAcceptanceMode
 import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.global.Mocks._
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
@@ -107,7 +108,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -197,7 +199,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotContext),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -272,7 +275,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotContext),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -336,7 +340,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotContext),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -418,7 +423,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -502,7 +508,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -582,7 +589,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -664,7 +672,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(initialSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, snapshotWithDelegatedStake, _, _, _, _, _) = result1
@@ -690,7 +699,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(snapshotWithDelegatedStake),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, finalSnapshotInfo, _, _, _, _, _) = result2
@@ -806,7 +816,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -900,7 +911,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -981,7 +993,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(initialSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, snapshotWithDelegatedStake, _, _, _, _, _) = result1
@@ -1006,7 +1019,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(snapshotWithDelegatedStake),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, snapshotWithWithdrawal, _, _, _, _, _) = result2
@@ -1040,7 +1054,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
           lastDeprecatedTips = SortedSet.empty,
           calculateRewardsFn = delegatedRewardsFunction(snapshotWithWithdrawal),
           validationType = StateChannelValidationType.Full,
-          getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+          getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+          allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
         )
       (_, _, _, _, _, _, _, _, finalSnapshotInfo, _, _, _, _, _) = result3
     } yield
@@ -1145,7 +1160,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(initialSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, snapshotWithDelegatedStake, _, _, _, _, _) = result1
@@ -1177,7 +1193,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(snapshotWithDelegatedStake),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, snapshotWithReplacement, _, _, _, _, _) = result2
@@ -1202,7 +1219,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(snapshotWithReplacement),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, snapshotWithWithdrawal, _, _, _, _, _) = result3
@@ -1225,7 +1243,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(snapshotWithWithdrawal),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, _, _, _, _, _, _, finalSnapshotInfo, _, _, _, _, _) = result4
@@ -1335,7 +1354,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1403,7 +1423,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1476,7 +1497,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1541,7 +1563,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1610,7 +1633,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1691,7 +1715,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1786,7 +1811,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1875,7 +1901,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result
@@ -1946,7 +1973,8 @@ object GlobalSnapshotAcceptanceManagerSuite extends MutableIOSuite {
         lastDeprecatedTips = SortedSet.empty,
         calculateRewardsFn = delegatedRewardsFunction(lastSnapshotInfo),
         validationType = StateChannelValidationType.Full,
-        getGlobalSnapshotByOrdinal = _ => None.pure[IO]
+        getGlobalSnapshotByOrdinal = _ => None.pure[IO],
+        allowSpendBlockAcceptanceMode = AllowSpendBlockAcceptanceMode.live
       )
 
       (_, _, tokenLockResult, _, _, _, _, _, newSnapshotInfo, _, _, _, _, _) = result

--- a/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/schema/artifact.scala
@@ -62,6 +62,7 @@ object artifact {
   case object SpendTransactionSourceNotApplied extends BalanceAdjustmentReason
   case object SpendTransactionDestinationNotApplied extends BalanceAdjustmentReason
   case object TokenUnlockBugDeduction extends BalanceAdjustmentReason
+  case object FeeTransactionBugDeduction extends BalanceAdjustmentReason
 
   @derive(decoder, encoder, order, ordering, show)
   case class BalanceAdjustment(


### PR DESCRIPTION
## Dependency

Depends on #1580 and must merge after it. This branch is intentionally stacked on #1580's reviewed head so CI exercises the combined state that `develop` will receive. After #1580 merges, this PR's effective diff is only the Pacaswap remediation and historical-replay work below.

#1566 is not part of this branch and has not been modified.

## What this does

- Appends `FeeTransactionBugDeduction` to `BalanceAdjustmentReason`, preserving the ordering of existing variants.
- Authorizes the exact 17-artifact Pacaswap remediation set at currency ordinal 731647.
- Keeps every historical adjustment block per currency available during replay rather than collapsing them to the last block.
- Enables exact field-for-field artifact authorization only for the new remediation; historical blocks retain their deployed subset behavior.
- Gates checked fee-transaction arithmetic using the previous currency snapshot's committed global sync-view ordinal, preserving legacy wrapping arithmetic below activation.
- Recreates already-signed pre-activation currency/global snapshots with the deployed legacy allow-spend destination-credit behavior while keeping all live creation and validation on escrow semantics.
- Threads the explicit allow-spend acceptance mode through creator, validator, traversal, and acceptance-manager paths.
- Updates the Snapshot Streaming compatibility patch to pass the same environment-resolved destination-credit activation into its currency validator and global historical-recreation context.

Unrelated E2E runner edits and the `.jvmopts` whitespace-only change from the old branch were removed.

## Verification

Run locally on JDK 21 against the stacked #1580 + #1576 state:

- `sbt nodeShared/Test/compile`
- `sbt runLinter`
- Pacaswap adjustment resource tests: 12/12
- Balance-adjustment loader tests: 9/9
- Allow-spend acceptance/recreation tests: 12/12
- #1580 resurrection/settlement regression tests: 9/9
- Fields-added-ordinals and global acceptance tests: 24/24
- Global consensus, traversal, and state-channel processing tests: 12/12
- Snapshot Streaming compatibility patch applies cleanly to the exact `release/testnet` head; authenticated CI validates its production assembly against this branch.

## Operational note

All GL0 nodes must run the release containing this change before the metagraph emits the remediation artifact. The balances covered by the 731647 authorization must remain operationally quiescent until the remediation fires.
