### PR TITLE
test: strengthen delegated withdrawal regression coverage

### DIFF
--- a/.github/action_scripts/delegated_staking/delegated-staking.js
+++ b/.github/action_scripts/delegated_staking/delegated-staking.js
@@ -17,6 +17,7 @@ const {
   parseSharedArgs,
   PRIVATE_KEYS,
   withRetry,
+  createAndConnectAccount,
   createNetworkConfig,
   logWorkflow,
 } = require('../shared')
@@ -728,6 +729,221 @@ const testWithdrawDelegatedStake = async (urls, account, stakeHash) => {
   logWorkflow.info('---- End testWithdrawDelegatedStake ----')
 }
 
+const getAlternateGlobalL0Url = (globalL0Url) => {
+  const alternate = new URL(globalL0Url)
+  alternate.port = `${Number(alternate.port) + 10}`
+  return alternate.toString().replace(/\/$/, '')
+}
+
+const waitForNextSnapshot = async (urls) => {
+  const initialSnapshot = await fetchSnapshot(urls, 'latest')
+  const initialOrdinal = initialSnapshot.value.ordinal
+
+  return withRetry(
+    async () => {
+      const latestSnapshot = await fetchSnapshot(urls, 'latest')
+      if (latestSnapshot.value.ordinal <= initialOrdinal) {
+        throw new Error(`Waiting for an ordinal after ${initialOrdinal}`)
+      }
+      return latestSnapshot.value.ordinal
+    },
+    {
+      name: 'waitForNextSnapshotBeforeDoubleWithdrawalRace',
+      maxAttempts: 60,
+      interval: 1000,
+      handleError: () => {},
+    },
+  )
+}
+
+const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
+  logWorkflow.info('---- Start testDoubleWithdrawalProtection ----')
+
+  const primaryAccount = createAndConnectAccount(PRIVATE_KEYS.key3, {
+    l0Url: urls.globalL0Url,
+    l1Url: urls.dagL1Url,
+  })
+  const secondaryAccount = createAndConnectAccount(PRIVATE_KEYS.key3, {
+    l0Url: getAlternateGlobalL0Url(urls.globalL0Url),
+    l1Url: urls.dagL1Url,
+  })
+  const lockAmount = 500000000001
+  const initialBalance = dagToDatum(await primaryAccount.getBalance())
+  const lockHash = await createTokenLock(primaryAccount, urls, lockAmount)
+  const balanceAfterLock = initialBalance - lockAmount
+
+  const originalStakeHash = await createDelegatedStake(
+    primaryAccount,
+    lockHash,
+    lockAmount,
+    nodeIds[0],
+  )
+
+  await withRetry(
+    async () => {
+      const state = await getAccountDelegatedStakes(
+        urls,
+        primaryAccount.address,
+      )
+      const originalStake = state.activeDelegatedStakes.find(
+        (stake) => stake.hash === originalStakeHash,
+      )
+      if (!originalStake) throw new Error('Original race stake is not active')
+      return originalStake
+    },
+    {
+      name: 'waitForOriginalDoubleWithdrawalStake',
+      maxAttempts: 30,
+      interval: 1000,
+      handleError: () => {},
+    },
+  )
+
+  await waitForNextSnapshot(urls)
+
+  // Submit the replacement and withdrawal through different gL0 nodes in the
+  // same fresh-round window. Consensus must never materialize both S2 and W1.
+  const [replacementResult, withdrawalResult] = await Promise.allSettled([
+    createDelegatedStake(
+      primaryAccount,
+      lockHash,
+      lockAmount,
+      nodeIds[1],
+    ),
+    withdrawDelegatedStake(secondaryAccount, originalStakeHash),
+  ])
+
+  if (
+    replacementResult.status !== 'fulfilled' ||
+    withdrawalResult.status !== 'fulfilled'
+  ) {
+    throw new Error(
+      `Failed to stage both double-withdrawal race requests: replacement=${replacementResult.status}, withdrawal=${withdrawalResult.status}`,
+    )
+  }
+
+  const replacementStakeHash = replacementResult.value
+
+  const raceOutcome = await withRetry(
+    async () => {
+      const state = await getAccountDelegatedStakes(
+        urls,
+        primaryAccount.address,
+      )
+      const activeForLock = state.activeDelegatedStakes.filter(
+        (stake) => stake.tokenLockRef === lockHash,
+      )
+      const pendingForLock = state.pendingWithdrawals.filter(
+        (stake) => stake.tokenLockRef === lockHash,
+      )
+
+      if (activeForLock.length > 1 || pendingForLock.length > 1) {
+        throw new Error(
+          `Multiple stake records reference race lock ${lockHash}: active=${activeForLock.length}, pending=${pendingForLock.length}`,
+        )
+      }
+      if (activeForLock.length === 1 && pendingForLock.length === 1) {
+        throw new Error(
+          `Consensus-breaking state detected for ${lockHash}: an active stake and pending withdrawal share one lock`,
+        )
+      }
+
+      const replacementIsActive =
+        replacementStakeHash &&
+        activeForLock.some((stake) => stake.hash === replacementStakeHash)
+      const originalIsPending = pendingForLock.some(
+        (stake) => stake.hash === originalStakeHash,
+      )
+
+      if (!replacementIsActive && !originalIsPending) {
+        throw new Error('Double-withdrawal race has not reached a terminal state')
+      }
+
+      return { replacementIsActive, pendingForLock }
+    },
+    {
+      name: 'assertDoubleWithdrawalRaceIsSafe',
+      maxAttempts: 30,
+      interval: 1000,
+      handleError: (err, attempt) => {
+        if (attempt === 30) throw err
+      },
+    },
+  )
+
+  if (raceOutcome.replacementIsActive) {
+    await withdrawDelegatedStake(primaryAccount, replacementStakeHash)
+  }
+
+  const pendingWithdrawal = await withRetry(
+    async () => {
+      const state = await getAccountDelegatedStakes(
+        urls,
+        primaryAccount.address,
+      )
+      const activeForLock = state.activeDelegatedStakes.filter(
+        (stake) => stake.tokenLockRef === lockHash,
+      )
+      const pendingForLock = state.pendingWithdrawals.filter(
+        (stake) => stake.tokenLockRef === lockHash,
+      )
+
+      if (activeForLock.length !== 0 || pendingForLock.length !== 1) {
+        throw new Error(
+          `Expected one withdrawal for ${lockHash}, got active=${activeForLock.length}, pending=${pendingForLock.length}`,
+        )
+      }
+
+      return pendingForLock[0]
+    },
+    {
+      name: 'assertExactlyOnePendingWithdrawalForTokenLock',
+      maxAttempts: 30,
+      interval: 1000,
+      handleError: (err, attempt) => {
+        if (attempt === 30) throw err
+      },
+    },
+  )
+
+  const expectedBalanceAfterUnlock =
+    balanceAfterLock + pendingWithdrawal.totalBalance
+
+  return async () => {
+    await withRetry(
+      async () => {
+        const state = await getAccountDelegatedStakes(
+          urls,
+          primaryAccount.address,
+        )
+        const activeForLock = state.activeDelegatedStakes.filter(
+          (stake) => stake.tokenLockRef === lockHash,
+        )
+        const pendingForLock = state.pendingWithdrawals.filter(
+          (stake) => stake.tokenLockRef === lockHash,
+        )
+
+        if (activeForLock.length !== 0 || pendingForLock.length !== 0) {
+          throw new Error(`Withdrawal for ${lockHash} has not resolved`)
+        }
+
+        await assertBalanceChange(primaryAccount, expectedBalanceAfterUnlock)
+      },
+      {
+        name: 'assertDoubleWithdrawalCreditsPrincipalOnce',
+        maxAttempts: 36,
+        interval: 10 * 1000,
+        handleError: (err, attempt) => {
+          if (attempt === 36) throw err
+        },
+      },
+    )
+
+    logWorkflow.info('Double-withdrawal race credited principal exactly once')
+    logWorkflow.info('---- End testDoubleWithdrawalProtection ----')
+  }
+}
+
 const testDelegatedStaking = async (urls) => {
   const account = setupDag4Account(urls)
   account.loginPrivateKey(PRIVATE_KEYS.key4)
@@ -735,6 +951,12 @@ const testDelegatedStaking = async (urls) => {
   await testCreateNodeParameters(urls)
 
   const nodeParams = await getNodeParams(urls)
+
+  const finishDoubleWithdrawalProtectionTest =
+    await beginDoubleWithdrawalProtectionTest(urls, [
+      nodeParams[0].peerId,
+      nodeParams[1].peerId,
+    ])
 
   const [stakeHash] = await testCreateDelegatedStake(urls, account, [
     nodeParams[0].peerId,
@@ -749,6 +971,7 @@ const testDelegatedStaking = async (urls) => {
   )
 
   await testWithdrawDelegatedStake(urls, account, updatedStakeHash)
+  await finishDoubleWithdrawalProtectionTest()
 }
 
 const executeWorkflowByType = async (workflowType) => {

--- a/.github/action_scripts/delegated_staking/delegated-staking.js
+++ b/.github/action_scripts/delegated_staking/delegated-staking.js
@@ -41,6 +41,8 @@ const {
   assertTokenUnlockInSnapshot,
 } = require('./lib')
 
+const { getSingleStakeForLock, withStakeRetry } = require('./stake-invariants')
+
 const throwUsage = () => {
   throw new Error(
     'Usage: node script.js <dagl0-port-prefix> <dagl1-port-prefix> <workflow-name>',
@@ -730,6 +732,8 @@ const testWithdrawDelegatedStake = async (urls, account, stakeHash) => {
 }
 
 const getAlternateGlobalL0Url = (globalL0Url) => {
+  // CI's dag_l0/dl0_cluster/action.yml exposes the next node at <prefix>10,
+  // while shared/network.js exposes the genesis node at <prefix>00.
   const alternate = new URL(globalL0Url)
   alternate.port = `${Number(alternate.port) + 10}`
   return alternate.toString().replace(/\/$/, '')
@@ -748,7 +752,7 @@ const waitForNextSnapshot = async (urls) => {
       return latestSnapshot.value.ordinal
     },
     {
-      name: 'waitForNextSnapshotBeforeDoubleWithdrawalRace',
+      name: 'waitForNextSnapshotBeforeConcurrentWithdrawal',
       maxAttempts: 60,
       interval: 1000,
       handleError: () => {},
@@ -756,8 +760,8 @@ const waitForNextSnapshot = async (urls) => {
   )
 }
 
-const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
-  logWorkflow.info('---- Start testDoubleWithdrawalProtection ----')
+const beginConcurrentWithdrawalTest = async (urls, nodeIds) => {
+  logWorkflow.info('---- Start testConcurrentWithdrawalSettlement ----')
 
   const primaryAccount = createAndConnectAccount(PRIVATE_KEYS.key3, {
     l0Url: urls.globalL0Url,
@@ -788,21 +792,23 @@ const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
       const originalStake = state.activeDelegatedStakes.find(
         (stake) => stake.hash === originalStakeHash,
       )
-      if (!originalStake) throw new Error('Original race stake is not active')
+      if (!originalStake) throw new Error('Original concurrent-test stake is not active')
       return originalStake
     },
     {
-      name: 'waitForOriginalDoubleWithdrawalStake',
+      name: 'waitForOriginalConcurrentWithdrawalStake',
       maxAttempts: 30,
       interval: 1000,
       handleError: () => {},
     },
   )
 
-  await waitForNextSnapshot(urls)
+  const submissionWindowOrdinal = await waitForNextSnapshot(urls)
 
-  // Submit the replacement and withdrawal through different gL0 nodes in the
-  // same fresh-round window. Consensus must never materialize both S2 and W1.
+  // Concurrent ingress submissions may be processed in different snapshots.
+  // This E2E checks observed state and settlement, not same-round co-processing.
+  // UpdateDelegatedStakeAcceptanceManagerSuite deterministically tests the same
+  // batch at A-1/A: the replacement wins and the original withdrawal is rejected.
   const [replacementResult, withdrawalResult] = await Promise.allSettled([
     createDelegatedStake(
       primaryAccount,
@@ -818,35 +824,25 @@ const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
     withdrawalResult.status !== 'fulfilled'
   ) {
     throw new Error(
-      `Failed to stage both double-withdrawal race requests: replacement=${replacementResult.status}, withdrawal=${withdrawalResult.status}`,
+      `Failed to submit concurrent requests to ${urls.globalL0Url} and ${getAlternateGlobalL0Url(urls.globalL0Url)}: replacement=${replacementResult.reason || replacementResult.status}, withdrawal=${withdrawalResult.reason || withdrawalResult.status}`,
     )
   }
 
   const replacementStakeHash = replacementResult.value
+  if (!replacementStakeHash || !withdrawalResult.value) {
+    throw new Error('Concurrent submissions must both return request hashes')
+  }
+  logWorkflow.info(
+    `Concurrent submissions after observed ordinal ${submissionWindowOrdinal}: replacement=${replacementStakeHash}, withdrawal=${withdrawalResult.value}; same-round processing is not established`,
+  )
 
-  const raceOutcome = await withRetry(
+  const outcome = await withStakeRetry(
     async () => {
       const state = await getAccountDelegatedStakes(
         urls,
         primaryAccount.address,
       )
-      const activeForLock = state.activeDelegatedStakes.filter(
-        (stake) => stake.tokenLockRef === lockHash,
-      )
-      const pendingForLock = state.pendingWithdrawals.filter(
-        (stake) => stake.tokenLockRef === lockHash,
-      )
-
-      if (activeForLock.length > 1 || pendingForLock.length > 1) {
-        throw new Error(
-          `Multiple stake records reference race lock ${lockHash}: active=${activeForLock.length}, pending=${pendingForLock.length}`,
-        )
-      }
-      if (activeForLock.length === 1 && pendingForLock.length === 1) {
-        throw new Error(
-          `Consensus-breaking state detected for ${lockHash}: an active stake and pending withdrawal share one lock`,
-        )
-      }
+      const { activeForLock, pendingForLock } = getSingleStakeForLock(state, lockHash)
 
       const replacementIsActive =
         replacementStakeHash &&
@@ -856,37 +852,31 @@ const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
       )
 
       if (!replacementIsActive && !originalIsPending) {
-        throw new Error('Double-withdrawal race has not reached a terminal state')
+        throw new Error('Concurrent submissions have not produced an observable outcome')
       }
 
-      return { replacementIsActive, pendingForLock }
+      return { replacementIsActive, activeForLock, pendingForLock }
     },
     {
-      name: 'assertDoubleWithdrawalRaceIsSafe',
+      name: 'waitForConcurrentWithdrawalOutcome',
       maxAttempts: 30,
       interval: 1000,
-      handleError: (err, attempt) => {
-        if (attempt === 30) throw err
-      },
     },
   )
 
-  if (raceOutcome.replacementIsActive) {
+  logWorkflow.info(`Observed concurrent-submission outcome: ${JSON.stringify(outcome)}`)
+
+  if (outcome.replacementIsActive) {
     await withdrawDelegatedStake(primaryAccount, replacementStakeHash)
   }
 
-  const pendingWithdrawal = await withRetry(
+  const pendingWithdrawal = await withStakeRetry(
     async () => {
       const state = await getAccountDelegatedStakes(
         urls,
         primaryAccount.address,
       )
-      const activeForLock = state.activeDelegatedStakes.filter(
-        (stake) => stake.tokenLockRef === lockHash,
-      )
-      const pendingForLock = state.pendingWithdrawals.filter(
-        (stake) => stake.tokenLockRef === lockHash,
-      )
+      const { activeForLock, pendingForLock } = getSingleStakeForLock(state, lockHash)
 
       if (activeForLock.length !== 0 || pendingForLock.length !== 1) {
         throw new Error(
@@ -900,9 +890,6 @@ const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
       name: 'assertExactlyOnePendingWithdrawalForTokenLock',
       maxAttempts: 30,
       interval: 1000,
-      handleError: (err, attempt) => {
-        if (attempt === 30) throw err
-      },
     },
   )
 
@@ -910,18 +897,13 @@ const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
     balanceAfterLock + pendingWithdrawal.totalBalance
 
   return async () => {
-    await withRetry(
+    await withStakeRetry(
       async () => {
         const state = await getAccountDelegatedStakes(
           urls,
           primaryAccount.address,
         )
-        const activeForLock = state.activeDelegatedStakes.filter(
-          (stake) => stake.tokenLockRef === lockHash,
-        )
-        const pendingForLock = state.pendingWithdrawals.filter(
-          (stake) => stake.tokenLockRef === lockHash,
-        )
+        const { activeForLock, pendingForLock } = getSingleStakeForLock(state, lockHash)
 
         if (activeForLock.length !== 0 || pendingForLock.length !== 0) {
           throw new Error(`Withdrawal for ${lockHash} has not resolved`)
@@ -930,17 +912,14 @@ const beginDoubleWithdrawalProtectionTest = async (urls, nodeIds) => {
         await assertBalanceChange(primaryAccount, expectedBalanceAfterUnlock)
       },
       {
-        name: 'assertDoubleWithdrawalCreditsPrincipalOnce',
+        name: 'assertConcurrentWithdrawalCreditsPrincipalOnce',
         maxAttempts: 36,
         interval: 10 * 1000,
-        handleError: (err, attempt) => {
-          if (attempt === 36) throw err
-        },
       },
     )
 
-    logWorkflow.info('Double-withdrawal race credited principal exactly once')
-    logWorkflow.info('---- End testDoubleWithdrawalProtection ----')
+    logWorkflow.info('Concurrent-withdrawal settlement credited principal exactly once')
+    logWorkflow.info('---- End testConcurrentWithdrawalSettlement ----')
   }
 }
 
@@ -952,26 +931,34 @@ const testDelegatedStaking = async (urls) => {
 
   const nodeParams = await getNodeParams(urls)
 
-  const finishDoubleWithdrawalProtectionTest =
-    await beginDoubleWithdrawalProtectionTest(urls, [
+  const finishConcurrentWithdrawalTest =
+    await beginConcurrentWithdrawalTest(urls, [
       nodeParams[0].peerId,
       nodeParams[1].peerId,
     ])
 
-  const [stakeHash] = await testCreateDelegatedStake(urls, account, [
-    nodeParams[0].peerId,
-    nodeParams[1].peerId,
+  // The accounts are independent. Observe settlement during the other flow and
+  // collect both results even when one fails, while overlapping the cooldown.
+  const results = await Promise.allSettled([
+    finishConcurrentWithdrawalTest(),
+    (async () => {
+      const [stakeHash] = await testCreateDelegatedStake(urls, account, [
+        nodeParams[0].peerId,
+        nodeParams[1].peerId,
+      ])
+      const updatedStakeHash = await testUpdateDelegatedStake(
+        urls,
+        account,
+        stakeHash,
+        nodeParams[2].peerId,
+      )
+      await testWithdrawDelegatedStake(urls, account, updatedStakeHash)
+    })(),
   ])
-
-  const updatedStakeHash = await testUpdateDelegatedStake(
-    urls,
-    account,
-    stakeHash,
-    nodeParams[2].peerId,
-  )
-
-  await testWithdrawDelegatedStake(urls, account, updatedStakeHash)
-  await finishDoubleWithdrawalProtectionTest()
+  const failures = results
+    .filter((result) => result.status === 'rejected')
+    .map((result) => result.reason)
+  if (failures.length) throw new AggregateError(failures, 'Delegated staking checks failed')
 }
 
 const executeWorkflowByType = async (workflowType) => {

--- a/.github/action_scripts/delegated_staking/stake-invariants.js
+++ b/.github/action_scripts/delegated_staking/stake-invariants.js
@@ -1,0 +1,36 @@
+const { withRetry } = require('../shared/operations')
+
+class StakeInvariantViolation extends Error {}
+
+const getSingleStakeForLock = (state, lockHash) => {
+  const activeForLock = state.activeDelegatedStakes.filter(
+    (stake) => stake.tokenLockRef === lockHash,
+  )
+  const pendingForLock = state.pendingWithdrawals.filter(
+    (stake) => stake.tokenLockRef === lockHash,
+  )
+
+  if (activeForLock.length + pendingForLock.length > 1) {
+    throw new StakeInvariantViolation(
+      `Multiple stake records reference token lock ${lockHash}: active=${JSON.stringify(activeForLock)}, pending=${JSON.stringify(pendingForLock)}`,
+    )
+  }
+
+  return { activeForLock, pendingForLock }
+}
+
+// Retry propagation/settlement delays, but never forgive an observed violation.
+const withStakeRetry = (operation, options) =>
+  withRetry(operation, {
+    ...options,
+    handleError: (error, attempt) => {
+      if (
+        error instanceof StakeInvariantViolation ||
+        attempt === options.maxAttempts
+      ) {
+        throw error
+      }
+    },
+  })
+
+module.exports = { getSingleStakeForLock, withStakeRetry, StakeInvariantViolation }

--- a/.github/action_scripts/delegated_staking/stake-invariants.test.js
+++ b/.github/action_scripts/delegated_staking/stake-invariants.test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+const {
+  getSingleStakeForLock,
+  withStakeRetry,
+  StakeInvariantViolation,
+} = require('./stake-invariants')
+
+const original = { hash: 'original', tokenLockRef: 'lock', acceptedOrdinal: 10 }
+const replacement = {
+  hash: 'replacement', tokenLockRef: 'lock', acceptedOrdinal: 11,
+}
+const options = { name: 'stake state', maxAttempts: 3, interval: 0 }
+
+for (const [name, active, pending] of [
+  ['active and pending', [replacement], [original]],
+  ['duplicate active', [original, replacement], []],
+  ['duplicate pending', [], [original, replacement]],
+]) {
+  test(`${name} fails immediately even if the next response would be safe`, async () => {
+    let reads = 0
+    await assert.rejects(
+      withStakeRetry(async () => {
+        reads += 1
+        return getSingleStakeForLock(
+          {
+            activeDelegatedStakes: reads === 1 ? active : [replacement],
+            pendingWithdrawals: reads === 1 ? pending : [],
+          },
+          'lock',
+        )
+      }, options),
+      (error) =>
+        error instanceof StakeInvariantViolation &&
+        error.message.includes('token lock lock') &&
+        error.message.includes('acceptedOrdinal'),
+    )
+    assert.equal(reads, 1)
+  })
+}
+
+test('a valid original stake can propagate to the replacement without failing', async () => {
+  let reads = 0
+  const result = await withStakeRetry(async () => {
+    reads += 1
+    const state = getSingleStakeForLock(
+      {
+        activeDelegatedStakes: [reads === 1 ? original : replacement],
+        pendingWithdrawals: [],
+      },
+      'lock',
+    )
+    if (state.activeForLock[0].hash !== replacement.hash) {
+      throw new Error('Replacement is not active yet')
+    }
+    return state
+  }, options)
+  assert.equal(reads, 2)
+  assert.deepEqual(result.activeForLock, [replacement])
+})
+
+test('pending withdrawal can resolve while unrelated token locks remain', async () => {
+  let reads = 0
+  const unrelated = { hash: 'unrelated', tokenLockRef: 'another-lock' }
+  await withStakeRetry(async () => {
+    reads += 1
+    const state = getSingleStakeForLock(
+      {
+        activeDelegatedStakes: [unrelated],
+        pendingWithdrawals: reads === 1 ? [original] : [],
+      },
+      'lock',
+    )
+    if (state.pendingForLock.length) throw new Error('Withdrawal has not resolved')
+    assert.equal(state.activeForLock.length, 0)
+  }, options)
+  assert.equal(reads, 2)
+})
+
+test('a transient read error can recover, but exhausted retries preserve the cause', async () => {
+  let reads = 0
+  await withStakeRetry(async () => {
+    if (++reads === 1) throw new Error('Temporary read failure')
+  }, options)
+  assert.equal(reads, 2)
+
+  const failure = new Error('Withdrawal has not resolved for lock')
+  await assert.rejects(
+    withStakeRetry(async () => { throw failure }, options),
+    (error) => error === failure,
+  )
+})

--- a/.github/workflows/test-delegated-staking.yml
+++ b/.github/workflows/test-delegated-staking.yml
@@ -60,7 +60,7 @@ jobs:
           DAG_L0_PORT_PREFIX: 90
           DAG_L1_PORT_PREFIX: 91
 
-      - name: Test Delegated Staking
+      - name: Test Delegated Staking and Double-Withdrawal Protection
         run: |
           cd .github/action_scripts/delegated_staking
           node delegated-staking.js 90 91 testDelegatedStaking

--- a/.github/workflows/test-delegated-staking.yml
+++ b/.github/workflows/test-delegated-staking.yml
@@ -29,6 +29,9 @@ jobs:
           npm i zod
           npm i elliptic
 
+      - name: Test delegated stake invariant checks
+        run: node --test .github/action_scripts/delegated_staking/stake-invariants.test.js
+
       - name: Download shared_jars artifacts
         uses: actions/download-artifact@v4
         env:
@@ -60,7 +63,7 @@ jobs:
           DAG_L0_PORT_PREFIX: 90
           DAG_L1_PORT_PREFIX: 91
 
-      - name: Test Delegated Staking and Double-Withdrawal Protection
+      - name: Test Delegated Staking and Concurrent Withdrawal Settlement
         run: |
           cd .github/action_scripts/delegated_staking
           node delegated-staking.js 90 91 testDelegatedStaking

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotDelegatedStakeUnlockSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/GlobalSnapshotDelegatedStakeUnlockSuite.scala
@@ -85,11 +85,28 @@ object GlobalSnapshotDelegatedStakeUnlockSuite extends SimpleIOSuite {
       activationOrdinal,
       activationOrdinal
     )
+    // A malformed legacy map may split the same lock's withdrawals across keys.
+    // Deduplication must be global, and only the active lock determines its owner.
+    val crossBucketWithdrawals = SortedMap(
+      tokenLockOwner -> SortedSet(expiredWithdrawals(incorrectWithdrawalBucket).head),
+      incorrectWithdrawalBucket -> SortedSet(expiredWithdrawals(incorrectWithdrawalBucket).last)
+    )
+    def crossBucketUnlocks(ordinal: Long) = GlobalSnapshotAcceptanceManager.generateDelegatedStakeTokenUnlocks(
+      crossBucketWithdrawals,
+      Map(tokenLockRef -> activeTokenLock),
+      SnapshotOrdinal.unsafeApply(ordinal),
+      activationOrdinal
+    )
 
     IO(
       expect.all(
         before == Right(Map(incorrectWithdrawalBucket -> List(expectedUnlock, expectedUnlock))),
         at == Right(Map(tokenLockOwner -> List(expectedUnlock))),
+        crossBucketUnlocks(9L) == Right(
+          Map(tokenLockOwner -> List(expectedUnlock), incorrectWithdrawalBucket -> List(expectedUnlock))
+        ),
+        crossBucketUnlocks(10L) == Right(Map(tokenLockOwner -> List(expectedUnlock))),
+        crossBucketUnlocks(11L) == Right(Map(tokenLockOwner -> List(expectedUnlock))),
         GlobalSnapshotAcceptanceManager
           .excludeNaturallyExpiredDelegatedStakeUnlocks(
             at.toOption.get,
@@ -125,7 +142,7 @@ object GlobalSnapshotDelegatedStakeUnlockSuite extends SimpleIOSuite {
     )
   }
 
-  test("the wired transition finalizes duplicate pending withdrawals exactly once at activation") {
+  test("the wired transition finalizes duplicate withdrawals across address buckets exactly once at activation") {
     JsonSerializer.forSync[IO].flatMap { implicit serializer =>
       implicit val hasher: Hasher[IO] = Hasher.forJson[IO]
       val owner = Address("DAG0y4eLqhhXUafeE3mgBstezPTnr8L3tZjAtMWB")
@@ -163,8 +180,10 @@ object GlobalSnapshotDelegatedStakeUnlockSuite extends SimpleIOSuite {
           proof
         )
         duplicatePending = SortedMap(
+          owner -> SortedSet(
+            PendingDelegatedStakeWithdrawal(firstStake, Amount.empty, SnapshotOrdinal.unsafeApply(1L), EpochProgress(1L))
+          ),
           staleBucket -> SortedSet(
-            PendingDelegatedStakeWithdrawal(firstStake, Amount.empty, SnapshotOrdinal.unsafeApply(1L), EpochProgress(1L)),
             PendingDelegatedStakeWithdrawal(secondStake, Amount.empty, SnapshotOrdinal.unsafeApply(2L), EpochProgress(2L))
           )
         )
@@ -184,7 +203,7 @@ object GlobalSnapshotDelegatedStakeUnlockSuite extends SimpleIOSuite {
             activationOrdinal,
             activationOrdinal,
             SnapshotOrdinal.MinValue,
-            SortedMap(owner -> startingBalance),
+            SortedMap(owner -> startingBalance, staleBucket -> startingBalance),
             SortedMap.empty,
             SortedMap(owner -> SortedSet(activeTokenLock)),
             Map(tokenLockRef -> activeTokenLock),
@@ -198,7 +217,10 @@ object GlobalSnapshotDelegatedStakeUnlockSuite extends SimpleIOSuite {
       } yield
         expect.all(
           transition.generatedTokenUnlocks == Map(owner -> List(expectedUnlock)),
-          transition.balances.get(owner).contains(Balance(NonNegLong.unsafeFrom(startingBalance.value.value + amount.value.value))),
+          transition.balances == SortedMap(
+            owner -> Balance(NonNegLong.unsafeFrom(startingBalance.value.value + amount.value.value)),
+            staleBucket -> startingBalance
+          ),
           transition.activeTokenLocks.isEmpty,
           transition.pendingWithdrawals.isEmpty,
           artifacts == SortedSet[SharedArtifact](expectedUnlock)


### PR DESCRIPTION
## Summary

Adds concurrent delegated-stake replacement/withdrawal submission and settlement coverage on the Mainnet safety fix in #1592. The E2E submits through two Global L0 nodes, checks that each observed state has at most one active or pending record per token lock, and verifies final principal settlement.

Invariant violations now fail immediately instead of being retried until a later safe observation. The checks run during outcome polling, pending-withdrawal polling, and settlement. The settlement check runs alongside the independent staking flow and both results are collected even if either fails. Request hashes, the submission-window ordinal, observed stake records, and endpoint failures are logged; the CI port convention is documented.

## Coverage contract

- Concurrent HTTP submission does **not** prove that both events were considered in one consensus round. The E2E names, comments, and output make that limit explicit.
- `UpdateDelegatedStakeAcceptanceManagerSuite` supplies deterministic same-batch A-1/A coverage: both requests are accepted before activation; the replacement is accepted and the original withdrawal is rejected at activation. Comparing two accepted ordinals would assert the wrong outcome.
- `GlobalSnapshotDelegatedStakeUnlockSuite` now also splits duplicate legacy withdrawals across two address buckets at A-1/A/A+1. The transition fixture checks one owner credit, an unchanged other-address balance, cleared lock/pending state, and one unlock artifact. This malformed state is constructed in Scala rather than through the public API.
- Six Node regression cases protect immediate invariant failure and retryable propagation/settlement behavior; they run in the delegated-staking workflow.

## Stacking

This tests-only PR remains based on `fix/mainnet-delegated-withdrawal-safety` (#1592). Production code and activation configuration are unchanged. After #1592 merges, retarget to `release/mainnet` and refresh CI.

## Verification

- Node 18: six invariant regression cases passed; JavaScript syntax checked.
- Focused Scala suites: 15 tests passed (acceptance manager, unlock transition, ordinal configuration).
- Six additional isolated probes through the actual E2E functions passed, covering successful settlement, immediate failure in all three polling phases, and collection of settlement results when the other flow fails.
- Full-project `sbt compile` passed at `62563135105e22e8ed2b8ea3a897ff874493ae4c` with a clean worktree afterward.
- Workflow YAML, `git diff --check`, PR title, and all commit messages in the PR range passed validation.

The live network E2E remains a GitHub CI gate; the isolated probes are not a network run.
