### PR TITLE
fix(currency-l0): recover downloaded validators safely

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -79,6 +79,19 @@ object CurrencyL0App {
     */
   private[currency] def rollbackBootstrapFacilitators(nodeId: PeerId): List[PeerId] =
     List(nodeId)
+
+  private[currency] def selectLocalChainTip(
+    checkpoint: Option[ChainTip],
+    snapshot: Option[ChainTip]
+  ): Option[ChainTip] =
+    (checkpoint, snapshot) match {
+      case (None, value)                                                         => value
+      case (value, None)                                                         => value
+      case (Some(left), Some(right)) if left.ordinal > right.ordinal             => left.some
+      case (Some(left), Some(right)) if right.ordinal > left.ordinal             => right.some
+      case (Some(left), Some(right)) if left.snapshotHash === right.snapshotHash => left.some
+      case _                                                                     => none[ChainTip]
+    }
 }
 
 abstract class CurrencyL0App(
@@ -232,23 +245,23 @@ abstract class CurrencyL0App(
 
       // Chain tip getter used by IHave HTTP endpoint (EventGossipRoutes, passed to HttpApi at line 231).
       // Intentionally NOT passed to EventGossipDaemon -- fork detection is deferred for currency-l0.
-      // The combined-checkpoint store is the primary source, but it is only written on the production
-      // path, so a node that stays caught up by FOLLOWING/downloading (e.g. a 2nd metagraph-L0 node
-      // before it is promoted) has an empty checkpoint even while its currency chain head advances
-      // every round. Without an advertised tip the B2 admission gate never witnesses it as at-tip and
-      // never promotes it to facilitator -- a deadlock for the joining node. Fall back to the latest
-      // currency snapshot we hold so a caught-up follower becomes a witnessable admission candidate.
-      getLocalChainTip = storages.combinedCurrencySnapshotCheckpointStorage.getLatestCheckpointInfo.flatMap { info =>
-        if (info.hash =!= Hash.empty) ChainTip(info.ordinal, info.hash).some.pure[IO]
-        else
-          storages.snapshot.headSnapshot.flatMap {
-            _.flatTraverse { signed =>
-              hasherSelectorAlwaysCurrent.withCurrent { implicit hasher =>
-                signed.toHashed[IO].map(hashed => ChainTip(signed.value.ordinal, hashed.hash).some)
-              }
+      // The periodic combined checkpoint can trail the signed Currency snapshot head by several
+      // rounds. Advertise the newer trustworthy local position so admission does not mistake a
+      // caught-up validator for a lagging one. Equal ordinals with different hashes are a local
+      // contradiction and fail closed instead of choosing one store silently.
+      getLocalChainTip = for {
+        checkpointInfo <- storages.combinedCurrencySnapshotCheckpointStorage.getLatestCheckpointInfo
+        checkpointTip =
+          if (checkpointInfo.hash =!= Hash.empty) ChainTip(checkpointInfo.ordinal, checkpointInfo.hash).some
+          else none[ChainTip]
+        snapshotTip <- storages.snapshot.headSnapshot.flatMap {
+          case None => none[ChainTip].pure[IO]
+          case Some(signed) =>
+            hasherSelectorAlwaysCurrent.withCurrent { implicit hasher =>
+              signed.toHashed[IO].map(hashed => ChainTip(signed.value.ordinal, hashed.hash).some)
             }
-          }
-      }
+        }
+      } yield CurrencyL0App.selectLocalChainTip(checkpointTip, snapshotTip)
 
       eventGossipDaemon <- {
         implicit val dtEncoder: CirceEncoder[DataTransaction] = DataTransactionCodecs.encoder(dataApplicationService)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/p2p/DataApplicationClient.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/p2p/DataApplicationClient.scala
@@ -18,6 +18,10 @@ trait DataApplicationClient[F[_]] {
   def getCalculatedState(
     implicit decoder: Decoder[DataCalculatedState]
   ): PeerResponse[F, (SnapshotOrdinal, DataCalculatedState)]
+
+  def getCalculatedState(
+    ordinal: SnapshotOrdinal
+  )(implicit decoder: Decoder[DataCalculatedState]): PeerResponse[F, Option[DataCalculatedState]]
 }
 
 object DataApplicationClient {
@@ -27,5 +31,10 @@ object DataApplicationClient {
         implicit decoder: Decoder[DataCalculatedState]
       ): PeerResponse[F, (SnapshotOrdinal, DataCalculatedState)] =
         PeerResponse[F, (SnapshotOrdinal, DataCalculatedState)]("currency/state/calculated")(client, session)
+
+      def getCalculatedState(
+        ordinal: SnapshotOrdinal
+      )(implicit decoder: Decoder[DataCalculatedState]): PeerResponse[F, Option[DataCalculatedState]] =
+        PeerResponse[F, Option[DataCalculatedState]](s"currency/state/calculated/${ordinal.value.value}")(client, session)
     }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/routes/DataBlockRoutes.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/routes/DataBlockRoutes.scala
@@ -6,9 +6,11 @@ import cats.syntax.functor._
 
 import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationBlock
+import io.constellationnetwork.currency.dataApplication.storage.CalculatedStateLocalFileSystemStorage
 import io.constellationnetwork.kernel._
 import io.constellationnetwork.node.shared.snapshot.currency.{CurrencySnapshotEvent, DataApplicationBlockEvent}
 import io.constellationnetwork.routes.internal._
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.signature.Signed
 
 import eu.timepit.refined.auto._
@@ -19,7 +21,8 @@ import org.http4s.dsl.Http4sDsl
 
 final case class DataBlockRoutes[F[_]: Async](
   mkCell: CurrencySnapshotEvent => Cell[F, StackF, _, Either[CellError, Ω], _],
-  dataApplication: BaseDataApplicationL0Service[F]
+  dataApplication: BaseDataApplicationL0Service[F],
+  calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F]
 )(implicit context: L0NodeContext[F], decoder: Decoder[DataTransaction], encoder: Encoder[DataCalculatedState])
     extends Http4sDsl[F]
     with PublicRoutes[F]
@@ -45,6 +48,13 @@ final case class DataBlockRoutes[F[_]: Async](
     case GET -> Root / "state" / "calculated" =>
       dataApplication.getCalculatedState
         .flatMap(Ok(_))
+
+    case GET -> Root / "state" / "calculated" / LongVar(rawOrdinal) =>
+      SnapshotOrdinal(rawOrdinal).fold(NotFound()) { ordinal =>
+        calculatedStateStorage
+          .read[DataCalculatedState](ordinal)(bytes => dataApplication.deserializeCalculatedState(bytes).flatMap(Async[F].fromEither))
+          .flatMap(Ok(_))
+      }
 
   }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
@@ -143,10 +143,10 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
   private val allowSpendBlockRoutes = AllowSpendBlockRoutes[F](queues.l1Output)
   private val tokenLockBlockRoutes = TokenLockBlockRoutes[F](queues.l1Output)
 
-  private val dataBlockRoutes = maybeDataApplication.map { da =>
+  private val dataBlockRoutes = (maybeDataApplication, storages.calculatedStateStorage).mapN { (da, calculatedStateStorage) =>
     implicit val dataUpdateDecoder: Decoder[DataUpdate] = da.dataDecoder
     implicit val (d, e) = (DataTransaction.decoder, da.calculatedStateEncoder)
-    DataBlockRoutes[F](mkCell, da)
+    DataBlockRoutes[F](mkCell, da, calculatedStateStorage)
   }
 
   private val transactionValidationErrorRoutes =

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -57,7 +57,7 @@ object Programs {
         services.consensus,
         peerSelect,
         storages.identifier,
-        dataApplication.map { case (da, _) => da },
+        dataApplication,
         services.globalL0.pullGlobalSnapshot,
         storages.snapshot,
         storages.currencySnapshotCleanup,

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -143,7 +143,8 @@ object CurrencySnapshotConsensus {
         maybeRewards,
         creator,
         validator,
-        maybeCustomArtifacts
+        maybeCustomArtifacts,
+        lastGlobalSnapshotStorage
       )
 
       eventGossipClient = EventGossipClient.make[F, CurrencySnapshotEvent](client, session)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
@@ -4,12 +4,15 @@ import cats.data.Validated.Invalid
 import cats.effect.Async
 import cats.syntax.all._
 
-import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.collection.immutable.SortedSet
+import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.currency.schema.currency._
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.node.shared.domain.consensus.ConsensusFunctions
 import io.constellationnetwork.node.shared.domain.rewards.Rewards
-import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSyncGlobalSnapshotStorage
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.node.shared.infrastructure.snapshot._
 import io.constellationnetwork.node.shared.snapshot.currency._
@@ -19,6 +22,7 @@ import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.consensus.CertifiedLineageEvidenceV1
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
@@ -48,6 +52,36 @@ abstract class CurrencySnapshotConsensusFunctions[F[_]: Async: SecurityProvider]
 
 object CurrencySnapshotConsensusFunctions {
 
+  final case class ExactGlobalFeeContextUnavailable(ordinal: SnapshotOrdinal) extends NoStackTrace {
+    override def getMessage: String = s"Exact Global L0 fee context is unavailable at ordinal=${ordinal.show}"
+  }
+
+  final case class ExactGlobalFeeContextHashMismatch(ordinal: SnapshotOrdinal, expected: Hash, actual: Hash) extends NoStackTrace {
+    override def getMessage: String =
+      s"Exact Global L0 fee context hash mismatch at ordinal=${ordinal.show}: expected=${expected.show} actual=${actual.show}"
+  }
+
+  /** Retain and verify the exact Global context selected by a Currency proposal before that context can leave bounded GL0 history.
+    *
+    * Synchronous Currency finalization needs the selected context to calculate the signed state-channel fee. Consensus can legitimately
+    * remain open while Global L0 advances by more than its rolling retention window, especially during membership contraction. Pinning at
+    * proposal creation and validation makes that lifetime independent of relative layer speed. A missing or conflicting context fails
+    * before the proposal can become local consensus authority.
+    */
+  private[snapshot] def retainExactGlobalFeeContext[F[_]: Async](
+    globalSyncView: Option[GlobalSyncView],
+    retain: SnapshotOrdinal => F[Option[Hash]]
+  ): F[Unit] =
+    globalSyncView.traverse_ { view =>
+      retain(view.ordinal)
+        .flatMap(_.liftTo[F](ExactGlobalFeeContextUnavailable(view.ordinal)))
+        .flatMap { actual =>
+          ExactGlobalFeeContextHashMismatch(view.ordinal, view.hash, actual)
+            .raiseError[F, Unit]
+            .whenA(actual =!= view.hash)
+        }
+    }
+
   final case class ProposalArtifactResult(
     artifact: CurrencySnapshotArtifact,
     context: CurrencySnapshotContext,
@@ -60,9 +94,20 @@ object CurrencySnapshotConsensusFunctions {
     rewards: Option[Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
     currencySnapshotCreator: CurrencySnapshotCreator[F],
     currencySnapshotValidator: CurrencySnapshotValidator[F],
-    maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]]
+    maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]],
+    lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F]
   ): CurrencySnapshotConsensusFunctions[F] = new CurrencySnapshotConsensusFunctions[F] {
     val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("CurrencySnapshotConsensusFunctions")
+
+    private def retainExactGlobalFeeContext(artifact: CurrencySnapshotArtifact)(implicit hasher: Hasher[F]): F[Unit] =
+      CurrencySnapshotConsensusFunctions.retainExactGlobalFeeContext(
+        artifact.globalSyncView,
+        ordinal =>
+          lastGlobalSnapshotStorage
+            .getCombined(ordinal)
+            .flatMap(_.traverse { case (snapshot, _) => snapshot.hash })
+      )
+
     override def triggerPredicate(event: CurrencySnapshotEvent): Boolean = event match {
       case GlobalSnapshotSyncEvent(_) => false // NOTE: Sync events should not trigger consensus to avoid infinite loop
       case _                          => true
@@ -99,7 +144,7 @@ object CurrencySnapshotConsensusFunctions {
         .flatTap {
           case Invalid(errors) =>
             logger.warn(s"Failed when validating currency artifact. Errors: ${errors.toList}")
-          case _ => Async[F].unit
+          case _ => retainExactGlobalFeeContext(artifact)
         }
         .map(_.leftMap(errors => CurrencyArtifactMismatch(errors.toList)).toEither)
 
@@ -161,6 +206,7 @@ object CurrencySnapshotConsensusFunctions {
           peerHistory,
           historicalDependencyResolution = false
         )
+        .flatTap(created => retainExactGlobalFeeContext(created.artifact))
         .map(created => ProposalArtifactResult(created.artifact, created.context, created.awaitingEvents, created.rejectedEvents))
     }
   }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Download.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Download.scala
@@ -1,13 +1,14 @@
 package io.constellationnetwork.currency.l0.snapshot.programs
 
-import cats.Applicative
 import cats.effect.Async
 import cats.effect.std.Random
 import cats.syntax.all._
+import cats.{Applicative, MonadThrow}
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
+import io.constellationnetwork.currency.dataApplication.storage.CalculatedStateLocalFileSystemStorage
 import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL0Service, DataCalculatedState, L0NodeContext}
 import io.constellationnetwork.currency.l0.domain.snapshot.storages.CurrencySnapshotCleanupStorage
 import io.constellationnetwork.currency.l0.http.p2p.P2PClient
@@ -31,7 +32,7 @@ import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEve
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.L0Peer.toP2PContext
-import io.constellationnetwork.schema.peer.{L0Peer, Peer}
+import io.constellationnetwork.schema.peer.Peer
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, HasherSelector}
@@ -43,6 +44,57 @@ import retry._
 
 /** Stable release/mainnet observe-and-register download flow with current crash-safe storage replacement. */
 object Download {
+
+  final case class ObservationPlan(catchUpThrough: SnapshotOrdinal, observationLimit: SnapshotOrdinal)
+
+  final case class PeerTipBehindCheckpoint(checkpoint: SnapshotOrdinal, peerTip: SnapshotOrdinal) extends NoStackTrace {
+    override def getMessage: String =
+      s"Selected peer tip ${peerTip.show} is behind its combined checkpoint ${checkpoint.show}"
+  }
+
+  final case class CalculatedStateConfigurationMismatch(hasArtifactState: Boolean, hasLocalApplication: Boolean) extends NoStackTrace {
+    override def getMessage: String =
+      s"Currency calculated-state recovery configuration mismatch: artifact=$hasArtifactState localApplication=$hasLocalApplication"
+  }
+
+  final case class CalculatedStateUnavailable(ordinal: SnapshotOrdinal, attemptedPeers: Int) extends NoStackTrace {
+    override def getMessage: String =
+      s"No Ready peer served the calculated state certified at Currency snapshot ordinal=${ordinal.show}; attemptedPeers=$attemptedPeers"
+  }
+
+  final case class CalculatedStateProofMismatch(ordinal: SnapshotOrdinal, actual: Hash, expected: Hash) extends NoStackTrace {
+    override def getMessage: String =
+      s"Calculated state at Currency ordinal=${ordinal.show} has hash=${actual.show}, expected=${expected.show}"
+  }
+
+  final case class CalculatedStateRejected(ordinal: SnapshotOrdinal) extends NoStackTrace {
+    override def getMessage: String =
+      s"Data application rejected recovered calculated state at Currency ordinal=${ordinal.show}"
+  }
+
+  private[snapshot] final case class CalculatedStateHooks[F[_], State](
+    fetchExact: (SnapshotOrdinal, Hash) => F[State],
+    hash: State => F[Hash],
+    persist: (SnapshotOrdinal, State) => F[Unit]
+  )
+
+  private[snapshot] def restoreCalculatedStateSteps[F[_]: MonadThrow, State](
+    ordinal: SnapshotOrdinal,
+    expectedProof: Option[Hash],
+    hooks: Option[CalculatedStateHooks[F, State]]
+  ): F[Unit] =
+    (expectedProof, hooks) match {
+      case (None, None) => Applicative[F].unit
+      case (Some(expected), Some(calculatedState)) =>
+        for {
+          state <- calculatedState.fetchExact(ordinal, expected)
+          actual <- calculatedState.hash(state)
+          _ <- CalculatedStateProofMismatch(ordinal, actual, expected).raiseError[F, Unit].whenA(actual =!= expected)
+          _ <- calculatedState.persist(ordinal, state)
+        } yield ()
+      case _ =>
+        CalculatedStateConfigurationMismatch(expectedProof.nonEmpty, hooks.nonEmpty).raiseError[F, Unit]
+    }
 
   /** A single successor gets roughly one normal Currency round to become available. Exhaustion returns control to DownloadDaemon, which
     * reselects a fresh latest anchor. Every successfully downloaded successor starts with a fresh budget.
@@ -60,6 +112,26 @@ object Download {
   private[snapshot] def observationLimit(current: SnapshotOrdinal, offset: Long): SnapshotOrdinal =
     SnapshotOrdinal.unsafeApply(Math.addExact(current.value.value, offset))
 
+  private[snapshot] def observationPlan(
+    checkpoint: SnapshotOrdinal,
+    peerTip: SnapshotOrdinal,
+    offset: Long
+  ): Either[PeerTipBehindCheckpoint, ObservationPlan] =
+    if (peerTip < checkpoint) PeerTipBehindCheckpoint(checkpoint, peerTip).asLeft
+    else ObservationPlan(peerTip, observationLimit(peerTip, offset)).asRight
+
+  /** Clear pre-recovery events before advertising the validator as an admission candidate.
+    *
+    * Once registration is visible, the current committee may select this validator for the next round and synchronously push every event
+    * named by its Facility declarations. Clearing after registration can therefore acknowledge those pushes and then erase them before the
+    * recovered validator creates the same round. The validator is left waiting forever for events that every incumbent was told it stored.
+    */
+  private[snapshot] def prepareObservationAdmission[F[_]: MonadThrow](
+    clearPreRecoveryEvents: F[Unit],
+    registerForConsensus: F[Unit]
+  ): F[Unit] =
+    clearPreRecoveryEvents >> registerForConsensus
+
   def make[F[_]: Async: Random](
     p2pClient: P2PClient[F],
     clusterStorage: ClusterStorage[F],
@@ -68,7 +140,7 @@ object Download {
     consensus: CurrencySnapshotConsensus[F],
     peerSelect: PeerSelect[F],
     identifierStorage: IdentifierStorage[F],
-    maybeDataApplication: Option[BaseDataApplicationL0Service[F]],
+    maybeDataApplication: Option[(BaseDataApplicationL0Service[F], CalculatedStateLocalFileSystemStorage[F])],
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo] with LatestBalances[F],
     currencySnapshotCleanupStorage: CurrencySnapshotCleanupStorage[F],
@@ -89,6 +161,7 @@ object Download {
 
     type DownloadResult = (Signed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)
     type ObservationLimit = SnapshotOrdinal
+    type DownloadAnchor = (DownloadResult, ObservationPlan)
 
     def recoveryDownload(implicit hasherSelector: HasherSelector[F]): F[Unit] = download
 
@@ -110,6 +183,7 @@ object Download {
                 )(
                   _ =>
                     for {
+                      _ <- restoreCalculatedState(snapshot)
                       snapshotHash <- snapshot.value.hash
                       // Discard node-local publication authority before replacing history.
                       // A crash at any later point can only lose a redundant validator copy;
@@ -128,8 +202,6 @@ object Download {
                           s"Failed to install exact Currency artifact/context ordinal=${snapshot.ordinal}; keeping consensus stopped"
                         )
                       )
-                      _ <- eventMempool.clear
-                      _ <- setCalculatedState(snapshot)
                     } yield (),
                   stateChannelBinarySender.clearPending >> stateChannelBinarySender.enablePublishing
                 )
@@ -157,46 +229,115 @@ object Download {
       }
     }
 
-    private def setCalculatedState(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit] =
-      maybeDataApplication.fold(Applicative[F].unit) { dataApplication =>
-        implicit val decoder = dataApplication.calculatedStateDecoder
+    private def restoreCalculatedState(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit] =
+      (snapshot.dataApplication, maybeDataApplication) match {
+        case (None, None) => Applicative[F].unit
+        case (Some(dataPart), Some((dataApplication, storage))) =>
+          implicit val decoder = dataApplication.calculatedStateDecoder
 
-        clusterStorage.getResponsivePeers
-          .map(NodeState.ready)
-          .map(_.toList)
-          .flatMap(Random[F].shuffleList)
-          .flatMap {
-            case Nil       => new Exception("No peers to fetch off-chain state from").raiseError[F, (SnapshotOrdinal, DataCalculatedState)]
-            case peer :: _ => p2pClient.dataApplication.getCalculatedState.run(peer)
-          }
-          .flatTap {
-            case (_, calculatedState) =>
-              dataApplication.hashCalculatedState(calculatedState).flatMap { hash =>
-                Async[F].raiseUnless(snapshot.dataApplication.map(_.calculatedStateProof).contains(hash))(
-                  new Exception("Downloaded calculated state does not match the snapshot proof")
-                )
+          def fetchExact(ordinal: SnapshotOrdinal, expectedProof: Hash): F[DataCalculatedState] =
+            clusterStorage.getResponsivePeers
+              .map(peers => NodeState.ready(peers).toList)
+              .flatMap(Random[F].shuffleList)
+              .flatMap { peers =>
+                def go(remaining: List[Peer]): F[DataCalculatedState] =
+                  remaining match {
+                    case Nil => Download.CalculatedStateUnavailable(ordinal, peers.size).raiseError[F, DataCalculatedState]
+                    case peer :: tail =>
+                      p2pClient.dataApplication
+                        .getCalculatedState(ordinal)
+                        .run(peer)
+                        .attempt
+                        .flatMap {
+                          case Right(Some(state)) =>
+                            dataApplication.hashCalculatedState(state).flatMap { actualProof =>
+                              if (actualProof === expectedProof) state.pure[F]
+                              else
+                                logger.warn(
+                                  Download.CalculatedStateProofMismatch(ordinal, actualProof, expectedProof)
+                                )(
+                                  s"Peer ${peer.id.show} served mismatched calculated state; trying another Ready peer"
+                                ) >> go(tail)
+                            }
+                          case Right(None) =>
+                            logger.warn(
+                              Download.CalculatedStateUnavailable(ordinal, 1)
+                            )(
+                              s"Peer ${peer.id.show} did not have calculated state ordinal=${ordinal.show}; trying another Ready peer"
+                            ) >> go(tail)
+                          case Left(error) =>
+                            logger.warn(error)(
+                              s"Peer ${peer.id.show} could not serve calculated state ordinal=${ordinal.show}; trying another Ready peer"
+                            ) >> go(tail)
+                        }
+                  }
+
+                go(peers)
               }
-          }
-          .flatMap { case (ordinal, state) => dataApplication.setCalculatedState(ordinal, state).void }
+
+          val hooks = Download.CalculatedStateHooks[F, DataCalculatedState](
+            fetchExact = fetchExact,
+            hash = dataApplication.hashCalculatedState,
+            persist = (ordinal, state) =>
+              storage.write(ordinal, state)(dataApplication.serializeCalculatedState) >>
+                dataApplication
+                  .setCalculatedState(ordinal, state)
+                  .flatMap(accepted => Download.CalculatedStateRejected(ordinal).raiseError[F, Unit].unlessA(accepted))
+          )
+
+          Download.restoreCalculatedStateSteps(
+            snapshot.ordinal,
+            dataPart.calculatedStateProof.some,
+            hooks.some
+          )
+        case (artifactState, localApplication) =>
+          Download
+            .CalculatedStateConfigurationMismatch(artifactState.nonEmpty, localApplication.nonEmpty)
+            .raiseError[F, Unit]
       }
 
-    def start: F[DownloadResult] = {
+    def start: F[DownloadAnchor] = {
       val retryPolicy = exponentialBackoff[F](1.second).join(limitRetries(5))
-      retryingOnAllErrors[DownloadResult](
+      retryingOnAllErrors[DownloadAnchor](
         policy = retryPolicy,
         onError = (error: Throwable, details: RetryDetails) =>
           logger.error(error)(s"Error fetching latest Currency snapshot attempt=${details.retriesSoFar}; selecting another peer")
-      )(peerSelect.select.flatMap((peer: L0Peer) => p2pClient.currencySnapshot.getLatest.run(peer)))
+      )(
+        peerSelect.select.flatMap { peer =>
+          for {
+            // Start from the peer's exact live artifact/context instead of a periodic
+            // checkpoint. Replaying a stale checkpoint can require deterministic Global
+            // dependencies that have already left every Ready peer's bounded history.
+            result <- p2pClient.currencySnapshot.getLatestHead.run(peer)
+            // The peer can finalize another snapshot while the combined body is in flight.
+            // Read its current ordinal after the body arrives, catch up through that small
+            // race window, and only then register a future observation window.
+            peerTip <- p2pClient.currencySnapshot.getLatestOrdinal.run(peer)
+            plan <- Async[F].fromEither(Download.observationPlan(result._1.ordinal, peerTip, observationOffset.value))
+          } yield result -> plan
+        }
+      )
     }
 
-    def observe(result: DownloadResult)(implicit hasher: Hasher[F]): F[(DownloadResult, ObservationLimit)] = {
-      val observationLimit = Download.observationLimit(result._1.ordinal, observationOffset.value)
+    def observe(anchor: DownloadAnchor)(implicit hasher: Hasher[F]): F[(DownloadResult, ObservationLimit)] = {
+      val (result, plan) = anchor
 
-      def go(current: DownloadResult): F[DownloadResult] =
-        if (current._1.ordinal === observationLimit) current.pure[F]
-        else fetchNextSnapshot(current).flatMap(go)
+      def go(current: DownloadResult, target: SnapshotOrdinal): F[DownloadResult] =
+        if (current._1.ordinal === target) current.pure[F]
+        else fetchNextSnapshot(current).flatMap(next => go(next, target))
 
-      consensus.manager.registerForConsensus(observationLimit) >> go(result).map(_ -> observationLimit)
+      for {
+        caughtUp <- go(result, plan.catchUpThrough)
+        _ <- logger.info(
+          s"Caught up Currency recovery head from ordinal=${result._1.ordinal.show} " +
+            s"through live peer tip=${caughtUp._1.ordinal.show}; registering future observation=${plan.observationLimit.show}"
+        )
+        _ <- Download.prepareObservationAdmission(
+          eventMempool.clear,
+          consensus.manager.registerForConsensus(plan.observationLimit)
+        )
+        observed <- go(caughtUp, plan.observationLimit)
+      } yield observed -> plan.observationLimit
     }
 
     def fetchNextSnapshot(result: DownloadResult)(implicit hasher: Hasher[F]): F[DownloadResult] = {
@@ -229,8 +370,7 @@ object Download {
 
     def fetchSnapshot(hash: Option[Hash], ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[Signed[CurrencyIncrementalSnapshot]] =
       clusterStorage.getResponsivePeers
-        .map(NodeState.ready)
-        .map(_.toList)
+        .map(peers => NodeState.ready(peers).toList)
         .flatMap(Random[F].shuffleList)
         .flatTap(_ => logger.info(s"Download currency snapshot hash=${hash.show}, ordinal=${ordinal.show}"))
         .flatMap { peers =>

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorage.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorage.scala
@@ -376,26 +376,33 @@ object StateChannelBinaryOutboxStorage {
                   case _ =>
                     val ordered = entries.values.toList.sortBy(_.currencySnapshotOrdinal)
                     val firstPending = ordered.find(_.currencySnapshotOrdinal > currencyOrdinal)
+                    val missingCanonicalBridge = firstPending.exists(_.currencySnapshotOrdinal > currencyOrdinal.next)
                     val pendingIsAttached = firstPending.forall(entry =>
                       entry.currencySnapshotOrdinal === currencyOrdinal.next && entry.binary.value.lastSnapshotHash === binaryHash
                     )
                     val firstPendingHash = firstPending.fold(binaryHash)(_.binary.value.lastSnapshotHash)
 
-                    Async[F].raiseUnless(pendingIsAttached)(
-                      CanonicalTipMismatch(
-                        firstPending.fold(currencyOrdinal.next)(_.currencySnapshotOrdinal),
-                        binaryHash,
-                        firstPendingHash
-                      )
-                    ) >> {
-                      val confirmed = ordered
-                        .filter(entry =>
-                          entry.locallyCommitted &&
-                            (entry.currencySnapshotOrdinal < currencyOrdinal ||
-                              (entry.currencySnapshotOrdinal === currencyOrdinal && entry.binaryHash === binaryHash))
+                    // A downloaded validator intentionally discards its local publication copies. It can therefore have a valid pending
+                    // binary N+1 while its local GL0 view still confirms only N-1. The missing binary N may already be queued at GL0 and
+                    // will close the gap in a later Global snapshot. Keep the suffix pending until the canonical tip reaches N; then the
+                    // ordinary direct-parent or same-ordinal hash check below can prove it. A direct conflicting successor still fails.
+                    if (missingCanonicalBridge) List.empty[Entry].pure[F]
+                    else
+                      Async[F].raiseUnless(pendingIsAttached)(
+                        CanonicalTipMismatch(
+                          firstPending.fold(currencyOrdinal.next)(_.currencySnapshotOrdinal),
+                          binaryHash,
+                          firstPendingHash
                         )
-                      confirmed.traverse_(delete).as(confirmed)
-                    }
+                      ) >> {
+                        val confirmed = ordered
+                          .filter(entry =>
+                            entry.locallyCommitted &&
+                              (entry.currencySnapshotOrdinal < currencyOrdinal ||
+                                (entry.currencySnapshotOrdinal === currencyOrdinal && entry.binaryHash === binaryHash))
+                          )
+                        confirmed.traverse_(delete).as(confirmed)
+                      }
                 }
               }
             }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/synchronous/ConsensusManager.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/synchronous/ConsensusManager.scala
@@ -128,15 +128,18 @@ object ConsensusManager {
 
   /** Preserve an installed immediate-successor attempt while the authority is only one finalized round ahead. That observation is
     * compatible with ordinary gossip/finalization lag because the local member may already have contributed the signatures that completed
-    * the remote outcome. A strict authority majority beyond the immediate successor proves the local attempt is obsolete and permits
-    * re-download. With no installed attempt, even a one-round lead is sufficient to re-anchor the local node.
+    * the remote outcome. A finished generation remains protected only if its outcome authorizes this node for the next round. A strict
+    * authority majority beyond the immediate successor proves any other local attempt is obsolete and permits re-download. With no
+    * installed attempt, even a one-round lead is sufficient to re-anchor the local node.
     */
   private[snapshot] def preservePeerAheadGeneration(
     hasCurrentGeneration: Boolean,
     currentGenerationFinished: Boolean,
+    currentOutcomeAuthorizesSelf: Boolean,
     authorityMajorityBeyondImmediateSuccessor: Boolean
   ): Boolean =
-    currentGenerationFinished || (hasCurrentGeneration && !authorityMajorityBeyondImmediateSuccessor)
+    (currentGenerationFinished && currentOutcomeAuthorizesSelf) ||
+      (hasCurrentGeneration && !authorityMajorityBeyondImmediateSuccessor)
 
   def make[F[_]: Async: Metrics, Event, Key: Show: Order: Next, Artifact: Eq, Context: Eq, Status: Eq, Outcome: Eq, Kind](
     selfId: PeerId,
@@ -210,9 +213,14 @@ object ConsensusManager {
                 Applicative[F].whenA(authorityMajorityAhead) {
                   consensusStorage
                     .abandonGenerationIfCurrent(localKey) { maybeState =>
+                      val maybeFinishedOutcome = maybeState.flatMap(
+                        consensusStateAdvancer.getConsensusOutcome(_).map { case (_, outcome) => outcome }
+                      )
+
                       preservePeerAheadGeneration(
                         hasCurrentGeneration = maybeState.nonEmpty,
-                        currentGenerationFinished = maybeState.exists(state => consensusStateAdvancer.getConsensusOutcome(state).nonEmpty),
+                        currentGenerationFinished = maybeFinishedOutcome.nonEmpty,
+                        currentOutcomeAuthorizesSelf = maybeFinishedOutcome.exists(isAuthorizedForNextRound),
                         authorityMajorityBeyondImmediateSuccessor = authorityMajorityBeyondImmediateSuccessor
                       )
                     }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/CurrencyL0AppSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/CurrencyL0AppSuite.scala
@@ -3,7 +3,10 @@ package io.constellationnetwork.currency.l0
 import cats.effect.IO
 
 import io.constellationnetwork.currency.l0.cli.method
+import io.constellationnetwork.node.shared.infrastructure.gossip.event.ChainTip
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
 
 import com.monovore.decline.Command
@@ -12,6 +15,8 @@ import weaver.SimpleIOSuite
 object CurrencyL0AppSuite extends SimpleIOSuite {
 
   private val self: PeerId = PeerId(Hex("aa" * 64))
+  private val checkpoint = ChainTip(SnapshotOrdinal.unsafeApply(10L), Hash("checkpoint"))
+  private val snapshot = ChainTip(SnapshotOrdinal.unsafeApply(11L), Hash("snapshot"))
 
   test("a coordinated Currency rollback always starts from the operator-controlled lead only") {
     IO(expect.same(List(self), CurrencyL0App.rollbackBootstrapFacilitators(self)))
@@ -23,6 +28,24 @@ object CurrencyL0AppSuite extends SimpleIOSuite {
     IO(
       expect.same(Some(false), command.parse(Seq.empty).toOption) &&
         expect.same(Some(true), command.parse(Seq("--allow-solo-consensus")).toOption)
+    )
+  }
+
+  test("local chain tip uses the newer signed snapshot instead of a stale combined checkpoint") {
+    IO(expect.same(Some(snapshot), CurrencyL0App.selectLocalChainTip(Some(checkpoint), Some(snapshot))))
+  }
+
+  test("local chain tip uses the newer combined checkpoint") {
+    IO(expect.same(Some(snapshot), CurrencyL0App.selectLocalChainTip(Some(snapshot), Some(checkpoint))))
+  }
+
+  test("local chain tip accepts matching stores and fails closed on an equal-ordinal hash conflict") {
+    val matching = ChainTip(checkpoint.ordinal, checkpoint.snapshotHash)
+    val conflicting = ChainTip(checkpoint.ordinal, Hash("conflict"))
+
+    IO(
+      expect.same(Some(checkpoint), CurrencyL0App.selectLocalChainTip(Some(checkpoint), Some(matching))) &&
+        expect.same(None, CurrencyL0App.selectLocalChainTip(Some(checkpoint), Some(conflicting)))
     )
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctionsSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctionsSuite.scala
@@ -1,0 +1,62 @@
+package io.constellationnetwork.currency.l0.snapshot
+
+import cats.effect.{IO, Ref}
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.security.hash.Hash
+
+import weaver.SimpleIOSuite
+
+object CurrencySnapshotConsensusFunctionsSuite extends SimpleIOSuite {
+
+  private val ordinal = SnapshotOrdinal.unsafeApply(354L)
+  private val expectedHash = Hash("expected")
+  private val view = GlobalSyncView(ordinal, expectedHash, EpochProgress.MinValue)
+
+  test("proposal fee context retention accepts the exact selected Global identity") {
+    for {
+      retained <- Ref.of[IO, Vector[SnapshotOrdinal]](Vector.empty)
+      _ <- CurrencySnapshotConsensusFunctions.retainExactGlobalFeeContext[IO](
+        view.some,
+        requested => retained.update(_ :+ requested).as(expectedHash.some)
+      )
+      observed <- retained.get
+    } yield expect.same(Vector(ordinal), observed)
+  }
+
+  test("proposal fee context retention fails when the selected Global state is unavailable") {
+    CurrencySnapshotConsensusFunctions
+      .retainExactGlobalFeeContext[IO](view.some, _ => IO.pure(none))
+      .attempt
+      .map(result => expect(result == Left(CurrencySnapshotConsensusFunctions.ExactGlobalFeeContextUnavailable(ordinal))))
+  }
+
+  test("proposal fee context retention fails on a same-ordinal Global hash conflict") {
+    val actualHash = Hash("conflicting")
+
+    CurrencySnapshotConsensusFunctions
+      .retainExactGlobalFeeContext[IO](view.some, _ => IO.pure(actualHash.some))
+      .attempt
+      .map(result =>
+        expect(
+          result == Left(
+            CurrencySnapshotConsensusFunctions.ExactGlobalFeeContextHashMismatch(ordinal, expectedHash, actualHash)
+          )
+        )
+      )
+  }
+
+  test("legacy proposal without a Global sync view does not request retention") {
+    for {
+      calls <- Ref.of[IO, Int](0)
+      _ <- CurrencySnapshotConsensusFunctions.retainExactGlobalFeeContext[IO](
+        none,
+        _ => calls.update(_ + 1).as(expectedHash.some)
+      )
+      observed <- calls.get
+    } yield expect.same(0, observed)
+  }
+}

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySynchronousCommitteeSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySynchronousCommitteeSuite.scala
@@ -360,7 +360,7 @@ object CurrencySynchronousCommitteeSuite extends SimpleIOSuite {
     )
   }
 
-  pureTest("a benign one-round peer lead preserves the installed immediate-successor attempt") {
+  pureTest("peer-ahead recovery preserves only current or still-authorized consensus generations") {
     val authority = Set(peer(1), peer(2), peer(3))
     val immediateSuccessor = Map(peer(2) -> 11.some, peer(3) -> 11.some)
     val beyondImmediateSuccessor = Map(peer(2) -> 12.some, peer(3) -> 12.some)
@@ -372,21 +372,31 @@ object CurrencySynchronousCommitteeSuite extends SimpleIOSuite {
       ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = true,
         currentGenerationFinished = false,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = false
       ),
       !ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = true,
         currentGenerationFinished = false,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = true
       ),
       !ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = false,
         currentGenerationFinished = false,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = false
       ),
       ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = true,
         currentGenerationFinished = true,
+        currentOutcomeAuthorizesSelf = true,
+        authorityMajorityBeyondImmediateSuccessor = true
+      ),
+      !ConsensusManager.preservePeerAheadGeneration(
+        hasCurrentGeneration = true,
+        currentGenerationFinished = true,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = true
       )
     )

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/programs/DownloadSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/programs/DownloadSuite.scala
@@ -1,14 +1,31 @@
 package io.constellationnetwork.currency.l0.snapshot.programs
 
-import cats.effect.IO
+import cats.effect.{IO, Ref}
 import cats.syntax.all._
 
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.node.NodeState
+import io.constellationnetwork.security.hash.Hash
 
 import weaver.SimpleIOSuite
 
 object DownloadSuite extends SimpleIOSuite {
+
+  private val stateOrdinal = SnapshotOrdinal.unsafeApply(17L)
+  private val expectedProof = Hash("expected")
+  private val recoveredState = "calculated-state-at-17"
+
+  private def record(ref: Ref[IO, Vector[String]], event: String): IO[Unit] = ref.update(_ :+ event)
+
+  private def calculatedStateHooks(
+    ref: Ref[IO, Vector[String]],
+    actualProof: Hash = expectedProof
+  ): Download.CalculatedStateHooks[IO, String] =
+    Download.CalculatedStateHooks[IO, String](
+      fetchExact = (ordinal, proof) => record(ref, s"fetch:${ordinal.value.value}:${proof.value}").as(recoveredState),
+      hash = state => record(ref, s"hash:$state").as(actualProof),
+      persist = (ordinal, state) => record(ref, s"persist:${ordinal.value.value}:$state")
+    )
 
   test("downloads retain the release/mainnet four-snapshot observation window") {
     val current = SnapshotOrdinal.unsafeApply(10L)
@@ -19,6 +36,46 @@ object DownloadSuite extends SimpleIOSuite {
         Download.observationLimit(current, 4L)
       )
       .pure[IO]
+  }
+
+  test("a stale periodic checkpoint catches up to the live peer tip before selecting a future observation") {
+    val checkpoint = SnapshotOrdinal.unsafeApply(146L)
+    val peerTip = SnapshotOrdinal.unsafeApply(150L)
+
+    expect
+      .same(
+        Right(
+          Download.ObservationPlan(
+            catchUpThrough = SnapshotOrdinal.unsafeApply(150L),
+            observationLimit = SnapshotOrdinal.unsafeApply(154L)
+          )
+        ),
+        Download.observationPlan(checkpoint, peerTip, 4L)
+      )
+      .pure[IO]
+  }
+
+  test("a selected peer tip behind its own checkpoint fails closed") {
+    val checkpoint = SnapshotOrdinal.unsafeApply(150L)
+    val peerTip = SnapshotOrdinal.unsafeApply(149L)
+
+    expect
+      .same(
+        Left(Download.PeerTipBehindCheckpoint(checkpoint, peerTip)),
+        Download.observationPlan(checkpoint, peerTip, 4L)
+      )
+      .pure[IO]
+  }
+
+  test("recovery clears stale events before publishing consensus registration") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      _ <- Download.prepareObservationAdmission(
+        record(events, "clear"),
+        record(events, "register")
+      )
+      observed <- events.get
+    } yield expect.same(Vector("clear", "register"), observed)
   }
 
   test("successor retries are bounded and only active download states re-anchor") {
@@ -34,5 +91,69 @@ object DownloadSuite extends SimpleIOSuite {
         !Download.shouldReanchorAfterFailure(NodeState.Leaving)
       )
       .pure[IO]
+  }
+
+  test("exact calculated state is fetched, verified, and persisted in order") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      _ <- Download.restoreCalculatedStateSteps[IO, String](
+        stateOrdinal,
+        expectedProof.some,
+        calculatedStateHooks(events).some
+      )
+      observed <- events.get
+    } yield
+      expect.same(
+        Vector(
+          "fetch:17:expected",
+          s"hash:$recoveredState",
+          s"persist:17:$recoveredState"
+        ),
+        observed
+      )
+  }
+
+  test("a calculated-state proof mismatch fails closed before persistence") {
+    val wrongProof = Hash("wrong")
+
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      result <- Download
+        .restoreCalculatedStateSteps[IO, String](
+          stateOrdinal,
+          expectedProof.some,
+          calculatedStateHooks(events, wrongProof).some
+        )
+        .attempt
+      observed <- events.get
+    } yield
+      expect
+        .same(Vector("fetch:17:expected", s"hash:$recoveredState"), observed)
+        .and(expect(result == Left(Download.CalculatedStateProofMismatch(stateOrdinal, wrongProof, expectedProof))))
+  }
+
+  test("calculated-state configuration mismatch fails closed without calling hooks") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      result <- Download
+        .restoreCalculatedStateSteps[IO, String](
+          stateOrdinal,
+          expectedProof.some,
+          none
+        )
+        .attempt
+      observed <- events.get
+    } yield
+      expect(observed.isEmpty)
+        .and(
+          expect(
+            result == Left(
+              Download.CalculatedStateConfigurationMismatch(
+                hasArtifactState = true,
+                hasLocalApplication = false
+              )
+            )
+          )
+        )
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorageSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorageSuite.scala
@@ -279,6 +279,31 @@ object StateChannelBinaryOutboxStorageSuite extends SimpleIOSuite {
     }
   }
 
+  test("a downloaded validator waits for a missing canonical bridge instead of reporting a false conflict") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+        canonicalHash = Hash("canonical-binary-60")
+        missingBridgeHash = Hash("canonical-binary-61")
+        storage <- StateChannelBinaryOutboxStorage.make[IO](directory)
+        successor <- binaryWithParent(62L, missingBridgeHash)
+        _ <- storage.prepare(successor, artifact(62L, "artifact-62"))
+        _ <- storage.markLocallyCommitted(successor.hash)
+        confirmedBeforeBridge <- storage.confirmCanonicalTip(SnapshotOrdinal.unsafeApply(60L), canonicalHash)
+        pendingBeforeBridge <- storage.getCommitted(Set.empty, 100)
+        confirmedAfterBridge <- storage.confirmCanonicalTip(SnapshotOrdinal.unsafeApply(61L), missingBridgeHash)
+        pendingAfterBridge <- storage.getCommitted(Set.empty, 100)
+      } yield
+        expect.all(
+          confirmedBeforeBridge.isEmpty,
+          pendingBeforeBridge.map(_.binaryHash) === List(successor.hash),
+          confirmedAfterBridge.isEmpty,
+          pendingAfterBridge.map(_.binaryHash) === List(successor.hash)
+        )
+    }
+  }
+
   test("outbox backpressures before count or serialized-byte bounds can grow without limit") {
     Files[IO].tempDirectory.use { directory =>
       for {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
@@ -3,6 +3,7 @@ package io.constellationnetwork.node.shared.domain.cluster.programs
 import cats.data.{EitherT, NonEmptySet}
 import cats.effect.Async
 import cats.effect.std.{Random, Supervisor}
+import cats.effect.syntax.all._
 import cats.syntax.applicative._
 import cats.syntax.applicativeError._
 import cats.syntax.apply._
@@ -16,6 +17,7 @@ import cats.syntax.parallel._
 import cats.syntax.show._
 import cats.{Applicative, MonadThrow, Parallel}
 
+import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.domain.allowance_list.AllowanceListEntry
@@ -88,7 +90,8 @@ class Joining[
             nodeStorage
               .tryModifyState(SessionStarted, stateAfterJoining)
               .whenA(peers.nonEmpty)
-          }
+          } >>
+          reconcileConcurrentJoin(toPeer)
       }.start
 
   def rejoin(withPeer: PeerToJoin): F[Unit] =
@@ -166,11 +169,32 @@ class Joining[
       .semiflatMap(discoverFrom)
       .map(_.map(toP2PContext))
 
-  private def joinAll(peerToJoin: P2PContext): F[Unit] = {
+  /** Initial joiners can contact the same entry peer at nearly the same time. Their first discovery responses are then valid but incomplete
+    * snapshots of the changing cluster, leaving peer pairs permanently unknown because ordinary discovery only runs during join. Re-query
+    * the authenticated entry peer on a short bounded backoff and connect every newly discovered peer. Each handshake remains fully
+    * validated, and an empty discovery response is a no-op.
+    */
+  private def reconcileConcurrentJoin(entryPeer: P2PContext): F[Unit] =
+    List(1.second, 2.seconds, 4.seconds).traverse_ { delay =>
+      Async[F].sleep(delay) >>
+        clusterStorage
+          .getPeer(entryPeer.id)
+          .flatMap {
+            case None => Applicative[F].unit
+            case Some(peer) =>
+              discoverFrom(peer).flatMap(discovered => joinAll(discovered.toList.map(toP2PContext).toSet))
+          }
+          .handleErrorWith(error => logger.warn(error)(s"Concurrent join reconciliation failed through ${entryPeer.id.show}"))
+    }
+
+  private def joinAll(peerToJoin: P2PContext): F[Unit] =
+    joinAll(Set(peerToJoin))
+
+  private def joinAll(initialPeers: Set[P2PContext]): F[Unit] = {
     type Agg = (Set[P2PContext], Set[P2PContext])
     type Res = Unit
 
-    (Set(peerToJoin), Set.empty[P2PContext]).tailRecM {
+    (initialPeers, Set.empty[P2PContext]).tailRecM {
       case (toJoin, _) if toJoin.isEmpty => ().asRight[Agg].pure
       case (toJoin, attempted) =>
         for {
@@ -181,6 +205,7 @@ class Joining[
                 .as(Set.empty[P2PContext])
             }
           }
+            .guarantee(peerDiscovery.markAttemptsFinished(toJoin.toList.map(_.id).toSet))
           reduced = discovered.combineAll
           updatedAttempted = attempted ++ toJoin
           updatedToJoin = reduced.diff(updatedAttempted)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscovery.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscovery.scala
@@ -41,6 +41,9 @@ sealed abstract class PeerDiscovery[F[_]: Async] private (
 
   def getPeers: F[Set[Peer]] = cache.get
 
+  def markAttemptsFinished(peerIds: Set[PeerId]): F[Unit] =
+    cache.update(_.filterNot(peer => peerIds.contains(peer.id)))
+
   def discoverFrom(peer: Peer): F[Set[Peer]] =
     for {
       peersQueue <- cache.updateAndGet(_ - peer)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/clients/SnapshotClient.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/clients/SnapshotClient.scala
@@ -54,6 +54,21 @@ abstract class SnapshotClient[
       decodeCombinedBody(body)
     }
 
+  /** Fetch the peer's current consensus head and its exact state context.
+    *
+    * [[getLatest]] intentionally reads the latest durable periodic checkpoint. That is useful for ordinary historical traversal, but a
+    * Currency validator joining after a long outage cannot always reconstruct every successor: deterministic Currency history may depend on
+    * Global snapshots that have already left the peer's bounded rolling window. The live head already carries the state proof that commits
+    * to this context, and Currency's private hand-off subsequently requires the artifact and context to match a corroborated consensus
+    * outcome before installation.
+    *
+    * This endpoint is peer-authenticated and decoded with the same bounded-memory spool-to-disk path as the checkpoint stream.
+    */
+  def getLatestHead: PeerResponse[F, (Signed[S], SI)] =
+    PeerResponse.stream[F, (Signed[S], SI)](uri => uri.addPath(s"$urlPrefix/latest/combined"))(client, optionalSession) { body =>
+      decodeCombinedBody(body)
+    }
+
   /** Conditional variant of [[getLatest]]. The client sends `If-None-Match: "<localOrdinal>-<localHash>"`; the server returns 304
     * NotModified (no body) when its tip matches the immutable identity `(ordinal, snapshotHash)` and 200 with a fresh combined-snapshot
     * stream otherwise.

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.node.shared.http.routes
 
+import cats.data.NonEmptySet
 import cats.effect._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
@@ -28,6 +29,7 @@ import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, Snapshot
 import io.constellationnetwork.schema.{GlobalSnapshot, SnapshotOrdinal}
 import io.constellationnetwork.security.HasherSelector
 import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.PosInt
@@ -654,52 +656,64 @@ trait CachedCombinedResponse[F[_], S <: Snapshot, SI <: SnapshotInfo[_]] {
 }
 
 object CachedCombinedResponse {
+  private type CacheIdentity = (SnapshotOrdinal, NonEmptySet[SignatureProof])
+
   private val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
   def make[F[_]: Async, S <: Snapshot: Encoder, SI <: SnapshotInfo[_]: Encoder]: F[CachedCombinedResponse[F, S, SI]] =
-    Ref[F].of(Option.empty[(SnapshotOrdinal, Deferred[F, Either[Throwable, Array[Byte]]])]).map { ref =>
-      new CachedCombinedResponse[F, S, SI] {
-        private def serialize(snapshot: Signed[S], state: SI): F[Array[Byte]] =
-          Async[F].blocking {
-            val baos = new java.io.ByteArrayOutputStream()
-            val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
+    Ref[F]
+      .of(Option.empty[(CacheIdentity, Deferred[F, Either[Throwable, Array[Byte]]])])
+      .map { ref =>
+        new CachedCombinedResponse[F, S, SI] {
+          private def serialize(snapshot: Signed[S], state: SI): F[Array[Byte]] =
+            Async[F].blocking {
+              val baos = new java.io.ByteArrayOutputStream()
+              val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
 
-            writer.append('[')
-            Encoder[Signed[S]] match {
-              case sce: StreamingCollectionEncoder[Signed[S]] =>
-                sce.streamEncode(snapshot, printer, writer)
-              case enc =>
-                printer.unsafePrintToAppendable(enc(snapshot), writer)
-            }
-            writer.append(',')
-            Encoder[SI] match {
-              case sce: StreamingCollectionEncoder[SI] =>
-                sce.streamEncode(state, printer, writer)
-              case enc =>
-                printer.unsafePrintToAppendable(enc(state), writer)
-            }
-            writer.append(']')
-            writer.flush()
-            baos.toByteArray
-          }
-
-        def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
-          ref.get.flatMap {
-            case Some((ord, existing)) if ord === currentOrdinal =>
-              existing.get.flatMap(Async[F].fromEither)
-            case _ =>
-              Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
-                ref.modify {
-                  case Some((ord, existing)) if ord === currentOrdinal =>
-                    (Some((ord, existing)), existing.get.flatMap(Async[F].fromEither))
-                  case _ =>
-                    (
-                      Some((currentOrdinal, newDef)),
-                      serialize(snapshot, state).attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither)
-                    )
-                }.flatten
+              writer.append('[')
+              Encoder[Signed[S]] match {
+                case sce: StreamingCollectionEncoder[Signed[S]] =>
+                  sce.streamEncode(snapshot, printer, writer)
+                case enc =>
+                  printer.unsafePrintToAppendable(enc(snapshot), writer)
               }
-          }
+              writer.append(',')
+              Encoder[SI] match {
+                case sce: StreamingCollectionEncoder[SI] =>
+                  sce.streamEncode(state, printer, writer)
+                case enc =>
+                  printer.unsafePrintToAppendable(enc(state), writer)
+              }
+              writer.append(']')
+              writer.flush()
+              baos.toByteArray
+            }
+
+          def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
+            // Ordinal alone is not an exact cache identity. Recovery can replace a
+            // same-ordinal canonical artifact with a different signed envelope. The
+            // proof set is bound to the artifact value and distinguishes that replacement,
+            // preventing this live endpoint from serving bytes cached before rollback.
+            // The state is committed by the artifact's state proof.
+            {
+              val currentIdentity = currentOrdinal -> snapshot.proofs
+              ref.get.flatMap {
+                case Some((identity, existing)) if identity === currentIdentity =>
+                  existing.get.flatMap(Async[F].fromEither)
+                case _ =>
+                  Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
+                    ref.modify {
+                      case Some((identity, existing)) if identity === currentIdentity =>
+                        (Some((identity, existing)), existing.get.flatMap(Async[F].fromEither))
+                      case _ =>
+                        (
+                          Some((currentIdentity, newDef)),
+                          serialize(snapshot, state).attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither)
+                        )
+                    }.flatten
+                  }
+              }
+            }
+        }
       }
-    }
 }

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastSyncGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastSyncGlobalSnapshotStorage.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.node.shared.infrastructure.snapshot.storage
 
+import cats.effect.Ref
 import cats.effect.kernel.Async
 import cats.syntax.all._
 import cats.{Applicative, MonadThrow}
@@ -26,27 +27,58 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object LastSyncGlobalSnapshotStorage {
+
+  /** Keep a small access-ordered window of exact historical contexts which have actually been used.
+    *
+    * Currency snapshots can intentionally carry the same signed GlobalSyncView for many rounds. A delayed Currency round must therefore
+    * retain that exact value/context pair even after the rolling GL0 download window and filesystem checkpoint retention have advanced.
+    * Four entries cover the active view plus recent recovery transitions without duplicating the much larger rolling GL0 window.
+    */
+  private val retainedExactCapacity = 4
+
+  private[storage] def retainExact[A](
+    retained: Vector[(SnapshotOrdinal, A)],
+    ordinal: SnapshotOrdinal,
+    value: A,
+    capacity: Int = retainedExactCapacity
+  ): Vector[(SnapshotOrdinal, A)] =
+    (retained.filterNot(_._1 === ordinal) :+ (ordinal -> value)).takeRight(math.max(1, capacity))
+
+  private[storage] def takeRetainedExact[A](
+    retained: Vector[(SnapshotOrdinal, A)],
+    ordinal: SnapshotOrdinal
+  ): (Vector[(SnapshotOrdinal, A)], Option[A]) =
+    retained.find(_._1 === ordinal) match {
+      case Some((_, value)) => (retainExact(retained, ordinal, value), value.some)
+      case None             => (retained, none)
+    }
+
   def make[F[_]: Async](
     lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
     currencySnapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     globalSnapshotsWithStateLocalFileSystemStorage: GlobalSnapshotsWithStateLocalFileSystemStorage[F],
     globalSnapshotsWithStateDeltasLocalFileSystemStorage: GlobalSnapshotsWithStateDeltasLocalFileSystemStorage[F]
   ): F[LastSnapshotStorage[F, GlobalIncrementalSnapshot, GlobalSnapshotInfo] with LastSyncGlobalSnapshotStorage[F]] =
-    SignallingRef
-      .of[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty)
-      .map(
+    (
+      SignallingRef
+        .of[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](SortedMap.empty),
+      Ref.of[F, Vector[(SnapshotOrdinal, (GlobalIncrementalSnapshot, GlobalSnapshotInfo))]](Vector.empty)
+    ).mapN {
+      case (snapshotsR, retainedExactR) =>
         make[F](
           lastGlobalSnapshotsSyncConfig,
-          _,
+          snapshotsR,
+          retainedExactR,
           currencySnapshotStorage,
           globalSnapshotsWithStateLocalFileSystemStorage,
           globalSnapshotsWithStateDeltasLocalFileSystemStorage
         )
-      )
+    }
 
   def make[F[_]: Async](
     lastGlobalSnapshotsSyncConfig: LastGlobalSnapshotsSyncConfig,
     snapshotsR: SignallingRef[F, SortedMap[SnapshotOrdinal, (Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]],
+    retainedExactR: Ref[F, Vector[(SnapshotOrdinal, (GlobalIncrementalSnapshot, GlobalSnapshotInfo))]],
     currencySnapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     globalSnapshotsWithStateLocalFileSystemStorage: GlobalSnapshotsWithStateLocalFileSystemStorage[F],
     globalSnapshotsWithStateDeltasLocalFileSystemStorage: GlobalSnapshotsWithStateDeltasLocalFileSystemStorage[F]
@@ -69,15 +101,31 @@ object LastSyncGlobalSnapshotStorage {
                 .read(ordinal)
         }
 
+      private def retainExact(
+        ordinal: SnapshotOrdinal,
+        combined: (GlobalIncrementalSnapshot, GlobalSnapshotInfo)
+      ): F[Unit] =
+        retainedExactR.update(LastSyncGlobalSnapshotStorage.retainExact(_, ordinal, combined))
+
+      private def getRetainedExact(ordinal: SnapshotOrdinal): F[Option[(GlobalIncrementalSnapshot, GlobalSnapshotInfo)]] =
+        retainedExactR.modify(LastSyncGlobalSnapshotStorage.takeRetainedExact(_, ordinal))
+
       def getCombined(ordinal: SnapshotOrdinal): F[Option[(GlobalIncrementalSnapshot, GlobalSnapshotInfo)]] =
         snapshotsR.get.map(_.get(ordinal)).flatMap {
           case Some(snapshotWithState) =>
-            logger.info(s"Getting ordinal $ordinal from memory") >> (snapshotWithState._1.signed.value, snapshotWithState._2).some.pure[F]
+            val combined = (snapshotWithState._1.signed.value, snapshotWithState._2)
+            logger.info(s"Getting ordinal $ordinal from memory") >> retainExact(ordinal, combined).as(combined.some)
           case None =>
-            logger.info(s"Trying to load $ordinal from file system") >>
-              globalSnapshotsWithStateLocalFileSystemStorage
-                .read(ordinal)
-                .map(_.map(value => (value.snapshot, value.state)))
+            getRetainedExact(ordinal).flatMap {
+              case Some(combined) =>
+                logger.info(s"Getting retained exact ordinal $ordinal from memory").as(combined.some)
+              case None =>
+                logger.info(s"Trying to load $ordinal from file system") >>
+                  globalSnapshotsWithStateLocalFileSystemStorage
+                    .read(ordinal)
+                    .map(_.map(value => (value.snapshot.value, value.state)))
+                    .flatTap(_.traverse_(retainExact(ordinal, _)))
+            }
         }
 
       def set(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
@@ -106,10 +154,12 @@ object LastSyncGlobalSnapshotStorage {
 
       def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
         logger.info(s"[LastSyncGlobalSnapshotStorage] Recovery reset at ordinal=${snapshot.ordinal}") >>
+          retainedExactR.set(Vector.empty) >>
           snapshotsR.set(SortedMap(snapshot.ordinal -> (snapshot, state)))
 
       def clear: F[Unit] =
         logger.info("[LastSyncGlobalSnapshotStorage] Clearing for recovery download") >>
+          retainedExactR.set(Vector.empty) >>
           snapshotsR.set(SortedMap.empty)
 
       def get: F[Option[Hashed[GlobalIncrementalSnapshot]]] = getCombined.map(_.map { case (snapshot, _) => snapshot })

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscoverySuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscoverySuite.scala
@@ -131,4 +131,44 @@ object PeerDiscoverySuite extends SimpleIOSuite with Checkers {
     }
   }
 
+  test("a peer is discoverable again after its join attempt finishes") {
+    forall { (discoverFromPeer: Peer, candidate: Peer) =>
+      val returnedPeers = Set(candidate)
+
+      for {
+        peerDiscovery <- mkPeerDiscovery(Set.empty, returnedPeers)
+        first <- peerDiscovery.discoverFrom(discoverFromPeer)
+        suppressedWhileQueued <- peerDiscovery.discoverFrom(discoverFromPeer)
+        _ <- peerDiscovery.markAttemptsFinished(Set(candidate.id))
+        rediscovered <- peerDiscovery.discoverFrom(discoverFromPeer)
+      } yield
+        expect.same(first, returnedPeers) &&
+          expect(suppressedWhileQueued.isEmpty) &&
+          expect.same(rediscovered, returnedPeers)
+    }
+  }
+
+  test("batch completion clears peers re-added by an in-flight discovery") {
+    val candidateA = peerGen.sample.get.copy(id = PeerId(Hex("11" * 64)))
+    val candidateB = peerGen.sample.get.copy(id = PeerId(Hex("22" * 64)))
+    val entryPeer = peerGen.sample.get.copy(id = PeerId(Hex("33" * 64)))
+    val concurrentPeer = peerGen.sample.get.copy(id = PeerId(Hex("44" * 64)))
+    val returnedPeers = Set(candidateA, candidateB)
+    val attemptedIds = returnedPeers.map(_.id)
+
+    for {
+      peerDiscovery <- mkPeerDiscovery(Set.empty, returnedPeers)
+      initial <- peerDiscovery.discoverFrom(entryPeer)
+      _ <- peerDiscovery.markAttemptsFinished(Set(candidateA.id))
+      readded <- peerDiscovery.discoverFrom(concurrentPeer)
+      _ <- peerDiscovery.markAttemptsFinished(attemptedIds)
+      cachedAfterBatch <- peerDiscovery.getPeers
+      rediscovered <- peerDiscovery.discoverFrom(entryPeer)
+    } yield
+      expect.same(initial, returnedPeers) &&
+        expect.same(readded, Set(candidateA)) &&
+        expect(cachedAfterBatch.isEmpty) &&
+        expect.same(rediscovered, returnedPeers)
+  }
+
 }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/http/routes/CachedCombinedResponseSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/http/routes/CachedCombinedResponseSuite.scala
@@ -1,0 +1,75 @@
+package io.constellationnetwork.node.shared.http.routes
+
+import cats.data.NonEmptySet
+import cats.effect.IO
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
+import io.constellationnetwork.schema.transaction.TransactionReference
+import io.constellationnetwork.schema.{BlockAsActiveTip, SnapshotOrdinal, SnapshotTips}
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import io.circe.Encoder
+import weaver.SimpleIOSuite
+
+object CachedCombinedResponseSuite extends SimpleIOSuite {
+
+  private final case class TestSnapshot(
+    ordinal: SnapshotOrdinal,
+    lastSnapshotHash: Hash,
+    height: Height = Height.MinValue,
+    subHeight: SubHeight = SubHeight.MinValue,
+    blocks: SortedSet[BlockAsActiveTip] = SortedSet.empty,
+    tips: SnapshotTips = SnapshotTips(SortedSet.empty, SortedSet.empty),
+    epochProgress: EpochProgress = EpochProgress.MinValue
+  ) extends Snapshot
+
+  private final case class TestState(
+    lastTxRefs: SortedMap[Address, TransactionReference],
+    balances: SortedMap[Address, Balance],
+    marker: String
+  ) extends SnapshotInfo[StateProof]
+
+  private implicit val testSnapshotEncoder: Encoder[TestSnapshot] =
+    Encoder.forProduct2("ordinal", "lastSnapshotHash")(snapshot =>
+      snapshot.ordinal.value.value -> snapshot.lastSnapshotHash.value
+    )
+
+  private implicit val testStateEncoder: Encoder[TestState] =
+    Encoder.forProduct1("marker")(_.marker)
+
+  private def signed(value: TestSnapshot, signature: String): Signed[TestSnapshot] =
+    Signed(
+      value,
+      NonEmptySet.one(SignatureProof(Id(Hex("signer")), Signature(Hex(signature))))
+    )
+
+  test("same-ordinal canonical proof replacement invalidates the live combined response cache") {
+    val ordinal = SnapshotOrdinal.unsafeApply(17L)
+    val value = TestSnapshot(ordinal, Hash("parent"))
+    val first = signed(value, "first-proof")
+    val replacement = signed(value, "replacement-proof")
+    val firstState = TestState(SortedMap.empty, SortedMap.empty, "first-state")
+    val replacementState = TestState(SortedMap.empty, SortedMap.empty, "replacement-state")
+
+    for {
+      cache <- CachedCombinedResponse.make[IO, TestSnapshot, TestState]
+      firstBytes <- cache.get(ordinal, first, firstState)
+      replacementBytes <- cache.get(ordinal, replacement, replacementState)
+      firstJson = new String(firstBytes, java.nio.charset.StandardCharsets.UTF_8)
+      replacementJson = new String(replacementBytes, java.nio.charset.StandardCharsets.UTF_8)
+    } yield
+      expect(firstJson.contains("first-state")) &&
+        expect(replacementJson.contains("replacement-state")) &&
+        expect(firstJson != replacementJson)
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastSyncGlobalSnapshotStorageSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastSyncGlobalSnapshotStorageSuite.scala
@@ -1,0 +1,42 @@
+package io.constellationnetwork.node.shared.infrastructure.snapshot.storage
+
+import cats.effect.IO
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import weaver.SimpleIOSuite
+
+object LastSyncGlobalSnapshotStorageSuite extends SimpleIOSuite {
+
+  private def ordinal(value: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(value)
+
+  test("retained exact contexts are bounded and evict the least recently used ordinal") {
+    val initial = Vector(1L, 2L, 3L, 4L).foldLeft(Vector.empty[(SnapshotOrdinal, String)]) {
+      case (cache, value) => LastSyncGlobalSnapshotStorage.retainExact(cache, ordinal(value), s"context-$value", capacity = 4)
+    }
+    val (touched, found) = LastSyncGlobalSnapshotStorage.takeRetainedExact(initial, ordinal(1L))
+    val updated = LastSyncGlobalSnapshotStorage.retainExact(touched, ordinal(5L), "context-5", capacity = 4)
+
+    IO.pure(
+      expect.same(Some("context-1"), found) &&
+        expect.same(Vector(3L, 4L, 1L, 5L), updated.map(_._1.value.value))
+    )
+  }
+
+  test("retaining the same exact ordinal replaces its context without growing the cache") {
+    val initial = Vector(ordinal(7L) -> "old", ordinal(8L) -> "eight")
+    val updated = LastSyncGlobalSnapshotStorage.retainExact(initial, ordinal(7L), "new", capacity = 4)
+
+    IO.pure(
+      expect.same(Vector(8L, 7L), updated.map(_._1.value.value)) &&
+        expect.same(Vector("eight", "new"), updated.map(_._2))
+    )
+  }
+
+  test("a missing exact ordinal does not change access order") {
+    val initial = Vector(ordinal(2L) -> "two", ordinal(3L) -> "three")
+    val (updated, found) = LastSyncGlobalSnapshotStorage.takeRetainedExact(initial, ordinal(1L))
+
+    IO.pure(expect.same(initial, updated) && expect(found.isEmpty))
+  }
+}


### PR DESCRIPTION
I found this while testing a five-validator Currency L0 metagraph. The original
failure was reproduced with the unmodified Tessellation v4.1.0-rc.12 code in an
isolated devnet.

The validators could appear healthy and reach `Ready`, but that did not mean
they had joined one stable Currency L0 group. In the concurrent control, all
five validators exchanged peer declarations and observed the same Currency
snapshot at ordinal 6. One validator was then admitted with the seed, while the
other three entered `WaitingForDownload`. They downloaded the certified
snapshot at ordinal 10 and repeatedly failed with:

```text
Failed to prepend currency snapshot ordinal=SnapshotOrdinal(10) to storage
```

Starting the validators one at a time did not avoid the problem. In that
control, the third validator reached `Ready`, but its local Currency snapshot
remained at ordinal 10 while the active pair advanced beyond ordinal 100.

No Data L1, Currency L1, or metagraph transaction had started in either
control. This ruled out the metagraph application, its data update, and the
historical three-Data-L1 startup procedure. The failure occurred first in
Tessellation's Currency L0 admission and recovery code.

## What was still missing in the proposed rc.13 work

The proposed rc.13 branch in PR 1566 substantially changes Currency L0
consensus and replaces several rc.12 committee behaviors. I did not copy the
old rc.12 patch onto it. I first audited the new design and ran 170 focused
stock tests.

Those tests passed, but they did not cover the recovery failures below:

1. A validator can have a downloaded Currency snapshot newer than its combined
   checkpoint. Advertising only the checkpoint makes the validator look behind
   even when its snapshot storage is current.
2. Recovery needs calculated state for the exact downloaded snapshot ordinal.
   The existing route exposes moving latest state, which may belong to a newer
   snapshot by the time the recovering validator asks for it.
3. Equal local ordinals with different hashes must be treated as a conflict.
   Picking one without proving which is correct can advertise unsafe state.
4. Currency L0 registered for consensus events and then cleared its old event
   mempool. Events accepted immediately after registration could therefore be
   acknowledged and then deleted before the validator processed them.
5. A temporary gap in canonical state-channel data could be treated as a
   permanent conflict instead of allowing recovery to wait and retry.
6. Join retries could reuse stale peer-discovery results from an earlier
   attempt.

These are Tessellation framework paths used by Currency L0 metagraphs. A
metagraph application cannot safely replace snapshot recovery, calculated-state
verification, event delivery, or consensus membership handling.

## What this changes

This pull request:

- compares the downloaded snapshot and combined checkpoint and advertises the
  newer trustworthy local tip;
- advertises neither tip when the ordinals match but the hashes conflict;
- adds an exact-ordinal calculated-state route and keeps a bounded history of
  four recent recovery contexts;
- requests calculated state for the downloaded snapshot's exact ordinal and
  verifies its hash against the proof in that snapshot;
- fails recovery when the exact state is unavailable or its hash does not
  match;
- resets stale consensus state before handling a non-contiguous downloaded
  chain and returns a failed attempt to `WaitingForDownload` so it can retry;
- clears the stale event mempool before publishing consensus registration, so
  events accepted after registration are preserved;
- waits and retries when the canonical state-channel bridge has not arrived
  yet;
- retains the exact Global snapshot context used to calculate a proposal's
  fees;
- removes stale finished consensus generations; and
- clears peer-discovery state after every join attempt and contacts the initial
  peers concurrently.

It does not lower quorum, fabricate a signature, accept calculated state from
the wrong ordinal, or bypass snapshot proof verification.

## How I verified the cause and the fix

### Stock failure controls

- A sequential rc.12 control admitted the first two validators, then left the
  third at Currency ordinal 10 while the active pair continued advancing.
- A concurrent rc.12 control started all four joiners together. All five
  exchanged declarations and observed the same initial head, but three
  validators entered `WaitingForDownload` and repeatedly failed to install the
  certified ordinal-10 snapshot.
- Both controls failed before Data L1, Currency L1, or application transaction
  processing began.

This ruled out launch order as a workaround and isolated the prerequisite
failure to Currency L0 recovery.

### Isolated patched-candidate campaigns

Two complete isolated campaigns used different throwaway metagraph identities.
Each campaign ran:

- one Global L0;
- five Currency L0 validators;
- three Data L1 validators; and
- one inert Currency L1.

In both campaigns:

- all five Currency L0 validators joined one common state;
- two byte-identical application updates were accepted;
- the Global L0 anchor was verified;
- the group finalized with one validator stopped;
- the stopped validator recovered its persisted state and returned to `Ready`;
- a validator whose local data had been emptied downloaded verified state and
  returned to `Ready`; and
- consensus resumed after both recovery cases.

The persisted-restart failure in this testing led to the event-cleanup ordering
fix. Moving stale cleanup before consensus registration preserved newly
accepted events and allowed the validator to rejoin stable participation.

### Verification on the current PR 1566 head

The same recovery changes were then applied cleanly to PR 1566 commit
`490011e1b648396378b275f08ae3f4deafc6818f`.

The current port passed:

- the complete Currency L0 test suite;
- `PeerDiscoverySuite`;
- `CachedCombinedResponseSuite`;
- `LastSyncGlobalSnapshotStorageSuite`;
- the affected Scalafix checks; and
- a clean source-diff check.

The two full topology campaigns were run against the earlier reviewed PR 1566
candidate commit, not commit `490011e1`. I am not presenting the focused test
run on `490011e1` as a third topology campaign.

## Impact on other metagraph builders

The failure happens before application-specific transaction handling. A simple
uninterrupted demonstration may never trigger every recovery path, but a
validator that joins late, restarts, loses local data, or observes a moving peer
can encounter it. The fix belongs in Tessellation so each metagraph does not
have to discover the same framework limitation independently.

## Scope and safety

The base is the proposed rc.13 work in PR 1566 at commit `490011e1`. This is not
an official rc.13 release artifact. All runtime testing used isolated networks
and throwaway identities. No public network was joined or modified, and no
production validator key was used.
