### PR TITLE
fix(dag-l0): emit replacement vote after round commit

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusStateCreator.scala
@@ -55,6 +55,16 @@ abstract class GlobalSnapshotConsensusStateCreator[F[_]: Sync]
 
 object GlobalSnapshotConsensusStateCreator {
 
+  /** Build the round-start atomic-replacement effect without running it. The state creator retains this effect with the new consensus
+    * state, so the voter can read the committed round before it signs or stores a vote. Assembly is checked before the first Facility.
+    */
+  private[snapshot] def atomicReplacementRoundStartEffect[F[_]: Sync](
+    alreadyVoted: Boolean,
+    emitVote: F[Unit],
+    checkAssembly: F[Unit]
+  ): F[Unit] =
+    (if (alreadyVoted) Sync[F].unit else emitVote) >> checkAssembly
+
   private def resetLegacyOutcomeToAuthenticatedSeed[F[_]: cats.Functor: Hasher](
     outcome: GlobalConsensusOutcome,
     seed: List[PeerId]
@@ -281,7 +291,7 @@ object GlobalSnapshotConsensusStateCreator {
       resources: ConsensusResources[GlobalSnapshotArtifact, GlobalConsensusKind],
       observedAt: FiniteDuration,
       cadenceAllowed: Boolean
-    ): F[Unit] = {
+    ): F[F[Unit]] = {
       val parentEvidence = lastOutcome.controllerEvidence.flatMap(_.get(lastOutcome.key))
       val locallyObservedParentSigners =
         lastOutcome.finished.signedMajorityArtifact.proofs.toList.map(_.id.toPeerId).toSet
@@ -294,13 +304,13 @@ object GlobalSnapshotConsensusStateCreator {
           // Recovery from a snapshot whose one-round operational sidecar is unavailable can
           // temporarily lack the exact parent round-start committee. Clear local streaks and
           // skip rather than bridging an unknown round into a false consecutive-miss sequence.
-          finalityParticipationMissHistoryRef.set(FinalityParticipationAuditor.MissHistory.empty) >>
+          (finalityParticipationMissHistoryRef.set(FinalityParticipationAuditor.MissHistory.empty) >>
             Metrics[F]
               .incrementCounter(
                 "dag_consensus_signing_finality_audit_total",
                 Seq(outcomeLabel -> "missing_parent_evidence")
               )
-              .whenA(!inBootstrap && currentCore.contains(selfId))
+              .whenA(!inBootstrap && currentCore.contains(selfId))).as(Sync[F].unit)
 
         case Some(evidence) =>
           val currentCommittee = currentSigningCommittee
@@ -373,14 +383,11 @@ object GlobalSnapshotConsensusStateCreator {
           }.flatMap {
             case Some(audit) if FinalityParticipationAuditor.shouldEmitAtomicReplacementVote(audit, finalityHeadroom, cadenceAllowed) =>
               val alreadyVoted = resources.evictionVotes.get(audit.target).exists(_.contains(selfId))
-              val emit =
-                if (alreadyVoted) Sync[F].unit
-                else evictionVoter.emitEvictionVote(key, audit.target, EvictionReason.Silent)
-
-              emit >>
-                // Queue assembly before the first Facility is sent. Every honest Core voter
-                // audits the same target; local proof differences can only cause abstention.
-                consensusQueue.offer(ConsensusCommand.CheckEvictionAssembly(key, audit.target)) >>
+              val roundStartEffect = GlobalSnapshotConsensusStateCreator.atomicReplacementRoundStartEffect(
+                alreadyVoted,
+                evictionVoter.emitEvictionVote(key, audit.target, EvictionReason.Silent),
+                consensusQueue.offer(ConsensusCommand.CheckEvictionAssembly(key, audit.target))
+              ) >>
                 ConsensusLog.info(
                   logger,
                   Facilitator,
@@ -408,11 +415,15 @@ object GlobalSnapshotConsensusStateCreator {
                   Seq(outcomeLabel -> (if (alreadyVoted) "already_voted" else "vote_emitted"))
                 )
 
+              Sync[F].pure(roundStartEffect)
+
             case Some(audit) if audit.signatureObserved =>
-              Metrics[F].incrementCounter(
-                "dag_consensus_signing_finality_audit_total",
-                Seq(outcomeLabel -> "signature_observed")
-              )
+              Metrics[F]
+                .incrementCounter(
+                  "dag_consensus_signing_finality_audit_total",
+                  Seq(outcomeLabel -> "signature_observed")
+                )
+                .as(Sync[F].unit)
 
             case Some(audit) =>
               val outcome =
@@ -444,12 +455,14 @@ object GlobalSnapshotConsensusStateCreator {
                 "nextSeatFinalityMargin" -> finalityHeadroom.nextSeatMargin.toString,
                 "cadenceAllowed" -> cadenceAllowed.toString
               ) >>
-                Metrics[F].incrementCounter(
-                  "dag_consensus_signing_finality_audit_total",
-                  Seq(outcomeLabel -> outcome)
-                )
+                Metrics[F]
+                  .incrementCounter(
+                    "dag_consensus_signing_finality_audit_total",
+                    Seq(outcomeLabel -> outcome)
+                  )
+                  .as(Sync[F].unit)
 
-            case None => Sync[F].unit
+            case None => Sync[F].pure(Sync[F].unit)
           }
       }
     }
@@ -1168,9 +1181,9 @@ object GlobalSnapshotConsensusStateCreator {
           ConsensusLog.info(logger, Lifecycle, key.show, role, RoundStarted, (basePairs ++ optionalPairs): _*)
         }
 
-        // Complete every dynamic/fallible read and local maintenance action before committing
-        // the state. The retained post-commit effect below may be replayed after delivery fails or
-        // is cancelled, so it must contain only the exact Facility self-store and gossip delivery.
+        // Complete dynamic reads and deterministic audit preparation before committing the state.
+        // The retained effect runs the prepared membership action and exact Facility delivery only
+        // after the round is committed, and may be replayed after failure or cancellation.
         assembledEvictionCertificates <- consensusStorage.getAssembledEvictionCertificates(key)
         _ <- GlobalSnapshotConsensusStateCreator
           .evictionVoteRetransmission(
@@ -1188,7 +1201,7 @@ object GlobalSnapshotConsensusStateCreator {
               consensusQueue.offer(ConsensusCommand.CheckEvictionAssembly(key, retransmission.target)) >>
               Metrics[F].incrementCounter("dag_consensus_eviction_vote_retransmitted_total")
           }
-        _ <-
+        roundStartMembershipEffect <-
           if (membershipPolicy.allowsCertifiedAtomicReplacement(config.certifiedConsensusActiveAt(key.value.value)))
             auditSigningFinalityParticipation(
               key,
@@ -1199,18 +1212,18 @@ object GlobalSnapshotConsensusStateCreator {
               time,
               expansionAllowedThisRound
             ).handleErrorWith { error =>
-              logger.warn(error)(s"Signing finality-participation audit failed for key=$key; continuing round") >>
+              (logger.warn(error)(s"Signing finality-participation audit failed for key=$key; continuing round") >>
                 Metrics[F].incrementCounter(
                   "dag_consensus_signing_finality_audit_total",
                   Seq(Metrics.unsafeLabelName("outcome") -> "error")
-                )
+                )).as(Sync[F].unit)
             }
           else
-            finalityParticipationMissHistoryRef.set(FinalityParticipationAuditor.MissHistory.empty) >>
+            (finalityParticipationMissHistoryRef.set(FinalityParticipationAuditor.MissHistory.empty) >>
               Metrics[F].incrementCounter(
                 "dag_consensus_signing_finality_audit_total",
                 Seq(Metrics.unsafeLabelName("outcome") -> "disabled_by_membership_policy")
-              )
+              )).as(Sync[F].unit)
         _ <- HasherSelector[F].withCurrent { implicit hasher =>
           DagAwaitingParentQueue.maintain(
             eventMempool,
@@ -1259,7 +1272,7 @@ object GlobalSnapshotConsensusStateCreator {
           triggerStatement = triggerStatement
         )
         declaration = ConsensusPeerDeclaration(key, facility)
-        effect = ConsensusStateCreator.exactFacilityEffect[F, GlobalSnapshotKey](
+        facilityEffect = ConsensusStateCreator.exactFacilityEffect[F, GlobalSnapshotKey](
           facility,
           declaration,
           signingFacilitators.toSet
@@ -1267,6 +1280,7 @@ object GlobalSnapshotConsensusStateCreator {
           captured => consensusStorage.addFacility(selfId, key, captured).void,
           (captured, targets) => gossip.spreadDirect(captured, targets)
         )
+        effect = roundStartMembershipEffect >> facilityEffect
 
       } yield (state, effect)
   }

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotRoundStartEffectSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotRoundStartEffectSuite.scala
@@ -1,0 +1,112 @@
+package io.constellationnetwork.dag.l0.infrastructure.snapshot
+
+import cats.Eq
+import cats.effect.{IO, Ref}
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.node.shared.config.types.{ConsensusConfig, EventCutterConfig}
+import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusStorage
+import io.constellationnetwork.node.shared.infrastructure.consensus.ConsensusStorage.ModifyStateFn
+import io.constellationnetwork.node.shared.infrastructure.consensus.state.{ConsensusState, Facilitators}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
+import monocle.Lens
+import weaver.SimpleIOSuite
+
+object GlobalSnapshotRoundStartEffectSuite extends SimpleIOSuite {
+
+  private final case class Outcome(key: SnapshotOrdinal)
+
+  private implicit val outcomeEq: Eq[Outcome] = Eq.fromUniversalEquals
+  private implicit val outcomeKey: Lens[Outcome, SnapshotOrdinal] =
+    Lens[Outcome, SnapshotOrdinal](_.key)(key => _.copy(key = key))
+
+  private type Storage = ConsensusStorage[IO, Unit, SnapshotOrdinal, Unit, Unit, String, Outcome, Unit]
+  private type State = ConsensusState[SnapshotOrdinal, String, Outcome, Unit]
+
+  private val consensusConfig =
+    ConsensusConfig(
+      timeTriggerInterval = 10.seconds,
+      declarationTimeout = 10.seconds,
+      declarationRangeLimit = 100L,
+      lockDuration = 10.seconds,
+      eventCutter = EventCutterConfig(
+        maxBinarySizeBytes = PosInt(1024),
+        maxUpdateNodeParametersSize = PosInt(1024)
+      )
+    )
+
+  private val leader = PeerId(Hex("01" * 64))
+  private val entropy = Hash.fromBytes("round-start-effect-suite".getBytes("UTF-8"))
+
+  private def storage: IO[Storage] =
+    ConsensusStorage.make[IO, Unit, SnapshotOrdinal, Unit, Unit, String, Outcome, Unit](consensusConfig)
+
+  private def state(key: SnapshotOrdinal): State =
+    ConsensusState(
+      key = key,
+      lastOutcome = Outcome(key),
+      facilitators = Facilitators(List(leader)),
+      roundStartFacilitators = Facilitators(List(leader)),
+      status = "committed",
+      createdAt = Duration.Zero,
+      leader = leader,
+      entropy = entropy
+    )
+
+  private def installWithEffect(
+    storage: Storage,
+    key: SnapshotOrdinal,
+    nextState: State,
+    effect: IO[Unit]
+  ): IO[Option[Unit]] = {
+    val modify: ModifyStateFn[IO, SnapshotOrdinal, String, Outcome, Unit, (Unit, IO[Unit])] =
+      _ => ((nextState.some, ((), effect))).some.pure[IO]
+
+    storage.condModifyStateWithSideEffect(key)(modify)
+  }
+
+  test("atomic replacement vote observes the committed round before Facility delivery") {
+    val key = SnapshotOrdinal.unsafeApply(40L)
+
+    for {
+      consensusStorage <- storage
+      observed <- Ref.of[IO, List[String]](List.empty)
+      vote = consensusStorage.getState(key).flatMap { committed =>
+        observed.update(_ :+ s"vote-state-${committed.isDefined}")
+      }
+      assembly = observed.update(_ :+ "assembly")
+      facility = observed.update(_ :+ "facility")
+      roundStartEffect = GlobalSnapshotConsensusStateCreator.atomicReplacementRoundStartEffect(
+        alreadyVoted = false,
+        emitVote = vote,
+        checkAssembly = assembly
+      )
+      before <- observed.get
+      _ <- installWithEffect(consensusStorage, key, state(key), roundStartEffect >> facility)
+      after <- observed.get
+    } yield
+      expect(before.isEmpty, s"the retained effect ran before state installation: $before") &&
+        expect.same(List("vote-state-true", "assembly", "facility"), after)
+  }
+
+  test("an existing vote skips signing but still checks certificate assembly") {
+    for {
+      observed <- Ref.of[IO, List[String]](List.empty)
+      effect = GlobalSnapshotConsensusStateCreator.atomicReplacementRoundStartEffect(
+        alreadyVoted = true,
+        emitVote = observed.update(_ :+ "vote"),
+        checkAssembly = observed.update(_ :+ "assembly")
+      )
+      _ <- effect
+      after <- observed.get
+    } yield expect.same(List("assembly"), after)
+  }
+}


### PR DESCRIPTION
PR 1566 was merged into `develop` and its source branch was deleted. GitHub automatically closed the earlier PR 1586 because it targeted that deleted branch. This replacement contains the same validated round-start vote fix on current `develop`.

The merged PR 1566 commit `ee1c7e08173bd63cd7c2f9e7b66699ef734374e1` has the same source tree as the previous PR 1566 head `490011e1b648396378b275f08ae3f4deafc6818f`. No source or behavioral changes were needed during the base transfer.

## Why this is needed

I found this while testing five-validator Global L0 recovery. When one authority validator stopped responding over P2P, the three Core validators correctly selected it for replacement by a healthy synchronized validator. At the allowed membership-change round, all three logged `skipped=no_state`. No signed eviction vote was produced, so the replacement could not happen.

The problem is in Tessellation round startup. The new consensus round is constructed, but the eviction voter is called before `ConsensusStorage` commits that round. The voter reads `ConsensusStorage` to find the round it must sign. Because the round is not there yet, it skips the vote.

## What this changes

Keep the prepared replacement action with the new state. After the state is committed, emit or reuse the vote, check eviction-certificate assembly, and then send the normal Facility message.

This does not change quorum, finality, certificate validation, target selection, or membership policy.

## How this was verified

I repeated the same isolated five-validator test with the companion Currency recovery and damaged-file recovery changes applied.

Stock result:

- Three Core validators selected the same silent member.
- All three logged `skipped=no_state`.
- Zero signed eviction votes were produced.
- The healthy spare could not enter authority.

Fixed result:

- The same three Core validators emitted three signed votes.
- There were zero `no_state` skips.
- The eviction and admission certificates reached quorum before proposal creation.
- Snapshot ordinal 36 certified removal of the silent validator and admission of the healthy spare.
- Authority stayed at four validators instead of shrinking.
- The four healthy authority nodes stayed synchronized through ordinal 41.
- All containers had zero restarts and no OOM kills.

The current replacement branch passed both round-start regression tests, `scalafmtCheckAll`, and `git diff --check`. The previously completed full standalone DAG L0 suite passed 231 tests with two pre-existing ignored tests. The combined candidate suite passed 233 DAG L0 tests with two pre-existing ignored tests and all 1440 Node Shared tests. DAG L0 assembly also passed.

This confirms that the defect remained after the companion fixes and that the round-start ordering change fixes it independently.

## Safety

The fix does not alter quorum, finality, certificate validation, target selection, or membership policy. All runtime testing used isolated networks and throwaway identities. No public network was joined or modified.

