### PR TITLE
fix(node-shared): restore develop validation baseline

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -111,7 +111,8 @@ object Services {
             service,
             l0NodeContext,
             storage,
-            sharedCfg.fieldsAddedOrdinals.feeTransactionSecurityFor(sharedCfg.environment)
+            sharedCfg.fieldsAddedOrdinals.feeTransactionSecurityFor(sharedCfg.environment),
+            sharedCfg.fieldsAddedOrdinals.fixingDataApplicationFeeValidationFor(sharedCfg.environment)
           )
       }
 

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutesSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/http/DataApplicationRoutesSuite.scala
@@ -606,7 +606,7 @@ object DataApplicationRoutesSuite extends HttpSuite {
     }
   }
 
-  test("POST /data returns OK - data transactions - Source wallet not sign the FeeTransaction") { implicit res =>
+  test("POST /data rejects a fee transaction not signed by its source wallet") { implicit res =>
     implicit val (sp, _, _, _, js) = res
 
     val req: Request[IO] = POST(uri"/data")
@@ -628,7 +628,7 @@ object DataApplicationRoutesSuite extends HttpSuite {
           dataQueue <- ViewableQueue.make[F, DataTransactions]
           l1Service = makeValidatingService(
             validateUpdateFn = valid,
-            validateFeeFn = invalid,
+            validateFeeFn = valid,
             estimateFeeResult = maybeEstimateFee
           )
           keypair <- KeyPairGenerator.makeKeyPair
@@ -681,9 +681,7 @@ object DataApplicationRoutesSuite extends HttpSuite {
             "retriable" -> Json.fromBoolean(false),
             "details" -> Json.fromJsonObject(
               JsonObject(
-                "reason" -> Json.fromString(
-                  "Invalid data update, reason: Chain(SourceWalletNotSignTheTransaction)"
-                )
+                "reason" -> Json.fromString("Invalid data update, reason: Chain(InvalidFeeTransactionSignature)")
               )
             )
           )
@@ -699,7 +697,7 @@ object DataApplicationRoutesSuite extends HttpSuite {
     }
   }
 
-  test("POST /data returns OK - data transactions - Invalid signature") { implicit res =>
+  test("POST /data rejects a fee transaction whose signature does not match its value") { implicit res =>
     implicit val (sp, _, _, _, js) = res
 
     val req: Request[IO] = POST(uri"/data")
@@ -721,7 +719,7 @@ object DataApplicationRoutesSuite extends HttpSuite {
           dataQueue <- ViewableQueue.make[F, DataTransactions]
           l1Service = makeValidatingService(
             validateUpdateFn = valid,
-            validateFeeFn = invalid,
+            validateFeeFn = valid,
             estimateFeeResult = maybeEstimateFee
           )
           keypair <- KeyPairGenerator.makeKeyPair
@@ -772,7 +770,14 @@ object DataApplicationRoutesSuite extends HttpSuite {
           )
 
           expectedResponse = JsonObject(
-            "error" -> Json.fromString("Invalid signature in data transactions")
+            "code" -> Json.fromLong(3L),
+            "message" -> Json.fromString("Invalid request body"),
+            "retriable" -> Json.fromBoolean(false),
+            "details" -> Json.fromJsonObject(
+              JsonObject(
+                "reason" -> Json.fromString("Invalid data update, reason: Chain(InvalidFeeTransactionSignature)")
+              )
+            )
           )
 
           testResult <- expectHttpBodyAndStatus(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -132,7 +132,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       context: AllowSpendBlockAcceptanceContext[IO],
       snapshotOrdinal: SnapshotOrdinal,
       shouldPerformMetagraphSpecificValidations: Boolean = true,
-      lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+      lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+      creditDestination: Boolean = false
     )(implicit hasher: Hasher[IO]): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] = ???
 
     override def acceptBlocksIteratively(
@@ -140,7 +141,8 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
       context: AllowSpendBlockAcceptanceContext[IO],
       snapshotOrdinal: SnapshotOrdinal,
       shouldPerformMetagraphSpecificValidations: Boolean = true,
-      lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+      lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+      creditDestination: Boolean = false
     )(implicit hasher: Hasher[IO]): IO[AllowSpendBlockAcceptanceResult] =
       AllowSpendBlockAcceptanceResult(
         AllowSpendBlockAcceptanceContextUpdate.empty,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/swap/block/AllowSpendBlockAcceptanceManager.scala
@@ -22,7 +22,8 @@ trait AllowSpendBlockAcceptanceManager[F[_]] {
     context: AllowSpendBlockAcceptanceContext[F],
     snapshotOrdinal: SnapshotOrdinal,
     shouldPerformMetagraphSpecificValidations: Boolean = true,
-    lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+    lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+    creditDestination: Boolean = false
   )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult]
 
   def acceptBlock(
@@ -30,7 +31,8 @@ trait AllowSpendBlockAcceptanceManager[F[_]] {
     context: AllowSpendBlockAcceptanceContext[F],
     snapshotOrdinal: SnapshotOrdinal,
     shouldPerformMetagraphSpecificValidations: Boolean = true,
-    lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+    lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+    creditDestination: Boolean = false
   )(implicit hasher: Hasher[F]): F[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]]
 
 }
@@ -53,7 +55,8 @@ object AllowSpendBlockAcceptanceManager {
         context: AllowSpendBlockAcceptanceContext[F],
         snapshotOrdinal: SnapshotOrdinal,
         shouldPerformMetagraphSpecificValidations: Boolean = true,
-        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+        creditDestination: Boolean = false
       )(implicit hasher: Hasher[F]): F[AllowSpendBlockAcceptanceResult] = {
 
         def go(
@@ -66,7 +69,14 @@ object AllowSpendBlockAcceptanceManager {
                 blockAndTxChains match {
                   case (block, txChains) =>
                     logic
-                      .acceptBlock(block, txChains, context, acc.contextUpdate, shouldPerformMetagraphSpecificValidations)
+                      .acceptBlock(
+                        block,
+                        txChains,
+                        context,
+                        acc.contextUpdate,
+                        shouldPerformMetagraphSpecificValidations,
+                        creditDestination
+                      )
                       .map {
                         case contextUpdate =>
                           acc
@@ -123,7 +133,8 @@ object AllowSpendBlockAcceptanceManager {
         context: AllowSpendBlockAcceptanceContext[F],
         snapshotOrdinal: SnapshotOrdinal,
         shouldPerformMetagraphSpecificValidations: Boolean = true,
-        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+        creditDestination: Boolean = false
       )(implicit hasher: Hasher[F]): F[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
         blockValidator.validate(block, snapshotOrdinal, AllowSpendBlockValidationParams.default, lastGlobalSnapshotEpochProgress).flatMap {
           _.toEither
@@ -136,7 +147,8 @@ object AllowSpendBlockAcceptanceManager {
                   txChains,
                   context,
                   AllowSpendBlockAcceptanceContextUpdate.empty,
-                  shouldPerformMetagraphSpecificValidations
+                  shouldPerformMetagraphSpecificValidations,
+                  creditDestination
                 )
             }
             .leftSemiflatTap(reason => logNotAcceptedBlock((block, reason)))

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/ext/pureconfig/pureconfig.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/ext/pureconfig/pureconfig.scala
@@ -69,7 +69,7 @@ package object pureconfig {
   implicit val envToOrdinalToDustSweepReader: ConfigReader[Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]] =
     genericMapReader(catchReadError(AppEnvironment.withName))
   implicit val fieldsAddedOrdinalsReader: ConfigReader[FieldsAddedOrdinals] =
-    ConfigReader.forProduct15(
+    ConfigReader.forProduct17(
       "tessellation-3-migration",
       "tessellation-301-migration",
       "check-sync-global-snapshot-field",
@@ -84,6 +84,8 @@ package object pureconfig {
       "sub-trie-roots",
       "delegated-rewards-full-committee",
       "fee-transaction-security",
-      "dust-sweeps"
+      "dust-sweeps",
+      "fixing-data-application-fee-validation",
+      "fixing-allow-spend-destination-credit"
     )(FieldsAddedOrdinals.apply)
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/DataApplicationSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/DataApplicationSnapshotAcceptanceManager.scala
@@ -6,7 +6,7 @@ import cats.data.{NonEmptyList, OptionT}
 import cats.effect.Async
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedSet
+import scala.collection.immutable.{SortedMap, SortedSet}
 import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate.getDataUpdates
@@ -21,7 +21,9 @@ import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.domain.block.processing.{BlockNotAcceptedReason, DataBlockNotAccepted}
 import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotArtifact
 import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.{SharedArtifact, TokenUnlock}
+import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, SecurityProvider}
@@ -70,9 +72,30 @@ object DataApplicationSnapshotAcceptanceManager {
     service: BaseDataApplicationL0Service[F],
     nodeContext: L0NodeContext[F],
     calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F],
-    feeTransactionSecurityActivationOrdinal: SnapshotOrdinal
+    feeTransactionSecurityActivationOrdinal: SnapshotOrdinal,
+    fixingDataApplicationFeeValidation: SnapshotOrdinal
   ): DataApplicationSnapshotAcceptanceManager[F] = new DataApplicationSnapshotAcceptanceManager[F] {
     private val logger = Slf4jLogger.getLogger
+
+    // Keep the same deterministic SortedSet iteration and checked arithmetic as currency snapshot acceptance.
+    // A fee transaction that cannot be applied rejects its whole data block so data updates are never accepted
+    // without collecting the corresponding fee.
+    private def applyFeeTransactions(
+      balances: SortedMap[Address, Balance],
+      feeTransactions: List[Signed[FeeTransaction]]
+    ): Either[Throwable, SortedMap[Address, Balance]] =
+      SortedSet.from(feeTransactions).foldLeft(balances.asRight[Throwable]) { (acc, tx) =>
+        acc.flatMap { current =>
+          (for {
+            debitedSource <- current.getOrElse(tx.source, Balance.empty).minus(tx.amount)
+            withSource = current.updated(tx.source, debitedSource)
+            creditedDestination <- withSource.getOrElse(tx.destination, Balance.empty).plus(tx.amount)
+          } yield withSource.updated(tx.destination, creditedDestination)).leftMap { e =>
+            val details = s"source: ${tx.source.show}, destination: ${tx.destination.show}, amount: ${tx.amount.value.value}"
+            new ArithmeticException(s"Cannot apply fee transaction: $e, $details")
+          }
+        }
+      }
 
     def expectCalculatedStateOrdinal(
       expectedOrdinal: SnapshotOrdinal
@@ -130,6 +153,10 @@ object DataApplicationSnapshotAcceptanceManager {
     ): F[Option[DataApplicationAcceptanceResult]] = {
       implicit val context: L0NodeContext[F] = nodeContext
 
+      // The previous currency snapshot carries this global-sync ordinal, making the activation decision stable
+      // during replay. Historical snapshots below the gate retain the exact legacy acceptance behavior.
+      val validateEveryFeeTransaction = parentGlobalSnapshotOrdinal >= fixingDataApplicationFeeValidation
+
       val newDataState: OptionT[F, DataApplicationAcceptanceResult] = for {
         lastOnChainState <- OptionT.fromOption(maybeLastDataApplication.map(_.onChainState)).flatMapF { lastDataApplication =>
           service
@@ -160,6 +187,7 @@ object DataApplicationSnapshotAcceptanceManager {
         dataState = DataState(lastOnChainState, lastCalculatedState)
         initialResult = (
           dataState,
+          balances,
           List.empty[Signed[FeeTransaction]],
           List.empty[Signed[DataApplicationBlock]],
           List.empty[(Signed[DataApplicationBlock], DataBlockNotAccepted)]
@@ -172,16 +200,20 @@ object DataApplicationSnapshotAcceptanceManager {
             .getOrElse(Nil)
 
           if (blocksToProcess.isEmpty) {
-            val (oldState, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks) = initialResult
+            val (oldState, oldBalances, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks) = initialResult
             // No blocks to process - call combine with empty updates
             service.combine(oldState, List.empty).map { newState =>
-              (newState, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks)
+              (newState, oldBalances, oldFeeTxns, oldAcceptedBlocks, oldRejectedBlocks)
             }
           } else {
             logger.info(s"Starting to process blocks: ${blocksToProcess.map(_.roundId)}") >>
               blocksToProcess.foldLeftM(initialResult) {
-                case ((currentState, accFeeTransactions, accAcceptedBlocks, accNotAcceptedBlocks), dataBlock) =>
+                case ((currentState, currentBalances, accFeeTransactions, accAcceptedBlocks, accNotAcceptedBlocks), dataBlock) =>
                   val dataTransactions = dataBlock.value.dataTransactions
+
+                  // Once active, earlier fee transactions in this snapshot must be reflected when validating
+                  // later blocks. Below the gate currentBalances remains equal to the historical snapshot balance.
+                  val validationBalances = if (validateEveryFeeTransaction) currentBalances else balances
 
                   val dataTransactionsValidations =
                     dataTransactions
@@ -189,11 +221,12 @@ object DataApplicationSnapshotAcceptanceManager {
                         validateDataTransactionsL0(
                           _,
                           service,
-                          balances,
+                          validationBalances,
                           currentOrdinal,
                           parentGlobalSnapshotOrdinal,
                           dataState,
-                          feeTransactionSecurityActivationOrdinal
+                          feeTransactionSecurityActivationOrdinal,
+                          validateEveryFeeTransaction
                         )
                       )
                       .map(_.reduce)
@@ -209,23 +242,45 @@ object DataApplicationSnapshotAcceptanceManager {
                       val dataUpdates = getDataUpdates(dataTransactionsAsList)
                       val feeTransactions = getFeeTransactions(dataTransactionsAsList)
 
-                      for {
-                        _ <- logger.info(s"Block ${dataBlock.value.roundId} is valid")
-                        result <- service.combine(currentState, dataUpdates).map { newState =>
-                          (
-                            newState,
-                            accFeeTransactions ++ feeTransactions,
-                            accAcceptedBlocks :+ dataBlock,
-                            accNotAcceptedBlocks
-                          )
-                        }
-                        _ <- logger.info(s"SharedArtifacts produced: ${result._1.sharedArtifacts}")
-                      } yield result
+                      val feeApplication =
+                        if (validateEveryFeeTransaction) applyFeeTransactions(currentBalances, feeTransactions)
+                        else currentBalances.asRight[Throwable]
+
+                      feeApplication match {
+                        case Left(err) =>
+                          logger
+                            .warn(s"Block ${dataBlock.value.roundId} not accepted: ${err.getMessage}")
+                            .as(
+                              (
+                                currentState,
+                                currentBalances,
+                                accFeeTransactions,
+                                accAcceptedBlocks,
+                                accNotAcceptedBlocks :+ (dataBlock, DataBlockNotAccepted(err.getMessage))
+                              )
+                            )
+
+                        case Right(updatedBalances) =>
+                          for {
+                            _ <- logger.info(s"Block ${dataBlock.value.roundId} is valid")
+                            result <- service.combine(currentState, dataUpdates).map { newState =>
+                              (
+                                newState,
+                                updatedBalances,
+                                accFeeTransactions ++ feeTransactions,
+                                accAcceptedBlocks :+ dataBlock,
+                                accNotAcceptedBlocks
+                              )
+                            }
+                            _ <- logger.info(s"SharedArtifacts produced: ${result._1.sharedArtifacts}")
+                          } yield result
+                      }
 
                     case Invalid(err) =>
                       Async[F].pure(
                         (
                           currentState,
+                          currentBalances,
                           accFeeTransactions,
                           accAcceptedBlocks,
                           accNotAcceptedBlocks :+ (dataBlock, DataBlockNotAccepted(err.toString))
@@ -236,6 +291,7 @@ object DataApplicationSnapshotAcceptanceManager {
                       Async[F].pure(
                         (
                           currentState,
+                          currentBalances,
                           accFeeTransactions,
                           accAcceptedBlocks,
                           accNotAcceptedBlocks :+ (dataBlock, DataBlockNotAccepted(err.getMessage))
@@ -246,7 +302,7 @@ object DataApplicationSnapshotAcceptanceManager {
           }
         }
 
-        (newDataState, validatedFeeTransactions, validatedBlocks, notAcceptedBlocks) = processingResult
+        (newDataState, _, validatedFeeTransactions, validatedBlocks, notAcceptedBlocks) = processingResult
 
         serializedOnChainState <- OptionT.liftF(
           service.serializeState(newDataState.onChain)

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
@@ -113,7 +113,8 @@ object Mocks {
         context: AllowSpendBlockAcceptanceContext[IO],
         snapshotOrdinal: SnapshotOrdinal,
         shouldPerformMetagraphSpecificValidations: Boolean,
-        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+        creditDestination: Boolean
       )(implicit hasher: Hasher[IO]): IO[AllowSpendBlockAcceptanceResult] = AllowSpendBlockAcceptanceResult(
         contextUpdate = AllowSpendBlockAcceptanceContextUpdate.empty,
         accepted = List.empty[Signed[AllowSpendBlock]],
@@ -125,7 +126,8 @@ object Mocks {
         context: AllowSpendBlockAcceptanceContext[IO],
         snapshotOrdinal: SnapshotOrdinal,
         shouldPerformMetagraphSpecificValidations: Boolean,
-        lastGlobalSnapshotEpochProgress: Option[EpochProgress]
+        lastGlobalSnapshotEpochProgress: Option[EpochProgress],
+        creditDestination: Boolean
       )(implicit hasher: Hasher[IO]): IO[Either[AllowSpendBlockNotAcceptedReason, AllowSpendBlockAcceptanceContextUpdate]] =
         AllowSpendBlockAcceptanceContextUpdate.empty.asRight.pure[IO]
     }


### PR DESCRIPTION
## Context

Develop contains the partial validation port from #1574, but it is missing the remaining compatibility wiring and fee-application behavior. This extracts the small CI baseline from #1566 and cross-checks the behavior already merged to mainnet in #1573 and #1577.

## Changes

- Thread `creditDestination` through `AllowSpendBlockAcceptanceManager`.
- Read the current 17-field `FieldsAddedOrdinals` shape with `forProduct17`.
- Activate full fee-transaction validation from the prior snapshot global-sync view.
- Validate later blocks against running balances and apply fee debits/credits with checked arithmetic.
- Reject a whole data block when its fee cannot be applied.
- Correct the two stale `DataApplicationRoutesSuite` expectations and affected test mocks.

## Scope

This deliberately excludes the v35/currency-protocol, replay, and consensus changes from #1566. It retains current develop interfaces and historical behavior below the activation gate.

## Verification

- `git diff --check`
- `sbt --error compile`
- `sbt --error nodeShared/Test/compile`
- `sbt --error currencyL0/Test/compile`
- `sbt --error 'scalafmtCheckAll;scalafixAll --check --rules OrganizeImports'`
- `sbt --error 'currencyL1/testOnly io.constellationnetwork.currency.l1.http.DataApplicationRoutesSuite'`
- `sbt --error 'currencyL0/testOnly io.constellationnetwork.currency.l0.ConfigLoadSuite'`
- `sbt --error 'nodeShared/testOnly io.constellationnetwork.node.shared.domain.transaction.FeeTransactionValidatorSuite'`

Related: #1566, #1573, #1577
