### PR TITLE
fix(currency-l0): recover downloaded validators safely

### DIFF
--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -79,6 +79,19 @@ object CurrencyL0App {
     */
   private[currency] def rollbackBootstrapFacilitators(nodeId: PeerId): List[PeerId] =
     List(nodeId)
+
+  private[currency] def selectLocalChainTip(
+    checkpoint: Option[ChainTip],
+    snapshot: Option[ChainTip]
+  ): Option[ChainTip] =
+    (checkpoint, snapshot) match {
+      case (None, value)                                                         => value
+      case (value, None)                                                         => value
+      case (Some(left), Some(right)) if left.ordinal > right.ordinal             => left.some
+      case (Some(left), Some(right)) if right.ordinal > left.ordinal             => right.some
+      case (Some(left), Some(right)) if left.snapshotHash === right.snapshotHash => left.some
+      case _                                                                     => none[ChainTip]
+    }
 }
 
 abstract class CurrencyL0App(
@@ -232,23 +245,23 @@ abstract class CurrencyL0App(
 
       // Chain tip getter used by IHave HTTP endpoint (EventGossipRoutes, passed to HttpApi at line 231).
       // Intentionally NOT passed to EventGossipDaemon -- fork detection is deferred for currency-l0.
-      // The combined-checkpoint store is the primary source, but it is only written on the production
-      // path, so a node that stays caught up by FOLLOWING/downloading (e.g. a 2nd metagraph-L0 node
-      // before it is promoted) has an empty checkpoint even while its currency chain head advances
-      // every round. Without an advertised tip the B2 admission gate never witnesses it as at-tip and
-      // never promotes it to facilitator -- a deadlock for the joining node. Fall back to the latest
-      // currency snapshot we hold so a caught-up follower becomes a witnessable admission candidate.
-      getLocalChainTip = storages.combinedCurrencySnapshotCheckpointStorage.getLatestCheckpointInfo.flatMap { info =>
-        if (info.hash =!= Hash.empty) ChainTip(info.ordinal, info.hash).some.pure[IO]
-        else
-          storages.snapshot.headSnapshot.flatMap {
-            _.flatTraverse { signed =>
-              hasherSelectorAlwaysCurrent.withCurrent { implicit hasher =>
-                signed.toHashed[IO].map(hashed => ChainTip(signed.value.ordinal, hashed.hash).some)
-              }
+      // The periodic combined checkpoint can trail the signed Currency snapshot head by several
+      // rounds. Advertise the newer trustworthy local position so admission does not mistake a
+      // caught-up validator for a lagging one. Equal ordinals with different hashes are a local
+      // contradiction and fail closed instead of choosing one store silently.
+      getLocalChainTip = for {
+        checkpointInfo <- storages.combinedCurrencySnapshotCheckpointStorage.getLatestCheckpointInfo
+        checkpointTip =
+          if (checkpointInfo.hash =!= Hash.empty) ChainTip(checkpointInfo.ordinal, checkpointInfo.hash).some
+          else none[ChainTip]
+        snapshotTip <- storages.snapshot.headSnapshot.flatMap {
+          case None => none[ChainTip].pure[IO]
+          case Some(signed) =>
+            hasherSelectorAlwaysCurrent.withCurrent { implicit hasher =>
+              signed.toHashed[IO].map(hashed => ChainTip(signed.value.ordinal, hashed.hash).some)
             }
-          }
-      }
+        }
+      } yield CurrencyL0App.selectLocalChainTip(checkpointTip, snapshotTip)
 
       eventGossipDaemon <- {
         implicit val dtEncoder: CirceEncoder[DataTransaction] = DataTransactionCodecs.encoder(dataApplicationService)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/p2p/DataApplicationClient.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/p2p/DataApplicationClient.scala
@@ -18,6 +18,10 @@ trait DataApplicationClient[F[_]] {
   def getCalculatedState(
     implicit decoder: Decoder[DataCalculatedState]
   ): PeerResponse[F, (SnapshotOrdinal, DataCalculatedState)]
+
+  def getCalculatedState(
+    ordinal: SnapshotOrdinal
+  )(implicit decoder: Decoder[DataCalculatedState]): PeerResponse[F, Option[DataCalculatedState]]
 }
 
 object DataApplicationClient {
@@ -27,5 +31,10 @@ object DataApplicationClient {
         implicit decoder: Decoder[DataCalculatedState]
       ): PeerResponse[F, (SnapshotOrdinal, DataCalculatedState)] =
         PeerResponse[F, (SnapshotOrdinal, DataCalculatedState)]("currency/state/calculated")(client, session)
+
+      def getCalculatedState(
+        ordinal: SnapshotOrdinal
+      )(implicit decoder: Decoder[DataCalculatedState]): PeerResponse[F, Option[DataCalculatedState]] =
+        PeerResponse[F, Option[DataCalculatedState]](s"currency/state/calculated/${ordinal.value.value}")(client, session)
     }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/routes/DataBlockRoutes.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/http/routes/DataBlockRoutes.scala
@@ -6,9 +6,11 @@ import cats.syntax.functor._
 
 import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationBlock
+import io.constellationnetwork.currency.dataApplication.storage.CalculatedStateLocalFileSystemStorage
 import io.constellationnetwork.kernel._
 import io.constellationnetwork.node.shared.snapshot.currency.{CurrencySnapshotEvent, DataApplicationBlockEvent}
 import io.constellationnetwork.routes.internal._
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.signature.Signed
 
 import eu.timepit.refined.auto._
@@ -19,7 +21,8 @@ import org.http4s.dsl.Http4sDsl
 
 final case class DataBlockRoutes[F[_]: Async](
   mkCell: CurrencySnapshotEvent => Cell[F, StackF, _, Either[CellError, Ω], _],
-  dataApplication: BaseDataApplicationL0Service[F]
+  dataApplication: BaseDataApplicationL0Service[F],
+  calculatedStateStorage: CalculatedStateLocalFileSystemStorage[F]
 )(implicit context: L0NodeContext[F], decoder: Decoder[DataTransaction], encoder: Encoder[DataCalculatedState])
     extends Http4sDsl[F]
     with PublicRoutes[F]
@@ -45,6 +48,13 @@ final case class DataBlockRoutes[F[_]: Async](
     case GET -> Root / "state" / "calculated" =>
       dataApplication.getCalculatedState
         .flatMap(Ok(_))
+
+    case GET -> Root / "state" / "calculated" / LongVar(rawOrdinal) =>
+      SnapshotOrdinal(rawOrdinal).fold(NotFound()) { ordinal =>
+        calculatedStateStorage
+          .read[DataCalculatedState](ordinal)(bytes => dataApplication.deserializeCalculatedState(bytes).flatMap(Async[F].fromEither))
+          .flatMap(Ok(_))
+      }
 
   }
 }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/HttpApi.scala
@@ -143,10 +143,10 @@ sealed abstract class HttpApi[F[_]: Async: SecurityProvider: HasherSelector: Met
   private val allowSpendBlockRoutes = AllowSpendBlockRoutes[F](queues.l1Output)
   private val tokenLockBlockRoutes = TokenLockBlockRoutes[F](queues.l1Output)
 
-  private val dataBlockRoutes = maybeDataApplication.map { da =>
+  private val dataBlockRoutes = (maybeDataApplication, storages.calculatedStateStorage).mapN { (da, calculatedStateStorage) =>
     implicit val dataUpdateDecoder: Decoder[DataUpdate] = da.dataDecoder
     implicit val (d, e) = (DataTransaction.decoder, da.calculatedStateEncoder)
-    DataBlockRoutes[F](mkCell, da)
+    DataBlockRoutes[F](mkCell, da, calculatedStateStorage)
   }
 
   private val transactionValidationErrorRoutes =

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Programs.scala
@@ -57,7 +57,7 @@ object Programs {
         services.consensus,
         peerSelect,
         storages.identifier,
-        dataApplication.map { case (da, _) => da },
+        dataApplication,
         services.globalL0.pullGlobalSnapshot,
         storages.snapshot,
         storages.currencySnapshotCleanup,
@@ -65,7 +65,8 @@ object Programs {
         storages.eventMempool,
         services.stateChannelBinarySender,
         storages.recoverySyncPublication,
-        storages.stateChannelBinaryOutbox
+        storages.stateChannelBinaryOutbox,
+        storages.currencyFeeContextReceipt
       )
 
     val globalL0PeerDiscovery = L0PeerDiscovery.make(
@@ -99,6 +100,7 @@ object Programs {
       storages.snapshot,
       storages.recoverySyncPublication,
       storages.stateChannelBinaryOutbox,
+      storages.currencyFeeContextReceipt,
       (snapshot, info) =>
         for {
           identifier <- storages.identifier.get

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -17,6 +17,7 @@ import io.constellationnetwork.currency.l0.infrastructure.snapshot.services.Curr
 import io.constellationnetwork.currency.l0.node.L0NodeContext
 import io.constellationnetwork.currency.l0.snapshot._
 import io.constellationnetwork.currency.l0.snapshot.services.{StateChannelBinarySender, StateChannelSnapshotService}
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage.CurrencyFeeContextKey
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.domain.allowance_list.AllowanceListEntry
 import io.constellationnetwork.domain.seedlist.SeedlistEntry
@@ -97,13 +98,23 @@ object Services {
       // Resolve process death between outbox preparation and local Currency commit before
       // the sender can restore anything. Exact artifact/state-proof readback is the only
       // promotion authority for both the ordinary queue and the special recovery receipt.
-      _ <- storages.recoverySyncPublication
+      recoveryPublication <- storages.recoverySyncPublication
         .reconcilePrepared(getDurableCurrencyArtifact)
       // A controlled rollback is itself the authority to replace the target/suffix. It
       // must be able to start even when an ordinary committed receipt belongs to that
       // superseded fork; Rollback prunes target-and-above before publication is enabled.
-      _ <- storages.stateChannelBinaryOutbox
+      ordinaryPublications <- storages.stateChannelBinaryOutbox
         .reconcilePrepared(getDurableCurrencyArtifact)
+      canonicalTerminal <- storages.snapshot.head.map(_.map(_._1.ordinal))
+      protectedFeeContextKeys =
+        ordinaryPublications
+          .map(entry => CurrencyFeeContextKey(entry.currencySnapshotOrdinal, entry.currencyArtifactHash))
+          .toSet ++ recoveryPublication
+          .map(entry => CurrencyFeeContextKey(entry.currencySnapshotOrdinal, entry.currencyArtifactHash))
+          .toSet
+      _ <- canonicalTerminal.traverse_(
+        storages.currencyFeeContextReceipt.sweepCompleted(_, protectedFeeContextKeys).void
+      )
 
       stateChannelBinarySender <- StateChannelBinarySender.make(
         storages.identifier,
@@ -151,6 +162,7 @@ object Services {
           storages.lastGlobalSnapshotSync,
           storages.recoverySyncPublication,
           storages.stateChannelBinaryOutbox,
+          storages.currencyFeeContextReceipt,
           feeCalculator,
           cfg.snapshotSize
         )
@@ -203,6 +215,7 @@ object Services {
           storages.cluster,
           storages.node,
           storages.lastSyncGlobalSnapshot,
+          storages.currencyFeeContextReceipt,
           // Services are allocated before run-genesis/run-validator/run-rollback
           // installs the metagraph identifier. Keep the read suspended until a
           // downloaded synchronous outcome needs to validate its context.

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Storages.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Storages.scala
@@ -15,7 +15,11 @@ import io.constellationnetwork.currency.l0.domain.snapshot.storages.CurrencySnap
 import io.constellationnetwork.currency.l0.infrastructure.mempool.CurrencyEventMempool
 import io.constellationnetwork.currency.l0.infrastructure.snapshot.CurrencySnapshotCleanupStorage
 import io.constellationnetwork.currency.l0.snapshot.DataTransactionCodecs
-import io.constellationnetwork.currency.l0.snapshot.storage.{RecoverySyncPublicationStorage, StateChannelBinaryOutboxStorage}
+import io.constellationnetwork.currency.l0.snapshot.storage.{
+  CurrencyFeeContextReceiptStorage,
+  RecoverySyncPublicationStorage,
+  StateChannelBinaryOutboxStorage
+}
 import io.constellationnetwork.currency.schema.CurrencyStateKey
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo, CurrencySnapshotStateProof}
 import io.constellationnetwork.json.JsonSerializer
@@ -94,6 +98,9 @@ object Storages {
           snapshotConfig.incrementalPersistedSnapshotPath / ".state-channel-binary-outbox"
         )
       }
+      currencyFeeContextReceiptStorage <- CurrencyFeeContextReceiptStorage.make[F](
+        snapshotConfig.incrementalPersistedSnapshotPath / ".currency-fee-context-receipts"
+      )
       currencySnapshotCleanupStorage = CurrencySnapshotCleanupStorage
         .make[F](
           snapshotLocalFileSystemStorage,
@@ -123,6 +130,7 @@ object Storages {
         lastGlobalSnapshotSync = lastGlobalSnapshotSyncStorage,
         recoverySyncPublication = recoverySyncPublicationStorage,
         stateChannelBinaryOutbox = stateChannelBinaryOutboxStorage,
+        currencyFeeContextReceipt = currencyFeeContextReceiptStorage,
         currencySnapshotEventValidationError = sharedStorages.currencySnapshotEventValidationError,
         currencySnapshotCleanup = currencySnapshotCleanupStorage,
         combinedCurrencySnapshotCheckpointStorage = combinedCurrencySnapshotCheckpointStorage,
@@ -149,6 +157,7 @@ sealed abstract class Storages[F[_]] private (
   val lastGlobalSnapshotSync: LastSentGlobalSnapshotSyncStorage[F],
   val recoverySyncPublication: RecoverySyncPublicationStorage[F],
   val stateChannelBinaryOutbox: StateChannelBinaryOutboxStorage[F],
+  val currencyFeeContextReceipt: CurrencyFeeContextReceiptStorage[F],
   val currencySnapshotEventValidationError: ValidationErrorStorage[F, CurrencySnapshotEvent, BlockRejectionReason],
   val currencySnapshotCleanup: CurrencySnapshotCleanupStorage[F],
   val globalSnapshotsWithStateFileStorage: GlobalSnapshotsWithStateLocalFileSystemStorage[F],

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensus.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration.FiniteDuration
 import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL0Service, DataTransaction}
 import io.constellationnetwork.currency.l0.snapshot.schema.{CurrencyConsensusKind, CurrencyConsensusOutcome}
 import io.constellationnetwork.currency.l0.snapshot.services.StateChannelSnapshotService
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage
 import io.constellationnetwork.currency.schema.CurrencyStateKey
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.domain.seedlist.SeedlistEntry
@@ -103,6 +104,7 @@ object CurrencySnapshotConsensus {
     clusterStorage: ClusterStorage[F],
     nodeStorage: NodeStorage[F],
     lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
+    feeContextReceiptStorage: CurrencyFeeContextReceiptStorage[F],
     getCurrencyAddress: F[Address],
     maybeRewards: Option[Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
     effectiveConsensusConfig: ConsensusConfig,
@@ -143,7 +145,9 @@ object CurrencySnapshotConsensus {
         maybeRewards,
         creator,
         validator,
-        maybeCustomArtifacts
+        maybeCustomArtifacts,
+        lastGlobalSnapshotStorage,
+        feeContextReceiptStorage
       )
 
       eventGossipClient = EventGossipClient.make[F, CurrencySnapshotEvent](client, session)
@@ -162,7 +166,8 @@ object CurrencySnapshotConsensus {
         leavingDelay,
         getGlobalSnapshotByOrdinal,
         seedlist,
-        eventMempool
+        eventMempool,
+        feeContextReceiptStorage
       )
 
       consensusStateCreator = CurrencySnapshotConsensusStateCreator.make[F](
@@ -225,7 +230,8 @@ object CurrencySnapshotConsensus {
         consensusClient,
         validateObservedOutcome,
         isAuthorizedForNextRound,
-        nextRoundAuthority
+        nextRoundAuthority,
+        feeContextReceiptStorage.abandonGeneration
       )
       routes = new synchronous.ConsensusRoutes(consensusStorage)
       handler = CurrencyConsensusHandler.make(consensusStorage, manager)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctions.scala
@@ -1,15 +1,20 @@
 package io.constellationnetwork.currency.l0.snapshot
 
-import cats.data.Validated.Invalid
+import cats.data.Validated.{Invalid, Valid}
 import cats.effect.Async
 import cats.syntax.all._
 
-import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.collection.immutable.SortedSet
+import scala.util.control.NoStackTrace
 
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage.CurrencyFeeContextReceipt
 import io.constellationnetwork.currency.schema.currency._
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.node.shared.domain.consensus.ConsensusFunctions
 import io.constellationnetwork.node.shared.domain.rewards.Rewards
-import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
+import io.constellationnetwork.node.shared.domain.snapshot.storage.LastSyncGlobalSnapshotStorage
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
 import io.constellationnetwork.node.shared.infrastructure.snapshot._
 import io.constellationnetwork.node.shared.snapshot.currency._
@@ -18,7 +23,9 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.schema.balance.{Amount, Balance}
 import io.constellationnetwork.schema.consensus.CertifiedLineageEvidenceV1
+import io.constellationnetwork.schema.currencyMessage.fetchStakingAddress
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
@@ -48,6 +55,69 @@ abstract class CurrencySnapshotConsensusFunctions[F[_]: Async: SecurityProvider]
 
 object CurrencySnapshotConsensusFunctions {
 
+  final case class MissingGlobalSyncViewForFeeContext(currencyOrdinal: SnapshotOrdinal) extends ConsensusFunctions.InvalidArtifact {
+    override def getMessage: String =
+      s"Currency proposal at ordinal=${currencyOrdinal.show} does not contain the Global L0 view required for fee calculation"
+  }
+
+  final case class ExactGlobalFeeContextUnavailable(ordinal: SnapshotOrdinal) extends ConsensusFunctions.InvalidArtifact {
+    override def getMessage: String = s"Exact Global L0 fee context is unavailable at ordinal=${ordinal.show}"
+  }
+
+  final case class ExactGlobalFeeContextHashMismatch(ordinal: SnapshotOrdinal, expected: Hash, actual: Hash) extends NoStackTrace {
+    override def getMessage: String =
+      s"Exact Global L0 fee context hash mismatch at ordinal=${ordinal.show}: expected=${expected.show} actual=${actual.show}"
+  }
+
+  /** Capture the small fee input while the proposal's exact Global context is locally available.
+    *
+    * The durable receipt is keyed by Currency ordinal and artifact hash. It does not retain a full Global snapshot in heap and it cannot be
+    * displaced by unrelated proposal accesses.
+    */
+  private[snapshot] def captureFeeContextReceipt[F[_]: Async](
+    currencyOrdinal: SnapshotOrdinal,
+    currencyArtifactHash: Hash,
+    globalSyncView: Option[GlobalSyncView],
+    stakingAddress: Option[Address],
+    resolve: SnapshotOrdinal => F[Option[(Hash, Balance)]],
+    putDurably: CurrencyFeeContextReceipt => F[Unit]
+  ): F[Unit] =
+    globalSyncView
+      .liftTo[F](MissingGlobalSyncViewForFeeContext(currencyOrdinal))
+      .flatMap { view =>
+        resolve(view.ordinal)
+          .flatMap(_.liftTo[F](ExactGlobalFeeContextUnavailable(view.ordinal)))
+          .flatMap {
+            case (actual, stakingBalance) =>
+              ExactGlobalFeeContextHashMismatch(view.ordinal, view.hash, actual)
+                .raiseError[F, Unit]
+                .whenA(actual =!= view.hash) >>
+                putDurably(
+                  CurrencyFeeContextReceipt(
+                    CurrencyFeeContextReceiptStorage.CurrentEncodingVersion,
+                    currencyOrdinal,
+                    currencyArtifactHash,
+                    view,
+                    stakingAddress,
+                    stakingBalance
+                  )
+                )
+          }
+      }
+
+  /** A temporarily unavailable exact Global context invalidates only the proposal being checked. A same-ordinal hash conflict remains a
+    * hard failure because it can indicate a fork or corrupted local authority.
+    */
+  private[snapshot] def validateFeeContextCapture[F[_]: Async](capture: F[Unit]): F[Either[ConsensusFunctions.InvalidArtifact, Unit]] =
+    capture.attempt.flatMap {
+      case Right(_) => ().asRight[ConsensusFunctions.InvalidArtifact].pure[F]
+      case Left(error: MissingGlobalSyncViewForFeeContext) =>
+        (error: ConsensusFunctions.InvalidArtifact).asLeft[Unit].pure[F]
+      case Left(error: ExactGlobalFeeContextUnavailable) =>
+        (error: ConsensusFunctions.InvalidArtifact).asLeft[Unit].pure[F]
+      case Left(error) => error.raiseError[F, Either[ConsensusFunctions.InvalidArtifact, Unit]]
+    }
+
   final case class ProposalArtifactResult(
     artifact: CurrencySnapshotArtifact,
     context: CurrencySnapshotContext,
@@ -60,9 +130,37 @@ object CurrencySnapshotConsensusFunctions {
     rewards: Option[Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent]],
     currencySnapshotCreator: CurrencySnapshotCreator[F],
     currencySnapshotValidator: CurrencySnapshotValidator[F],
-    maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]]
+    maybeCustomArtifacts: Option[Signed[CurrencyIncrementalSnapshot] => Option[SortedSet[SharedArtifact]]],
+    lastGlobalSnapshotStorage: LastSyncGlobalSnapshotStorage[F],
+    feeContextReceiptStorage: CurrencyFeeContextReceiptStorage[F]
   ): CurrencySnapshotConsensusFunctions[F] = new CurrencySnapshotConsensusFunctions[F] {
     val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("CurrencySnapshotConsensusFunctions")
+
+    private def captureFeeContextReceipt(
+      artifact: CurrencySnapshotArtifact,
+      lastContext: CurrencySnapshotContext
+    )(implicit hasher: Hasher[F]): F[Unit] =
+      for {
+        artifactHash <- artifact.hash
+        stakingAddress = fetchStakingAddress(lastContext.snapshotInfo)
+        _ <- CurrencySnapshotConsensusFunctions.captureFeeContextReceipt(
+          artifact.ordinal,
+          artifactHash,
+          artifact.globalSyncView,
+          stakingAddress,
+          ordinal =>
+            lastGlobalSnapshotStorage
+              .getCombined(ordinal)
+              .flatMap(
+                _.traverse {
+                  case (snapshot, info) =>
+                    snapshot.hash.map(_ -> stakingAddress.flatMap(info.balances.get).getOrElse(Balance.empty))
+                }
+              ),
+          receipt => feeContextReceiptStorage.putDurably(receipt).void
+        )
+      } yield ()
+
     override def triggerPredicate(event: CurrencySnapshotEvent): Boolean = event match {
       case GlobalSnapshotSyncEvent(_) => false // NOTE: Sync events should not trigger consensus to avoid infinite loop
       case _                          => true
@@ -96,12 +194,16 @@ object CurrencySnapshotConsensusFunctions {
           peerHistory,
           historicalDependencyResolution = false
         )
-        .flatTap {
+        .flatMap {
           case Invalid(errors) =>
-            logger.warn(s"Failed when validating currency artifact. Errors: ${errors.toList}")
-          case _ => Async[F].unit
+            logger
+              .warn(s"Failed when validating currency artifact. Errors: ${errors.toList}")
+              .as(CurrencyArtifactMismatch(errors.toList).asLeft)
+          case Valid(validated) =>
+            CurrencySnapshotConsensusFunctions
+              .validateFeeContextCapture(captureFeeContextReceipt(artifact, lastContext))
+              .map(_.map(_ => validated))
         }
-        .map(_.leftMap(errors => CurrencyArtifactMismatch(errors.toList)).toEither)
 
     def createProposalArtifact(
       lastKey: SnapshotOrdinal,
@@ -161,6 +263,7 @@ object CurrencySnapshotConsensusFunctions {
           peerHistory,
           historicalDependencyResolution = false
         )
+        .flatTap(created => captureFeeContextReceipt(created.artifact, lastContext))
         .map(created => ProposalArtifactResult(created.artifact, created.context, created.awaitingEvents, created.rejectedEvents))
     }
   }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusStateAdvancer.scala
@@ -13,6 +13,12 @@ import scala.concurrent.duration.FiniteDuration
 import io.constellationnetwork.currency.dataApplication.BaseDataApplicationL0Service
 import io.constellationnetwork.currency.l0.snapshot.schema._
 import io.constellationnetwork.currency.l0.snapshot.services.StateChannelSnapshotService
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage.{
+  CurrencyFeeContextKey,
+  CurrencyFeeContextReceipt,
+  MissingCurrencyFeeContextReceipt
+}
 import io.constellationnetwork.currency.l0.snapshot.synchronous.ConsensusStateUpdater._
 import io.constellationnetwork.currency.l0.snapshot.synchronous._
 import io.constellationnetwork.currency.l0.snapshot.synchronous.declaration._
@@ -59,6 +65,15 @@ object CurrencySnapshotConsensusStateAdvancer {
   private val hashOrdering: Ordering[Hash] = cats.Order[Hash].toOrdering
 
   private[snapshot] final case class CandidateSelection(candidates: Candidates, cursor: Option[PeerId])
+
+  /** Verify the selected proposal's durable fee authority before returning a state transition. Receipt cleanup remains in the retained
+    * effect, but a permanently missing receipt cannot commit CollectingSignatures and become an endlessly retried retained effect.
+    */
+  private[snapshot] def requireFeeContextReceipt[F[_]: cats.MonadThrow](
+    key: CurrencyFeeContextKey,
+    get: CurrencyFeeContextKey => F[Option[CurrencyFeeContextReceipt]]
+  ): F[Unit] =
+    get(key).flatMap(_.liftTo[F](MissingCurrencyFeeContextReceipt(key))).void
 
   private[snapshot] def boundedFacilityEventHashes(hashes: Iterable[Hash]): SortedSet[Hash] =
     SortedSet.from(hashes)(hashOrdering).take(EventMempool.DefaultSnapshotLimit)
@@ -138,7 +153,8 @@ object CurrencySnapshotConsensusStateAdvancer {
     leavingDelay: FiniteDuration,
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     seedlist: Option[Set[SeedlistEntry]],
-    eventMempool: EventMempool[F, CurrencySnapshotEvent, CurrencyStateKey]
+    eventMempool: EventMempool[F, CurrencySnapshotEvent, CurrencyStateKey],
+    feeContextReceiptStorage: CurrencyFeeContextReceiptStorage[F]
   ): CurrencySnapshotConsensusStateAdvancer[F] =
     new CurrencySnapshotConsensusStateAdvancer[F] {
       val logger = Slf4jLogger.getLogger[F]
@@ -328,6 +344,7 @@ object CurrencySnapshotConsensusStateAdvancer {
                               maybeMajorityArtifactInfo.traverse { majorityArtifactInfo =>
                                 val acceptedEventHashes =
                                   if (majorityArtifactInfo.hash === proposalInfo.hash) ownAcceptedEventHashes else SortedSet.empty[Hash]
+                                val feeContextKey = CurrencyFeeContextKey(state.key, majorityArtifactInfo.hash)
                                 val newState =
                                   state.copy(status =
                                     identity[CurrencySnapshotStatus](
@@ -341,6 +358,7 @@ object CurrencySnapshotConsensusStateAdvancer {
                                     )
                                   )
                                 for {
+                                  _ <- requireFeeContextReceipt(feeContextKey, feeContextReceiptStorage.get)
                                   parentHash <- parentArtifactHash(state)
                                   signature <- Signature.fromHash(keyPair.getPrivate, majorityArtifactInfo.hash)
                                   declaration = MajoritySignature(
@@ -348,7 +366,9 @@ object CurrencySnapshotConsensusStateAdvancer {
                                     majorityArtifactInfo.hash,
                                     AttemptDomain(facilitatorsHash, parentHash, state.lastOutcome.finished.binaryArtifactHash)
                                   )
-                                  effect = consensusStorage.addSignature(selfId, state.key, declaration, declaration.domain.some) >>
+                                  effect = feeContextReceiptStorage
+                                    .retainSelected(feeContextKey)
+                                    .void >> consensusStorage.addSignature(selfId, state.key, declaration, declaration.domain.some) >>
                                     gossip.spread(ConsensusPeerDeclaration(state.key, declaration)) >>
                                     Metrics[F].recordDistribution(
                                       "dag_consensus_proposal_affinity",

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Download.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Download.scala
@@ -1,19 +1,24 @@
 package io.constellationnetwork.currency.l0.snapshot.programs
 
-import cats.Applicative
 import cats.effect.Async
 import cats.effect.std.Random
 import cats.syntax.all._
+import cats.{Applicative, MonadThrow}
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
+import io.constellationnetwork.currency.dataApplication.storage.CalculatedStateLocalFileSystemStorage
 import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL0Service, DataCalculatedState, L0NodeContext}
 import io.constellationnetwork.currency.l0.domain.snapshot.storages.CurrencySnapshotCleanupStorage
 import io.constellationnetwork.currency.l0.http.p2p.P2PClient
 import io.constellationnetwork.currency.l0.snapshot.CurrencySnapshotConsensus
 import io.constellationnetwork.currency.l0.snapshot.services.StateChannelBinarySender
-import io.constellationnetwork.currency.l0.snapshot.storage.{RecoverySyncPublicationStorage, StateChannelBinaryOutboxStorage}
+import io.constellationnetwork.currency.l0.snapshot.storage.{
+  CurrencyFeeContextReceiptStorage,
+  RecoverySyncPublicationStorage,
+  StateChannelBinaryOutboxStorage
+}
 import io.constellationnetwork.currency.schema.CurrencyStateKey
 import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
@@ -31,7 +36,7 @@ import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEve
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.node.NodeState
 import io.constellationnetwork.schema.peer.L0Peer.toP2PContext
-import io.constellationnetwork.schema.peer.{L0Peer, Peer}
+import io.constellationnetwork.schema.peer.Peer
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, HasherSelector}
@@ -43,6 +48,103 @@ import retry._
 
 /** Stable release/mainnet observe-and-register download flow with current crash-safe storage replacement. */
 object Download {
+
+  final case class ObservationPlan(catchUpThrough: SnapshotOrdinal, observationLimit: SnapshotOrdinal)
+
+  final case class PeerTipBehindDownloadedHead(downloadedHead: SnapshotOrdinal, peerTip: SnapshotOrdinal) extends NoStackTrace {
+    override def getMessage: String =
+      s"Selected peer tip ${peerTip.show} is behind the downloaded snapshot head ${downloadedHead.show} served by that peer"
+  }
+
+  final case class CalculatedStateConfigurationMismatch(hasArtifactState: Boolean, hasLocalApplication: Boolean) extends NoStackTrace {
+    override def getMessage: String =
+      s"Currency calculated-state recovery configuration mismatch: artifact=$hasArtifactState localApplication=$hasLocalApplication"
+  }
+
+  final case class CalculatedStateUnavailable(ordinal: SnapshotOrdinal, attemptedPeers: Int) extends NoStackTrace {
+    override def getMessage: String =
+      s"No Ready peer served the calculated state certified at Currency snapshot ordinal=${ordinal.show}; attemptedPeers=$attemptedPeers"
+  }
+
+  final case class CalculatedStateProofMismatch(ordinal: SnapshotOrdinal, actual: Hash, expected: Hash) extends NoStackTrace {
+    override def getMessage: String =
+      s"Calculated state at Currency ordinal=${ordinal.show} has hash=${actual.show}, expected=${expected.show}"
+  }
+
+  final case class CalculatedStateRejected(ordinal: SnapshotOrdinal) extends NoStackTrace {
+    override def getMessage: String =
+      s"Data application rejected recovered calculated state at Currency ordinal=${ordinal.show}"
+  }
+
+  final case class CalculatedStatePersistenceMissing(ordinal: SnapshotOrdinal) extends NoStackTrace {
+    override def getMessage: String =
+      s"Atomically persisted calculated state is missing at Currency ordinal=${ordinal.show}"
+  }
+
+  final case class CalculatedStateCurrentConflict(
+    targetOrdinal: SnapshotOrdinal,
+    currentOrdinal: SnapshotOrdinal,
+    actual: Hash,
+    expected: Hash
+  ) extends NoStackTrace {
+    override def getMessage: String =
+      s"Current calculated state cannot be replaced safely: targetOrdinal=${targetOrdinal.show} " +
+        s"currentOrdinal=${currentOrdinal.show} actual=${actual.show} expected=${expected.show}"
+  }
+
+  private[snapshot] final case class CalculatedStateHooks[F[_], State](
+    fetchExact: (SnapshotOrdinal, Hash) => F[State],
+    hash: State => F[Hash],
+    persistAtomically: (SnapshotOrdinal, State) => F[Unit],
+    readPersisted: SnapshotOrdinal => F[Option[State]],
+    getCurrent: F[(SnapshotOrdinal, State)],
+    setCurrent: (SnapshotOrdinal, State) => F[Boolean]
+  )
+
+  private[snapshot] def restoreCalculatedStateSteps[F[_]: MonadThrow, State](
+    ordinal: SnapshotOrdinal,
+    expectedProof: Option[Hash],
+    hooks: Option[CalculatedStateHooks[F, State]]
+  ): F[Unit] =
+    (expectedProof, hooks) match {
+      case (None, None) => Applicative[F].unit
+      case (Some(expected), Some(calculatedState)) =>
+        def persistAndVerify(state: State): F[State] =
+          for {
+            _ <- calculatedState.persistAtomically(ordinal, state)
+            persisted <- calculatedState
+              .readPersisted(ordinal)
+              .flatMap(_.liftTo[F](CalculatedStatePersistenceMissing(ordinal)))
+            persistedHash <- calculatedState.hash(persisted)
+            _ <- CalculatedStateProofMismatch(ordinal, persistedHash, expected)
+              .raiseError[F, Unit]
+              .whenA(persistedHash =!= expected)
+          } yield persisted
+
+        for {
+          current <- calculatedState.getCurrent
+          (currentOrdinal, currentState) = current
+          currentHash <- calculatedState.hash(currentState)
+          _ <-
+            if (currentOrdinal > ordinal || (currentOrdinal === ordinal && currentHash =!= expected))
+              CalculatedStateCurrentConflict(ordinal, currentOrdinal, currentHash, expected).raiseError[F, Unit]
+            else if (currentOrdinal === ordinal)
+              persistAndVerify(currentState).void
+            else
+              for {
+                state <- calculatedState.fetchExact(ordinal, expected)
+                actual <- calculatedState.hash(state)
+                _ <- CalculatedStateProofMismatch(ordinal, actual, expected)
+                  .raiseError[F, Unit]
+                  .whenA(actual =!= expected)
+                persisted <- persistAndVerify(state)
+                accepted <- calculatedState.setCurrent(ordinal, persisted)
+                _ <- CalculatedStateRejected(ordinal).raiseError[F, Unit].unlessA(accepted)
+              } yield ()
+        } yield ()
+      case _ =>
+        CalculatedStateConfigurationMismatch(expectedProof.nonEmpty, hooks.nonEmpty).raiseError[F, Unit]
+    }
 
   /** A single successor gets roughly one normal Currency round to become available. Exhaustion returns control to DownloadDaemon, which
     * reselects a fresh latest anchor. Every successfully downloaded successor starts with a fresh budget.
@@ -60,6 +162,26 @@ object Download {
   private[snapshot] def observationLimit(current: SnapshotOrdinal, offset: Long): SnapshotOrdinal =
     SnapshotOrdinal.unsafeApply(Math.addExact(current.value.value, offset))
 
+  private[snapshot] def observationPlan(
+    downloadedHead: SnapshotOrdinal,
+    peerTip: SnapshotOrdinal,
+    offset: Long
+  ): Either[PeerTipBehindDownloadedHead, ObservationPlan] =
+    if (peerTip < downloadedHead) PeerTipBehindDownloadedHead(downloadedHead, peerTip).asLeft
+    else ObservationPlan(peerTip, observationLimit(peerTip, offset)).asRight
+
+  /** Clear pre-recovery events before advertising the validator as an admission candidate.
+    *
+    * Once registration is visible, the current committee may select this validator for the next round and synchronously push every event
+    * named by its Facility declarations. Clearing after registration can therefore acknowledge those pushes and then erase them before the
+    * recovered validator creates the same round. The validator is left waiting forever for events that every incumbent was told it stored.
+    */
+  private[snapshot] def prepareObservationAdmission[F[_]: MonadThrow](
+    clearPreRecoveryEvents: F[Unit],
+    registerForConsensus: F[Unit]
+  ): F[Unit] =
+    clearPreRecoveryEvents >> registerForConsensus
+
   def make[F[_]: Async: Random](
     p2pClient: P2PClient[F],
     clusterStorage: ClusterStorage[F],
@@ -68,7 +190,7 @@ object Download {
     consensus: CurrencySnapshotConsensus[F],
     peerSelect: PeerSelect[F],
     identifierStorage: IdentifierStorage[F],
-    maybeDataApplication: Option[BaseDataApplicationL0Service[F]],
+    maybeDataApplication: Option[(BaseDataApplicationL0Service[F], CalculatedStateLocalFileSystemStorage[F])],
     getGlobalSnapshotByOrdinal: SnapshotOrdinal => F[Option[Hashed[GlobalIncrementalSnapshot]]],
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo] with LatestBalances[F],
     currencySnapshotCleanupStorage: CurrencySnapshotCleanupStorage[F],
@@ -80,7 +202,8 @@ object Download {
     eventMempool: EventMempool[F, CurrencySnapshotEvent, CurrencyStateKey],
     stateChannelBinarySender: StateChannelBinarySender[F],
     recoverySyncPublicationStorage: RecoverySyncPublicationStorage[F],
-    stateChannelBinaryOutboxStorage: StateChannelBinaryOutboxStorage[F]
+    stateChannelBinaryOutboxStorage: StateChannelBinaryOutboxStorage[F],
+    feeContextReceiptStorage: CurrencyFeeContextReceiptStorage[F]
   )(implicit l0NodeContext: L0NodeContext[F]): Download[F, CurrencyIncrementalSnapshot] = new Download[F, CurrencyIncrementalSnapshot] {
 
     private val logger = Slf4jLogger.getLogger[F]
@@ -89,6 +212,7 @@ object Download {
 
     type DownloadResult = (Signed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)
     type ObservationLimit = SnapshotOrdinal
+    type DownloadAnchor = (DownloadResult, ObservationPlan)
 
     def recoveryDownload(implicit hasherSelector: HasherSelector[F]): F[Unit] = download
 
@@ -110,12 +234,14 @@ object Download {
                 )(
                   _ =>
                     for {
+                      _ <- restoreCalculatedState(snapshot)
                       snapshotHash <- snapshot.value.hash
                       // Discard node-local publication authority before replacing history.
                       // A crash at any later point can only lose a redundant validator copy;
                       // it cannot revive a superseded randomized proof envelope at startup.
                       _ <- recoverySyncPublicationStorage.discardForCanonicalReplacement
                       _ <- stateChannelBinaryOutboxStorage.discardAllForCanonicalReplacement
+                      _ <- feeContextReceiptStorage.discardAllForCanonicalReplacement
                       exactInstalled <- ExactSnapshotStorage.installCanonicalSuffixForRecovery(
                         snapshotStorage,
                         snapshot,
@@ -128,8 +254,6 @@ object Download {
                           s"Failed to install exact Currency artifact/context ordinal=${snapshot.ordinal}; keeping consensus stopped"
                         )
                       )
-                      _ <- eventMempool.clear
-                      _ <- setCalculatedState(snapshot)
                     } yield (),
                   stateChannelBinarySender.clearPending >> stateChannelBinarySender.enablePublishing
                 )
@@ -157,46 +281,115 @@ object Download {
       }
     }
 
-    private def setCalculatedState(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit] =
-      maybeDataApplication.fold(Applicative[F].unit) { dataApplication =>
-        implicit val decoder = dataApplication.calculatedStateDecoder
+    private def restoreCalculatedState(snapshot: Signed[CurrencyIncrementalSnapshot]): F[Unit] =
+      (snapshot.dataApplication, maybeDataApplication) match {
+        case (None, None) => Applicative[F].unit
+        case (Some(dataPart), Some((dataApplication, storage))) =>
+          implicit val decoder = dataApplication.calculatedStateDecoder
 
-        clusterStorage.getResponsivePeers
-          .map(NodeState.ready)
-          .map(_.toList)
-          .flatMap(Random[F].shuffleList)
-          .flatMap {
-            case Nil       => new Exception("No peers to fetch off-chain state from").raiseError[F, (SnapshotOrdinal, DataCalculatedState)]
-            case peer :: _ => p2pClient.dataApplication.getCalculatedState.run(peer)
-          }
-          .flatTap {
-            case (_, calculatedState) =>
-              dataApplication.hashCalculatedState(calculatedState).flatMap { hash =>
-                Async[F].raiseUnless(snapshot.dataApplication.map(_.calculatedStateProof).contains(hash))(
-                  new Exception("Downloaded calculated state does not match the snapshot proof")
-                )
+          def fetchExact(ordinal: SnapshotOrdinal, expectedProof: Hash): F[DataCalculatedState] =
+            clusterStorage.getResponsivePeers
+              .map(peers => NodeState.ready(peers).toList)
+              .flatMap(Random[F].shuffleList)
+              .flatMap { peers =>
+                def go(remaining: List[Peer]): F[DataCalculatedState] =
+                  remaining match {
+                    case Nil => Download.CalculatedStateUnavailable(ordinal, peers.size).raiseError[F, DataCalculatedState]
+                    case peer :: tail =>
+                      p2pClient.dataApplication
+                        .getCalculatedState(ordinal)
+                        .run(peer)
+                        .attempt
+                        .flatMap {
+                          case Right(Some(state)) =>
+                            dataApplication.hashCalculatedState(state).flatMap { actualProof =>
+                              if (actualProof === expectedProof) state.pure[F]
+                              else
+                                logger.warn(
+                                  Download.CalculatedStateProofMismatch(ordinal, actualProof, expectedProof)
+                                )(
+                                  s"Peer ${peer.id.show} served mismatched calculated state; trying another Ready peer"
+                                ) >> go(tail)
+                            }
+                          case Right(None) =>
+                            logger.warn(
+                              Download.CalculatedStateUnavailable(ordinal, 1)
+                            )(
+                              s"Peer ${peer.id.show} did not have calculated state ordinal=${ordinal.show}; trying another Ready peer"
+                            ) >> go(tail)
+                          case Left(error) =>
+                            logger.warn(error)(
+                              s"Peer ${peer.id.show} could not serve calculated state ordinal=${ordinal.show}; trying another Ready peer"
+                            ) >> go(tail)
+                        }
+                  }
+
+                go(peers)
               }
-          }
-          .flatMap { case (ordinal, state) => dataApplication.setCalculatedState(ordinal, state).void }
+
+          val hooks = Download.CalculatedStateHooks[F, DataCalculatedState](
+            fetchExact = fetchExact,
+            hash = dataApplication.hashCalculatedState,
+            persistAtomically = (ordinal, state) => storage.writeAtomically(ordinal, state)(dataApplication.serializeCalculatedState),
+            readPersisted =
+              ordinal => storage.read(ordinal)(bytes => dataApplication.deserializeCalculatedState(bytes).flatMap(_.liftTo[F])),
+            getCurrent = dataApplication.getCalculatedState,
+            setCurrent = dataApplication.setCalculatedState
+          )
+
+          Download.restoreCalculatedStateSteps(
+            snapshot.ordinal,
+            dataPart.calculatedStateProof.some,
+            hooks.some
+          )
+        case (artifactState, localApplication) =>
+          Download
+            .CalculatedStateConfigurationMismatch(artifactState.nonEmpty, localApplication.nonEmpty)
+            .raiseError[F, Unit]
       }
 
-    def start: F[DownloadResult] = {
+    def start: F[DownloadAnchor] = {
       val retryPolicy = exponentialBackoff[F](1.second).join(limitRetries(5))
-      retryingOnAllErrors[DownloadResult](
+      retryingOnAllErrors[DownloadAnchor](
         policy = retryPolicy,
         onError = (error: Throwable, details: RetryDetails) =>
           logger.error(error)(s"Error fetching latest Currency snapshot attempt=${details.retriesSoFar}; selecting another peer")
-      )(peerSelect.select.flatMap((peer: L0Peer) => p2pClient.currencySnapshot.getLatest.run(peer)))
+      )(
+        peerSelect.select.flatMap { peer =>
+          for {
+            // Start from the peer's exact live artifact/context instead of a periodic
+            // checkpoint. Replaying a stale checkpoint can require deterministic Global
+            // dependencies that have already left every Ready peer's bounded history.
+            result <- p2pClient.currencySnapshot.getLatestHead.run(peer)
+            // The peer can finalize another snapshot while the combined body is in flight.
+            // Read its current ordinal after the body arrives, catch up through that small
+            // race window, and only then register a future observation window.
+            peerTip <- p2pClient.currencySnapshot.getLatestOrdinal.run(peer)
+            plan <- Async[F].fromEither(Download.observationPlan(result._1.ordinal, peerTip, observationOffset.value))
+          } yield result -> plan
+        }
+      )
     }
 
-    def observe(result: DownloadResult)(implicit hasher: Hasher[F]): F[(DownloadResult, ObservationLimit)] = {
-      val observationLimit = Download.observationLimit(result._1.ordinal, observationOffset.value)
+    def observe(anchor: DownloadAnchor)(implicit hasher: Hasher[F]): F[(DownloadResult, ObservationLimit)] = {
+      val (result, plan) = anchor
 
-      def go(current: DownloadResult): F[DownloadResult] =
-        if (current._1.ordinal === observationLimit) current.pure[F]
-        else fetchNextSnapshot(current).flatMap(go)
+      def go(current: DownloadResult, target: SnapshotOrdinal): F[DownloadResult] =
+        if (current._1.ordinal === target) current.pure[F]
+        else fetchNextSnapshot(current).flatMap(next => go(next, target))
 
-      consensus.manager.registerForConsensus(observationLimit) >> go(result).map(_ -> observationLimit)
+      for {
+        caughtUp <- go(result, plan.catchUpThrough)
+        _ <- logger.info(
+          s"Caught up Currency recovery head from ordinal=${result._1.ordinal.show} " +
+            s"through live peer tip=${caughtUp._1.ordinal.show}; registering future observation=${plan.observationLimit.show}"
+        )
+        _ <- Download.prepareObservationAdmission(
+          eventMempool.clear,
+          consensus.manager.registerForConsensus(plan.observationLimit)
+        )
+        observed <- go(caughtUp, plan.observationLimit)
+      } yield observed -> plan.observationLimit
     }
 
     def fetchNextSnapshot(result: DownloadResult)(implicit hasher: Hasher[F]): F[DownloadResult] = {
@@ -229,8 +422,7 @@ object Download {
 
     def fetchSnapshot(hash: Option[Hash], ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[Signed[CurrencyIncrementalSnapshot]] =
       clusterStorage.getResponsivePeers
-        .map(NodeState.ready)
-        .map(_.toList)
+        .map(peers => NodeState.ready(peers).toList)
         .flatMap(Random[F].shuffleList)
         .flatTap(_ => logger.info(s"Download currency snapshot hash=${hash.show}, ordinal=${ordinal.show}"))
         .flatMap { peers =>

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/programs/Rollback.scala
@@ -14,7 +14,11 @@ import io.constellationnetwork.currency.dataApplication.storage.{
 }
 import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL0Service, L0NodeContext}
 import io.constellationnetwork.currency.l0.domain.snapshot.storages.CurrencySnapshotCleanupStorage
-import io.constellationnetwork.currency.l0.snapshot.storage.{RecoverySyncPublicationStorage, StateChannelBinaryOutboxStorage}
+import io.constellationnetwork.currency.l0.snapshot.storage.{
+  CurrencyFeeContextReceiptStorage,
+  RecoverySyncPublicationStorage,
+  StateChannelBinaryOutboxStorage
+}
 import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotInfo}
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.json.JsonSerializer
@@ -61,6 +65,7 @@ object Rollback {
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
     recoverySyncPublicationStorage: RecoverySyncPublicationStorage[F],
     stateChannelBinaryOutboxStorage: StateChannelBinaryOutboxStorage[F],
+    feeContextReceiptStorage: CurrencyFeeContextReceiptStorage[F],
     validateLeadBeforeMutation: (Signed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo) => F[Unit]
   )(implicit context: L0NodeContext[F]): Rollback[F] = new Rollback[F] {
     private val logger = Slf4jLogger.getLoggerFromName[F]("CurrencyRollback")
@@ -101,6 +106,7 @@ object Rollback {
       // never calls this.
       _ <- recoverySyncPublicationStorage.discardForCanonicalReplacement
       _ <- stateChannelBinaryOutboxStorage.discardAllForCanonicalReplacement
+      _ <- feeContextReceiptStorage.discardAllForCanonicalReplacement
 
       _ <- logger.info(s"[Rollback] Cleanup for snapshots greater than ${lastIncremental.ordinal}")
       lastIncrementalHash <- lastIncremental.value.hash

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotService.scala
@@ -2,13 +2,23 @@ package io.constellationnetwork.currency.l0.snapshot.services
 
 import java.security.KeyPair
 
-import cats.Monad
 import cats.data.NonEmptySet
 import cats.effect.Async
 import cats.syntax.all._
+import cats.{Monad, MonadThrow}
 
-import io.constellationnetwork.currency.l0.snapshot.storage.{RecoverySyncPublicationStorage, StateChannelBinaryOutboxStorage}
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage.{
+  CurrencyFeeContextKey,
+  CurrencyFeeContextReceipt,
+  MissingCurrencyFeeContextReceipt
+}
+import io.constellationnetwork.currency.l0.snapshot.storage.{
+  CurrencyFeeContextReceiptStorage,
+  RecoverySyncPublicationStorage,
+  StateChannelBinaryOutboxStorage
+}
 import io.constellationnetwork.currency.schema.currency._
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.json.{JsonSerializer, SizeCalculator}
 import io.constellationnetwork.node.shared.config.types.SnapshotSizeConfig
@@ -85,9 +95,9 @@ trait StateChannelSnapshotService[F[_]] {
     implicit hasher: Hasher[F]
   ): F[Signed[StateChannelSnapshotBinary]]
 
-  /** Construct the common unsigned binary value used by flat synchronous Currency consensus. Fee inputs come only from the exact
-    * `globalSyncView` already signed into the Currency artifact. The historical GL0 value and state are hash-checked before their fee epoch
-    * and staking balance are used, so a moving node-local GL0 tip cannot change the binary hash.
+  /** Construct the common unsigned binary value used by flat synchronous Currency consensus. Fee inputs come only from the durable local
+    * receipt captured while the artifact's exact Global context was available and hash-checked. The receipt must match the selected
+    * artifact, signed Global view, and staking address before its balance is used.
     */
   def createSynchronousBinaryValue(
     snapshot: Signed[CurrencySnapshotArtifact],
@@ -98,6 +108,28 @@ trait StateChannelSnapshotService[F[_]] {
 }
 
 object StateChannelSnapshotService {
+
+  final case class CurrencyFeeContextReceiptMismatch(key: CurrencyFeeContextKey)
+      extends IllegalStateException(s"Currency fee-context receipt does not match selected artifact key=$key")
+
+  private[services] def loadFeeContextBalance[F[_]: MonadThrow](
+    key: CurrencyFeeContextKey,
+    expectedGlobalSyncView: GlobalSyncView,
+    expectedStakingAddress: Option[Address],
+    get: CurrencyFeeContextKey => F[Option[CurrencyFeeContextReceipt]]
+  ): F[Balance] =
+    get(key)
+      .flatMap(_.liftTo[F](MissingCurrencyFeeContextReceipt(key)))
+      .flatMap { receipt =>
+        CurrencyFeeContextReceiptMismatch(key)
+          .raiseError[F, Unit]
+          .whenA(
+            receipt.key =!= key ||
+              receipt.globalSyncView =!= expectedGlobalSyncView ||
+              receipt.stakingAddress =!= expectedStakingAddress
+          )
+          .as(receipt.stakingBalance)
+      }
 
   /** Sequence finalize-time effects only after the accepted snapshot is present in storage.
     *
@@ -127,6 +159,20 @@ object StateChannelSnapshotService {
       ensureRecoveryArtifactDurable >> markRecoveryLocallyCommitted >> markOrdinaryLocallyCommitted
     else markOrdinaryLocallyCommitted
 
+  private[services] def commitPreparedPublicationsAndReleaseFeeContext[F[_]: Monad](
+    recoveryRequired: Boolean,
+    ensureRecoveryArtifactDurable: F[Unit],
+    markRecoveryLocallyCommitted: F[Unit],
+    markOrdinaryLocallyCommitted: F[Unit],
+    releaseFeeContext: F[Unit]
+  ): F[Unit] =
+    commitPreparedPublications(
+      recoveryRequired,
+      ensureRecoveryArtifactDurable,
+      markRecoveryLocallyCommitted,
+      markOrdinaryLocallyCommitted
+    ) >> releaseFeeContext
+
   def make[F[_]: Async: JsonSerializer: SecurityProvider: Metrics](
     keyPair: KeyPair,
     snapshotStorage: SnapshotStorage[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo],
@@ -142,6 +188,7 @@ object StateChannelSnapshotService {
     lastSentGlobalSnapshotSyncStorage: LastSentGlobalSnapshotSyncStorage[F],
     recoverySyncPublicationStorage: RecoverySyncPublicationStorage[F],
     stateChannelBinaryOutboxStorage: StateChannelBinaryOutboxStorage[F],
+    feeContextReceiptStorage: CurrencyFeeContextReceiptStorage[F],
     feeCalculator: FeeCalculator[F],
     snapshotSizeConfig: SnapshotSizeConfig
   ): StateChannelSnapshotService[F] =
@@ -215,21 +262,12 @@ object StateChannelSnapshotService {
               s"Synchronous Currency artifact ordinal=${snapshot.ordinal} has no signed globalSyncView"
             )
           )
-          combined <- lastGlobalSnapshotStorage
-            .getCombined(globalSyncView.ordinal)
-            .flatMap(
-              _.liftTo[F](
-                new IllegalStateException(
-                  s"Exact GL0 fee context is unavailable ordinal=${globalSyncView.ordinal} currencyOrdinal=${snapshot.ordinal}"
-                )
-              )
-            )
-          (globalSnapshot, globalInfo) = combined
-          globalHash <- globalSnapshot.hash
-          _ <- Async[F].raiseUnless(globalHash === globalSyncView.hash)(
-            new IllegalStateException(
-              s"Exact GL0 fee context hash mismatch ordinal=${globalSyncView.ordinal} expected=${globalSyncView.hash} actual=$globalHash"
-            )
+          artifactHash <- snapshot.value.hash
+          stakingBalance <- StateChannelSnapshotService.loadFeeContextBalance(
+            CurrencyFeeContextKey(snapshot.ordinal, artifactHash),
+            globalSyncView,
+            stakingAddress,
+            feeContextReceiptStorage.get
           )
           bytes <- JsonSerializer[F].serialize(snapshot)
           fee <- calculateFeeFromBalance(
@@ -237,7 +275,7 @@ object StateChannelSnapshotService {
             bytes,
             snapshot.proofs.length,
             globalSyncView.ordinal.some,
-            stakingAddress.flatMap(globalInfo.balances.get).getOrElse(Balance.empty)
+            stakingBalance
           )
         } yield StateChannelSnapshotBinary(lastSnapshotBinaryHash, bytes, fee)
 
@@ -351,11 +389,14 @@ object StateChannelSnapshotService {
         context: CurrencySnapshotInfo
       )(implicit hasher: Hasher[F]): F[Unit] =
         lastSentGlobalSnapshotSyncStorage.getRequiredRecoveryRefresh.flatMap { requiredRecovery =>
-          StateChannelSnapshotService.commitPreparedPublications(
+          StateChannelSnapshotService.commitPreparedPublicationsAndReleaseFeeContext(
             recoveryRequired = requiredRecovery.nonEmpty,
             ensureRecoveryArtifactDurable = ensureRecoveryArtifactDurable(signedArtifact, context),
             markRecoveryLocallyCommitted = recoverySyncPublicationStorage.markLocallyCommitted(binaryHash).void,
-            markOrdinaryLocallyCommitted = stateChannelBinaryOutboxStorage.markLocallyCommitted(binaryHash).void
+            markOrdinaryLocallyCommitted = stateChannelBinaryOutboxStorage.markLocallyCommitted(binaryHash).void,
+            releaseFeeContext = signedArtifact.value.hash.flatMap { artifactHash =>
+              feeContextReceiptStorage.complete(CurrencyFeeContextKey(signedArtifact.ordinal, artifactHash))
+            }
           )
         }
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/CurrencyFeeContextReceiptStorage.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/CurrencyFeeContextReceiptStorage.scala
@@ -1,0 +1,228 @@
+package io.constellationnetwork.currency.l0.snapshot.storage
+
+import cats.effect.kernel.{Async, Ref}
+import cats.effect.std.Mutex
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.infrastructure.storage.CrashSafeAtomicFileWriter
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.security.hash.Hash
+
+import derevo.cats.eqv
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import fs2.io.file.{Files, Flags, Path}
+
+/** Small durable fee input captured while a proposal's exact Global context is locally available.
+  *
+  * The receipt is local implementation state. It is not accepted from peers and it does not change Currency or Global wire schemas.
+  * Multiple facilitator proposals at one Currency ordinal are keyed independently by their artifact hashes.
+  */
+trait CurrencyFeeContextReceiptStorage[F[_]] {
+  import CurrencyFeeContextReceiptStorage.{CurrencyFeeContextKey, CurrencyFeeContextReceipt}
+
+  def putDurably(receipt: CurrencyFeeContextReceipt): F[CurrencyFeeContextReceipt]
+
+  def get(key: CurrencyFeeContextKey): F[Option[CurrencyFeeContextReceipt]]
+
+  /** Release rejected proposals only after one exact proposal has been selected. */
+  def retainSelected(key: CurrencyFeeContextKey): F[CurrencyFeeContextReceipt]
+
+  /** Release a selected receipt only after its exact artifact and binary outbox are durable. */
+  def complete(key: CurrencyFeeContextKey): F[Unit]
+
+  /** Release every proposal receipt when its consensus generation is abandoned. */
+  def abandonGeneration(ordinal: SnapshotOrdinal): F[Unit]
+
+  /** Startup cleanup for receipts at or below the canonical terminal state.
+    *
+    * Pending ordinary or recovery publication keys remain protected until their durable work is reconciled.
+    */
+  def sweepCompleted(
+    canonicalTerminal: SnapshotOrdinal,
+    protectedKeys: Set[CurrencyFeeContextKey]
+  ): F[List[CurrencyFeeContextKey]]
+
+  /** A validated download or controlled rollback replaces all node-local proposal authority. */
+  def discardAllForCanonicalReplacement: F[Unit]
+
+  private[storage] def list: F[List[CurrencyFeeContextReceipt]]
+}
+
+object CurrencyFeeContextReceiptStorage {
+  val CurrentEncodingVersion: String = "currency-fee-context-json-v1"
+
+  @derive(encoder, decoder, eqv)
+  final case class CurrencyFeeContextKey(
+    currencyOrdinal: SnapshotOrdinal,
+    currencyArtifactHash: Hash
+  )
+
+  @derive(encoder, decoder, eqv)
+  final case class CurrencyFeeContextReceipt(
+    encodingVersion: String,
+    currencyOrdinal: SnapshotOrdinal,
+    currencyArtifactHash: Hash,
+    globalSyncView: GlobalSyncView,
+    stakingAddress: Option[Address],
+    stakingBalance: Balance
+  ) {
+    def key: CurrencyFeeContextKey = CurrencyFeeContextKey(currencyOrdinal, currencyArtifactHash)
+  }
+
+  final case class MissingCurrencyFeeContextReceipt(key: CurrencyFeeContextKey)
+      extends IllegalStateException(s"Missing Currency fee-context receipt for key=$key")
+
+  final case class CurrencyFeeContextReceiptConflict(key: CurrencyFeeContextKey)
+      extends IllegalStateException(s"Conflicting Currency fee-context receipt for key=$key")
+
+  final case class CorruptCurrencyFeeContextReceipt(key: CurrencyFeeContextKey, reason: String)
+      extends IllegalStateException(s"Corrupt Currency fee-context receipt for key=$key: $reason")
+
+  final case class UnsupportedCurrencyFeeContextEncoding(key: CurrencyFeeContextKey, version: String)
+      extends IllegalStateException(s"Unsupported Currency fee-context encoding for key=$key version=$version")
+
+  private def fileName(key: CurrencyFeeContextKey): String =
+    s"${key.currencyOrdinal.value.value}-${key.currencyArtifactHash.value}.json"
+
+  def make[F[_]: Async: Files: JsonSerializer](base: Path): F[CurrencyFeeContextReceiptStorage[F]] = {
+    def validate(receipt: CurrencyFeeContextReceipt): F[CurrencyFeeContextReceipt] =
+      if (receipt.encodingVersion === CurrentEncodingVersion) receipt.pure[F]
+      else UnsupportedCurrencyFeeContextEncoding(receipt.key, receipt.encodingVersion).raiseError[F, CurrencyFeeContextReceipt]
+
+    def readPath(path: Path): F[CurrencyFeeContextReceipt] =
+      Files[F]
+        .readAll(path, 64 * 1024, Flags.Read)
+        .compile
+        .to(Array)
+        .flatMap(JsonSerializer[F].deserialize[CurrencyFeeContextReceipt])
+        .flatMap(_.liftTo[F])
+        .flatMap(validate)
+
+    for {
+      writer <- CrashSafeAtomicFileWriter.make[F](base)
+      loaded <- Files[F]
+        .list(base)
+        .filter(_.extName === ".json")
+        .compile
+        .toList
+        .flatMap(_.traverse(readPath))
+      _ <- loaded
+        .groupBy(_.key)
+        .collectFirst { case (key, duplicates) if duplicates.size =!= 1 => key }
+        .traverse_(key => CorruptCurrencyFeeContextReceipt(key, "duplicate key").raiseError[F, Unit])
+      state <- Ref.of[F, Map[CurrencyFeeContextKey, CurrencyFeeContextReceipt]](loaded.map(receipt => receipt.key -> receipt).toMap)
+      mutex <- Mutex[F]
+    } yield
+      new CurrencyFeeContextReceiptStorage[F] {
+
+        private def readDisk(key: CurrencyFeeContextKey): F[Option[CurrencyFeeContextReceipt]] = {
+          val path = base / fileName(key)
+          Files[F].exists(path).ifM(readPath(path).map(_.some), none[CurrencyFeeContextReceipt].pure[F])
+        }
+
+        private def writeAndVerify(receipt: CurrencyFeeContextReceipt): F[CurrencyFeeContextReceipt] =
+          JsonSerializer[F].serialize(receipt).flatMap(writer.write(fileName(receipt.key), _)) >>
+            readDisk(receipt.key).flatMap {
+              case Some(stored) if stored === receipt =>
+                state.update(_.updated(receipt.key, receipt)).as(receipt)
+              case Some(_) => CurrencyFeeContextReceiptConflict(receipt.key).raiseError[F, CurrencyFeeContextReceipt]
+              case None =>
+                CorruptCurrencyFeeContextReceipt(receipt.key, "missing after atomic replacement")
+                  .raiseError[F, CurrencyFeeContextReceipt]
+            }
+
+        private def delete(key: CurrencyFeeContextKey): F[Unit] =
+          writer.delete(fileName(key)).void >> state.update(_ - key)
+
+        def putDurably(receipt: CurrencyFeeContextReceipt): F[CurrencyFeeContextReceipt] =
+          mutex.lock.surround {
+            Async[F].uncancelable { _ =>
+              state.get.flatMap(_.get(receipt.key) match {
+                case Some(existing) if existing === receipt => writeAndVerify(receipt)
+                case Some(_) => CurrencyFeeContextReceiptConflict(receipt.key).raiseError[F, CurrencyFeeContextReceipt]
+                case None    => writeAndVerify(receipt)
+              })
+            }
+          }
+
+        def get(key: CurrencyFeeContextKey): F[Option[CurrencyFeeContextReceipt]] =
+          mutex.lock.surround {
+            state.get.flatMap(_.get(key) match {
+              case None => none[CurrencyFeeContextReceipt].pure[F]
+              case Some(expected) =>
+                readDisk(key).flatMap {
+                  case Some(stored) if stored === expected => stored.some.pure[F]
+                  case Some(_) => CurrencyFeeContextReceiptConflict(key).raiseError[F, Option[CurrencyFeeContextReceipt]]
+                  case None    => state.update(_ - key).as(none[CurrencyFeeContextReceipt])
+                }
+            })
+          }
+
+        def retainSelected(key: CurrencyFeeContextKey): F[CurrencyFeeContextReceipt] =
+          mutex.lock.surround {
+            Async[F].uncancelable { _ =>
+              state.get.flatMap { entries =>
+                entries.get(key) match {
+                  case None => MissingCurrencyFeeContextReceipt(key).raiseError[F, CurrencyFeeContextReceipt]
+                  case Some(selected) =>
+                    readDisk(key).flatMap {
+                      case Some(stored) if stored === selected =>
+                        entries.keys
+                          .filter(candidate => candidate.currencyOrdinal === key.currencyOrdinal && candidate =!= key)
+                          .toList
+                          .traverse_(delete)
+                          .as(selected)
+                      case Some(_) => CurrencyFeeContextReceiptConflict(key).raiseError[F, CurrencyFeeContextReceipt]
+                      case None    => MissingCurrencyFeeContextReceipt(key).raiseError[F, CurrencyFeeContextReceipt]
+                    }
+                }
+              }
+            }
+          }
+
+        def complete(key: CurrencyFeeContextKey): F[Unit] =
+          mutex.lock.surround(Async[F].uncancelable(_ => delete(key)))
+
+        def abandonGeneration(ordinal: SnapshotOrdinal): F[Unit] =
+          mutex.lock.surround {
+            Async[F].uncancelable { _ =>
+              state.get.flatMap(
+                _.keys.filter(_.currencyOrdinal === ordinal).toList.traverse_(delete)
+              )
+            }
+          }
+
+        def sweepCompleted(
+          canonicalTerminal: SnapshotOrdinal,
+          protectedKeys: Set[CurrencyFeeContextKey]
+        ): F[List[CurrencyFeeContextKey]] =
+          mutex.lock.surround {
+            Async[F].uncancelable { _ =>
+              state.get.flatMap { entries =>
+                val removable = entries.keys
+                  .filter(key => key.currencyOrdinal <= canonicalTerminal && !protectedKeys.contains(key))
+                  .toList
+                  .sortBy(key => (key.currencyOrdinal.value.value, key.currencyArtifactHash.value))
+
+                removable.traverse_(delete).as(removable)
+              }
+            }
+          }
+
+        def discardAllForCanonicalReplacement: F[Unit] =
+          mutex.lock.surround {
+            Async[F].uncancelable(_ => state.get.flatMap(_.keys.toList.traverse_(delete)))
+          }
+
+        def list: F[List[CurrencyFeeContextReceipt]] =
+          state.get.map(
+            _.values.toList.sortBy(receipt => (receipt.currencyOrdinal.value.value, receipt.currencyArtifactHash.value))
+          )
+      }
+  }
+}

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorage.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorage.scala
@@ -17,6 +17,7 @@ import derevo.cats.eqv
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import fs2.io.file.{Files, Flags, Path}
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 /** Crash-safe local outbox for every finalized Currency state-channel binary.
   *
@@ -149,6 +150,8 @@ object StateChannelBinaryOutboxStorage {
   )(
     implicit hasher: io.constellationnetwork.security.Hasher[F]
   ): F[StateChannelBinaryOutboxStorage[F]] = {
+    val logger = Slf4jLogger.getLoggerFromName[F]("StateChannelBinaryOutboxStorage")
+
     def validate(entry: Entry): F[Entry] =
       if (entry.encodingVersion =!= CurrentEncodingVersion)
         UnsupportedEncodingVersion(entry.currencySnapshotOrdinal, entry.encodingVersion).raiseError[F, Entry]
@@ -376,26 +379,39 @@ object StateChannelBinaryOutboxStorage {
                   case _ =>
                     val ordered = entries.values.toList.sortBy(_.currencySnapshotOrdinal)
                     val firstPending = ordered.find(_.currencySnapshotOrdinal > currencyOrdinal)
+                    val missingCanonicalBridge = firstPending.exists(_.currencySnapshotOrdinal > currencyOrdinal.next)
                     val pendingIsAttached = firstPending.forall(entry =>
                       entry.currencySnapshotOrdinal === currencyOrdinal.next && entry.binary.value.lastSnapshotHash === binaryHash
                     )
                     val firstPendingHash = firstPending.fold(binaryHash)(_.binary.value.lastSnapshotHash)
 
-                    Async[F].raiseUnless(pendingIsAttached)(
-                      CanonicalTipMismatch(
-                        firstPending.fold(currencyOrdinal.next)(_.currencySnapshotOrdinal),
-                        binaryHash,
-                        firstPendingHash
-                      )
-                    ) >> {
-                      val confirmed = ordered
-                        .filter(entry =>
-                          entry.locallyCommitted &&
-                            (entry.currencySnapshotOrdinal < currencyOrdinal ||
-                              (entry.currencySnapshotOrdinal === currencyOrdinal && entry.binaryHash === binaryHash))
+                    // A downloaded validator intentionally discards its local publication copies. It can therefore have a valid pending
+                    // binary N+1 while its local GL0 view still confirms only N-1. The missing binary N may already be queued at GL0 and
+                    // will close the gap in a later Global snapshot. Keep the suffix pending until the canonical tip reaches N; then the
+                    // ordinary direct-parent or same-ordinal hash check below can prove it. A direct conflicting successor still fails.
+                    if (missingCanonicalBridge)
+                      logger
+                        .info(
+                          s"Waiting for canonical Currency bridge: canonicalTipOrdinal=${currencyOrdinal.show} " +
+                            s"firstPendingOrdinal=${firstPending.fold("none")(_.currencySnapshotOrdinal.show)}"
                         )
-                      confirmed.traverse_(delete).as(confirmed)
-                    }
+                        .as(List.empty[Entry])
+                    else
+                      Async[F].raiseUnless(pendingIsAttached)(
+                        CanonicalTipMismatch(
+                          firstPending.fold(currencyOrdinal.next)(_.currencySnapshotOrdinal),
+                          binaryHash,
+                          firstPendingHash
+                        )
+                      ) >> {
+                        val confirmed = ordered
+                          .filter(entry =>
+                            entry.locallyCommitted &&
+                              (entry.currencySnapshotOrdinal < currencyOrdinal ||
+                                (entry.currencySnapshotOrdinal === currencyOrdinal && entry.binaryHash === binaryHash))
+                          )
+                        confirmed.traverse_(delete).as(confirmed)
+                      }
                 }
               }
             }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/synchronous/ConsensusManager.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/snapshot/synchronous/ConsensusManager.scala
@@ -128,15 +128,18 @@ object ConsensusManager {
 
   /** Preserve an installed immediate-successor attempt while the authority is only one finalized round ahead. That observation is
     * compatible with ordinary gossip/finalization lag because the local member may already have contributed the signatures that completed
-    * the remote outcome. A strict authority majority beyond the immediate successor proves the local attempt is obsolete and permits
-    * re-download. With no installed attempt, even a one-round lead is sufficient to re-anchor the local node.
+    * the remote outcome. A finished generation remains protected only if its outcome authorizes this node for the next round. A strict
+    * authority majority beyond the immediate successor proves any other local attempt is obsolete and permits re-download. With no
+    * installed attempt, even a one-round lead is sufficient to re-anchor the local node.
     */
   private[snapshot] def preservePeerAheadGeneration(
     hasCurrentGeneration: Boolean,
     currentGenerationFinished: Boolean,
+    currentOutcomeAuthorizesSelf: Boolean,
     authorityMajorityBeyondImmediateSuccessor: Boolean
   ): Boolean =
-    currentGenerationFinished || (hasCurrentGeneration && !authorityMajorityBeyondImmediateSuccessor)
+    (currentGenerationFinished && currentOutcomeAuthorizesSelf) ||
+      (hasCurrentGeneration && !authorityMajorityBeyondImmediateSuccessor)
 
   def make[F[_]: Async: Metrics, Event, Key: Show: Order: Next, Artifact: Eq, Context: Eq, Status: Eq, Outcome: Eq, Kind](
     selfId: PeerId,
@@ -152,7 +155,8 @@ object ConsensusManager {
     consensusClient: ConsensusClient[F, Key, Outcome],
     validateObservedOutcome: (Outcome, Key, Signed[Artifact], Context) => F[Boolean],
     isAuthorizedForNextRound: Outcome => Boolean,
-    nextRoundAuthority: Outcome => Set[PeerId]
+    nextRoundAuthority: Outcome => Set[PeerId],
+    onGenerationAbandoned: Key => F[Unit]
   )(
     implicit S: Supervisor[F],
     _artifact: Lens[Outcome, Signed[Artifact]],
@@ -210,15 +214,21 @@ object ConsensusManager {
                 Applicative[F].whenA(authorityMajorityAhead) {
                   consensusStorage
                     .abandonGenerationIfCurrent(localKey) { maybeState =>
+                      val maybeFinishedOutcome = maybeState.flatMap(
+                        consensusStateAdvancer.getConsensusOutcome(_).map { case (_, outcome) => outcome }
+                      )
+
                       preservePeerAheadGeneration(
                         hasCurrentGeneration = maybeState.nonEmpty,
-                        currentGenerationFinished = maybeState.exists(state => consensusStateAdvancer.getConsensusOutcome(state).nonEmpty),
+                        currentGenerationFinished = maybeFinishedOutcome.nonEmpty,
+                        currentOutcomeAuthorizesSelf = maybeFinishedOutcome.exists(isAuthorizedForNextRound),
                         authorityMajorityBeyondImmediateSuccessor = authorityMajorityBeyondImmediateSuccessor
                       )
                     }
                     .flatMap { abandoned =>
                       Applicative[F].whenA(abandoned) {
-                        Metrics[F].incrementCounter("dag_currency_consensus_peer_ahead_reanchor_total") >>
+                        onGenerationAbandoned(localKey.next) >>
+                          Metrics[F].incrementCounter("dag_currency_consensus_peer_ahead_reanchor_total") >>
                           logger.warn(
                             s"A strict majority of the frozen Currency authority is ahead; re-entering download {localKey=${localKey.show}}"
                           ) >>
@@ -397,8 +407,9 @@ object ConsensusManager {
                       // No outcome is the normal path when this validator registered but was
                       // not selected in the bounded candidate set. Clear the observation and
                       // re-download so it can register at a later key.
-                      consensusStorage.resetInitialConsensusOutcome(key).void >>
-                        consensusStorage.clearObservationKey >>
+                      consensusStorage.resetInitialConsensusOutcome(key).flatMap { reset =>
+                        onGenerationAbandoned(key.next).whenA(reset)
+                      } >> consensusStorage.clearObservationKey >>
                         nodeStorage
                           .tryModifyStateGetResult(Set[NodeState](Observing, WaitingForReady), WaitingForDownload)
                           .flatMap {
@@ -450,7 +461,8 @@ object ConsensusManager {
         for {
           maybeLastOutcome <- consensusStorage.clearAndGetLastConsensusOutcome
           _ <- maybeLastOutcome.traverse { lastOutcome =>
-            consensusStateRemover.withdrawFromConsensus(_key.get(lastOutcome).next)
+            val generation = _key.get(lastOutcome).next
+            consensusStateRemover.withdrawFromConsensus(generation) >> onGenerationAbandoned(generation)
           }
           _ <- consensusStorage.clearObservationKey
         } yield ()

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/CurrencyL0AppSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/CurrencyL0AppSuite.scala
@@ -3,7 +3,10 @@ package io.constellationnetwork.currency.l0
 import cats.effect.IO
 
 import io.constellationnetwork.currency.l0.cli.method
+import io.constellationnetwork.node.shared.infrastructure.gossip.event.ChainTip
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
 
 import com.monovore.decline.Command
@@ -12,6 +15,8 @@ import weaver.SimpleIOSuite
 object CurrencyL0AppSuite extends SimpleIOSuite {
 
   private val self: PeerId = PeerId(Hex("aa" * 64))
+  private val checkpoint = ChainTip(SnapshotOrdinal.unsafeApply(10L), Hash("checkpoint"))
+  private val snapshot = ChainTip(SnapshotOrdinal.unsafeApply(11L), Hash("snapshot"))
 
   test("a coordinated Currency rollback always starts from the operator-controlled lead only") {
     IO(expect.same(List(self), CurrencyL0App.rollbackBootstrapFacilitators(self)))
@@ -23,6 +28,24 @@ object CurrencyL0AppSuite extends SimpleIOSuite {
     IO(
       expect.same(Some(false), command.parse(Seq.empty).toOption) &&
         expect.same(Some(true), command.parse(Seq("--allow-solo-consensus")).toOption)
+    )
+  }
+
+  test("local chain tip uses the newer signed snapshot instead of a stale combined checkpoint") {
+    IO(expect.same(Some(snapshot), CurrencyL0App.selectLocalChainTip(Some(checkpoint), Some(snapshot))))
+  }
+
+  test("local chain tip uses the newer combined checkpoint") {
+    IO(expect.same(Some(snapshot), CurrencyL0App.selectLocalChainTip(Some(snapshot), Some(checkpoint))))
+  }
+
+  test("local chain tip accepts matching stores and fails closed on an equal-ordinal hash conflict") {
+    val matching = ChainTip(checkpoint.ordinal, checkpoint.snapshotHash)
+    val conflicting = ChainTip(checkpoint.ordinal, Hash("conflict"))
+
+    IO(
+      expect.same(Some(checkpoint), CurrencyL0App.selectLocalChainTip(Some(checkpoint), Some(matching))) &&
+        expect.same(None, CurrencyL0App.selectLocalChainTip(Some(checkpoint), Some(conflicting)))
     )
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctionsSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySnapshotConsensusFunctionsSuite.scala
@@ -1,0 +1,192 @@
+package io.constellationnetwork.currency.l0.snapshot
+
+import cats.effect.{IO, Ref}
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.security.hash.Hash
+
+import eu.timepit.refined.types.numeric.NonNegLong
+import fs2.io.file.Files
+import weaver.SimpleIOSuite
+
+object CurrencySnapshotConsensusFunctionsSuite extends SimpleIOSuite {
+
+  private val ordinal = SnapshotOrdinal.unsafeApply(354L)
+  private val expectedHash = Hash("expected")
+  private val view = GlobalSyncView(ordinal, expectedHash, EpochProgress.MinValue)
+  private val currencyOrdinal = SnapshotOrdinal.unsafeApply(77L)
+  private val artifactHash = Hash("currency-artifact")
+  private val stakingAddress = Address.fromBytes("staking-address".getBytes("UTF-8"))
+  private val stakingBalance = Balance(NonNegLong.unsafeFrom(123L))
+
+  test("proposal validation durably captures the exact fee input") {
+    for {
+      retained <- Ref.of[IO, Option[CurrencyFeeContextReceiptStorage.CurrencyFeeContextReceipt]](none)
+      _ <- CurrencySnapshotConsensusFunctions.captureFeeContextReceipt[IO](
+        currencyOrdinal,
+        artifactHash,
+        view.some,
+        stakingAddress.some,
+        _ => (expectedHash -> stakingBalance).some.pure[IO],
+        receipt => retained.set(receipt.some)
+      )
+      observed <- retained.get
+    } yield
+      expect(
+        observed.exists(receipt =>
+          receipt.currencyOrdinal === currencyOrdinal &&
+            receipt.currencyArtifactHash === artifactHash &&
+            receipt.globalSyncView === view &&
+            receipt.stakingAddress.contains(stakingAddress) &&
+            receipt.stakingBalance === stakingBalance
+        )
+      )
+  }
+
+  test("proposal fee context capture fails when the selected Global state is unavailable") {
+    CurrencySnapshotConsensusFunctions
+      .captureFeeContextReceipt[IO](
+        currencyOrdinal,
+        artifactHash,
+        view.some,
+        stakingAddress.some,
+        _ => IO.pure(none),
+        _ => IO.unit
+      )
+      .attempt
+      .map(result => expect(result == Left(CurrencySnapshotConsensusFunctions.ExactGlobalFeeContextUnavailable(ordinal))))
+  }
+
+  test("temporary Global context unavailability invalidates only the proposal") {
+    CurrencySnapshotConsensusFunctions
+      .validateFeeContextCapture[IO](
+        CurrencySnapshotConsensusFunctions.captureFeeContextReceipt[IO](
+          currencyOrdinal,
+          artifactHash,
+          view.some,
+          stakingAddress.some,
+          _ => IO.pure(none),
+          _ => IO.unit
+        )
+      )
+      .map(result => expect.same(Left(CurrencySnapshotConsensusFunctions.ExactGlobalFeeContextUnavailable(ordinal)), result))
+  }
+
+  test("proposal fee context capture fails on a same-ordinal Global hash conflict") {
+    val actualHash = Hash("conflicting")
+
+    CurrencySnapshotConsensusFunctions
+      .captureFeeContextReceipt[IO](
+        currencyOrdinal,
+        artifactHash,
+        view.some,
+        stakingAddress.some,
+        _ => IO.pure((actualHash -> stakingBalance).some),
+        _ => IO.unit
+      )
+      .attempt
+      .map(result =>
+        expect(
+          result == Left(
+            CurrencySnapshotConsensusFunctions.ExactGlobalFeeContextHashMismatch(ordinal, expectedHash, actualHash)
+          )
+        )
+      )
+  }
+
+  test("proposal fee context capture fails closed without a Global sync view") {
+    for {
+      calls <- Ref.of[IO, Int](0)
+      result <- CurrencySnapshotConsensusFunctions
+        .validateFeeContextCapture[IO](
+          CurrencySnapshotConsensusFunctions.captureFeeContextReceipt[IO](
+            currencyOrdinal,
+            artifactHash,
+            none,
+            stakingAddress.some,
+            _ => calls.update(_ + 1).as((expectedHash -> stakingBalance).some),
+            _ => calls.update(_ + 1)
+          )
+        )
+      observed <- calls.get
+    } yield
+      expect.same(Left(CurrencySnapshotConsensusFunctions.MissingGlobalSyncViewForFeeContext(currencyOrdinal)), result) &&
+        expect.same(0, observed)
+  }
+
+  test("same-ordinal Global hash conflicts remain hard failures during proposal validation") {
+    val actualHash = Hash("conflicting")
+
+    CurrencySnapshotConsensusFunctions
+      .validateFeeContextCapture[IO](
+        CurrencySnapshotConsensusFunctions.captureFeeContextReceipt[IO](
+          currencyOrdinal,
+          artifactHash,
+          view.some,
+          stakingAddress.some,
+          _ => IO.pure((actualHash -> stakingBalance).some),
+          _ => IO.unit
+        )
+      )
+      .attempt
+      .map(result =>
+        expect.same(
+          Left(CurrencySnapshotConsensusFunctions.ExactGlobalFeeContextHashMismatch(ordinal, expectedHash, actualHash)),
+          result
+        )
+      )
+  }
+
+  test("the oldest of twelve proposal views remains usable after normal Global history is pruned") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        storage <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        proposals = (1 to 12).toList.map { index =>
+          val globalOrdinal = SnapshotOrdinal.unsafeApply(1000L + index)
+          val globalHash = Hash(s"global-$index")
+          val proposalHash = Hash(s"proposal-$index")
+          val proposalBalance = Balance(NonNegLong.unsafeFrom(index.toLong))
+          (GlobalSyncView(globalOrdinal, globalHash, EpochProgress.MinValue), proposalHash, proposalBalance)
+        }
+        normalGlobalHistory <- Ref.of[IO, Map[SnapshotOrdinal, (Hash, Balance)]](
+          proposals.map {
+            case (proposalView, _, proposalBalance) =>
+              proposalView.ordinal -> (proposalView.hash -> proposalBalance)
+          }.toMap
+        )
+        _ <- proposals.traverse_ {
+          case (proposalView, proposalHash, _) =>
+            CurrencySnapshotConsensusFunctions.captureFeeContextReceipt[IO](
+              currencyOrdinal,
+              proposalHash,
+              proposalView.some,
+              stakingAddress.some,
+              requested => normalGlobalHistory.get.map(_.get(requested)),
+              receipt => storage.putDurably(receipt).void
+            )
+        }
+        _ <- normalGlobalHistory.set(Map.empty)
+        restarted <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        (oldestView, oldestHash, oldestBalance) = proposals.head
+        oldestKey = CurrencyFeeContextReceiptStorage.CurrencyFeeContextKey(currencyOrdinal, oldestHash)
+        _ <- restarted.retainSelected(oldestKey)
+        restored <- restarted.get(oldestKey)
+      } yield
+        expect(
+          restored.exists(receipt =>
+            receipt.globalSyncView === oldestView &&
+              receipt.stakingAddress.contains(stakingAddress) &&
+              receipt.stakingBalance === oldestBalance
+          )
+        )
+    }
+  }
+}

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySynchronousCommitteeSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySynchronousCommitteeSuite.scala
@@ -6,6 +6,7 @@ import cats.syntax.all._
 import scala.concurrent.duration.{Duration, _}
 
 import io.constellationnetwork.currency.l0.snapshot.schema.CurrencyConsensusKind._
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage
 import io.constellationnetwork.currency.l0.snapshot.synchronous._
 import io.constellationnetwork.currency.l0.snapshot.synchronous.update.UnlockConsensusUpdate
 import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.{EventTrigger, TimeTrigger}
@@ -134,6 +135,21 @@ object CurrencySynchronousCommitteeSuite extends SimpleIOSuite {
         List(EventTrigger.some, none, TimeTrigger.some, EventTrigger.some)
       ) === EventTrigger
     )
+  }
+
+  test("a missing selected fee receipt fails before the consensus state can advance") {
+    val key = CurrencyFeeContextReceiptStorage.CurrencyFeeContextKey(SnapshotOrdinal.unsafeApply(42L), Hash("selected"))
+
+    for {
+      advanced <- Ref.of[IO, Boolean](false)
+      result <- CurrencySnapshotConsensusStateAdvancer
+        .requireFeeContextReceipt[IO](key, _ => none.pure[IO])
+        .flatMap(_ => advanced.set(true))
+        .attempt
+      didAdvance <- advanced.get
+    } yield
+      expect.same(Left(CurrencyFeeContextReceiptStorage.MissingCurrencyFeeContextReceipt(key)), result) &&
+        expect(!didAdvance)
   }
 
   private def lockedState(members: List[PeerId]): ConsensusState[Int, Option[Unit], Unit, Unit] =
@@ -360,7 +376,7 @@ object CurrencySynchronousCommitteeSuite extends SimpleIOSuite {
     )
   }
 
-  pureTest("a benign one-round peer lead preserves the installed immediate-successor attempt") {
+  pureTest("peer-ahead recovery preserves only current or still-authorized consensus generations") {
     val authority = Set(peer(1), peer(2), peer(3))
     val immediateSuccessor = Map(peer(2) -> 11.some, peer(3) -> 11.some)
     val beyondImmediateSuccessor = Map(peer(2) -> 12.some, peer(3) -> 12.some)
@@ -372,21 +388,31 @@ object CurrencySynchronousCommitteeSuite extends SimpleIOSuite {
       ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = true,
         currentGenerationFinished = false,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = false
       ),
       !ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = true,
         currentGenerationFinished = false,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = true
       ),
       !ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = false,
         currentGenerationFinished = false,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = false
       ),
       ConsensusManager.preservePeerAheadGeneration(
         hasCurrentGeneration = true,
         currentGenerationFinished = true,
+        currentOutcomeAuthorizesSelf = true,
+        authorityMajorityBeyondImmediateSuccessor = true
+      ),
+      !ConsensusManager.preservePeerAheadGeneration(
+        hasCurrentGeneration = true,
+        currentGenerationFinished = true,
+        currentOutcomeAuthorizesSelf = false,
         authorityMajorityBeyondImmediateSuccessor = true
       )
     )

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySynchronousHandoffSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/CurrencySynchronousHandoffSuite.scala
@@ -231,7 +231,8 @@ object CurrencySynchronousHandoffSuite extends SimpleIOSuite {
         client(responses),
         validateObservedOutcome,
         _.authority.contains(peerId(99)),
-        _.authority
+        _.authority,
+        _ => IO.unit
       )
     } yield Harness(storage, nodeStorage, manager)
 

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/programs/DownloadSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/programs/DownloadSuite.scala
@@ -1,14 +1,36 @@
 package io.constellationnetwork.currency.l0.snapshot.programs
 
-import cats.effect.IO
+import cats.effect.{IO, Ref}
 import cats.syntax.all._
 
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.node.NodeState
+import io.constellationnetwork.security.hash.Hash
 
 import weaver.SimpleIOSuite
 
 object DownloadSuite extends SimpleIOSuite {
+
+  private val stateOrdinal = SnapshotOrdinal.unsafeApply(17L)
+  private val expectedProof = Hash("expected")
+  private val recoveredState = "calculated-state-at-17"
+
+  private def record(ref: Ref[IO, Vector[String]], event: String): IO[Unit] = ref.update(_ :+ event)
+
+  private def calculatedStateHooks(
+    ref: Ref[IO, Vector[String]],
+    actualProof: Hash = expectedProof,
+    currentOrdinal: SnapshotOrdinal = SnapshotOrdinal.unsafeApply(16L),
+    currentState: String = "calculated-state-at-16"
+  ): Download.CalculatedStateHooks[IO, String] =
+    Download.CalculatedStateHooks[IO, String](
+      fetchExact = (ordinal, proof) => record(ref, s"fetch:${ordinal.value.value}:${proof.value}").as(recoveredState),
+      hash = state => record(ref, s"hash:$state").as(if (state === recoveredState) actualProof else Hash("current")),
+      persistAtomically = (ordinal, state) => record(ref, s"persist:${ordinal.value.value}:$state"),
+      readPersisted = ordinal => record(ref, s"read:${ordinal.value.value}").as(recoveredState.some),
+      getCurrent = record(ref, "current").as(currentOrdinal -> currentState),
+      setCurrent = (ordinal, state) => record(ref, s"set:${ordinal.value.value}:$state").as(true)
+    )
 
   test("downloads retain the release/mainnet four-snapshot observation window") {
     val current = SnapshotOrdinal.unsafeApply(10L)
@@ -19,6 +41,46 @@ object DownloadSuite extends SimpleIOSuite {
         Download.observationLimit(current, 4L)
       )
       .pure[IO]
+  }
+
+  test("a downloaded head catches up to the live peer tip before selecting a future observation") {
+    val downloadedHead = SnapshotOrdinal.unsafeApply(146L)
+    val peerTip = SnapshotOrdinal.unsafeApply(150L)
+
+    expect
+      .same(
+        Right(
+          Download.ObservationPlan(
+            catchUpThrough = SnapshotOrdinal.unsafeApply(150L),
+            observationLimit = SnapshotOrdinal.unsafeApply(154L)
+          )
+        ),
+        Download.observationPlan(downloadedHead, peerTip, 4L)
+      )
+      .pure[IO]
+  }
+
+  test("a selected peer tip behind the downloaded head it served fails closed") {
+    val downloadedHead = SnapshotOrdinal.unsafeApply(150L)
+    val peerTip = SnapshotOrdinal.unsafeApply(149L)
+
+    expect
+      .same(
+        Left(Download.PeerTipBehindDownloadedHead(downloadedHead, peerTip)),
+        Download.observationPlan(downloadedHead, peerTip, 4L)
+      )
+      .pure[IO]
+  }
+
+  test("recovery clears stale events before publishing consensus registration") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      _ <- Download.prepareObservationAdmission(
+        record(events, "clear"),
+        record(events, "register")
+      )
+      observed <- events.get
+    } yield expect.same(Vector("clear", "register"), observed)
   }
 
   test("successor retries are bounded and only active download states re-anchor") {
@@ -34,5 +96,189 @@ object DownloadSuite extends SimpleIOSuite {
         !Download.shouldReanchorAfterFailure(NodeState.Leaving)
       )
       .pure[IO]
+  }
+
+  test("exact calculated state is fetched, verified, and persisted in order") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      _ <- Download.restoreCalculatedStateSteps[IO, String](
+        stateOrdinal,
+        expectedProof.some,
+        calculatedStateHooks(events).some
+      )
+      observed <- events.get
+    } yield
+      expect.same(
+        Vector(
+          "current",
+          "hash:calculated-state-at-16",
+          "fetch:17:expected",
+          s"hash:$recoveredState",
+          s"persist:17:$recoveredState",
+          "read:17",
+          s"hash:$recoveredState",
+          s"set:17:$recoveredState"
+        ),
+        observed
+      )
+  }
+
+  test("a retry after atomic calculated-state persistence completes safely") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      persisted <- Ref.of[IO, Option[String]](none)
+      failOnce <- Ref.of[IO, Boolean](true)
+      current <- Ref.of[IO, (SnapshotOrdinal, String)](SnapshotOrdinal.unsafeApply(16L) -> "old")
+      hooks = Download.CalculatedStateHooks[IO, String](
+        fetchExact = (_, _) => recoveredState.pure[IO],
+        hash = state => (if (state === recoveredState) expectedProof else Hash("old")).pure[IO],
+        persistAtomically = (_, state) =>
+          persisted.set(state.some) >> failOnce.getAndSet(false).flatMap(IO.raiseWhen(_)(new RuntimeException("crash after persistence"))),
+        readPersisted = _ => persisted.get,
+        getCurrent = current.get,
+        setCurrent = (ordinal, state) => current.set(ordinal -> state).as(true)
+      )
+      first <- Download.restoreCalculatedStateSteps(stateOrdinal, expectedProof.some, hooks.some).attempt
+      _ <- Download.restoreCalculatedStateSteps(stateOrdinal, expectedProof.some, hooks.some)
+      installed <- current.get
+      stored <- persisted.get
+      observed <- events.get
+    } yield
+      expect(first.isLeft) &&
+        expect.same(stateOrdinal -> recoveredState, installed) &&
+        expect.same(recoveredState.some, stored) &&
+        expect(observed.isEmpty)
+  }
+
+  test("an exact-current retry after application state installation persists without another peer fetch") {
+    val crash = new RuntimeException("crash before canonical snapshot installation")
+
+    for {
+      current <- Ref.of[IO, (SnapshotOrdinal, String)](SnapshotOrdinal.unsafeApply(16L) -> "old")
+      fetchCount <- Ref.of[IO, Int](0)
+      persistCount <- Ref.of[IO, Int](0)
+      setCount <- Ref.of[IO, Int](0)
+      canonicalInstallCount <- Ref.of[IO, Int](0)
+      hooks = Download.CalculatedStateHooks[IO, String](
+        fetchExact = (_, _) => fetchCount.update(_ + 1).as(recoveredState),
+        hash = state => (if (state === recoveredState) expectedProof else Hash("old")).pure[IO],
+        persistAtomically = (_, _) => persistCount.update(_ + 1),
+        readPersisted = _ => recoveredState.some.pure[IO],
+        getCurrent = current.get,
+        setCurrent = (ordinal, state) => setCount.update(_ + 1) >> current.set(ordinal -> state).as(true)
+      )
+      first <- (Download.restoreCalculatedStateSteps(stateOrdinal, expectedProof.some, hooks.some) >> crash.raiseError[IO, Unit]).attempt
+      _ <- Download.restoreCalculatedStateSteps(stateOrdinal, expectedProof.some, hooks.some) >> canonicalInstallCount.update(_ + 1)
+      fetched <- fetchCount.get
+      persisted <- persistCount.get
+      count <- setCount.get
+      canonicalCount <- canonicalInstallCount.get
+    } yield
+      expect.same(Left(crash), first) &&
+        expect.same(1, fetched) &&
+        expect.same(2, persisted) &&
+        expect.same(1, count) &&
+        expect.same(1, canonicalCount)
+  }
+
+  test("same calculated-state ordinal with a different hash fails closed") {
+    val conflicting = "conflicting-state-at-17"
+
+    for {
+      fetchCount <- Ref.of[IO, Int](0)
+      persistCount <- Ref.of[IO, Int](0)
+      setCount <- Ref.of[IO, Int](0)
+      hooks = Download.CalculatedStateHooks[IO, String](
+        fetchExact = (_, _) => fetchCount.update(_ + 1).as(recoveredState),
+        hash = state => (if (state === recoveredState) expectedProof else Hash("conflicting")).pure[IO],
+        persistAtomically = (_, _) => persistCount.update(_ + 1),
+        readPersisted = _ => recoveredState.some.pure[IO],
+        getCurrent = (stateOrdinal -> conflicting).pure[IO],
+        setCurrent = (_, _) => setCount.update(_ + 1).as(true)
+      )
+      result <- Download.restoreCalculatedStateSteps(stateOrdinal, expectedProof.some, hooks.some).attempt
+      fetched <- fetchCount.get
+      persisted <- persistCount.get
+      set <- setCount.get
+    } yield
+      expect(
+        result == Left(
+          Download.CalculatedStateCurrentConflict(stateOrdinal, stateOrdinal, Hash("conflicting"), expectedProof)
+        )
+      ) && expect.same(0, fetched) && expect.same(0, persisted) && expect.same(0, set)
+  }
+
+  test("application state ahead of the recovery target fails closed") {
+    val aheadOrdinal = SnapshotOrdinal.unsafeApply(18L)
+
+    for {
+      fetchCount <- Ref.of[IO, Int](0)
+      persistCount <- Ref.of[IO, Int](0)
+      setCount <- Ref.of[IO, Int](0)
+      hooks = Download.CalculatedStateHooks[IO, String](
+        fetchExact = (_, _) => fetchCount.update(_ + 1).as(recoveredState),
+        hash = state => (if (state === recoveredState) expectedProof else Hash("ahead")).pure[IO],
+        persistAtomically = (_, _) => persistCount.update(_ + 1),
+        readPersisted = _ => recoveredState.some.pure[IO],
+        getCurrent = (aheadOrdinal -> "ahead-state").pure[IO],
+        setCurrent = (_, _) => setCount.update(_ + 1).as(true)
+      )
+      result <- Download.restoreCalculatedStateSteps(stateOrdinal, expectedProof.some, hooks.some).attempt
+      fetched <- fetchCount.get
+      persisted <- persistCount.get
+      set <- setCount.get
+    } yield
+      expect(
+        result == Left(
+          Download.CalculatedStateCurrentConflict(stateOrdinal, aheadOrdinal, Hash("ahead"), expectedProof)
+        )
+      ) && expect.same(0, fetched) && expect.same(0, persisted) && expect.same(0, set)
+  }
+
+  test("a calculated-state proof mismatch fails closed before persistence") {
+    val wrongProof = Hash("wrong")
+
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      result <- Download
+        .restoreCalculatedStateSteps[IO, String](
+          stateOrdinal,
+          expectedProof.some,
+          calculatedStateHooks(events, wrongProof).some
+        )
+        .attempt
+      observed <- events.get
+    } yield
+      expect
+        .same(
+          Vector("current", "hash:calculated-state-at-16", "fetch:17:expected", s"hash:$recoveredState"),
+          observed
+        )
+        .and(expect(result == Left(Download.CalculatedStateProofMismatch(stateOrdinal, wrongProof, expectedProof))))
+  }
+
+  test("calculated-state configuration mismatch fails closed without calling hooks") {
+    for {
+      events <- Ref.of[IO, Vector[String]](Vector.empty)
+      result <- Download
+        .restoreCalculatedStateSteps[IO, String](
+          stateOrdinal,
+          expectedProof.some,
+          none
+        )
+        .attempt
+      observed <- events.get
+    } yield
+      expect(observed.isEmpty)
+        .and(
+          expect(
+            result == Left(
+              Download.CalculatedStateConfigurationMismatch(
+                hasArtifactState = true,
+                hasLocalApplication = false
+              )
+            )
+          )
+        )
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotServiceSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/services/StateChannelSnapshotServiceSuite.scala
@@ -3,9 +3,35 @@ package io.constellationnetwork.currency.l0.snapshot.services
 import cats.effect.{IO, Ref}
 import cats.syntax.all._
 
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage.{
+  CurrencyFeeContextKey,
+  CurrencyFeeContextReceipt
+}
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.security.hash.Hash
+
+import eu.timepit.refined.types.numeric.NonNegLong
 import weaver.SimpleIOSuite
 
 object StateChannelSnapshotServiceSuite extends SimpleIOSuite {
+
+  private val key = CurrencyFeeContextKey(SnapshotOrdinal.unsafeApply(12L), Hash("artifact"))
+  private val view = GlobalSyncView(SnapshotOrdinal.unsafeApply(90L), Hash("global"), EpochProgress.MinValue)
+  private val stakingAddress = Address.fromBytes("staking".getBytes("UTF-8"))
+  private val balance = Balance(NonNegLong.unsafeFrom(50L))
+  private val receipt = CurrencyFeeContextReceipt(
+    CurrencyFeeContextReceiptStorage.CurrentEncodingVersion,
+    key.currencyOrdinal,
+    key.currencyArtifactHash,
+    view,
+    stakingAddress.some,
+    balance
+  )
 
   test("a rejected snapshot does not run data-application or binary-enqueue effects") {
     for {
@@ -75,5 +101,59 @@ object StateChannelSnapshotServiceSuite extends SimpleIOSuite {
       )
       observed <- order.get
     } yield expect.same(Vector("ordinary"), observed)
+  }
+
+  test("the selected fee receipt is released only after the durable outbox commit") {
+    for {
+      order <- Ref.of[IO, Vector[String]](Vector.empty)
+      _ <- StateChannelSnapshotService.commitPreparedPublicationsAndReleaseFeeContext(
+        recoveryRequired = false,
+        ensureRecoveryArtifactDurable = order.update(_ :+ "unexpected-durable"),
+        markRecoveryLocallyCommitted = order.update(_ :+ "unexpected-recovery"),
+        markOrdinaryLocallyCommitted = order.update(_ :+ "ordinary"),
+        releaseFeeContext = order.update(_ :+ "release")
+      )
+      observed <- order.get
+    } yield expect.same(Vector("ordinary", "release"), observed)
+  }
+
+  test("a failed outbox commit retains the selected fee receipt") {
+    val failure = new RuntimeException("outbox commit failed")
+
+    for {
+      order <- Ref.of[IO, Vector[String]](Vector.empty)
+      result <- StateChannelSnapshotService
+        .commitPreparedPublicationsAndReleaseFeeContext(
+          recoveryRequired = false,
+          ensureRecoveryArtifactDurable = IO.unit,
+          markRecoveryLocallyCommitted = IO.unit,
+          markOrdinaryLocallyCommitted = order.update(_ :+ "ordinary") >> failure.raiseError[IO, Unit],
+          releaseFeeContext = order.update(_ :+ "release")
+        )
+        .attempt
+      observed <- order.get
+    } yield expect.same(Left(failure), result) && expect.same(Vector("ordinary"), observed)
+  }
+
+  test("binary fee input loads only from the exact selected receipt") {
+    StateChannelSnapshotService
+      .loadFeeContextBalance(key, view, stakingAddress.some, _ => receipt.some.pure[IO])
+      .map(observed => expect.same(balance, observed))
+  }
+
+  test("a missing fee-context receipt fails before binary signing") {
+    StateChannelSnapshotService
+      .loadFeeContextBalance[IO](key, view, stakingAddress.some, _ => none.pure[IO])
+      .attempt
+      .map(result => expect(result.swap.exists(_.isInstanceOf[CurrencyFeeContextReceiptStorage.MissingCurrencyFeeContextReceipt])))
+  }
+
+  test("a mismatched fee-context receipt fails before binary signing") {
+    val differentView = view.copy(hash = Hash("different-global"))
+
+    StateChannelSnapshotService
+      .loadFeeContextBalance[IO](key, differentView, stakingAddress.some, _ => receipt.some.pure[IO])
+      .attempt
+      .map(result => expect(result.swap.exists(_.isInstanceOf[StateChannelSnapshotService.CurrencyFeeContextReceiptMismatch])))
   }
 }

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/storage/CurrencyFeeContextReceiptStorageSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/storage/CurrencyFeeContextReceiptStorageSuite.scala
@@ -1,0 +1,118 @@
+package io.constellationnetwork.currency.l0.snapshot.storage
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.l0.snapshot.storage.CurrencyFeeContextReceiptStorage.CurrencyFeeContextReceipt
+import io.constellationnetwork.currency.schema.globalSnapshotSync.GlobalSyncView
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.security.hash.Hash
+
+import eu.timepit.refined.types.numeric.NonNegLong
+import fs2.io.file.Files
+import weaver.SimpleIOSuite
+
+object CurrencyFeeContextReceiptStorageSuite extends SimpleIOSuite {
+
+  private val stakingAddress = Address.fromBytes("fee-receipt-staking".getBytes("UTF-8"))
+
+  private def receipt(currencyOrdinal: Long, proposal: Int): CurrencyFeeContextReceipt =
+    CurrencyFeeContextReceipt(
+      CurrencyFeeContextReceiptStorage.CurrentEncodingVersion,
+      SnapshotOrdinal.unsafeApply(currencyOrdinal),
+      Hash(s"artifact-$proposal"),
+      GlobalSyncView(
+        SnapshotOrdinal.unsafeApply(1000L + proposal),
+        Hash(s"global-$proposal"),
+        EpochProgress.MinValue
+      ),
+      stakingAddress.some,
+      Balance(NonNegLong.unsafeFrom(proposal.toLong))
+    )
+
+  test("twelve facilitator proposal receipts survive restart and the oldest can be selected") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        storage <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        proposals = (1 to 12).toList.map(receipt(50L, _))
+        _ <- proposals.traverse_(storage.putDurably)
+        restarted <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        beforeSelection <- restarted.list
+        selected <- restarted.retainSelected(proposals.head.key)
+        afterSelection <- restarted.list
+      } yield
+        expect.all(
+          beforeSelection.toSet === proposals.toSet,
+          selected === proposals.head,
+          afterSelection === List(proposals.head)
+        )
+    }
+  }
+
+  test("a durable receipt remains available after restart before binary construction") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        storage <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        expected = receipt(60L, 1)
+        _ <- storage.putDurably(expected)
+        restarted <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        restored <- restarted.get(expected.key)
+      } yield expect.same(expected.some, restored)
+    }
+  }
+
+  test("receipts are released only after selection, durable completion, or abandonment") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        storage <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        selected = receipt(70L, 1)
+        rejected = receipt(70L, 2)
+        abandoned = receipt(71L, 3)
+        _ <- List(selected, rejected, abandoned).traverse_(storage.putDurably)
+        beforeSelection <- storage.list
+        _ <- storage.retainSelected(selected.key)
+        afterSelection <- storage.list
+        _ <- storage.complete(selected.key)
+        afterCompletion <- storage.list
+        _ <- storage.abandonGeneration(abandoned.currencyOrdinal)
+        afterAbandonment <- storage.list
+      } yield
+        expect.all(
+          beforeSelection.toSet === Set(selected, rejected, abandoned),
+          afterSelection.toSet === Set(selected, abandoned),
+          afterCompletion === List(abandoned),
+          afterAbandonment.isEmpty
+        )
+    }
+  }
+
+  test("startup sweep preserves pending publication receipts and active generations") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        storage <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        completed = receipt(80L, 1)
+        protectedPublication = receipt(81L, 2)
+        activeGeneration = receipt(82L, 3)
+        _ <- List(completed, protectedPublication, activeGeneration).traverse_(storage.putDurably)
+        removed <- storage.sweepCompleted(
+          SnapshotOrdinal.unsafeApply(81L),
+          Set(protectedPublication.key)
+        )
+        restarted <- CurrencyFeeContextReceiptStorage.make[IO](directory)
+        remaining <- restarted.list
+      } yield
+        expect.all(
+          removed === List(completed.key),
+          remaining.toSet === Set(protectedPublication, activeGeneration)
+        )
+    }
+  }
+}

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorageSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/snapshot/storage/StateChannelBinaryOutboxStorageSuite.scala
@@ -279,6 +279,31 @@ object StateChannelBinaryOutboxStorageSuite extends SimpleIOSuite {
     }
   }
 
+  test("a downloaded validator waits for a missing canonical bridge instead of reporting a false conflict") {
+    Files[IO].tempDirectory.use { directory =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+        canonicalHash = Hash("canonical-binary-60")
+        missingBridgeHash = Hash("canonical-binary-61")
+        storage <- StateChannelBinaryOutboxStorage.make[IO](directory)
+        successor <- binaryWithParent(62L, missingBridgeHash)
+        _ <- storage.prepare(successor, artifact(62L, "artifact-62"))
+        _ <- storage.markLocallyCommitted(successor.hash)
+        confirmedBeforeBridge <- storage.confirmCanonicalTip(SnapshotOrdinal.unsafeApply(60L), canonicalHash)
+        pendingBeforeBridge <- storage.getCommitted(Set.empty, 100)
+        confirmedAfterBridge <- storage.confirmCanonicalTip(SnapshotOrdinal.unsafeApply(61L), missingBridgeHash)
+        pendingAfterBridge <- storage.getCommitted(Set.empty, 100)
+      } yield
+        expect.all(
+          confirmedBeforeBridge.isEmpty,
+          pendingBeforeBridge.map(_.binaryHash) === List(successor.hash),
+          confirmedAfterBridge.isEmpty,
+          pendingAfterBridge.map(_.binaryHash) === List(successor.hash)
+        )
+    }
+  }
+
   test("outbox backpressures before count or serialized-byte bounds can grow without limit") {
     Files[IO].tempDirectory.use { directory =>
       for {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/Joining.scala
@@ -3,6 +3,7 @@ package io.constellationnetwork.node.shared.domain.cluster.programs
 import cats.data.{EitherT, NonEmptySet}
 import cats.effect.Async
 import cats.effect.std.{Random, Supervisor}
+import cats.effect.syntax.all._
 import cats.syntax.applicative._
 import cats.syntax.applicativeError._
 import cats.syntax.apply._
@@ -16,6 +17,7 @@ import cats.syntax.parallel._
 import cats.syntax.show._
 import cats.{Applicative, MonadThrow, Parallel}
 
+import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.domain.allowance_list.AllowanceListEntry
@@ -88,7 +90,8 @@ class Joining[
             nodeStorage
               .tryModifyState(SessionStarted, stateAfterJoining)
               .whenA(peers.nonEmpty)
-          }
+          } >>
+          reconcileConcurrentJoin(toPeer)
       }.start
 
   def rejoin(withPeer: PeerToJoin): F[Unit] =
@@ -166,11 +169,32 @@ class Joining[
       .semiflatMap(discoverFrom)
       .map(_.map(toP2PContext))
 
-  private def joinAll(peerToJoin: P2PContext): F[Unit] = {
+  /** Initial joiners can contact the same entry peer at nearly the same time. Their first discovery responses are then valid but incomplete
+    * snapshots of the changing cluster, leaving peer pairs permanently unknown because ordinary discovery only runs during join. Re-query
+    * the authenticated entry peer on a short bounded backoff and connect every newly discovered peer. Each handshake remains fully
+    * validated, and an empty discovery response is a no-op.
+    */
+  private def reconcileConcurrentJoin(entryPeer: P2PContext): F[Unit] =
+    List(1.second, 2.seconds, 4.seconds).traverse_ { delay =>
+      Async[F].sleep(delay) >>
+        clusterStorage
+          .getPeer(entryPeer.id)
+          .flatMap {
+            case None => Applicative[F].unit
+            case Some(peer) =>
+              discoverFrom(peer).flatMap(discovered => joinAll(discovered.toList.map(toP2PContext).toSet))
+          }
+          .handleErrorWith(error => logger.warn(error)(s"Concurrent join reconciliation failed through ${entryPeer.id.show}"))
+    }
+
+  private def joinAll(peerToJoin: P2PContext): F[Unit] =
+    joinAll(Set(peerToJoin))
+
+  private def joinAll(initialPeers: Set[P2PContext]): F[Unit] = {
     type Agg = (Set[P2PContext], Set[P2PContext])
     type Res = Unit
 
-    (Set(peerToJoin), Set.empty[P2PContext]).tailRecM {
+    (initialPeers, Set.empty[P2PContext]).tailRecM {
       case (toJoin, _) if toJoin.isEmpty => ().asRight[Agg].pure
       case (toJoin, attempted) =>
         for {
@@ -181,6 +205,7 @@ class Joining[
                 .as(Set.empty[P2PContext])
             }
           }
+            .guarantee(peerDiscovery.markAttemptsFinished(toJoin.toList.map(_.id).toSet))
           reduced = discovered.combineAll
           updatedAttempted = attempted ++ toJoin
           updatedToJoin = reduced.diff(updatedAttempted)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscovery.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscovery.scala
@@ -41,6 +41,9 @@ sealed abstract class PeerDiscovery[F[_]: Async] private (
 
   def getPeers: F[Set[Peer]] = cache.get
 
+  def markAttemptsFinished(peerIds: Set[PeerId]): F[Unit] =
+    cache.update(_.filterNot(peer => peerIds.contains(peer.id)))
+
   def discoverFrom(peer: Peer): F[Set[Peer]] =
     for {
       peersQueue <- cache.updateAndGet(_ - peer)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/clients/SnapshotClient.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/p2p/clients/SnapshotClient.scala
@@ -54,6 +54,21 @@ abstract class SnapshotClient[
       decodeCombinedBody(body)
     }
 
+  /** Fetch the peer's current consensus head and its exact state context.
+    *
+    * [[getLatest]] intentionally reads the latest durable periodic checkpoint. That is useful for ordinary historical traversal, but a
+    * Currency validator joining after a long outage cannot always reconstruct every successor: deterministic Currency history may depend on
+    * Global snapshots that have already left the peer's bounded rolling window. The live head already carries the state proof that commits
+    * to this context, and Currency's private hand-off subsequently requires the artifact and context to match a corroborated consensus
+    * outcome before installation.
+    *
+    * This endpoint is peer-authenticated and decoded with the same bounded-memory spool-to-disk path as the checkpoint stream.
+    */
+  def getLatestHead: PeerResponse[F, (Signed[S], SI)] =
+    PeerResponse.stream[F, (Signed[S], SI)](uri => uri.addPath(s"$urlPrefix/latest/combined"))(client, optionalSession) { body =>
+      decodeCombinedBody(body)
+    }
+
   /** Conditional variant of [[getLatest]]. The client sends `If-None-Match: "<localOrdinal>-<localHash>"`; the server returns 304
     * NotModified (no body) when its tip matches the immutable identity `(ordinal, snapshotHash)` and 200 with a fresh combined-snapshot
     * stream otherwise.

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/http/routes/SnapshotRoutes.scala
@@ -1,5 +1,6 @@
 package io.constellationnetwork.node.shared.http.routes
 
+import cats.data.NonEmptySet
 import cats.effect._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
@@ -28,6 +29,7 @@ import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, Snapshot
 import io.constellationnetwork.schema.{GlobalSnapshot, SnapshotOrdinal}
 import io.constellationnetwork.security.HasherSelector
 import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.PosInt
@@ -654,52 +656,64 @@ trait CachedCombinedResponse[F[_], S <: Snapshot, SI <: SnapshotInfo[_]] {
 }
 
 object CachedCombinedResponse {
+  private type CacheIdentity = (SnapshotOrdinal, NonEmptySet[SignatureProof])
+
   private val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
   def make[F[_]: Async, S <: Snapshot: Encoder, SI <: SnapshotInfo[_]: Encoder]: F[CachedCombinedResponse[F, S, SI]] =
-    Ref[F].of(Option.empty[(SnapshotOrdinal, Deferred[F, Either[Throwable, Array[Byte]]])]).map { ref =>
-      new CachedCombinedResponse[F, S, SI] {
-        private def serialize(snapshot: Signed[S], state: SI): F[Array[Byte]] =
-          Async[F].blocking {
-            val baos = new java.io.ByteArrayOutputStream()
-            val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
+    Ref[F]
+      .of(Option.empty[(CacheIdentity, Deferred[F, Either[Throwable, Array[Byte]]])])
+      .map { ref =>
+        new CachedCombinedResponse[F, S, SI] {
+          private def serialize(snapshot: Signed[S], state: SI): F[Array[Byte]] =
+            Async[F].blocking {
+              val baos = new java.io.ByteArrayOutputStream()
+              val writer = new java.io.OutputStreamWriter(baos, "UTF-8")
 
-            writer.append('[')
-            Encoder[Signed[S]] match {
-              case sce: StreamingCollectionEncoder[Signed[S]] =>
-                sce.streamEncode(snapshot, printer, writer)
-              case enc =>
-                printer.unsafePrintToAppendable(enc(snapshot), writer)
-            }
-            writer.append(',')
-            Encoder[SI] match {
-              case sce: StreamingCollectionEncoder[SI] =>
-                sce.streamEncode(state, printer, writer)
-              case enc =>
-                printer.unsafePrintToAppendable(enc(state), writer)
-            }
-            writer.append(']')
-            writer.flush()
-            baos.toByteArray
-          }
-
-        def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
-          ref.get.flatMap {
-            case Some((ord, existing)) if ord === currentOrdinal =>
-              existing.get.flatMap(Async[F].fromEither)
-            case _ =>
-              Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
-                ref.modify {
-                  case Some((ord, existing)) if ord === currentOrdinal =>
-                    (Some((ord, existing)), existing.get.flatMap(Async[F].fromEither))
-                  case _ =>
-                    (
-                      Some((currentOrdinal, newDef)),
-                      serialize(snapshot, state).attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither)
-                    )
-                }.flatten
+              writer.append('[')
+              Encoder[Signed[S]] match {
+                case sce: StreamingCollectionEncoder[Signed[S]] =>
+                  sce.streamEncode(snapshot, printer, writer)
+                case enc =>
+                  printer.unsafePrintToAppendable(enc(snapshot), writer)
               }
-          }
+              writer.append(',')
+              Encoder[SI] match {
+                case sce: StreamingCollectionEncoder[SI] =>
+                  sce.streamEncode(state, printer, writer)
+                case enc =>
+                  printer.unsafePrintToAppendable(enc(state), writer)
+              }
+              writer.append(']')
+              writer.flush()
+              baos.toByteArray
+            }
+
+          def get(currentOrdinal: SnapshotOrdinal, snapshot: Signed[S], state: SI): F[Array[Byte]] =
+            // Ordinal alone is not an exact cache identity. Recovery can replace a
+            // same-ordinal canonical artifact with a different signed envelope. The
+            // proof set is bound to the artifact value and distinguishes that replacement,
+            // preventing this live endpoint from serving bytes cached before rollback.
+            // The state is committed by the artifact's state proof.
+            {
+              val currentIdentity = currentOrdinal -> snapshot.proofs
+              ref.get.flatMap {
+                case Some((identity, existing)) if identity === currentIdentity =>
+                  existing.get.flatMap(Async[F].fromEither)
+                case _ =>
+                  Deferred[F, Either[Throwable, Array[Byte]]].flatMap { newDef =>
+                    ref.modify {
+                      case Some((identity, existing)) if identity === currentIdentity =>
+                        (Some((identity, existing)), existing.get.flatMap(Async[F].fromEither))
+                      case _ =>
+                        (
+                          Some((currentIdentity, newDef)),
+                          serialize(snapshot, state).attempt.flatTap(newDef.complete).flatMap(Async[F].fromEither)
+                        )
+                    }.flatten
+                  }
+              }
+            }
+        }
       }
-    }
 }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscoverySuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/domain/cluster/programs/PeerDiscoverySuite.scala
@@ -131,4 +131,44 @@ object PeerDiscoverySuite extends SimpleIOSuite with Checkers {
     }
   }
 
+  test("a peer is discoverable again after its join attempt finishes") {
+    forall { (discoverFromPeer: Peer, candidate: Peer) =>
+      val returnedPeers = Set(candidate)
+
+      for {
+        peerDiscovery <- mkPeerDiscovery(Set.empty, returnedPeers)
+        first <- peerDiscovery.discoverFrom(discoverFromPeer)
+        suppressedWhileQueued <- peerDiscovery.discoverFrom(discoverFromPeer)
+        _ <- peerDiscovery.markAttemptsFinished(Set(candidate.id))
+        rediscovered <- peerDiscovery.discoverFrom(discoverFromPeer)
+      } yield
+        expect.same(first, returnedPeers) &&
+          expect(suppressedWhileQueued.isEmpty) &&
+          expect.same(rediscovered, returnedPeers)
+    }
+  }
+
+  test("batch completion clears peers re-added by an in-flight discovery") {
+    val candidateA = peerGen.sample.get.copy(id = PeerId(Hex("11" * 64)))
+    val candidateB = peerGen.sample.get.copy(id = PeerId(Hex("22" * 64)))
+    val entryPeer = peerGen.sample.get.copy(id = PeerId(Hex("33" * 64)))
+    val concurrentPeer = peerGen.sample.get.copy(id = PeerId(Hex("44" * 64)))
+    val returnedPeers = Set(candidateA, candidateB)
+    val attemptedIds = returnedPeers.map(_.id)
+
+    for {
+      peerDiscovery <- mkPeerDiscovery(Set.empty, returnedPeers)
+      initial <- peerDiscovery.discoverFrom(entryPeer)
+      _ <- peerDiscovery.markAttemptsFinished(Set(candidateA.id))
+      readded <- peerDiscovery.discoverFrom(concurrentPeer)
+      _ <- peerDiscovery.markAttemptsFinished(attemptedIds)
+      cachedAfterBatch <- peerDiscovery.getPeers
+      rediscovered <- peerDiscovery.discoverFrom(entryPeer)
+    } yield
+      expect.same(initial, returnedPeers) &&
+        expect.same(readded, Set(candidateA)) &&
+        expect(cachedAfterBatch.isEmpty) &&
+        expect.same(rediscovered, returnedPeers)
+  }
+
 }

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/http/routes/CachedCombinedResponseSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/http/routes/CachedCombinedResponseSuite.scala
@@ -1,0 +1,73 @@
+package io.constellationnetwork.node.shared.http.routes
+
+import cats.data.NonEmptySet
+import cats.effect.IO
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.snapshot.{Snapshot, SnapshotInfo, StateProof}
+import io.constellationnetwork.schema.transaction.TransactionReference
+import io.constellationnetwork.schema.{BlockAsActiveTip, SnapshotOrdinal, SnapshotTips}
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import io.circe.Encoder
+import weaver.SimpleIOSuite
+
+object CachedCombinedResponseSuite extends SimpleIOSuite {
+
+  private final case class TestSnapshot(
+    ordinal: SnapshotOrdinal,
+    lastSnapshotHash: Hash,
+    height: Height = Height.MinValue,
+    subHeight: SubHeight = SubHeight.MinValue,
+    blocks: SortedSet[BlockAsActiveTip] = SortedSet.empty,
+    tips: SnapshotTips = SnapshotTips(SortedSet.empty, SortedSet.empty),
+    epochProgress: EpochProgress = EpochProgress.MinValue
+  ) extends Snapshot
+
+  private final case class TestState(
+    lastTxRefs: SortedMap[Address, TransactionReference],
+    balances: SortedMap[Address, Balance],
+    marker: String
+  ) extends SnapshotInfo[StateProof]
+
+  private implicit val testSnapshotEncoder: Encoder[TestSnapshot] =
+    Encoder.forProduct2("ordinal", "lastSnapshotHash")(snapshot => snapshot.ordinal.value.value -> snapshot.lastSnapshotHash.value)
+
+  private implicit val testStateEncoder: Encoder[TestState] =
+    Encoder.forProduct1("marker")(_.marker)
+
+  private def signed(value: TestSnapshot, signature: String): Signed[TestSnapshot] =
+    Signed(
+      value,
+      NonEmptySet.one(SignatureProof(Id(Hex("signer")), Signature(Hex(signature))))
+    )
+
+  test("same-ordinal canonical proof replacement invalidates the live combined response cache") {
+    val ordinal = SnapshotOrdinal.unsafeApply(17L)
+    val value = TestSnapshot(ordinal, Hash("parent"))
+    val first = signed(value, "first-proof")
+    val replacement = signed(value, "replacement-proof")
+    val firstState = TestState(SortedMap.empty, SortedMap.empty, "first-state")
+    val replacementState = TestState(SortedMap.empty, SortedMap.empty, "replacement-state")
+
+    for {
+      cache <- CachedCombinedResponse.make[IO, TestSnapshot, TestState]
+      firstBytes <- cache.get(ordinal, first, firstState)
+      replacementBytes <- cache.get(ordinal, replacement, replacementState)
+      firstJson = new String(firstBytes, java.nio.charset.StandardCharsets.UTF_8)
+      replacementJson = new String(replacementBytes, java.nio.charset.StandardCharsets.UTF_8)
+    } yield
+      expect(firstJson.contains("first-state")) &&
+        expect(replacementJson.contains("replacement-state")) &&
+        expect(firstJson != replacementJson)
+  }
+}

--- a/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/storage/CalculatedStateLocalFileSystemStorage.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/currency/dataApplication/storage/CalculatedStateLocalFileSystemStorage.scala
@@ -1,5 +1,9 @@
 package io.constellationnetwork.currency.dataApplication.storage
 
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.{Files => JFiles, _}
+
 import cats.effect.kernel.Async
 import cats.syntax.all._
 
@@ -23,6 +27,9 @@ final class CalculatedStateLocalFileSystemStorage[F[_]: Async] private (
   def write[A](ordinal: SnapshotOrdinal, state: A)(implicit encoder: A => F[Array[Byte]]): F[Unit] =
     encoder(state).flatMap(write(toOrdinalName(ordinal), _))
 
+  def writeAtomically[A](ordinal: SnapshotOrdinal, state: A)(implicit encoder: A => F[Array[Byte]]): F[Unit] =
+    encoder(state).flatMap(writeAtomicBytes(toOrdinalName(ordinal), _))
+
   def delete[A](ordinal: SnapshotOrdinal): F[Unit] =
     delete(toOrdinalName(ordinal))
 
@@ -45,11 +52,65 @@ final class CalculatedStateLocalFileSystemStorage[F[_]: Async] private (
     }
 
   private def toOrdinalName(ordinal: SnapshotOrdinal): String = ordinal.value.value.toString
+
+  private def writeAtomicBytes(fileName: String, bytes: Array[Byte]): F[Unit] = {
+    val directory = path.toNioPath
+    val target = directory.resolve(fileName)
+
+    Async[F].bracketCase(Async[F].blocking(JFiles.createTempFile(directory, s".atomic-$fileName.", ".tmp"))) { temp =>
+      Async[F].blocking {
+        val channel = FileChannel.open(temp, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
+        try {
+          val buffer = ByteBuffer.wrap(bytes)
+          while (buffer.hasRemaining) channel.write(buffer)
+          channel.force(true)
+        } finally channel.close()
+
+        try
+          JFiles.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        catch {
+          case error: AtomicMoveNotSupportedException =>
+            throw new IllegalStateException("atomic move is required for calculated-state recovery", error)
+        }
+
+        try {
+          val directoryChannel = FileChannel.open(directory, StandardOpenOption.READ)
+          try directoryChannel.force(true)
+          finally directoryChannel.close()
+        } catch {
+          case _: UnsupportedOperationException                                                      => ()
+          case _: AccessDeniedException if System.getProperty("os.name").toLowerCase.contains("win") => ()
+        }
+      }
+    } {
+      case (_, cats.effect.kernel.Outcome.Succeeded(_)) => Async[F].unit
+      case (temp, _)                                    => Async[F].blocking(JFiles.deleteIfExists(temp)).void.handleError(_ => ())
+    }
+  }
 }
 
 object CalculatedStateLocalFileSystemStorage {
+  private val AbandonedAtomicTempFile = raw"\.atomic-\d+\..+\.tmp".r
+
+  private[storage] def cleanupAbandonedAtomicTemps[F[_]: Async](path: Path): F[Unit] =
+    Async[F].blocking {
+      val directory = JFiles.newDirectoryStream(path.toNioPath)
+
+      try {
+        val iterator = directory.iterator()
+
+        while (iterator.hasNext) {
+          val candidate = iterator.next()
+          val isGeneratedAtomicTemp = AbandonedAtomicTempFile.matches(candidate.getFileName.toString)
+
+          if (isGeneratedAtomicTemp && JFiles.isRegularFile(candidate, LinkOption.NOFOLLOW_LINKS))
+            JFiles.deleteIfExists(candidate)
+        }
+      } finally directory.close()
+    }.void
+
   def make[F[_]: Async](path: Path): F[CalculatedStateLocalFileSystemStorage[F]] =
     new CalculatedStateLocalFileSystemStorage[F](path).pure[F].flatTap { storage =>
-      storage.createDirectoryIfNotExists().rethrowT
+      storage.createDirectoryIfNotExists().rethrowT >> cleanupAbandonedAtomicTemps(path)
     }
 }

--- a/modules/shared/src/test/scala/io/constellationnetwork/currency/dataApplication/storage/CalculatedStateLocalFileSystemStorageSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/currency/dataApplication/storage/CalculatedStateLocalFileSystemStorageSuite.scala
@@ -1,0 +1,49 @@
+package io.constellationnetwork.currency.dataApplication.storage
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import fs2.Stream
+import fs2.io.file.Files
+import weaver.SimpleIOSuite
+
+object CalculatedStateLocalFileSystemStorageSuite extends SimpleIOSuite {
+
+  test("atomic calculated-state writes replace one exact ordinal without leaving temporary files") {
+    Files[IO].tempDirectory.use { directory =>
+      val ordinal = SnapshotOrdinal.unsafeApply(42L)
+      implicit val encode: String => IO[Array[Byte]] = value => value.getBytes(UTF_8).pure[IO]
+      implicit val decode: Array[Byte] => IO[String] = bytes => new String(bytes, UTF_8).pure[IO]
+
+      for {
+        storage <- CalculatedStateLocalFileSystemStorage.make[IO](directory)
+        _ <- storage.writeAtomically(ordinal, "first")
+        _ <- storage.writeAtomically(ordinal, "second")
+        restored <- storage.read[String](ordinal)
+        files <- Files[IO].list(directory).map(_.fileName.toString).compile.toList
+      } yield expect.same("second".some, restored) && expect.same(List("42"), files)
+    }
+  }
+
+  test("startup removes abandoned atomic-write files without touching unrelated files") {
+    Files[IO].tempDirectory.use { directory =>
+      val abandoned = directory / ".atomic-42.interrupted.tmp"
+      val unrelated = directory / "unrelated.tmp"
+      val malformed = directory / ".atomic-not-an-ordinal.interrupted.tmp"
+
+      for {
+        _ <- Stream.emits(Array[Byte](1)).through(Files[IO].writeAll(abandoned)).compile.drain
+        _ <- Stream.emits(Array[Byte](2)).through(Files[IO].writeAll(unrelated)).compile.drain
+        _ <- Stream.emits(Array[Byte](3)).through(Files[IO].writeAll(malformed)).compile.drain
+        _ <- CalculatedStateLocalFileSystemStorage.make[IO](directory)
+        abandonedExists <- Files[IO].exists(abandoned)
+        unrelatedExists <- Files[IO].exists(unrelated)
+        malformedExists <- Files[IO].exists(malformed)
+      } yield expect.all(!abandonedExists, unrelatedExists, malformedExists)
+    }
+  }
+}


### PR DESCRIPTION
PR 1566 was merged into `develop` and its source branch was deleted. GitHub automatically closed the earlier PR 1584 because it targeted that deleted branch. This replacement contains the same validated recovery changes on current `develop`.

The merged PR 1566 commit `ee1c7e08173bd63cd7c2f9e7b66699ef734374e1` has the same source tree as the previous PR 1566 head `490011e1b648396378b275f08ae3f4deafc6818f`. No behavioral adaptation was needed when the recovery changes were moved to `develop`. The branch was later updated in response to review to replace the four-entry full Global-context cache with durable fee-context receipts and to make calculated-state recovery safely retryable after a crash.

## Why this is needed

I found this while testing a five-validator Currency L0 metagraph. The original failure was reproduced with the unmodified Tessellation v4.1.0-rc.12 code in an isolated devnet.

The validators could appear healthy and reach `Ready`, but that did not mean they had joined one stable Currency L0 group. In the concurrent control, all five validators exchanged peer declarations and observed the same Currency snapshot at ordinal 6. One validator was then admitted with the seed, while the other three entered `WaitingForDownload`. They downloaded the certified snapshot at ordinal 10 and repeatedly failed with:

`Failed to prepend currency snapshot ordinal=SnapshotOrdinal(10) to storage`

Starting the validators one at a time did not avoid the problem. In that control, the third validator reached `Ready`, but its local Currency snapshot remained at ordinal 10 while the active pair advanced beyond ordinal 100.

No Data L1, Currency L1, or metagraph transaction had started in either control. This ruled out the metagraph application, its data update, and the historical three-Data-L1 startup procedure. The failure occurred first in Tessellation's Currency L0 admission and recovery code.

## What remained after PR 1566

PR 1566 substantially changed Currency L0 consensus and replaced several rc.12 committee behaviors. I did not copy the old rc.12 patch onto it. I first audited the new design and ran 170 focused stock tests.

Those tests passed, but they did not cover the recovery failures below:

1. A validator can have a downloaded Currency snapshot newer than its combined checkpoint. Advertising only the checkpoint makes the validator look behind even when its snapshot storage is current.
2. Recovery needs calculated state for the exact downloaded snapshot ordinal. The existing route exposes moving latest state, which may belong to a newer snapshot by the time the recovering validator asks for it.
3. Equal local ordinals with different hashes must be treated as a conflict. Picking one without proving which is correct can advertise unsafe state.
4. Currency L0 registered for consensus events and then cleared its old event mempool. Events accepted immediately after registration could therefore be acknowledged and then deleted before the validator processed them.
5. A temporary gap in canonical state-channel data could be treated as a permanent conflict instead of allowing recovery to wait and retry.
6. Join retries could reuse stale peer-discovery results from an earlier attempt.

These are Tessellation framework paths used by Currency L0 metagraphs. A metagraph application cannot safely replace snapshot recovery, calculated-state verification, event delivery, or consensus membership handling.

## What this changes

This pull request:

* compares the downloaded snapshot and combined checkpoint and advertises the newer trustworthy local tip;
* advertises neither tip when the ordinals match but the hashes conflict;
* adds an exact-ordinal calculated-state route;
* requests calculated state for the downloaded snapshot's exact ordinal and verifies its hash against the proof in that snapshot;
* writes recovered calculated state atomically and verifies the written file before continuing;
* safely retries when application state was installed before a crash but canonical Currency snapshot installation was not completed;
* fails recovery when the exact state is unavailable, its hash does not match, the application has conflicting state at the same ordinal, or the application is already ahead of the recovery target;
* stores a small durable fee-context receipt for every locally created or successfully validated Currency proposal;
* requires the receipt for the exact selected artifact before binary signing;
* retains proposal receipts according to the consensus and publication lifecycle instead of using a fixed-size cache of complete Global snapshots;
* resets stale consensus state before handling a non-contiguous downloaded chain and returns a failed attempt to `WaitingForDownload` so it can retry;
* clears the stale event mempool before publishing consensus registration, so events accepted after registration are preserved;
* waits and retries when the canonical state-channel bridge has not arrived yet;
* removes stale finished consensus generations; and
* clears peer-discovery state after every join attempt and contacts the initial peers concurrently.

It does not lower quorum, fabricate a signature, accept calculated state from the wrong ordinal, or bypass snapshot proof verification.

## How I verified the cause and the fix

### Stock failure controls

* A sequential rc.12 control admitted the first two validators, then left the third at Currency ordinal 10 while the active pair continued advancing.
* A concurrent rc.12 control started all four joiners together. All five exchanged declarations and observed the same initial head, but three validators entered `WaitingForDownload` and repeatedly failed to install the certified ordinal-10 snapshot.
* Both controls failed before Data L1, Currency L1, or application transaction processing began.

This ruled out launch order as a workaround and isolated the prerequisite failure to Currency L0 recovery.

### Isolated patched-candidate campaigns

Two complete isolated campaigns used different throwaway metagraph identities. Each campaign ran:

* one Global L0;
* five Currency L0 validators;
* three Data L1 validators; and
* one inert Currency L1.

In both campaigns:

* all five Currency L0 validators joined one common state;
* two byte-identical application updates were accepted;
* the Global L0 anchor was verified;
* the group finalized with one validator stopped;
* the stopped validator recovered its persisted state and returned to `Ready`;
* a validator whose local data had been emptied downloaded verified state and returned to `Ready`; and
* consensus resumed after both recovery cases.

The persisted-restart failure in this testing led to the event-cleanup ordering fix. Moving stale cleanup before consensus registration preserved newly accepted events and allowed the validator to rejoin stable participation.

### Verification on current develop

The replacement branch is based directly on merged PR 1566 commit `ee1c7e08173bd63cd7c2f9e7b66699ef734374e1`.

After the reviewer-requested fee-context receipt and calculated-state durability changes, the current branch passed:

* all 153 Currency L0 tests;
* all 313 shared tests;
* all 6 affected tests in `PeerDiscoverySuite` and `CachedCombinedResponseSuite`;
* `scalafmtCheckAll`; and
* `git diff --check`.

The added tests cover durable receipt creation, restart recovery, more than four active Global views, missing or mismatched receipts before signing, lifecycle cleanup, atomic calculated-state replacement, interrupted recovery, idempotent retry, same-ordinal hash conflicts, and application state ahead of the recovery target.

The two full topology campaigns were run against the earlier reviewed PR 1566 candidate, not this replacement commit. I am not presenting the focused current-`develop` run as a third topology campaign.

## Impact on other metagraph builders

The failure happens before application-specific transaction handling. A simple uninterrupted demonstration may never trigger every recovery path, but a validator that joins late, restarts, loses local data, or observes a moving peer can encounter it. The fix belongs in Tessellation so each metagraph does not have to discover the same framework limitation independently.

## Scope and safety

The base is current `develop` after PR 1566 was merged. All runtime testing used isolated networks and throwaway identities. No public network was joined or modified, and no production validator key was used.