### PR TITLE
fix(dag-l0): recover past damaged snapshot files

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -1563,11 +1563,13 @@ object Download {
               snapshotStorage.readCombined(ord).flatMap {
                 case Some(result) => result.some.pure[F]
                 case None         =>
-                  // readCombined self-healed by deleting the bad pair at `ord`. The next call to
-                  // getHighestSnapshotInfoOrdinal will return a strictly-lower ord, but we also
-                  // pass `ord` explicitly (rather than `ord - 1`) to keep the bound aligned with
-                  // any new write races. SnapshotOrdinal.MinValue terminates if we reach genesis.
-                  findHighestValidPersisted(ord, attempts - 1)
+                  // Always decrease the search bound. A missing or unreadable snapshot can leave
+                  // its info file in place, so asking for the highest info at `ord` again would
+                  // select the same unusable pair until the attempt budget is exhausted.
+                  PartialPrevious[SnapshotOrdinal]
+                    .partialPrevious(ord)
+                    .map(findHighestValidPersisted(_, attempts - 1))
+                    .getOrElse(none[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)].pure[F])
               }
           }
 

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
@@ -120,8 +120,8 @@ object SnapshotDownloadStorage {
 
       private def hasSnapshotInfo(ordinal: SnapshotOrdinal): F[Boolean] =
         hashSelect.select(ordinal) match {
-          case JsonHash => snapshotInfoStorage.exists(ordinal)
-          case KryoHash => snapshotInfoKryoStorage.exists(ordinal)
+          case JsonHash => snapshotInfoStorage.read(ordinal).map(_.isDefined)
+          case KryoHash => snapshotInfoKryoStorage.read(ordinal).map(_.isDefined)
         }
 
       def hasCorrectSnapshotInfo(
@@ -242,7 +242,11 @@ object SnapshotDownloadStorage {
 
       def moveTmpToPersisted(snapshot: Signed[GlobalIncrementalSnapshot]): F[Unit] =
         HasherSelector[F].withCurrent { implicit hasher =>
-          persistedStorage.getPath(snapshot).flatMap(tmpStorage.moveByOrdinal(snapshot, _) >> persistedStorage.link(snapshot))
+          persistedStorage.getPath(snapshot).flatMap { path =>
+            persistedStorage.delete(snapshot.ordinal) >>
+              tmpStorage.moveByOrdinal(snapshot, path) >>
+              persistedStorage.link(snapshot)
+          }
         }
 
       def readGenesis(ordinal: SnapshotOrdinal): F[Option[Signed[GlobalSnapshot]]] = fullGlobalSnapshotStorage.read(ordinal)

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorageValidatedSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorageValidatedSuite.scala
@@ -313,4 +313,109 @@ object SnapshotDownloadStorageValidatedSuite extends MutableIOSuite {
           expect.same(None, wrongSameOrdinalRead)
     }
   }
+
+  test("a damaged snapshot-info file is not accepted as a persisted recovery anchor") { implicit res =>
+    implicit val (kryoSerializer, jsonSerializer, hasher, securityProvider, metrics) = res
+    implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(hasher)
+
+    val hashSelect = new HashSelect {
+      def select(ordinal: SnapshotOrdinal): HashLogic = JsonHash
+    }
+
+    File.temporaryDirectory() { root =>
+      def path(name: String): Path = Path((root / name).pathAsString)
+
+      val ordinal = SnapshotOrdinal.unsafeApply(1L)
+
+      for {
+        tmpStorage <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](path("tmp"))
+        persistedStorage <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](path("persisted"))
+        fullSnapshotStorage <- GlobalSnapshotLocalFileSystemStorage.make[IO](path("full"))
+        snapshotInfoStorage <- GlobalSnapshotInfoLocalFileSystemStorage.make[IO](path("info-json"))
+        snapshotInfoKryoStorage <- GlobalSnapshotInfoKryoLocalFileSystemStorage.make[IO](path("info-kryo"))
+        checkpointStorage <-
+          CombinedSnapshotCheckpointFileSystemStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](path("checkpoint"))
+        producer <- InMemoryMerklePatriciaProducer.make[IO]()
+        mptStore <- MptStore.make[IO, GlobalStateKey](producer, GlobalStateKey.toHex[IO])
+        storage = SnapshotDownloadStorage.make[IO](
+          tmpStorage,
+          persistedStorage,
+          fullSnapshotStorage,
+          snapshotInfoStorage,
+          snapshotInfoKryoStorage,
+          checkpointStorage,
+          hashSelect,
+          mptStore
+        )
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        genesis = GlobalSnapshot.mkGenesis(Map.empty, EpochProgress.MinValue)
+        signedGenesis <- Signed.forAsyncHasher[IO, GlobalSnapshot](genesis, keyPair)
+        incremental <- GlobalIncrementalSnapshot.fromGlobalSnapshot[IO](signedGenesis.value)
+        signedIncremental <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          incremental.copy(ordinal = ordinal),
+          keyPair
+        )
+        hashed <- signedIncremental.toHashed[IO]
+        _ <- storage.writePersisted(signedIncremental)
+        _ <- snapshotInfoStorage.write(ordinal, GlobalSnapshotInfo.empty)
+        _ <- IO.blocking((root / "info-json" / ordinal.value.value.toString).writeByteArray(Array[Byte](1, 2, 3)))
+        usable <- storage.ensurePersistedAnchor(hashed.hash, ordinal)
+      } yield expect(!usable)
+    }
+  }
+
+  test("moving a recovered snapshot replaces an older envelope at the same ordinal") { implicit res =>
+    implicit val (kryoSerializer, jsonSerializer, hasher, securityProvider, metrics) = res
+    implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(hasher)
+
+    val hashSelect = new HashSelect {
+      def select(ordinal: SnapshotOrdinal): HashLogic = JsonHash
+    }
+
+    File.temporaryDirectory() { root =>
+      def path(name: String): Path = Path((root / name).pathAsString)
+
+      for {
+        tmpStorage <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](path("tmp"))
+        persistedStorage <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](path("persisted"))
+        fullSnapshotStorage <- GlobalSnapshotLocalFileSystemStorage.make[IO](path("full"))
+        snapshotInfoStorage <- GlobalSnapshotInfoLocalFileSystemStorage.make[IO](path("info-json"))
+        snapshotInfoKryoStorage <- GlobalSnapshotInfoKryoLocalFileSystemStorage.make[IO](path("info-kryo"))
+        checkpointStorage <-
+          CombinedSnapshotCheckpointFileSystemStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](path("checkpoint"))
+        producer <- InMemoryMerklePatriciaProducer.make[IO]()
+        mptStore <- MptStore.make[IO, GlobalStateKey](producer, GlobalStateKey.toHex[IO])
+        storage = SnapshotDownloadStorage.make[IO](
+          tmpStorage,
+          persistedStorage,
+          fullSnapshotStorage,
+          snapshotInfoStorage,
+          snapshotInfoKryoStorage,
+          checkpointStorage,
+          hashSelect,
+          mptStore
+        )
+        originalKey <- KeyPairGenerator.makeKeyPair[IO]
+        replacementKey <- KeyPairGenerator.makeKeyPair[IO]
+        genesis = GlobalSnapshot.mkGenesis(Map.empty, EpochProgress.MinValue)
+        signedGenesis <- Signed.forAsyncHasher[IO, GlobalSnapshot](genesis, originalKey)
+        incremental <- GlobalIncrementalSnapshot.fromGlobalSnapshot[IO](signedGenesis.value)
+        original <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](incremental, originalKey)
+        replacement <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](incremental, replacementKey)
+        replacementHashed <- replacement.toHashed[IO]
+        _ <- persistedStorage.writeUnderOrdinal(original)
+        _ <- tmpStorage.writeUnderOrdinal(replacement)
+        _ <- storage.moveTmpToPersisted(replacement)
+        byOrdinal <- persistedStorage.read(replacement.ordinal)
+        byHash <- persistedStorage.read(replacementHashed.hash)
+        temporary <- tmpStorage.read(replacement.ordinal)
+      } yield
+        expect.all(
+          original.proofs != replacement.proofs,
+          byOrdinal.contains(replacement),
+          byHash.contains(replacement),
+          temporary.isEmpty
+        )
+    }
+  }
 }

