### PR TITLE
fix(node-shared): validate fee transactions individually and apply the ones that pass

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManager.scala
@@ -54,19 +54,54 @@ class BalanceOpsManager[F[_]: Async](
     (finalBalances, acceptedTxs).pure
   }
 
+  /** Validates the fee transactions carried by a data application block and returns the ones that passed.
+    *
+    * At or above the activation ordinal each transaction is judged on its own and the invalid ones are left out, so the rest of the set is
+    * still applied. This mirrors how `applyFeeTransactions` already treats a transaction its source cannot cover. The selection is
+    * deterministic: a verdict is a pure function of the transaction and the authorization flag, and the surviving set keeps the incoming
+    * `SortedSet` ordering, so every node computes the same subset.
+    *
+    * Below the activation ordinal the earlier all-or-nothing behaviour is kept. Selecting per transaction changes which artifact a given
+    * set of events produces, and down there the data application layer applies its earlier rules - it checks neither source != destination
+    * nor signature exclusivity - so a mixed fleet would disagree during a rolling upgrade.
+    *
+    * @return
+    *   the transactions that passed validation, in the incoming order
+    */
   def validateFeeTxs(
     maybeTxs: Option[SortedSet[Signed[FeeTransaction]]],
-    enforceWalletAuthorization: Boolean
-  ): F[Unit] =
-    NonEmptyList.fromList(maybeTxs.toList.flatMap(_.toList)).fold(().pure[F]) { nonEmptyTxs =>
-      feeTransactionValidator.validate(nonEmptyTxs, enforceWalletAuthorization).flatMap {
-        case Validated.Valid(_) =>
-          ().pure[F]
-        case Validated.Invalid(errors) =>
-          new Exception(s"FeeTransaction validation failed: ${errors.toList.mkString(", ")}")
-            .raiseError[F, Unit]
+    enforceWalletAuthorization: Boolean,
+    atOrAboveActivationOrdinal: Boolean
+  ): F[Option[SortedSet[Signed[FeeTransaction]]]] =
+    if (!atOrAboveActivationOrdinal)
+      NonEmptyList.fromList(maybeTxs.toList.flatMap(_.toList)).fold(maybeTxs.pure[F]) { nonEmptyTxs =>
+        feeTransactionValidator.validate(nonEmptyTxs, enforceWalletAuthorization).flatMap {
+          case Validated.Valid(_) =>
+            maybeTxs.pure[F]
+          case Validated.Invalid(errors) =>
+            new Exception(s"FeeTransaction validation failed: ${errors.toList.mkString(", ")}")
+              .raiseError[F, Option[SortedSet[Signed[FeeTransaction]]]]
+        }
       }
-    }
+    else
+      maybeTxs.traverse { txs =>
+        txs.toList.traverseFilter { signedTx =>
+          feeTransactionValidator.validate(signedTx, enforceWalletAuthorization).flatMap {
+            case Validated.Valid(_) =>
+              signedTx.some.pure[F]
+            case Validated.Invalid(errors) =>
+              logger
+                .warn(
+                  s"Dropped fee transaction from ${signedTx.value.source} to ${signedTx.value.destination} of " +
+                    s"${signedTx.value.amount.value.value}: ${errors.toList.mkString(", ")}"
+                )
+                .as(none[Signed[FeeTransaction]])
+          }
+        }.map { kept =>
+          val keptTxs = kept.toSet
+          txs.filter(keptTxs.contains)
+        }
+      }
 
   def acceptFeeTxs(
     balances: SortedMap[Address, Balance],

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
@@ -169,6 +169,10 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
     extends CurrencySnapshotAcceptanceManager[F] {
   private val feeTransactionSecurityActivationOrdinal = fieldsAddedOrdinals.feeTransactionSecurityFor(environment)
   private val currencySnapshotProtocolV1ActivationOrdinal = fieldsAddedOrdinals.currencySnapshotProtocolV1For(environment)
+  // Same boundary the data application layer uses for `validateEveryFeeTransaction`, so both layers agree on when
+  // an invalid fee transaction becomes a drop rather than a raise.
+  private val fixingDataApplicationFeeValidationActivationOrdinal =
+    fieldsAddedOrdinals.fixingDataApplicationFeeValidationFor(environment)
 
   def accept(
     blocksForAcceptance: List[Signed[Block]],
@@ -247,12 +251,14 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
       rewards
     )
 
-    _ <- balanceOps.validateFeeTxs(
+    validatedFeeTxs <- balanceOps.validateFeeTxs(
       feeTransactionsForAcceptance,
       isEnabled(
         maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue),
         feeTransactionSecurityActivationOrdinal
-      )
+      ),
+      maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >=
+        fixingDataApplicationFeeValidationActivationOrdinal
     )
 
     // Gated on the GLOBAL ordinal, like every other FieldsAddedOrdinals entry -- the currency ordinal is
@@ -260,7 +266,7 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
     // history replays to the state that was actually signed.
     (updatedBalancesByFeeTransactions, acceptedFeeTxs) <- balanceOps.acceptFeeTxs(
       updatedBalancesByRewards,
-      feeTransactionsForAcceptance,
+      validatedFeeTxs,
       maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >
         fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow.getOrElse(environment, SnapshotOrdinal.MaxValue)
     )

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManagerFeeTxsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/BalanceOpsManagerFeeTxsSuite.scala
@@ -1,10 +1,17 @@
 package io.constellationnetwork.node.shared.infrastructure.snapshot.managers.currency
 
-import cats.data.NonEmptySet
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.effect.IO
+import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.currency.dataApplication.FeeTransaction
+import io.constellationnetwork.node.shared.domain.transaction.FeeTransactionValidator
+import io.constellationnetwork.node.shared.domain.transaction.FeeTransactionValidator.{
+  FeeTransactionValidationErrorOr,
+  SameSourceAndDestinationAddress
+}
 import io.constellationnetwork.node.shared.infrastructure.snapshot.managers.currency.BalanceOpsManager.applyFeeTransactions
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.Address
@@ -173,5 +180,84 @@ object BalanceOpsManagerFeeTxsSuite extends SimpleIOSuite with Checkers {
 
         expect.eql(totalSupply(before), totalSupply(after))
     }
+  }
+
+  /** Rejects transactions whose source and destination match, which is enough to exercise both selection modes without a SecurityProvider:
+    * the real validator's verdicts are also a pure function of the transaction.
+    */
+  private val stubValidator: FeeTransactionValidator[IO] = new FeeTransactionValidator[IO] {
+    private def verdict(tx: Signed[FeeTransaction]): FeeTransactionValidationErrorOr[Signed[FeeTransaction]] =
+      if (tx.value.source =!= tx.value.destination) tx.validNec
+      else SameSourceAndDestinationAddress(tx.value.source).invalidNec
+
+    def validate(
+      signedTransaction: Signed[FeeTransaction],
+      enforceWalletAuthorization: Boolean
+    ): IO[FeeTransactionValidationErrorOr[Signed[FeeTransaction]]] = verdict(signedTransaction).pure[IO]
+
+    def validate(
+      signedTransactions: NonEmptyList[Signed[FeeTransaction]],
+      enforceWalletAuthorization: Boolean
+    ): IO[FeeTransactionValidationErrorOr[NonEmptyList[Signed[FeeTransaction]]]] =
+      signedTransactions.traverse(verdict).pure[IO]
+  }
+
+  private val balanceOps = new BalanceOpsManager[IO](stubValidator)
+
+  private val validTx = feeTx(payer, payeeA, 10L, 1)
+  private val otherValidTx = feeTx(payer, payeeB, 20L, 2)
+  private val selfPayingTx = feeTx(payer, payer, 30L, 3)
+
+  test("at or above the activation ordinal, an invalid fee transaction is dropped and the rest are applied") {
+    // One invalid entry must not decide the fate of the whole set: the valid transactions alongside it are
+    // still applied, and only the invalid one is left out.
+    val txs = SortedSet(validTx, otherValidTx, selfPayingTx)
+
+    balanceOps.validateFeeTxs(txs.some, enforceWalletAuthorization = true, atOrAboveActivationOrdinal = true).map { result =>
+      expect.all(
+        result.contains(SortedSet(validTx, otherValidTx)),
+        result.forall(!_.contains(selfPayingTx))
+      )
+    }
+  }
+
+  test("at or above the activation ordinal, an all-invalid set yields an empty set rather than raising") {
+    balanceOps
+      .validateFeeTxs(SortedSet(selfPayingTx).some, enforceWalletAuthorization = true, atOrAboveActivationOrdinal = true)
+      .attempt
+      .map(result => expect(result == Right(Some(SortedSet.empty[Signed[FeeTransaction]]))))
+  }
+
+  test("at or above the activation ordinal, an all-valid set is returned unchanged") {
+    val txs = SortedSet(validTx, otherValidTx)
+
+    balanceOps
+      .validateFeeTxs(txs.some, enforceWalletAuthorization = true, atOrAboveActivationOrdinal = true)
+      .map(result => expect(result.contains(txs)))
+  }
+
+  test("below the activation ordinal, an invalid fee transaction still raises") {
+    // Deliberate: selecting per transaction changes which artifact the same events produce, and below the
+    // gate the data application layer applies its earlier rules, so a mixed fleet would disagree during a
+    // rolling upgrade.
+    balanceOps
+      .validateFeeTxs(SortedSet(validTx, selfPayingTx).some, enforceWalletAuthorization = false, atOrAboveActivationOrdinal = false)
+      .attempt
+      .map(result => expect(result.isLeft))
+  }
+
+  test("below the activation ordinal, an all-valid set is returned unchanged") {
+    val txs = SortedSet(validTx, otherValidTx)
+
+    balanceOps
+      .validateFeeTxs(txs.some, enforceWalletAuthorization = false, atOrAboveActivationOrdinal = false)
+      .map(result => expect(result.contains(txs)))
+  }
+
+  test("no fee transactions is a no-op in both modes") {
+    for {
+      above <- balanceOps.validateFeeTxs(none, enforceWalletAuthorization = true, atOrAboveActivationOrdinal = true)
+      below <- balanceOps.validateFeeTxs(none, enforceWalletAuthorization = false, atOrAboveActivationOrdinal = false)
+    } yield expect.all(above.isEmpty, below.isEmpty)
   }
 }


### PR DESCRIPTION
`validateFeeTxs` returned `Unit` and raised if any single fee transaction failed validation, so one entry decided the fate of the whole set. It now judges each transaction on its own and returns the ones that passed, and only that surviving set reaches `acceptFeeTxs` and the snapshot artifact. This mirrors how `applyFeeTransactions` already treats a transaction its source cannot cover, and it matches the equivalent site on release/mainnet.

The selection is deterministic: a verdict is a pure function of the transaction and the authorization flag, and the surviving set keeps the incoming SortedSet ordering, so every node computes the same subset.

Behavior below the activation ordinal is unchanged. Selecting per transaction changes which artifact a given set of events produces, and down there the data application layer applies its earlier rules, so a mixed fleet would disagree during a rolling upgrade.

The gate is `fixingDataApplicationFeeValidation`, the same boundary the data application layer uses for validateEveryFeeTransaction, so both layers agree on when selection applies. No new `FieldsAddedOrdinals` entry is needed.