--- a/modules/shared/src/main/scala/io/constellationnetwork/storage/LocalFileSystemStorage.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/storage/LocalFileSystemStorage.scala
@@ -30,21 +30,22 @@ abstract class SerializableLocalFileSystemStorage[F[_]: JsonSerializer, A: Encod
   def read(fileName: String): F[Option[A]] =
     readBytes(fileName).flatMap {
       _.flatTraverse { bytes =>
-        JsonSerializer[F].deserialize[A](bytes).flatMap { result =>
-          result.fold(
-            jsonErr =>
-              logger.warn(
-                s"Failed to deserialize $fileName - JSON error: ${jsonErr.getMessage}, using the fallback deserializer..."
-              ) >>
-                (deserializeFallback(bytes) match {
-                  case Right(value) => value.some.pure[F]
-                  case Left(fallbackErr) =>
-                    logger.warn(
-                      s"Failed to deserialize $fileName - Fallback error: ${fallbackErr.getMessage}"
-                    ) >> none[A].pure[F]
-                }),
-            value => value.some.pure[F]
-          )
+        def useFallback(jsonErr: Throwable): F[Option[A]] =
+          logger.warn(
+            s"Failed to deserialize $fileName - JSON error: ${jsonErr.getMessage}, using the fallback deserializer..."
+          ) >>
+            F.delay(deserializeFallback(bytes)).attempt.map(_.flatten).flatMap {
+              case Right(value) => value.some.pure[F]
+              case Left(fallbackErr) =>
+                logger.warn(
+                  s"Failed to deserialize $fileName - Fallback error: ${fallbackErr.getMessage}"
+                ) >> none[A].pure[F]
+            }
+
+        JsonSerializer[F].deserialize[A](bytes).attempt.flatMap {
+          case Right(Right(value)) => value.some.pure[F]
+          case Right(Left(error))  => useFallback(error)
+          case Left(error)         => useFallback(error)
         }
       }
     }

--- a/modules/shared/src/test/scala/io/constellationnetwork/storage/LocalFileSystemStorageSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/storage/LocalFileSystemStorageSuite.scala
@@ -1,0 +1,36 @@
+package io.constellationnetwork.storage
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.json.JsonSerializer
+
+import better.files.File
+import fs2.io.file.Path
+import io.circe.{Decoder, Encoder}
+import weaver.SimpleIOSuite
+
+object LocalFileSystemStorageSuite extends SimpleIOSuite {
+
+  test("read returns None when both deserializers throw") {
+    File.temporaryDirectory() { root =>
+      implicit val jsonSerializer: JsonSerializer[IO] = new JsonSerializer[IO] {
+        def serialize[A: Encoder](content: A): IO[Array[Byte]] = IO.pure(Array.emptyByteArray)
+
+        def deserialize[A: Decoder](content: Array[Byte]): IO[Either[Throwable, A]] =
+          IO.raiseError(new IllegalArgumentException("damaged JSON bytes"))
+      }
+
+      val storage = new SerializableLocalFileSystemStorage[IO, String](Path(root.pathAsString)) {
+        def deserializeFallback(bytes: Array[Byte]): Either[Throwable, String] =
+          throw new IllegalStateException("damaged fallback bytes")
+      }
+
+      for {
+        _ <- storage.createDirectoryIfNotExists().rethrowT
+        _ <- storage.write("damaged", Array[Byte](1, 2, 3))
+        result <- storage.read("damaged")
+      } yield expect.same(None, result)
+    }
+  }
+}


### PR DESCRIPTION
Why this is needed

I found that a Global L0 validator could remain in WaitingForDownload even when healthy peers had valid snapshot history available. The validator kept selecting the same damaged local snapshot or snapshot-info file and repeating the download failure. Manual restoration of the damaged file was the only way to move it forward.

The problem was not missing peer data. Tessellation treated a local filename as a usable recovery anchor without first proving that the file could be decoded. Decoder exceptions could also escape the storage layer instead of being returned as an unreadable-file result. When the ordinal and hash links both referred to damaged bytes, retrying the same ordinal reproduced the same failure.

In the untouched control, unreadable snapshot-info caused 13 repeated download failures and the validator did not recover on its own. When two validators were damaged at the same time, the remaining five validators preserved finality, but both damaged validators remained stranded.

The proposed rc.13 work already adds substantial crash-safe snapshot storage, so the older patch was not copied without review. The audit found four cases that were still missing:

1. Exceptions from the primary and fallback deserializers were not always contained as an unreadable-file result.
2. Snapshot-info availability was based on filename existence instead of a successful decode.
3. Recovery could select the same unusable persisted ordinal again.
4. Installing a validated same-ordinal replacement could leave the stale ordinal link pointing at the older snapshot.

What this changes

Contain JSON and fallback decoder exceptions and report the damaged file as unreadable. Decode snapshot-info before accepting it as a recovery anchor. If the snapshot or metadata at an ordinal cannot be read, continue the search below that ordinal instead of selecting it again.

Before installing a validated same-ordinal replacement, remove the stale ordinal link. This keeps the hash and ordinal indexes pointed at the same recovered snapshot.

How this was verified

The isolated seven-validator recovery matrix covered:

- unreadable snapshot-info;
- unreadable snapshot bytes through both local indexes;
- valid snapshot-info paired with the wrong snapshot;
- a missing ordinal link with a valid hash link;
- readable snapshot-info with both snapshot indexes missing;
- a corrupt Merkle Patricia Trie; and
- two validators with unreadable local state at the same time.

All cases recovered with the fix. In the two-validator damage case, the other five validators preserved finality, both damaged validators returned to Ready, and all seven later reported the same snapshot ordinal and hash. The recovered validators also returned to the active signing group.

The original campaign passed 45 focused tests plus compile, assembly, formatting, and source-diff checks.

This pre-rc.13 port is based on PR 1566 commit
490011e1b648396378b275f08ae3f4deafc6818f. It passed LocalFileSystemStorageSuite, SnapshotLocalFileSystemStorageSuite, SnapshotDownloadStorageValidatedSuite, SnapshotStorageSuite, DownloadSuite, the affected Scalafix checks, and the source-diff check. The seven-validator matrix is preserved evidence for the original behavior; the focused current head run is not presented as a new seven-validator campaign.

Safety

Downloaded data is still validated before it becomes persisted state. This change does not trust corrupt local bytes, skip snapshot validation, or weaken finality. All runtime testing used isolated networks and throwaway identities. No public network was joined or modified.