### PR TITLE
fix(dag-l0): harden downloaded snapshot head handoff

### DIFF
--- a/.github/workflows/e2e-just-test.yml
+++ b/.github/workflows/e2e-just-test.yml
@@ -111,6 +111,13 @@ jobs:
           # 30 min default would have killed it regardless).
           # The previous note here blocked on PR #1485, which was closed without ever merging.
           # - { name: fork-recovery,          tests: "fork-recovery", extra-args: "--num-gl0=5", runner: "Ubuntu-22-64-core", timeout: 60 }
+          # Exercises the production cold-restart topology: one rollback lead, one warm validator,
+          # and one validator restored from an older same-prefix snapshot. The healthy pair must
+          # advance, the lagged validator must publish its exact downloaded head before consensus
+          # initialization, become Ready, sign again, and converge on the same post-recovery hash.
+          # This test needs 2/3 finality while one member is deliberately offline; keep that quorum
+          # override scoped to this matrix row rather than weakening the other E2E jobs.
+          - { name: rollback-download-head,  tests: "rollback-download-head", extra-args: "--num-gl0=3 --num-gl1=0", quorum: "0.6666666666666666", timeout: 60 }
           - { name: currency,               tests: "currency" }
           - { name: rewards,                tests: "rewards" }
           - { name: token-locks,            tests: "token-locks" }
@@ -141,7 +148,7 @@ jobs:
       # Cadence when there ARE pending events (the flood): lowered so gl0 drains the chain faster without
       # spawning empty rounds when idle.
       CL_EVENT_TRIGGER_COOLDOWN: "5 seconds"
-      CL_QUORUM_THRESHOLD_FRACTION: "1.0"
+      CL_QUORUM_THRESHOLD_FRACTION: ${{ matrix.test-group.quorum || '1.0' }}
 
     steps:
       - name: Checkout code
@@ -243,7 +250,7 @@ jobs:
           docker logs "snapshot-streaming-postgres" > "runner-logs/snapshot-streaming-postgres.log" 2>&1 || echo "No snapshot-streaming-postgres container"
 
           # Collect node log directories (mounted volumes). Covers indices beyond the default 3
-          # so multi-node rigs (committee-rewards, fork-recovery) upload their late joiners' logs,
+          # so multi-node rigs (committee-rewards, fork-recovery, rollback-download-head) upload their late joiners' logs,
           # which are exactly the ones needed to diagnose an admission-timing failure.
           for i in 0 1 2 3 4 5 6 7 8 9; do
             cp -r "nodes/$i/gl0-logs" "runner-logs/node-$i-gl0-logs" 2>/dev/null || true

--- a/.github/workflows/e2e-just-test.yml
+++ b/.github/workflows/e2e-just-test.yml
@@ -115,9 +115,9 @@ jobs:
           # and one validator restored from an older same-prefix snapshot. The healthy pair must
           # advance, the lagged validator must publish its exact downloaded head before consensus
           # initialization, become Ready, sign again, and converge on the same post-recovery hash.
-          # This test needs 2/3 finality while one member is deliberately offline; keep that quorum
-          # override scoped to this matrix row rather than weakening the other E2E jobs.
-          - { name: rollback-download-head,  tests: "rollback-download-head", extra-args: "--num-gl0=3 --num-gl1=0", quorum: "0.6666666666666666", timeout: 60 }
+          # The committed DAG-L0 development config uses 2/3 finality, which this scenario verifies
+          # by requiring the two healthy members to advance while the third is deliberately offline.
+          - { name: rollback-download-head,  tests: "rollback-download-head", extra-args: "--num-gl0=3 --num-gl1=0", timeout: 60 }
           - { name: currency,               tests: "currency" }
           - { name: rewards,                tests: "rewards" }
           - { name: token-locks,            tests: "token-locks" }
@@ -148,7 +148,6 @@ jobs:
       # Cadence when there ARE pending events (the flood): lowered so gl0 drains the chain faster without
       # spawning empty rounds when idle.
       CL_EVENT_TRIGGER_COOLDOWN: "5 seconds"
-      CL_QUORUM_THRESHOLD_FRACTION: ${{ matrix.test-group.quorum || '1.0' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-just-test.yml
+++ b/.github/workflows/e2e-just-test.yml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          - { name: dag-cluster,            tests: "dag-cluster" }
+          - { name: dag-cluster,            tests: "dag-cluster", extra-args: "--num-gl0=4" }
           - { name: delegated-staking,      tests: "delegated-staking" }
           - { name: token-lock-replacement, tests: "token-lock-replacement" }
           # DISABLED on a NODE bug, not a test bug. The Phase-1 gate was unsatisfiable and is now
@@ -115,8 +115,7 @@ jobs:
           # and one validator restored from an older same-prefix snapshot. The healthy pair must
           # advance, the lagged validator must publish its target ordinal/hash before consensus
           # initialization, become Ready, sign again, and converge on the same post-recovery hash.
-          # Restore the job-wide unanimous E2E baseline through the env fallback below. This test alone
-          # needs a per-row 2/3 override while one member is deliberately offline.
+          # Keep this scenario's 2/3 requirement explicit while one member is deliberately offline.
           - { name: rollback-download-head,  tests: "rollback-download-head", extra-args: "--num-gl0=3 --num-gl1=0", quorum: "0.6666666666666666", timeout: 60 }
           - { name: currency,               tests: "currency" }
           - { name: rewards,                tests: "rewards" }
@@ -148,7 +147,9 @@ jobs:
       # Cadence when there ARE pending events (the flood): lowered so gl0 drains the chain faster without
       # spawning empty rounds when idle.
       CL_EVENT_TRIGGER_COOLDOWN: "5 seconds"
-      CL_QUORUM_THRESHOLD_FRACTION: ${{ matrix.test-group.quorum || '1.0' }}
+      # GL0 uses 2/3 so current signers can support certified committee expansion.
+      # This pass-through is GL0-only; Currency L0 retains its own quorum setting.
+      CL_QUORUM_THRESHOLD_FRACTION: ${{ matrix.test-group.quorum || '0.6666666666666666' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-just-test.yml
+++ b/.github/workflows/e2e-just-test.yml
@@ -113,11 +113,11 @@ jobs:
           # - { name: fork-recovery,          tests: "fork-recovery", extra-args: "--num-gl0=5", runner: "Ubuntu-22-64-core", timeout: 60 }
           # Exercises the production cold-restart topology: one rollback lead, one warm validator,
           # and one validator restored from an older same-prefix snapshot. The healthy pair must
-          # advance, the lagged validator must publish its exact downloaded head before consensus
+          # advance, the lagged validator must publish its target ordinal/hash before consensus
           # initialization, become Ready, sign again, and converge on the same post-recovery hash.
-          # The committed DAG-L0 development config uses 2/3 finality, which this scenario verifies
-          # by requiring the two healthy members to advance while the third is deliberately offline.
-          - { name: rollback-download-head,  tests: "rollback-download-head", extra-args: "--num-gl0=3 --num-gl1=0", timeout: 60 }
+          # Restore the job-wide unanimous E2E baseline through the env fallback below. This test alone
+          # needs a per-row 2/3 override while one member is deliberately offline.
+          - { name: rollback-download-head,  tests: "rollback-download-head", extra-args: "--num-gl0=3 --num-gl1=0", quorum: "0.6666666666666666", timeout: 60 }
           - { name: currency,               tests: "currency" }
           - { name: rewards,                tests: "rewards" }
           - { name: token-locks,            tests: "token-locks" }
@@ -148,6 +148,7 @@ jobs:
       # Cadence when there ARE pending events (the flood): lowered so gl0 drains the chain faster without
       # spawning empty rounds when idle.
       CL_EVENT_TRIGGER_COOLDOWN: "5 seconds"
+      CL_QUORUM_THRESHOLD_FRACTION: ${{ matrix.test-group.quorum || '1.0' }}
 
     steps:
       - name: Checkout code

--- a/docker/bin/compose-runner.sh
+++ b/docker/bin/compose-runner.sh
@@ -51,6 +51,7 @@ if [ "$LIST_TESTS" = "true" ]; then
   echo "  dag-cluster              DAG cluster check"
   echo "  delegated-staking        Delegated staking tests"
   echo "  fork-recovery            Fork recovery test (needs --num-gl0=5)"
+  echo "  rollback-download-head   Rollback-lead-first cold restart and lagged-validator download"
   echo "  committee-rewards        Full-committee delegated reward split"
   echo "                           (needs --num-gl0=5 --num-gl0-early=3;"
   echo "                            --gl0-late-delay=<seconds>, default 240, tunes the join stagger)"
@@ -583,6 +584,15 @@ if should_run_test "fork-recovery"; then
   show_time "Fork recovery test completed"
 fi
 
+if should_run_test "rollback-download-head"; then
+  echo "================================================"
+  echo "Running rollback-download-head test"
+  echo "================================================"
+  cd $PROJECT_ROOT
+  bash docker/bin/test-rollback-download-head.sh $DAG_L0_PORT_PREFIX
+  show_time "Rollback download-head test completed"
+fi
+
 if should_run_test "committee-rewards"; then
   echo "================================================"
   echo "Running committee rewards test"
@@ -773,4 +783,3 @@ echo "End-to-end tests completed"
 echo "------------------------------------------------"
 
 cd $PROJECT_ROOT
-

--- a/docker/bin/test-rollback-download-head.sh
+++ b/docker/bin/test-rollback-download-head.sh
@@ -74,10 +74,6 @@ get_ordinal() {
     jq -r '.value.ordinal // empty' 2>/dev/null || true
 }
 
-get_metadata() {
-  curl -fsS --max-time 5 "$(node_url "$1")/global-snapshots/latest/metadata" 2>/dev/null || true
-}
-
 get_snapshot_hash() {
   local node=$1
   local ordinal=$2
@@ -300,7 +296,7 @@ wait_target_rejoin() {
   local since=$2
   local timeout=$3
   local deadline=$(( $(date +%s) + timeout ))
-  local state ordinal metadata metadata_ordinal metadata_hash artifact_hash logs metric
+  local state ordinal logs metric publication_ordinals publication_ordinal init_ordinals init_ordinal target_hash lead_hash
 
   while [ "$(date +%s)" -lt "$deadline" ]; do
     state=$(get_node_state "$TARGET_NODE")
@@ -309,18 +305,23 @@ wait_target_rejoin() {
     metric=$(curl -fsS --max-time 5 "$(node_url "$TARGET_NODE")/metrics" 2>/dev/null |
       awk '/^dag_download_head_publication_total\{.*path="full"/ { total += $NF } END { print total + 0 }' || true)
 
+    publication_ordinals=$(sed -n \
+      's/.*Publishing validated download\/recovery head ordinal=SnapshotOrdinal{value=\([0-9][0-9]*\)}.*/\1/p' <<<"$logs")
+    publication_ordinal=${publication_ordinals%%$'\n'*}
+    init_ordinals=$(sed -n \
+      -e 's/.*round=SnapshotOrdinal(\([0-9][0-9]*\)).*event=DOWNLOAD_INIT_START.*/\1/p' \
+      -e 's/.*round=SnapshotOrdinal{value=\([0-9][0-9]*\)}.*event=DOWNLOAD_INIT_START.*/\1/p' <<<"$logs")
+    init_ordinal=${init_ordinals%%$'\n'*}
+
     if [ "$state" = "Ready" ] && [ -n "$ordinal" ] && [ "$ordinal" -ge "$minimum" ] \
-      && grep -Fq 'event=DOWNLOAD_INIT_START' <<<"$logs" \
-      && { [ "${metric:-0}" -ge 1 ] || grep -Fq '[SnapshotStorage] Publishing validated download/recovery head' <<<"$logs"; }; then
-      metadata=$(get_metadata "$TARGET_NODE")
-      metadata_ordinal=$(jq -r '.ordinal // empty' <<<"$metadata" 2>/dev/null || true)
-      metadata_hash=$(jq -r '.hash // empty' <<<"$metadata" 2>/dev/null || true)
-      if [ -n "$metadata_ordinal" ] && [ -n "$metadata_hash" ]; then
-        artifact_hash=$(get_snapshot_hash "$TARGET_NODE" "$metadata_ordinal")
-        if [ "$artifact_hash" = "$metadata_hash" ]; then
-          printf '%s|%s\n' "$metadata_ordinal" "$metadata_hash"
-          return 0
-        fi
+      && [ "${metric:-0}" -ge 1 ] \
+      && [ -n "$publication_ordinal" ] && [ "$publication_ordinal" = "$init_ordinal" ] \
+      && [ "$publication_ordinal" -ge "$minimum" ]; then
+      target_hash=$(get_snapshot_hash "$TARGET_NODE" "$publication_ordinal")
+      lead_hash=$(get_snapshot_hash "$LEAD_NODE" "$publication_ordinal")
+      if [ -n "$target_hash" ] && [ "$target_hash" = "$lead_hash" ]; then
+        printf '%s|%s\n' "$publication_ordinal" "$target_hash"
+        return 0
       fi
     fi
 
@@ -336,14 +337,18 @@ wait_consensus_completion_after() {
   local ordinal=$3
   local timeout=$4
   local deadline=$(( $(date +%s) + timeout ))
-  local logs
+  local logs peer_prefix signed_completions
+
+  peer_prefix=$(peer_id_of "${node##gl0-}" | cut -c1-8)
+  [ -n "$peer_prefix" ] || return 1
 
   while [ "$(date +%s)" -lt "$deadline" ]; do
     logs=$(docker logs --since "$since" "$node" 2>&1 || true)
-    if grep -F 'event=CONSENSUS_FINISHED' <<<"$logs" |
-      sed -n \
-        -e 's/.*round=SnapshotOrdinal(\([0-9][0-9]*\)).*/\1/p' \
-        -e 's/.*round=SnapshotOrdinal{value=\([0-9][0-9]*\)}.*/\1/p' |
+    signed_completions=$(awk -v peer="$peer_prefix" \
+      'index($0, "event=ROUND_COMPLETED") && index($0, "signerIds=") && index($0, peer) { print }' <<<"$logs")
+    if sed -n \
+      -e 's/.*round=SnapshotOrdinal(\([0-9][0-9]*\)).*/\1/p' \
+      -e 's/.*round=SnapshotOrdinal{value=\([0-9][0-9]*\)}.*/\1/p' <<<"$signed_completions" |
       awk -v minimum="$ordinal" '$1 > minimum { found=1 } END { exit !found }'; then
       return 0
     fi
@@ -470,7 +475,7 @@ IFS='|' read -r downloaded_ordinal downloaded_hash <<<"$downloaded"
 echo "  Downloaded public head: ordinal=$downloaded_ordinal hash=${downloaded_hash:0:16}..."
 
 wait_consensus_completion_after "$TARGET_NODE" "$target_since" "$downloaded_ordinal" "$DOWNLOAD_TIMEOUT" ||
-  fail "$TARGET_NODE became Ready but did not complete a later consensus round"
+  fail "$TARGET_NODE became Ready but did not sign a later completed consensus round"
 
 echo "Phase 5: checking one exact post-join hash and continued production..."
 common=$(wait_all_ready_common "$downloaded_ordinal" "$DOWNLOAD_TIMEOUT" false) ||

--- a/docker/bin/test-rollback-download-head.sh
+++ b/docker/bin/test-rollback-download-head.sh
@@ -344,8 +344,17 @@ wait_consensus_completion_after() {
 
   while [ "$(date +%s)" -lt "$deadline" ]; do
     logs=$(docker logs --since "$since" "$node" 2>&1 || true)
-    signed_completions=$(awk -v peer="$peer_prefix" \
-      'index($0, "event=ROUND_COMPLETED") && index($0, "signerIds=") && index($0, peer) { print }' <<<"$logs")
+    signed_completions=$(awk -v peer="$peer_prefix" '
+      index($0, "event=ROUND_COMPLETED") && match($0, /signerIds=[^ ]*/) {
+        signerIds = substr($0, RSTART + 10, RLENGTH - 10)
+        count = split(signerIds, signers, ",")
+        for (i = 1; i <= count; i++)
+          if (signers[i] == peer) {
+            print
+            break
+          }
+      }
+    ' <<<"$logs")
     if sed -n \
       -e 's/.*round=SnapshotOrdinal(\([0-9][0-9]*\)).*/\1/p' \
       -e 's/.*round=SnapshotOrdinal{value=\([0-9][0-9]*\)}.*/\1/p' <<<"$signed_completions" |

--- a/docker/bin/test-rollback-download-head.sh
+++ b/docker/bin/test-rollback-download-head.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+#
+# Controlled GL0 cold-restart and validator-download qualification.
+#
+# This is an ordinary Just/Docker E2E payload. It exercises the production
+# topology: one run-rollback lead starts while every validator is stopped, then
+# validators start as run-validator. One validator's real data directory is
+# restored to an earlier, previously finalized head so its rejoin must traverse
+# the ordinary full-download path.
+#
+# Usage: bash docker/bin/test-rollback-download-head.sh [gl0_port_prefix]
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+GL0_PORT_PREFIX=${1:-90}
+TEST_HOST=${TEST_HOST:-http://localhost}
+EXPECTED_GL0_NODES=3
+LEAD_INDEX=0
+WARM_INDEX=1
+TARGET_INDEX=2
+LEAD_NODE="gl0-${LEAD_INDEX}"
+WARM_NODE="gl0-${WARM_INDEX}"
+TARGET_NODE="gl0-${TARGET_INDEX}"
+SETUP_TIMEOUT=${ROLLBACK_DOWNLOAD_SETUP_TIMEOUT_SECONDS:-900}
+LEAD_TIMEOUT=${ROLLBACK_DOWNLOAD_LEAD_TIMEOUT_SECONDS:-300}
+DOWNLOAD_TIMEOUT=${ROLLBACK_DOWNLOAD_VALIDATOR_TIMEOUT_SECONDS:-900}
+CONTINUATION_TIMEOUT=${ROLLBACK_DOWNLOAD_CONTINUATION_TIMEOUT_SECONDS:-600}
+MIN_BASELINE_ORDINAL=${ROLLBACK_DOWNLOAD_MIN_BASELINE_ORDINAL:-8}
+LAG_DISTANCE=${ROLLBACK_DOWNLOAD_LAG_DISTANCE:-4}
+CONTINUATION_DISTANCE=${ROLLBACK_DOWNLOAD_CONTINUATION_DISTANCE:-3}
+
+RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
+EVIDENCE_ROOT=${ROLLBACK_DOWNLOAD_EVIDENCE_ROOT:-${TMPDIR:-/tmp}/tessellation-e2e-evidence}
+EVIDENCE_DIR="${EVIDENCE_ROOT}/rollback-download-head-${RUN_ID}"
+ENV_BACKUP_DIR="${EVIDENCE_DIR}/env-backup"
+TARGET_DATA_ARCHIVE="${EVIDENCE_DIR}/target-lagged-data.tar"
+mkdir -p "$ENV_BACKUP_DIR"
+
+env_file() {
+  echo "${PROJECT_ROOT}/nodes/$1/.env"
+}
+
+node_port() {
+  local index=${1##gl0-}
+  echo $((GL0_PORT_PREFIX * 100 + index * 10))
+}
+
+node_url() {
+  echo "${TEST_HOST}:$(node_port "$1")"
+}
+
+node_p2p_url() {
+  echo "${TEST_HOST}:$(( $(node_port "$1") + 1 ))"
+}
+
+peer_id_of() {
+  tr -d '[:space:]' < "${PROJECT_ROOT}/nodes/$1/peer_id" 2>/dev/null || true
+}
+
+get_node_state() {
+  curl -fsS --max-time 5 "$(node_url "$1")/node/info" 2>/dev/null |
+    jq -r '.state // empty' 2>/dev/null || true
+}
+
+get_node_version() {
+  curl -fsS --max-time 5 "$(node_url "$1")/node/info" 2>/dev/null |
+    jq -r '.version // empty' 2>/dev/null || true
+}
+
+get_ordinal() {
+  curl -fsS --max-time 5 "$(node_url "$1")/global-snapshots/latest" 2>/dev/null |
+    jq -r '.value.ordinal // empty' 2>/dev/null || true
+}
+
+get_metadata() {
+  curl -fsS --max-time 5 "$(node_url "$1")/global-snapshots/latest/metadata" 2>/dev/null || true
+}
+
+get_snapshot_hash() {
+  local node=$1
+  local ordinal=$2
+  curl -fsS --max-time 10 "$(node_url "$node")/global-snapshots/${ordinal}/hash" 2>/dev/null |
+    jq -er 'if type == "string" then . else .value // .hash // empty end' 2>/dev/null || true
+}
+
+get_snapshot() {
+  local node=$1
+  local ordinal=$2
+  curl -fsS --max-time 15 "$(node_url "$node")/global-snapshots/${ordinal}" 2>/dev/null || true
+}
+
+set_env_key() {
+  local file=$1
+  local key=$2
+  local value=$3
+  local temporary
+  temporary=$(mktemp "${file}.XXXXXX")
+  awk -F= -v key="$key" '$1 != key { print }' "$file" > "$temporary"
+  printf '%s=%s\n' "$key" "$value" >> "$temporary"
+  mv "$temporary" "$file"
+}
+
+remove_env_key() {
+  local file=$1
+  local key=$2
+  local temporary
+  temporary=$(mktemp "${file}.XXXXXX")
+  awk -F= -v key="$key" '$1 != key { print }' "$file" > "$temporary"
+  mv "$temporary" "$file"
+}
+
+compose_up() {
+  local index=$1
+  (
+    cd "${PROJECT_ROOT}/nodes/${index}"
+    docker compose \
+      -f docker-compose.test.yaml \
+      -f docker-compose.yaml \
+      -f docker-compose.volumes.yaml \
+      --profile l0 \
+      up -d --force-recreate gl0
+  )
+}
+
+capture_evidence() {
+  local phase=${1:-final}
+  mkdir -p "${EVIDENCE_DIR}/${phase}"
+  docker ps -a --format '{{.Names}}\t{{.Status}}\t{{.Image}}' > "${EVIDENCE_DIR}/${phase}/containers.txt" 2>&1 || true
+  for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+    docker logs "gl0-${index}" > "${EVIDENCE_DIR}/${phase}/gl0-${index}.log" 2>&1 || true
+    curl -fsS --max-time 5 "$(node_url "gl0-${index}")/node/info" \
+      > "${EVIDENCE_DIR}/${phase}/gl0-${index}-node-info.json" 2>/dev/null || true
+    curl -fsS --max-time 5 "$(node_url "gl0-${index}")/global-snapshots/latest/metadata" \
+      > "${EVIDENCE_DIR}/${phase}/gl0-${index}-metadata.json" 2>/dev/null || true
+  done
+}
+
+restore_env_files() {
+  local index
+  for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+    if [ -f "${ENV_BACKUP_DIR}/gl0-${index}.env" ]; then
+      cp "${ENV_BACKUP_DIR}/gl0-${index}.env" "$(env_file "$index")"
+    fi
+  done
+}
+
+cleanup() {
+  local status=$?
+  capture_evidence final
+  restore_env_files
+  echo "E2E evidence preserved at ${EVIDENCE_DIR}"
+  exit "$status"
+}
+trap cleanup EXIT
+
+fail() {
+  local message=$1
+  echo "FAIL: $message" >&2
+  capture_evidence failure
+  for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+    local node="gl0-${index}"
+    echo "  $node state=$(get_node_state "$node") ordinal=$(get_ordinal "$node")" >&2
+  done
+  exit 1
+}
+
+wait_log() {
+  local node=$1
+  local since=$2
+  local pattern=$3
+  local timeout=$4
+  local deadline=$(( $(date +%s) + timeout ))
+  local logs
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    logs=$(docker logs --since "$since" "$node" 2>&1 || true)
+    if grep -Fq "$pattern" <<<"$logs"; then
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
+}
+
+wait_registration_endpoint() {
+  local node=$1
+  local timeout=$2
+  local deadline=$(( $(date +%s) + timeout ))
+  local status
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(curl -sS --max-time 3 -o /dev/null -w '%{http_code}' \
+      "$(node_p2p_url "$node")/registration/request" 2>/dev/null || true)
+    if [ "$status" = "200" ]; then
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
+}
+
+snapshot_has_all_test_proofs() {
+  local node=$1
+  local ordinal=$2
+  local snapshot peer_id index
+  snapshot=$(get_snapshot "$node" "$ordinal")
+  [ -n "$snapshot" ] || return 1
+  for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+    peer_id=$(peer_id_of "$index")
+    [ -n "$peer_id" ] || return 1
+    jq -e --arg peer "$peer_id" 'any(.proofs[]?; .id == $peer)' <<<"$snapshot" >/dev/null || return 1
+  done
+}
+
+# Print `ordinal|hash` once all three nodes are Ready, serve one exact hash at
+# that ordinal, and the artifact carries a proof from each test operator.
+wait_all_ready_common() {
+  local minimum=$1
+  local timeout=$2
+  local require_all_proofs=${3:-true}
+  local deadline=$(( $(date +%s) + timeout ))
+  local index node state ordinal minimum_seen hash reference all_match status
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    minimum_seen=""
+    all_match=true
+    status=""
+    for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+      node="gl0-${index}"
+      state=$(get_node_state "$node")
+      ordinal=$(get_ordinal "$node")
+      status="${status} ${node}:${state:-?}/${ordinal:-?}"
+      if [ "$state" != "Ready" ] || [ -z "$ordinal" ]; then
+        all_match=false
+        break
+      fi
+      if [ -z "$minimum_seen" ] || [ "$ordinal" -lt "$minimum_seen" ]; then
+        minimum_seen=$ordinal
+      fi
+    done
+
+    if [ "$all_match" = "true" ] && [ -n "$minimum_seen" ] && [ "$minimum_seen" -ge "$minimum" ]; then
+      reference=""
+      for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+        hash=$(get_snapshot_hash "gl0-${index}" "$minimum_seen")
+        if [ -z "$hash" ]; then
+          all_match=false
+          break
+        fi
+        if [ -z "$reference" ]; then
+          reference=$hash
+        elif [ "$hash" != "$reference" ]; then
+          all_match=false
+          break
+        fi
+      done
+      if [ "$all_match" = "true" ] \
+        && { [ "$require_all_proofs" != "true" ] || snapshot_has_all_test_proofs "$LEAD_NODE" "$minimum_seen"; }; then
+        printf '%s|%s\n' "$minimum_seen" "$reference"
+        return 0
+      fi
+    fi
+
+    echo "  Waiting for three-operator common proof (minimum=$minimum):${status}" >&2
+    sleep 5
+  done
+  return 1
+}
+
+wait_two_node_advance() {
+  local minimum=$1
+  local timeout=$2
+  local deadline=$(( $(date +%s) + timeout ))
+  local left right hash_left hash_right candidate
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    left=$(get_ordinal "$LEAD_NODE")
+    right=$(get_ordinal "$WARM_NODE")
+    if [ -n "$left" ] && [ -n "$right" ]; then
+      candidate=$(( left < right ? left : right ))
+      if [ "$candidate" -ge "$minimum" ]; then
+        hash_left=$(get_snapshot_hash "$LEAD_NODE" "$candidate")
+        hash_right=$(get_snapshot_hash "$WARM_NODE" "$candidate")
+        if [ -n "$hash_left" ] && [ "$hash_left" = "$hash_right" ]; then
+          printf '%s|%s\n' "$candidate" "$hash_left"
+          return 0
+        fi
+      fi
+    fi
+    echo "  Waiting for $LEAD_NODE/$WARM_NODE to reach common ordinal $minimum (left=${left:-?}, right=${right:-?})..." >&2
+    sleep 5
+  done
+  return 1
+}
+
+wait_target_rejoin() {
+  local minimum=$1
+  local since=$2
+  local timeout=$3
+  local deadline=$(( $(date +%s) + timeout ))
+  local state ordinal metadata metadata_ordinal metadata_hash artifact_hash logs metric
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    state=$(get_node_state "$TARGET_NODE")
+    ordinal=$(get_ordinal "$TARGET_NODE")
+    logs=$(docker logs --since "$since" "$TARGET_NODE" 2>&1 || true)
+    metric=$(curl -fsS --max-time 5 "$(node_url "$TARGET_NODE")/metrics" 2>/dev/null |
+      awk '/^dag_download_head_publication_total\{.*path="full"/ { total += $NF } END { print total + 0 }' || true)
+
+    if [ "$state" = "Ready" ] && [ -n "$ordinal" ] && [ "$ordinal" -ge "$minimum" ] \
+      && grep -Fq 'event=DOWNLOAD_INIT_START' <<<"$logs" \
+      && { [ "${metric:-0}" -ge 1 ] || grep -Fq '[SnapshotStorage] Publishing validated download/recovery head' <<<"$logs"; }; then
+      metadata=$(get_metadata "$TARGET_NODE")
+      metadata_ordinal=$(jq -r '.ordinal // empty' <<<"$metadata" 2>/dev/null || true)
+      metadata_hash=$(jq -r '.hash // empty' <<<"$metadata" 2>/dev/null || true)
+      if [ -n "$metadata_ordinal" ] && [ -n "$metadata_hash" ]; then
+        artifact_hash=$(get_snapshot_hash "$TARGET_NODE" "$metadata_ordinal")
+        if [ "$artifact_hash" = "$metadata_hash" ]; then
+          printf '%s|%s\n' "$metadata_ordinal" "$metadata_hash"
+          return 0
+        fi
+      fi
+    fi
+
+    echo "  Waiting for lagged validator full download: state=${state:-?} ordinal=${ordinal:-?} publication=${metric:-0}" >&2
+    sleep 5
+  done
+  return 1
+}
+
+wait_consensus_completion_after() {
+  local node=$1
+  local since=$2
+  local ordinal=$3
+  local timeout=$4
+  local deadline=$(( $(date +%s) + timeout ))
+  local logs
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    logs=$(docker logs --since "$since" "$node" 2>&1 || true)
+    if grep -F 'event=CONSENSUS_FINISHED' <<<"$logs" |
+      sed -n \
+        -e 's/.*round=SnapshotOrdinal(\([0-9][0-9]*\)).*/\1/p' \
+        -e 's/.*round=SnapshotOrdinal{value=\([0-9][0-9]*\)}.*/\1/p' |
+      awk -v minimum="$ordinal" '$1 > minimum { found=1 } END { exit !found }'; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+archive_target_data() {
+  local image
+  image=$(docker inspect -f '{{.Config.Image}}' "$TARGET_NODE")
+  [ -n "$image" ] || fail "could not resolve assembled image for $TARGET_NODE"
+  docker run --rm \
+    --volumes-from "$TARGET_NODE" \
+    -v "${EVIDENCE_DIR}:/evidence" \
+    --entrypoint /bin/bash \
+    "$image" -c 'set -e; tar -C /tessellation/data -cpf /evidence/target-lagged-data.tar .'
+  [ -s "$TARGET_DATA_ARCHIVE" ] || fail "lagged target archive was not created"
+}
+
+restore_target_data() {
+  local image
+  image=$(docker inspect -f '{{.Config.Image}}' "$TARGET_NODE")
+  [ -n "$image" ] || fail "could not resolve assembled image for $TARGET_NODE"
+  docker run --rm \
+    --volumes-from "$TARGET_NODE" \
+    -v "${EVIDENCE_DIR}:/evidence:ro" \
+    --entrypoint /bin/bash \
+    "$image" -c '
+      set -e
+      test -s /evidence/target-lagged-data.tar
+      find /tessellation/data -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+      tar -C /tessellation/data -xpf /evidence/target-lagged-data.tar
+    '
+}
+
+echo "================================================"
+echo "Rollback-lead / full-download head qualification"
+echo "================================================"
+echo "  lead:       $LEAD_NODE (run-rollback)"
+echo "  warm peer:  $WARM_NODE (run-validator)"
+echo "  lagged peer:$TARGET_NODE (run-validator)"
+echo "  evidence:   $EVIDENCE_DIR"
+
+running_gl0=$(docker ps --format '{{.Names}}' | awk '/^gl0-[0-9]+$/ { count++ } END { print count+0 }')
+[ "$running_gl0" -eq "$EXPECTED_GL0_NODES" ] ||
+  fail "requires exactly $EXPECTED_GL0_NODES running GL0 nodes; found $running_gl0"
+
+for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+  [ -f "$(env_file "$index")" ] || fail "missing generated environment for gl0-${index}"
+  cp "$(env_file "$index")" "${ENV_BACKUP_DIR}/gl0-${index}.env"
+done
+
+{
+  echo "run_id=$RUN_ID"
+  echo "git_head=$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
+  echo "gl0_jar_sha256=$(sha256sum "${PROJECT_ROOT}/docker/jars/gl0.jar" | awk '{print $1}')"
+  for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
+    echo "gl0_${index}_peer_id=$(peer_id_of "$index")"
+    echo "gl0_${index}_version=$(get_node_version "gl0-${index}")"
+  done
+} > "${EVIDENCE_DIR}/run-metadata.txt"
+
+echo "Phase 1: preserving a genuine lagged validator head..."
+baseline=$(wait_all_ready_common "$MIN_BASELINE_ORDINAL" "$SETUP_TIMEOUT") ||
+  fail "could not establish an all-Ready, all-signed baseline"
+IFS='|' read -r lagged_ordinal lagged_hash <<<"$baseline"
+echo "  Lagged checkpoint: ordinal=$lagged_ordinal hash=${lagged_hash:0:16}..."
+
+docker stop "$TARGET_NODE" >/dev/null
+archive_target_data
+docker start "$TARGET_NODE" >/dev/null
+
+anchor_minimum=$((lagged_ordinal + LAG_DISTANCE))
+anchor=$(wait_all_ready_common "$anchor_minimum" "$SETUP_TIMEOUT") ||
+  fail "cluster did not produce a later all-signed rollback anchor"
+IFS='|' read -r rollback_ordinal rollback_hash <<<"$anchor"
+echo "  Rollback anchor: ordinal=$rollback_ordinal hash=${rollback_hash:0:16}..."
+capture_evidence before-cold-restart
+
+echo "Phase 2: stopping the full fleet and restoring $TARGET_NODE to ordinal $lagged_ordinal..."
+docker stop "$LEAD_NODE" "$WARM_NODE" "$TARGET_NODE" >/dev/null
+restore_target_data
+
+set_env_key "$(env_file "$LEAD_INDEX")" CL_DOCKER_GL0_GENESIS true
+set_env_key "$(env_file "$LEAD_INDEX")" CL_DOCKER_GL0_JOIN false
+set_env_key "$(env_file "$LEAD_INDEX")" CL_DOCKER_ROLLBACK true
+set_env_key "$(env_file "$LEAD_INDEX")" CL_DOCKER_ROLLBACK_HASH "$rollback_hash"
+
+for index in "$WARM_INDEX" "$TARGET_INDEX"; do
+  set_env_key "$(env_file "$index")" CL_DOCKER_GL0_GENESIS false
+  set_env_key "$(env_file "$index")" CL_DOCKER_GL0_JOIN true
+  remove_env_key "$(env_file "$index")" CL_DOCKER_ROLLBACK
+  remove_env_key "$(env_file "$index")" CL_DOCKER_ROLLBACK_HASH
+done
+
+echo "Phase 3: starting only the rollback lead..."
+lead_since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+compose_up "$LEAD_INDEX"
+wait_registration_endpoint "$LEAD_NODE" "$LEAD_TIMEOUT" ||
+  fail "rollback lead never exposed its registration endpoint"
+wait_log "$LEAD_NODE" "$lead_since" 'Successfully initialized lastNGlobalSnapshot shared storage' "$LEAD_TIMEOUT" ||
+  fail "rollback lead did not reconstruct Last-N while validators were stopped"
+
+running_peers=$(docker ps --format '{{.Names}}' | awk -v lead="$LEAD_NODE" '/^gl0-[0-9]+$/ && $0 != lead { count++ } END { print count+0 }')
+[ "$running_peers" -eq 0 ] || fail "a validator was running during rollback-lead-only initialization"
+lead_logs=$(docker logs --since "$lead_since" "$LEAD_NODE" 2>&1 || true)
+grep -Fq "run-rollback $rollback_hash" <<<"$lead_logs" ||
+  fail "lead did not start with the selected rollback hash"
+capture_evidence lead-only
+
+echo "Phase 4: starting the warm validator, then the lagged validator..."
+compose_up "$WARM_INDEX"
+warm_progress=$(wait_two_node_advance "$((rollback_ordinal + 1))" "$SETUP_TIMEOUT") ||
+  fail "rollback lead and warm validator did not align on the selected anchor"
+IFS='|' read -r warm_ordinal warm_hash <<<"$warm_progress"
+echo "  Lead/warm aligned: ordinal=$warm_ordinal hash=${warm_hash:0:16}..."
+
+target_since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+compose_up "$TARGET_INDEX"
+downloaded=$(wait_target_rejoin "$rollback_ordinal" "$target_since" "$DOWNLOAD_TIMEOUT") ||
+  fail "$TARGET_NODE did not complete ordinary full download and publish its exact head"
+IFS='|' read -r downloaded_ordinal downloaded_hash <<<"$downloaded"
+echo "  Downloaded public head: ordinal=$downloaded_ordinal hash=${downloaded_hash:0:16}..."
+
+wait_consensus_completion_after "$TARGET_NODE" "$target_since" "$downloaded_ordinal" "$DOWNLOAD_TIMEOUT" ||
+  fail "$TARGET_NODE became Ready but did not complete a later consensus round"
+
+echo "Phase 5: checking one exact post-join hash and continued production..."
+common=$(wait_all_ready_common "$downloaded_ordinal" "$DOWNLOAD_TIMEOUT" false) ||
+  fail "all three nodes did not converge to one post-download artifact"
+IFS='|' read -r common_ordinal common_hash <<<"$common"
+continuation_target=$((common_ordinal + CONTINUATION_DISTANCE))
+continued=$(wait_all_ready_common "$continuation_target" "$CONTINUATION_TIMEOUT" false) ||
+  fail "cluster did not continue for $CONTINUATION_DISTANCE ordinals after validator rejoin"
+IFS='|' read -r final_ordinal final_hash <<<"$continued"
+
+{
+  echo "lagged_ordinal=$lagged_ordinal"
+  echo "lagged_hash=$lagged_hash"
+  echo "rollback_ordinal=$rollback_ordinal"
+  echo "rollback_hash=$rollback_hash"
+  echo "downloaded_ordinal=$downloaded_ordinal"
+  echo "downloaded_hash=$downloaded_hash"
+  echo "common_ordinal=$common_ordinal"
+  echo "common_hash=$common_hash"
+  echo "final_ordinal=$final_ordinal"
+  echo "final_hash=$final_hash"
+  docker logs --since "$lead_since" "$LEAD_NODE" 2>&1 |
+    grep -m1 -E 'deterministicConfigHash|deterministic config hash' || true
+} >> "${EVIDENCE_DIR}/run-metadata.txt"
+
+capture_evidence success
+echo
+echo "================================================"
+echo "PASS: rollback lead and downloaded-head lifecycle"
+echo "================================================"
+echo "Lead initialized Last-N alone at $rollback_ordinal; $TARGET_NODE downloaded from retained $lagged_ordinal,"
+echo "published exact head $downloaded_ordinal, became Ready, completed consensus, matched all peers at"
+echo "$common_ordinal/$common_hash, and the cluster continued through $final_ordinal."

--- a/docker/bin/test-rollback-download-head.sh
+++ b/docker/bin/test-rollback-download-head.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Controlled GL0 cold-restart and validator-download qualification.
+# Controlled GL0 cold-restart and forward validator-download qualification.
 #
-# This is an ordinary Just/Docker E2E payload. It exercises the production
-# topology: one run-rollback lead starts while every validator is stopped, then
-# validators start as run-validator. One validator's real data directory is
-# restored to an earlier, previously finalized head so its rejoin must traverse
-# the ordinary full-download path.
+# This ordinary Just/Docker E2E validates rollback-lead initialization,
+# restoration of a lagged validator to an earlier finalized checkpoint, forward
+# full download from that checkpoint, and durable head publication before
+# consensus resumes. It does not exercise a validator replacing its current
+# public head with a lower ordinal or prove the backward-publication branch.
 #
 # Usage: bash docker/bin/test-rollback-download-head.sh [gl0_port_prefix]
 
@@ -395,7 +395,7 @@ restore_target_data() {
 }
 
 echo "================================================"
-echo "Rollback-lead / full-download head qualification"
+echo "Rollback-lead / forward full-download head qualification"
 echo "================================================"
 echo "  lead:       $LEAD_NODE (run-rollback)"
 echo "  warm peer:  $WARM_NODE (run-validator)"
@@ -413,6 +413,8 @@ done
 
 {
   echo "run_id=$RUN_ID"
+  echo "coverage=rollback-lead initialization; lagged-validator checkpoint restoration; forward full download; durable head publication before consensus"
+  echo "not_covered=backward publication from a higher current public head"
   echo "git_head=$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
   echo "gl0_jar_sha256=$(sha256sum "${PROJECT_ROOT}/docker/jars/gl0.jar" | awk '{print $1}')"
   for index in $(seq 0 $((EXPECTED_GL0_NODES - 1))); do
@@ -479,7 +481,7 @@ echo "  Lead/warm aligned: ordinal=$warm_ordinal hash=${warm_hash:0:16}..."
 target_since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 compose_up "$TARGET_INDEX"
 downloaded=$(wait_target_rejoin "$rollback_ordinal" "$target_since" "$DOWNLOAD_TIMEOUT") ||
-  fail "$TARGET_NODE did not complete ordinary full download and publish its exact head"
+  fail "$TARGET_NODE did not complete ordinary full download and publish its target ordinal/hash"
 IFS='|' read -r downloaded_ordinal downloaded_hash <<<"$downloaded"
 echo "  Downloaded public head: ordinal=$downloaded_ordinal hash=${downloaded_hash:0:16}..."
 
@@ -513,8 +515,9 @@ IFS='|' read -r final_ordinal final_hash <<<"$continued"
 capture_evidence success
 echo
 echo "================================================"
-echo "PASS: rollback lead and downloaded-head lifecycle"
+echo "PASS: rollback lead and forward downloaded-head lifecycle"
 echo "================================================"
-echo "Lead initialized Last-N alone at $rollback_ordinal; $TARGET_NODE downloaded from retained $lagged_ordinal,"
-echo "published exact head $downloaded_ordinal, became Ready, completed consensus, matched all peers at"
+echo "Lead initialized Last-N alone at $rollback_ordinal; $TARGET_NODE restored finalized checkpoint $lagged_ordinal,"
+echo "downloaded forward, durably published target ordinal/hash $downloaded_ordinal/$downloaded_hash before consensus resumed, and matched all peers at"
 echo "$common_ordinal/$common_hash, and the cluster continued through $final_ordinal."
+echo "This scenario does not exercise replacement of a current public head with a lower ordinal."

--- a/docker/docker-compose.test.yaml
+++ b/docker/docker-compose.test.yaml
@@ -23,6 +23,7 @@ services:
       - CL_TIME_TRIGGER_INTERVAL
       - CL_MAX_ROUND_DURATION
       - CL_EVENT_TRIGGER_COOLDOWN
+      - CL_QUORUM_THRESHOLD_FRACTION
       # Chronic-non-signer thresholds — disabled for fork-recovery test.
       #
       # Background: the chronic-non-signer filter classifies a peer as silent if

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
@@ -326,6 +326,19 @@ object Main
 
   private[dag] def validateRecoverySeedRollbackHash(expected: Hash, got: Hash): Either[RecoverySeedRollbackHashMismatch, Unit] =
     Either.cond(expected === got, (), RecoverySeedRollbackHashMismatch(expected, got))
+
+  /** Snapshot-info roots that must survive the ordinary logarithmic cutoff so a restarted validator can authenticate certified lineage.
+    *
+    * A production-style ordinal-gated activation roots at `activation - 1`. The development active-from-genesis mode instead roots at the
+    * first incremental artifact: its state proof is derived from full genesis, but replay still needs the ordinal-1 artifact/context pair.
+    * A dormant (`Long.MaxValue`) deployment has no certified root to retain.
+    */
+  private[dag] def protectedCertifiedSnapshotInfoOrdinals(activationKey: Long): Set[SnapshotOrdinal] =
+    if (activationKey === Long.MaxValue) Set.empty
+    else if (CertifiedConsensusGenesis.isActiveFromGenesis(activationKey))
+      Set(CertifiedConsensusGenesis.FirstIncrementalOrdinal)
+    else Set(SnapshotOrdinal.unsafeApply(activationKey - 1L))
+
   private[dag] final case class RecentCoreReconstructionDiagnostic(
     source: String,
     entries: SortedMap[SnapshotOrdinal, SortedSet[PeerId]]
@@ -379,11 +392,7 @@ object Main
       }).asResource
       certifiedConsensusActivationOrdinal = SnapshotOrdinal.unsafeApply(loadedConsensusConfig.certifiedConsensusActivationKey)
       protectedCertifiedSnapshotInfoOrdinals =
-        if (
-          loadedConsensusConfig.certifiedConsensusActivationKey === Long.MaxValue ||
-          CertifiedConsensusGenesis.isActiveFromGenesis(loadedConsensusConfig.certifiedConsensusActivationKey)
-        ) Set.empty[SnapshotOrdinal]
-        else Set(SnapshotOrdinal.unsafeApply(loadedConsensusConfig.certifiedConsensusActivationKey - 1L))
+        Main.protectedCertifiedSnapshotInfoOrdinals(loadedConsensusConfig.certifiedConsensusActivationKey)
       recoveryMaxFacilitatorCount = loadedConsensusConfig.facilitatorSelectionMax
       recoverySeedCommittee = method match {
         case m: RunRollback                 => m.recoverySeedCommittee

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/StoragesInitializer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/StoragesInitializer.scala
@@ -42,7 +42,11 @@ object StoragesInitializer {
       _ <- lastNGlobalSnapshotStorage.setInitialFetchingGL0(
         hashedGlobalIncrementalSnapshot,
         globalSnapshotInfo,
-        none,
+        // A coordinated cold restart deliberately starts the rollback lead before
+        // validators are available. Reconstruct the declared recent lineage from
+        // the lead's canonical archive first and consult peers only for an exact
+        // local hash miss.
+        globalSnapshotStorage.asRight.some,
         Some((hash, ordinal) => download.fetchSnapshot(hash, ordinal))
       )
       _ <- Logger[F].info(s"Successfully initialized lastNGlobalSnapshot shared storage")

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/StoragesInitializer.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/StoragesInitializer.scala
@@ -44,8 +44,9 @@ object StoragesInitializer {
         globalSnapshotInfo,
         // A coordinated cold restart deliberately starts the rollback lead before
         // validators are available. Reconstruct the declared recent lineage from
-        // the lead's canonical archive first and consult peers only for an exact
-        // local hash miss.
+        // the lead's canonical archive first. globalSnapshotStorage.get(hash)
+        // reads through to the filesystem when its caches are cold; consult peers
+        // only after that exact local hash lookup misses.
         globalSnapshotStorage.asRight.some,
         Some((hash, ordinal) => download.fetchSnapshot(hash, ordinal))
       )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -3,7 +3,7 @@ package io.constellationnetwork.dag.l0.domain.snapshot.programs
 import cats.effect.std.Random
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
-import cats.{Applicative, Parallel}
+import cats.{Applicative, Monad, Parallel}
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -85,6 +85,33 @@ case class RollbackTargetNotCorroborated(
     with NoStackTrace
 
 object Download {
+
+  private[snapshot] def headPublicationDirection(
+    previous: Option[SnapshotOrdinal],
+    target: SnapshotOrdinal
+  ): String =
+    previous.fold("initial") { ordinal =>
+      if (target > ordinal) "forward"
+      else if (target === ordinal) "same_ordinal"
+      else "backward"
+    }
+
+  /** Serialize the terminal handoff shared by ordinary full download and bounded follower catch-up.
+    *
+    * Both callbacks receive the same immutable artifact/context references. If publication fails, the consensus callback is never
+    * evaluated; the enclosing download lifecycle retains ownership of reverting to WaitingForDownload and retrying. This is deliberately a
+    * small effect-order helper, not a second download harness or a new authority boundary.
+    */
+  private[snapshot] def publishValidatedHeadBeforeConsensus[F[_]: Monad, A, C](
+    artifact: A,
+    context: C,
+    publish: (A, C) => F[Unit],
+    afterPublication: (A, C) => F[Unit],
+    startConsensus: (A, C) => F[Unit]
+  ): F[Unit] =
+    publish(artifact, context) >>
+      afterPublication(artifact, context) >>
+      startConsensus(artifact, context)
 
   /** Run a long recovery operation with an inactivity watchdog rather than a total wall-clock deadline. Deep canonical replay is allowed to
     * take hours as long as ordinals continue moving; a fiber that makes no recorded progress for `maxIdle` is cancelled and retried by
@@ -506,6 +533,52 @@ object Download {
         _ <- Metrics[F].updateGauge("dag_global_snapshot_signature_count", snapshot.proofs.size.toDouble)
       } yield ()
 
+    /** Publish the exact terminal artifact/context selected by an already validated download before consensus can initialize from it.
+      *
+      * Full download may legitimately replace a higher local fork head with a lower canonical head after its validated cleanup. That move
+      * remains allowed and is made explicit through warning/metrics rather than blocked by a monotonicity guard.
+      */
+    private def handoffValidatedDownloadHead(
+      path: String,
+      observationLimit: ObservationLimit,
+      snapshot: Signed[GlobalIncrementalSnapshot],
+      context: GlobalSnapshotInfo,
+      isRecovery: Boolean
+    )(implicit hasherSelector: HasherSelector[F]): F[Unit] =
+      for {
+        previous <- globalSnapshotConsensusStorage.headSnapshot.map(_.map(_.ordinal))
+        direction = Download.headPublicationDirection(previous, snapshot.ordinal)
+        _ <- Applicative[F].whenA(direction === "backward") {
+          logger.warn(
+            s"[DownloadHeadPublication] Publishing validated lower canonical head: " +
+              s"path=$path previous=${previous.map(_.show).getOrElse("none")} target=${snapshot.ordinal.show}"
+          )
+        }
+        _ <- Download.publishValidatedHeadBeforeConsensus[F, Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo](
+          snapshot,
+          context,
+          (artifact, state) =>
+            hasherSelector.withCurrent { implicit hasher =>
+              globalSnapshotConsensusStorage.setHeadForRecovery(artifact, state)
+            },
+          (_, _) =>
+            Metrics[F].incrementCounter(
+              "dag_download_head_publication_total",
+              Seq(
+                Metrics.unsafeLabelName("path") -> path,
+                Metrics.unsafeLabelName("direction") -> direction
+              )
+            ),
+          (artifact, state) =>
+            consensus.manager.startFacilitatingAfterDownload(
+              observationLimit,
+              artifact,
+              state,
+              isRecovery = isRecovery
+            )
+        )
+      } yield ()
+
     def download(implicit hasherSelector: HasherSelector[F]): F[Unit] = {
       val guardedStart =
         recordDownloadPhase("full", "start_entered") >>
@@ -542,7 +615,13 @@ object Download {
         .flatMap { result =>
           val ((snapshot, context), observationLimit) = result
           for {
-            _ <- consensus.manager.startFacilitatingAfterDownload(observationLimit, snapshot, context)
+            _ <- handoffValidatedDownloadHead(
+              path = "full",
+              observationLimit = observationLimit,
+              snapshot = snapshot,
+              context = context,
+              isRecovery = false
+            )
             _ <- recordDownloadPhase("full", "facilitate_enqueued")
           } yield ()
         }
@@ -793,13 +872,11 @@ object Download {
                     for {
                       observed <- observeWithLimit(result, snapshot.ordinal)
                       ((observedSnapshot, observedContext), observationLimit) = observed
-                      _ <- HasherSelector[F].withCurrent { implicit hasher =>
-                        globalSnapshotConsensusStorage.setHeadForRecovery(observedSnapshot, observedContext)
-                      }
-                      _ <- consensus.manager.startFacilitatingAfterDownload(
-                        observationLimit,
-                        observedSnapshot,
-                        observedContext,
+                      _ <- handoffValidatedDownloadHead(
+                        path = "follower_catch_up",
+                        observationLimit = observationLimit,
+                        snapshot = observedSnapshot,
+                        context = observedContext,
                         isRecovery = true
                       )
                       _ <- Metrics[F].incrementCounter(
@@ -1128,6 +1205,8 @@ object Download {
 
       convergingRecoveryCycle.flatMap { result =>
         val ((snapshot, context), observationLimit) = result
+        // The final tuple is returned by the last recoveryObserve iteration, which has already published this exact artifact/context to
+        // globalSnapshotConsensusStorage. Keep recovery's per-iteration publication boundary intact and initialize only after convergence.
         consensus.manager.startFacilitatingAfterDownload(observationLimit, snapshot, context, isRecovery = true) >>
           recordDownloadPhase("recovery", "facilitate_enqueued")
       }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -3,7 +3,7 @@ package io.constellationnetwork.dag.l0.domain.snapshot.programs
 import cats.effect.std.Random
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
-import cats.{Applicative, Monad, Parallel}
+import cats.{Applicative, MonadThrow, Parallel}
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -30,6 +30,11 @@ import io.constellationnetwork.node.shared.infrastructure.metrics.Metrics
 import io.constellationnetwork.node.shared.infrastructure.snapshot.GlobalSnapshotContextFunctions
 import io.constellationnetwork.node.shared.infrastructure.snapshot.daemon.RecoveryFallbackEligible
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.CombinedSnapshotCheckpointFileSystemStorage
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.SnapshotStorage.{
+  SnapshotContextReadbackFailure,
+  SnapshotIndexReadbackFailure,
+  SnapshotOrdinalCollision
+}
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax._
 import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
@@ -96,20 +101,29 @@ object Download {
       else "backward"
     }
 
+  private[snapshot] def headPublicationFailureReason(error: Throwable): String =
+    error match {
+      case _: SnapshotOrdinalCollision       => "target_ordinal_collision"
+      case _: SnapshotIndexReadbackFailure   => "snapshot_index_readback"
+      case _: SnapshotContextReadbackFailure => "context_readback"
+      case _                                 => "other"
+    }
+
   /** Serialize the terminal handoff shared by ordinary full download and bounded follower catch-up.
     *
-    * Both callbacks receive the same immutable artifact/context references. If publication fails, the consensus callback is never
-    * evaluated; the enclosing download lifecycle retains ownership of reverting to WaitingForDownload and retrying. This is deliberately a
-    * small effect-order helper, not a second download harness or a new authority boundary.
+    * Each artifact/context callback receives the same immutable references. If publication fails, the success-metric and consensus
+    * callbacks are never evaluated; the enclosing download lifecycle retains ownership of reverting to WaitingForDownload and retrying.
+    * This is deliberately a small effect-order helper, not a second download harness or a new authority boundary.
     */
-  private[snapshot] def publishValidatedHeadBeforeConsensus[F[_]: Monad, A, C](
+  private[snapshot] def publishValidatedHeadBeforeConsensus[F[_]: MonadThrow, A, C](
     artifact: A,
     context: C,
     publish: (A, C) => F[Unit],
+    onPublicationFailure: Throwable => F[Unit],
     afterPublication: (A, C) => F[Unit],
     startConsensus: (A, C) => F[Unit]
   ): F[Unit] =
-    publish(artifact, context) >>
+    publish(artifact, context).onError { case error => onPublicationFailure(error) } >>
       afterPublication(artifact, context) >>
       startConsensus(artifact, context)
 
@@ -533,10 +547,70 @@ object Download {
         _ <- Metrics[F].updateGauge("dag_global_snapshot_signature_count", snapshot.proofs.size.toDouble)
       } yield ()
 
-    /** Publish the exact terminal artifact/context selected by an already validated download before consensus can initialize from it.
+    private def recordHeadPublicationFailure(
+      path: String,
+      direction: String,
+      previous: Option[SnapshotOrdinal],
+      target: SnapshotOrdinal,
+      error: Throwable
+    ): F[Unit] = {
+      val reason = Download.headPublicationFailureReason(error)
+      val logContext = Map(
+        "path" -> path,
+        "direction" -> direction,
+        "previous_ordinal" -> previous.map(_.value.value.toString).getOrElse("none"),
+        "target_ordinal" -> target.value.value.toString,
+        "reason" -> reason
+      )
+
+      logger.error(logContext, error)("[DownloadHeadPublication] Publication failed") >>
+        Metrics[F].incrementCounter(
+          "dag_download_head_publication_failure_total",
+          Seq(
+            Metrics.unsafeLabelName("path") -> path,
+            Metrics.unsafeLabelName("direction") -> direction,
+            Metrics.unsafeLabelName("reason") -> reason
+          )
+        )
+    }
+
+    private def recordHeadPublicationSuccess(path: String, direction: String): F[Unit] =
+      Metrics[F].incrementCounter(
+        "dag_download_head_publication_total",
+        Seq(
+          Metrics.unsafeLabelName("path") -> path,
+          Metrics.unsafeLabelName("direction") -> direction
+        )
+      )
+
+    private def publishRecoveryDownloadHead(
+      snapshot: Signed[GlobalIncrementalSnapshot],
+      context: GlobalSnapshotInfo
+    )(implicit hasherSelector: HasherSelector[F]): F[Unit] =
+      for {
+        previous <- globalSnapshotConsensusStorage.headSnapshot.map(_.map(_.ordinal))
+        direction = Download.headPublicationDirection(previous, snapshot.ordinal)
+        _ <- Applicative[F].whenA(direction === "backward") {
+          logger.warn(
+            s"[DownloadHeadPublication] Publishing validated lower canonical head: " +
+              s"path=recovery previous=${previous.map(_.show).getOrElse("none")} target=${snapshot.ordinal.show}"
+          )
+        }
+        _ <- hasherSelector.withCurrent { implicit hasher =>
+          globalSnapshotConsensusStorage.setHeadForRecovery(snapshot, context)
+        }.onError {
+          case error =>
+            recordHeadPublicationFailure("recovery", direction, previous, snapshot.ordinal, error)
+        }
+        _ <- recordHeadPublicationSuccess("recovery", direction)
+      } yield ()
+
+    /** Publish the terminal snapshot value and context selected by an already validated download before consensus can initialize from it.
       *
-      * Full download may legitimately replace a higher local fork head with a lower canonical head after its validated cleanup. That move
-      * remains allowed and is made explicit through warning/metrics rather than blocked by a monotonicity guard.
+      * A lower head may be published only when the target ordinal is absent or already contains the same canonical snapshot value/hash, the
+      * caller has validated the target and its persisted ancestry, and storage has reconciled its positive caches against that validated
+      * history. A different value at the target ordinal remains a collision: this handoff does not select a branch, replace suffix files,
+      * or repair lower files.
       */
     private def handoffValidatedDownloadHead(
       path: String,
@@ -561,14 +635,8 @@ object Download {
             hasherSelector.withCurrent { implicit hasher =>
               globalSnapshotConsensusStorage.setHeadForRecovery(artifact, state)
             },
-          (_, _) =>
-            Metrics[F].incrementCounter(
-              "dag_download_head_publication_total",
-              Seq(
-                Metrics.unsafeLabelName("path") -> path,
-                Metrics.unsafeLabelName("direction") -> direction
-              )
-            ),
+          error => recordHeadPublicationFailure(path, direction, previous, snapshot.ordinal, error),
+          (_, _) => recordHeadPublicationSuccess(path, direction),
           (artifact, state) =>
             consensus.manager.startFacilitatingAfterDownload(
               observationLimit,
@@ -1040,9 +1108,7 @@ object Download {
           hashedSnapshot <- hasherSelector.withCurrent(implicit hs => lastSnapshot.toHashed)
           _ <- lastNGlobalSnapshotStorage.setForRecovery(hashedSnapshot, lastContext)
           _ <- lastGlobalSnapshotStorage.setForRecovery(hashedSnapshot, lastContext)
-          _ <- hasherSelector.withCurrent { implicit hs =>
-            globalSnapshotConsensusStorage.setHeadForRecovery(lastSnapshot, lastContext)
-          }
+          _ <- publishRecoveryDownloadHead(lastSnapshot, lastContext)
           // Sync MptStore to match the downloaded snapshot's state. During network isolation,
           // the MPT may have accumulated stale mutations (from abandoned rounds that partially
           // mutated state before savepoint restore, or from ordinals computed against a
@@ -1100,9 +1166,7 @@ object Download {
           (observedResult, observationLimit) = observeResult
           (observedSnapshot, observedContext) = observedResult
           // Sync consensus SnapshotStorage head to observed tip so prepend works on the next round
-          _ <- hasherSelector.withCurrent { implicit hs =>
-            globalSnapshotConsensusStorage.setHeadForRecovery(observedSnapshot, observedContext)
-          }
+          _ <- publishRecoveryDownloadHead(observedSnapshot, observedContext)
           _ <- logger.info(
             s"[RecoveryDownload] Consensus head synced to ordinal ${observedSnapshot.ordinal.show}, observationLimit=${observationLimit.show}, mode=$observeMode"
           )
@@ -1205,8 +1269,9 @@ object Download {
 
       convergingRecoveryCycle.flatMap { result =>
         val ((snapshot, context), observationLimit) = result
-        // The final tuple is returned by the last recoveryObserve iteration, which has already published this exact artifact/context to
-        // globalSnapshotConsensusStorage. Keep recovery's per-iteration publication boundary intact and initialize only after convergence.
+        // The final tuple is returned by the last recoveryObserve iteration, which has already published this snapshot value and
+        // semantically equal context to globalSnapshotConsensusStorage. Keep recovery's per-iteration publication boundary intact and
+        // initialize only after convergence.
         consensus.manager.startFacilitatingAfterDownload(observationLimit, snapshot, context, isRecovery = true) >>
           recordDownloadPhase("recovery", "facilitate_enqueued")
       }

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/MainSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/MainSuite.scala
@@ -122,6 +122,19 @@ object MainSuite extends SimpleIOSuite {
     expect(Main.validateRecoverySeedPublicDiscoverability(root, futureActivation).isRight)
   }
 
+  pureTest("certified replay retains the exact root snapshot info for every activation mode") {
+    val root = CertifiedConsensusGenesis.FirstIncrementalOrdinal
+    val futureActivation = 2000L
+
+    expect.same(Set.empty[SnapshotOrdinal], Main.protectedCertifiedSnapshotInfoOrdinals(Long.MaxValue)) &&
+    expect.same(Set(root), Main.protectedCertifiedSnapshotInfoOrdinals(SnapshotOrdinal.MinValue.value.value)) &&
+    expect.same(Set(root), Main.protectedCertifiedSnapshotInfoOrdinals(root.value.value)) &&
+    expect.same(
+      Set(SnapshotOrdinal.unsafeApply(futureActivation - 1L)),
+      Main.protectedCertifiedSnapshotInfoOrdinals(futureActivation)
+    )
+  }
+
   pureTest("an unsigned recovery seed is bound to the same independent checkpoint comparison") {
     expect(Main.validateRecoverySeedAnchorCompatibility(recoveryAnchor, None).isRight) &&
     expect(Main.validateRecoverySeedAnchorCompatibility(recoveryAnchor, Some(recoveryAnchor)).isRight) &&

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/StoragesInitializerSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/StoragesInitializerSuite.scala
@@ -1,0 +1,168 @@
+package io.constellationnetwork.dag.l0
+
+import cats.data.NonEmptyList
+import cats.effect.{IO, Ref}
+import cats.syntax.all._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.config.types.LastGlobalSnapshotsSyncConfig
+import io.constellationnetwork.node.shared.domain.snapshot.programs.Download
+import io.constellationnetwork.node.shared.domain.snapshot.storage.{LastSnapshotStorage, SnapshotStorage}
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.LastNGlobalSnapshotStorage
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.height.{Height, SubHeight}
+import io.constellationnetwork.schema.peer.PeerId
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops._
+import io.constellationnetwork.security.signature.Signed
+
+import eu.timepit.refined.types.numeric.{NonNegLong, PosInt}
+import fs2.Stream
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import weaver.SimpleIOSuite
+
+object StoragesInitializerSuite extends SimpleIOSuite {
+
+  private implicit val stateProofSelector: GlobalStateProofSelector =
+    GlobalStateProofSelector(SnapshotOrdinal(NonNegLong(Long.MaxValue)))
+
+  private val info =
+    GlobalSnapshotInfo(
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty),
+      Some(SortedMap.empty)
+    )
+
+  private def chain(first: Long, last: Long, keyPair: java.security.KeyPair)(
+    implicit hasher: Hasher[IO],
+    serializer: JsonSerializer[IO],
+    securityProvider: SecurityProvider[IO]
+  ): IO[Map[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]]] =
+    (first to last).toList
+      .foldLeftM((Hash.empty, Map.empty[SnapshotOrdinal, Hashed[GlobalIncrementalSnapshot]])) {
+        case ((parentHash, acc), value) =>
+          val ordinal = SnapshotOrdinal.unsafeApply(value)
+          info.stateProof[IO](ordinal).flatMap { stateProof =>
+            Signed
+              .forAsyncHasher[IO, GlobalIncrementalSnapshot](
+                GlobalIncrementalSnapshot(
+                  ordinal,
+                  Height(ordinal.value),
+                  SubHeight.MinValue,
+                  parentHash,
+                  SortedSet.empty,
+                  SortedMap.empty,
+                  SortedSet.empty,
+                  None,
+                  EpochProgress.MinValue,
+                  NonEmptyList.one(PeerId.fromId(keyPair.getPublic.toId)),
+                  SnapshotTips(SortedSet.empty, SortedSet.empty),
+                  stateProof,
+                  Some(SortedSet.empty),
+                  Some(SortedSet.empty),
+                  Some(SortedMap.empty),
+                  Some(SortedMap.empty),
+                  Some(SortedSet.empty),
+                  Some(SortedMap.empty),
+                  Some(SortedMap.empty),
+                  Some(SortedMap.empty),
+                  Some(SortedMap.empty)
+                ),
+                keyPair
+              )
+              .flatMap(_.toHashed[IO])
+              .map(hashed => (hashed.hash, acc.updated(ordinal, hashed)))
+          }
+      }
+      .map(_._2)
+
+  test("rollback storage initialization uses the lead archive while every peer fetch fails") {
+    SecurityProvider.forAsync[IO].use { implicit securityProvider =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+        implicit0(hasherSelector: HasherSelector[IO]) = HasherSelector.forSyncAlwaysCurrent(hasher)
+        implicit0(logger: Logger[IO]) = Slf4jLogger.getLogger[IO]
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        snapshots <- chain(98L, 100L, keyPair)
+        archiveByHash <- Ref.of[IO, Map[Hash, Signed[GlobalIncrementalSnapshot]]](
+          snapshots.valuesIterator.map(snapshot => snapshot.hash -> snapshot.signed).toMap
+        )
+        archiveHead <- Ref.of[IO, Option[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
+        peerFetches <- Ref.of[IO, Int](0)
+        globalSnapshotStorage = new SnapshotStorage[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
+          private def unused[A]: IO[A] = IO.raiseError(new IllegalStateException("unexpected storage operation"))
+
+          def prepend(snapshot: Signed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo)(
+            implicit hasher: Hasher[IO]
+          ): IO[Boolean] = archiveHead.set((snapshot, state).some).as(true)
+          def head: IO[Option[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = archiveHead.get
+          def headSnapshot: IO[Option[Signed[GlobalIncrementalSnapshot]]] = archiveHead.get.map(_.map(_._1))
+          def get(ordinal: SnapshotOrdinal): IO[Option[Signed[GlobalIncrementalSnapshot]]] =
+            IO.raiseError(new IllegalStateException(s"ordinal lookup must not select rollback lineage: $ordinal"))
+          def getHashed(ordinal: SnapshotOrdinal)(implicit hasher: Hasher[IO]): IO[Option[Hashed[GlobalIncrementalSnapshot]]] = unused
+          def get(hash: Hash): IO[Option[Signed[GlobalIncrementalSnapshot]]] = archiveByHash.get.map(_.get(hash))
+          def getHash(ordinal: SnapshotOrdinal)(implicit hasher: Hasher[IO]): IO[Option[Hash]] = unused
+          def setHeadForRecovery(snapshot: Signed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo)(
+            implicit hasher: Hasher[IO]
+          ): IO[Unit] = unused
+        }
+        lastN <- LastNGlobalSnapshotStorage.make[IO](LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(2)))
+        lastHead <- Ref.of[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]](None)
+        last = new LastSnapshotStorage[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
+          def set(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): IO[Unit] = lastHead.set((snapshot, state).some)
+          def setInitial(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): IO[Unit] =
+            lastHead.set((snapshot, state).some)
+          def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): IO[Unit] =
+            lastHead.set((snapshot, state).some)
+          def clear: IO[Unit] = lastHead.set(none)
+          def get: IO[Option[Hashed[GlobalIncrementalSnapshot]]] = lastHead.get.map(_.map(_._1))
+          def getCombined: IO[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = lastHead.get
+          def getCombinedStream: Stream[IO, Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
+            Stream.eval(lastHead.get)
+          def getOrdinal: IO[Option[SnapshotOrdinal]] = get.map(_.map(_.ordinal))
+          def getHeight: IO[Option[Height]] = get.map(_.map(_.height))
+        }
+        download = new Download[IO, GlobalIncrementalSnapshot] {
+          def download(implicit hasherSelector: HasherSelector[IO]): IO[Unit] = IO.unit
+          def recoveryDownload(implicit hasherSelector: HasherSelector[IO]): IO[Unit] = IO.unit
+          def fetchSnapshot(hash: Option[Hash], ordinal: SnapshotOrdinal)(
+            implicit hasher: Hasher[IO]
+          ): IO[Signed[GlobalIncrementalSnapshot]] =
+            peerFetches.update(_ + 1) >> IO.raiseError(new IllegalStateException(s"peer unavailable for $ordinal/$hash"))
+        }
+        parent = snapshots(SnapshotOrdinal.unsafeApply(100L))
+        _ <- StoragesInitializer.initializeStorages(globalSnapshotStorage, lastN, last, download, parent, info)
+        fetchedFromPeers <- peerFetches.get
+        retained <- lastN.getLastN
+        initializedLast <- last.get
+      } yield
+        expect.same(0, fetchedFromPeers) &&
+          expect.same(
+            Set(SnapshotOrdinal.unsafeApply(98L), SnapshotOrdinal.unsafeApply(99L), SnapshotOrdinal.unsafeApply(100L)),
+            retained.map(_.ordinal).toSet
+          ) &&
+          expect(initializedLast.exists(_.hash === parent.hash))
+    }
+  }
+}

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadHeadPublicationSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadHeadPublicationSuite.scala
@@ -1,0 +1,60 @@
+package io.constellationnetwork.dag.l0.domain.snapshot.programs
+
+import cats.effect.{IO, Ref}
+
+import weaver.SimpleIOSuite
+
+object DownloadHeadPublicationSuite extends SimpleIOSuite {
+
+  private final case class TerminalArtifact(id: String)
+  private final case class TerminalContext(id: String)
+  private final case class Step(name: String, artifact: TerminalArtifact, context: TerminalContext)
+
+  test("validated terminal publication precedes metrics and consensus initialization with one exact pair") {
+    val terminalArtifact = TerminalArtifact("observed-T")
+    val terminalContext = TerminalContext("context-T")
+
+    for {
+      steps <- Ref.of[IO, List[Step]](List.empty)
+      _ <- Download.publishValidatedHeadBeforeConsensus[IO, TerminalArtifact, TerminalContext](
+        terminalArtifact,
+        terminalContext,
+        (artifact, context) => steps.update(_ :+ Step("publish", artifact, context)),
+        (artifact, context) => steps.update(_ :+ Step("published-metric", artifact, context)),
+        (artifact, context) => steps.update(_ :+ Step("consensus-init", artifact, context))
+      )
+      observed <- steps.get
+    } yield
+      expect.same(
+        List(
+          Step("publish", terminalArtifact, terminalContext),
+          Step("published-metric", terminalArtifact, terminalContext),
+          Step("consensus-init", terminalArtifact, terminalContext)
+        ),
+        observed
+      )
+  }
+
+  test("terminal publication failure never evaluates metrics or consensus initialization") {
+    val terminalArtifact = TerminalArtifact("observed-T")
+    val terminalContext = TerminalContext("context-T")
+
+    for {
+      steps <- Ref.of[IO, List[Step]](List.empty)
+      result <- Download
+        .publishValidatedHeadBeforeConsensus[IO, TerminalArtifact, TerminalContext](
+          terminalArtifact,
+          terminalContext,
+          (artifact, context) =>
+            steps.update(_ :+ Step("publish", artifact, context)) >>
+              IO.raiseError(new RuntimeException("injected publication failure")),
+          (artifact, context) => steps.update(_ :+ Step("published-metric", artifact, context)),
+          (artifact, context) => steps.update(_ :+ Step("consensus-init", artifact, context))
+        )
+        .attempt
+      observed <- steps.get
+    } yield
+      expect(result.isLeft) &&
+        expect.same(List(Step("publish", terminalArtifact, terminalContext)), observed)
+  }
+}

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadHeadPublicationSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadHeadPublicationSuite.scala
@@ -10,7 +10,7 @@ object DownloadHeadPublicationSuite extends SimpleIOSuite {
   private final case class TerminalContext(id: String)
   private final case class Step(name: String, artifact: TerminalArtifact, context: TerminalContext)
 
-  test("validated terminal publication precedes metrics and consensus initialization with one exact pair") {
+  test("validated terminal publication precedes metrics and consensus initialization with one selected pair") {
     val terminalArtifact = TerminalArtifact("observed-T")
     val terminalContext = TerminalContext("context-T")
 
@@ -20,6 +20,7 @@ object DownloadHeadPublicationSuite extends SimpleIOSuite {
         terminalArtifact,
         terminalContext,
         (artifact, context) => steps.update(_ :+ Step("publish", artifact, context)),
+        _ => steps.update(_ :+ Step("publication-failure-metric", terminalArtifact, terminalContext)),
         (artifact, context) => steps.update(_ :+ Step("published-metric", artifact, context)),
         (artifact, context) => steps.update(_ :+ Step("consensus-init", artifact, context))
       )
@@ -35,7 +36,7 @@ object DownloadHeadPublicationSuite extends SimpleIOSuite {
       )
   }
 
-  test("terminal publication failure never evaluates metrics or consensus initialization") {
+  test("terminal publication failure emits only the failure metric and never starts consensus") {
     val terminalArtifact = TerminalArtifact("observed-T")
     val terminalContext = TerminalContext("context-T")
 
@@ -48,6 +49,7 @@ object DownloadHeadPublicationSuite extends SimpleIOSuite {
           (artifact, context) =>
             steps.update(_ :+ Step("publish", artifact, context)) >>
               IO.raiseError(new RuntimeException("injected publication failure")),
+          _ => steps.update(_ :+ Step("publication-failure-metric", terminalArtifact, terminalContext)),
           (artifact, context) => steps.update(_ :+ Step("published-metric", artifact, context)),
           (artifact, context) => steps.update(_ :+ Step("consensus-init", artifact, context))
         )
@@ -55,6 +57,12 @@ object DownloadHeadPublicationSuite extends SimpleIOSuite {
       observed <- steps.get
     } yield
       expect(result.isLeft) &&
-        expect.same(List(Step("publish", terminalArtifact, terminalContext)), observed)
+        expect.same(
+          List(
+            Step("publish", terminalArtifact, terminalContext),
+            Step("publication-failure-metric", terminalArtifact, terminalContext)
+          ),
+          observed
+        )
   }
 }

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadSuite.scala
@@ -35,6 +35,13 @@ object DownloadSuite extends FunSuite {
   private def decide(tips: List[PeerTip]): SnapshotOrdinal =
     Download.chooseObservationLimit(localOrd, localHash, tips, observationOffset)
 
+  test("download head publication classifies initial, forward, same-ordinal, and backward movement") {
+    expect.same("initial", Download.headPublicationDirection(none, localOrd)) &&
+    expect.same("forward", Download.headPublicationDirection(prevOrd.some, localOrd)) &&
+    expect.same("same_ordinal", Download.headPublicationDirection(localOrd.some, localOrd)) &&
+    expect.same("backward", Download.headPublicationDirection(nextOrd.some, localOrd))
+  }
+
   test("first incremental checkpoint detection is relative to the configured full snapshot") {
     val publicCheckpoint = SnapshotOrdinal.unsafeApply(766717L)
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/DownloadSuite.scala
@@ -4,6 +4,11 @@ import cats.syntax.option._
 
 import io.constellationnetwork.dag.l0.domain.snapshot.programs.Download.PeerTip
 import io.constellationnetwork.node.shared.infrastructure.snapshot.daemon.RecoveryFallbackEligible
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.SnapshotStorage.{
+  SnapshotContextReadbackFailure,
+  SnapshotIndexReadbackFailure,
+  SnapshotOrdinalCollision
+}
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
 
@@ -40,6 +45,17 @@ object DownloadSuite extends FunSuite {
     expect.same("forward", Download.headPublicationDirection(prevOrd.some, localOrd)) &&
     expect.same("same_ordinal", Download.headPublicationDirection(localOrd.some, localOrd)) &&
     expect.same("backward", Download.headPublicationDirection(nextOrd.some, localOrd))
+  }
+
+  test("download head publication classifies collision, index, context, and other failures separately") {
+    val collision = SnapshotOrdinalCollision(localOrd, localHash, altHashSameOrd)
+    val indexReadback = SnapshotIndexReadbackFailure(localOrd, localHash)
+    val contextReadback = SnapshotContextReadbackFailure(localOrd)
+
+    expect.same("target_ordinal_collision", Download.headPublicationFailureReason(collision)) &&
+    expect.same("snapshot_index_readback", Download.headPublicationFailureReason(indexReadback)) &&
+    expect.same("context_readback", Download.headPublicationFailureReason(contextReadback)) &&
+    expect.same("other", Download.headPublicationFailureReason(new RuntimeException("other")))
   }
 
   test("first incremental checkpoint detection is relative to the configured full snapshot") {

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
@@ -62,7 +62,7 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
       }
     }
 
-  def mkSeparatedStorage(
+  def mkInspectableStorage(
     tmpDir: File,
     persistenceMutex: Mutex[IO],
     protectedSnapshotInfoOrdinals: Set[SnapshotOrdinal] = Set.empty
@@ -102,8 +102,28 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
             protectedSnapshotInfoOrdinals
           )
       }
-    } yield (storage, snapshotFileStorage, snapshotInfoFileStorage, checkpointStorage)
+    } yield
+      (
+        storage,
+        snapshotFileStorage,
+        snapshotInfoFileStorage,
+        checkpointStorage,
+        headRef,
+        ordinalCache,
+        hashCache,
+        notPersistedCache
+      )
   }
+
+  def mkSeparatedStorage(
+    tmpDir: File,
+    persistenceMutex: Mutex[IO],
+    protectedSnapshotInfoOrdinals: Set[SnapshotOrdinal] = Set.empty
+  )(implicit K: KryoSerializer[IO], J: JsonSerializer[IO], H: Hasher[IO], S: Supervisor[IO]) =
+    mkInspectableStorage(tmpDir, persistenceMutex, protectedSnapshotInfoOrdinals).map {
+      case (storage, snapshotFileStorage, snapshotInfoFileStorage, checkpointStorage, _, _, _, _) =>
+        (storage, snapshotFileStorage, snapshotInfoFileStorage, checkpointStorage)
+    }
 
   def mkStorageWithAcceptedHead(
     tmpDir: File,
@@ -367,6 +387,176 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
                   .and(expect.eql(persistedStateAfterRetry, acceptedState.some))
           }
       }
+    }
+  }
+
+  test("validated head publication exposes an externally installed suffix hidden by a cached miss") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, _) = built
+        (genesis, historical) <- mkSnapshots
+        historicalHash <- historical.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        terminal <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          historical.value.copy(
+            ordinal = historical.ordinal.next,
+            lastSnapshotHash = historicalHash
+          ),
+          keyPair
+        )
+        context = genesis.info.toGlobalSnapshotInfo
+        missingBeforeInstall <- storage.get(historical.ordinal)
+        _ <- snapshotFiles.write(historical)
+        hiddenBeforePublication <- storage.get(historical.ordinal)
+        _ <- storage.setHeadForRecovery(terminal, context)
+        visibleAfterPublication <- storage.get(historical.ordinal)
+        publishedHead <- storage.head
+      } yield
+        expect.all(
+          missingBeforeInstall.isEmpty,
+          hiddenBeforePublication.isEmpty,
+          visibleAfterPublication.contains(historical),
+          publishedHead.contains((terminal, context))
+        )
+    }
+  }
+
+  test("validated head publication leaves the visible head unchanged when snapshot-info persistence fails") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        built <- mkStorageWithFailingFirstSnapshotInfoWrite(tmpDir)
+        (storage, _, snapshotInfoFiles) = built
+        (genesis, snapshot) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        first <- storage.setHeadForRecovery(snapshot, context).attempt
+        headAfterFailure <- storage.head
+        contextAfterFailure <- snapshotInfoFiles.read(snapshot.ordinal)
+        _ <- storage.setHeadForRecovery(snapshot, context)
+        headAfterRetry <- storage.head
+      } yield
+        expect.all(
+          first.isLeft,
+          headAfterFailure.isEmpty,
+          contextAfterFailure.isEmpty,
+          headAfterRetry.contains((snapshot, context))
+        )
+    }
+  }
+
+  test("validated head publication rejects a different value occupying the target ordinal without changing the head") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, _, snapshotInfoFiles, _, _, _, _, _) = built
+        (genesis, original) <- mkSnapshots
+        originalContext = genesis.info.toGlobalSnapshotInfo
+        conflictingContext = originalContext.copy(
+          balances = SortedMap(
+            address.Address("DAG2AUdecqFwEGcgAcH1ac2wrsg8acrgGwrQojzw") -> balance.Balance(100L)
+          )
+        )
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        conflicting <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          original.value.copy(version = semver.SnapshotVersion("1.0.0")),
+          keyPair
+        )
+        _ <- storage.prepend(original, originalContext)
+        publication <- storage.setHeadForRecovery(conflicting, conflictingContext).attempt
+        headAfterFailure <- storage.head
+        cachedAtTarget <- storage.get(original.ordinal)
+        contextAfterFailure <- snapshotInfoFiles.read(original.ordinal)
+      } yield
+        expect.all(
+          publication.isLeft,
+          headAfterFailure.contains((original, originalContext)),
+          cachedAtTarget.contains(original),
+          contextAfterFailure.contains(originalContext)
+        )
+    }
+  }
+
+  test("validated lower-head publication evicts a deleted future suffix from positive caches") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, _) = built
+        (genesis, original) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        originalHash <- original.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        future <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          original.value.copy(
+            ordinal = original.ordinal.next,
+            lastSnapshotHash = originalHash
+          ),
+          keyPair
+        )
+        futureHash <- future.value.hash
+        _ <- storage.prepend(original, context)
+        _ <- storage.prepend(future, context)
+        _ <- snapshotFiles.delete(future.ordinal)
+        _ <- snapshotFiles.delete(futureHash)
+        cachedBeforePublication <- storage.get(future.ordinal)
+        _ <- storage.setHeadForRecovery(original, context)
+        byOrdinalAfterPublication <- storage.get(future.ordinal)
+        byHashAfterPublication <- storage.get(futureHash)
+        headAfterPublication <- storage.head
+      } yield
+        expect.all(
+          cachedBeforePublication.contains(future),
+          byOrdinalAfterPublication.isEmpty,
+          byHashAfterPublication.isEmpty,
+          headAfterPublication.contains((original, context))
+        )
+    }
+  }
+
+  test("validated head retry clears a stale not-persisted marker only after exact disk readback succeeds") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, notPersisted) = built
+        (genesis, target) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        occupying <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          target.value.copy(version = semver.SnapshotVersion("1.0.0")),
+          keyPair
+        )
+        occupyingHash <- occupying.value.hash
+        _ <- snapshotFiles.write(occupying)
+        _ <- notPersisted.update(_ + target.ordinal)
+        failed <- storage.setHeadForRecovery(target, context).attempt
+        markerAfterFailure <- notPersisted.get
+        headAfterFailure <- storage.head
+        _ <- snapshotFiles.delete(occupying.ordinal)
+        _ <- snapshotFiles.delete(occupyingHash)
+        _ <- storage.setHeadForRecovery(target, context)
+        markerAfterRetry <- notPersisted.get
+        headAfterRetry <- storage.head
+      } yield
+        expect.all(
+          failed.isLeft,
+          markerAfterFailure.contains(target.ordinal),
+          headAfterFailure.isEmpty,
+          !markerAfterRetry.contains(target.ordinal),
+          headAfterRetry.contains((target, context))
+        )
     }
   }
 

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
@@ -4,9 +4,10 @@ import cats.effect._
 import cats.effect.std.{Mutex, Queue, Supervisor}
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{SortedMap, SortedSet}
 import scala.concurrent.duration._
 
+import io.constellationnetwork.currency.schema.currency._
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.ext.crypto._
@@ -15,9 +16,11 @@ import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage._
 import io.constellationnetwork.node.shared.nodeSharedKryoRegistrar
 import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.height.{Height, SubHeight}
 import io.constellationnetwork.schema.{GlobalStateProofSelector, SnapshotOrdinal, _}
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops.PublicKeyOps
 import io.constellationnetwork.security.signature.Signed
 
 import better.files._
@@ -421,6 +424,55 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
           hiddenBeforePublication.isEmpty,
           visibleAfterPublication.contains(historical),
           publishedHead.contains((terminal, context))
+        )
+    }
+  }
+
+  test("validated head publication compares metagraph data-application context by byte content") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, _, snapshotInfoFiles, _, _, _, _, _) = built
+        (genesis, target) <- mkSnapshots
+        currencyKeyPair <- KeyPairGenerator.makeKeyPair[IO]
+        currencySnapshot <- Signed.forAsyncHasher[IO, CurrencyIncrementalSnapshot](
+          CurrencyIncrementalSnapshot(
+            SnapshotOrdinal.MinIncrementalValue,
+            Height.MinValue,
+            SubHeight.MinValue,
+            Hash.empty,
+            SortedSet.empty,
+            SortedSet.empty,
+            SnapshotTips(SortedSet.empty, SortedSet.empty),
+            CurrencySnapshotStateProof(Hash.empty, Hash.empty, None, None, None, None, None, None, None),
+            EpochProgress.MinValue,
+            DataApplicationPart(Array[Byte](1, 2, 3), List(Array[Byte](4, 5, 6)), Hash.empty, None).some,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None
+          ),
+          currencyKeyPair
+        )
+        currencyInfo = CurrencySnapshotInfo(SortedMap.empty, SortedMap.empty, None, None, None, None, None, None, None)
+        currencyEntry: Either[Signed[CurrencySnapshot], (Signed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)] =
+          Right((currencySnapshot, currencyInfo))
+        context = genesis.info.toGlobalSnapshotInfo.copy(
+          lastCurrencySnapshots = SortedMap(currencyKeyPair.getPublic.toAddress -> currencyEntry)
+        )
+        _ <- storage.setHeadForRecovery(target, context)
+        persistedContext <- snapshotInfoFiles.read(target.ordinal)
+        publishedHead <- storage.head
+      } yield
+        expect.all(
+          persistedContext.exists(_ === context),
+          publishedHead.exists { case (snapshot, state) => snapshot === target && state === context }
         )
     }
   }

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotStorageSuite.scala
@@ -68,7 +68,8 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
   def mkInspectableStorage(
     tmpDir: File,
     persistenceMutex: Mutex[IO],
-    protectedSnapshotInfoOrdinals: Set[SnapshotOrdinal] = Set.empty
+    protectedSnapshotInfoOrdinals: Set[SnapshotOrdinal] = Set.empty,
+    historicalReadFailure: Option[(SnapshotOrdinal, Throwable)] = None
   )(implicit K: KryoSerializer[IO], J: JsonSerializer[IO], H: Hasher[IO], S: Supervisor[IO]) = {
     val snapshotsPath = Path((tmpDir / "snapshots").pathAsString)
     val snapshotInfoPath = Path((tmpDir / "snapshot-info").pathAsString)
@@ -81,7 +82,20 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
       notPersistedCache <- Ref.of[IO, Set[SnapshotOrdinal]](Set.empty)
       offloadQueue <- Queue.unbounded[IO, SnapshotOrdinal]
       snapshotInfoCutoffQueue <- Queue.unbounded[IO, SnapshotOrdinal]
-      snapshotFileStorage <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](snapshotsPath)
+      snapshotFileStorage <- {
+        val storage = new SnapshotLocalFileSystemStorage[IO, GlobalIncrementalSnapshot](snapshotsPath) {
+          def deserializeFallback(bytes: Array[Byte]): Either[Throwable, Signed[GlobalIncrementalSnapshot]] =
+            K.deserialize[Signed[GlobalIncrementalSnapshotV1]](bytes).map(_.map(_.toGlobalIncrementalSnapshot))
+
+          override def read(ordinal: SnapshotOrdinal): IO[Option[Signed[GlobalIncrementalSnapshot]]] =
+            historicalReadFailure.filter(_._1 === ordinal) match {
+              case Some((_, error)) => IO.raiseError(error)
+              case None             => super.read(ordinal)
+            }
+        }
+
+        storage.createDirectoryIfNotExists().rethrowT.as(storage)
+      }
       snapshotInfoFileStorage <- GlobalSnapshotInfoLocalFileSystemStorage.make[IO](snapshotInfoPath)
       checkpointStorage <- CombinedSnapshotCheckpointFileSystemStorage
         .make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](checkpointsPath)
@@ -216,6 +230,95 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
           )
       }
     } yield (storage, snapshotFileStorage, snapshotInfoFileStorage)
+  }
+
+  def mkStorageWithSnapshotIndexReadbackFailure(
+    tmpDir: File,
+    removeHashIndex: Boolean,
+    writeFailure: Option[Throwable] = None
+  )(implicit K: KryoSerializer[IO], J: JsonSerializer[IO], H: Hasher[IO], S: Supervisor[IO]) = {
+    val snapshotsPath = Path((tmpDir / "snapshots").pathAsString)
+    val snapshotInfoPath = Path((tmpDir / "snapshot-info").pathAsString)
+    val checkpointsPath = Path((tmpDir / "checkpoints").pathAsString)
+
+    for {
+      writeAttempts <- Ref.of[IO, Int](0)
+      ordinalReadAttempts <- Ref.of[IO, Int](0)
+      hashReadAttempts <- Ref.of[IO, Int](0)
+      snapshotFileStorage <- {
+        val storage = new SnapshotLocalFileSystemStorage[IO, GlobalIncrementalSnapshot](snapshotsPath) {
+          def deserializeFallback(bytes: Array[Byte]): Either[Throwable, Signed[GlobalIncrementalSnapshot]] =
+            K.deserialize[Signed[GlobalIncrementalSnapshotV1]](bytes).map(_.map(_.toGlobalIncrementalSnapshot))
+
+          override def write(snapshot: Signed[GlobalIncrementalSnapshot])(implicit hasher: Hasher[IO]): IO[Unit] =
+            writeAttempts.update(_ + 1) >>
+              super.write(snapshot)(hasher) >>
+              (if (removeHashIndex) hasher.hash(snapshot.value).flatMap(delete) else delete(snapshot.ordinal)) >>
+              writeFailure.traverse_(IO.raiseError[Unit])
+
+          override def read(ordinal: SnapshotOrdinal): IO[Option[Signed[GlobalIncrementalSnapshot]]] =
+            ordinalReadAttempts.update(_ + 1) >> super.read(ordinal)
+
+          override def read(hash: Hash): IO[Option[Signed[GlobalIncrementalSnapshot]]] =
+            hashReadAttempts.update(_ + 1) >> super.read(hash)
+        }
+
+        storage.createDirectoryIfNotExists().rethrowT.as(storage)
+      }
+      snapshotInfoFileStorage <- GlobalSnapshotInfoLocalFileSystemStorage.make[IO](snapshotInfoPath)
+      checkpointStorage <- CombinedSnapshotCheckpointFileSystemStorage
+        .make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](checkpointsPath)
+      storage <- {
+        implicit val hs = HasherSelector.forSyncAlwaysCurrent(H)
+        io.constellationnetwork.node.shared.infrastructure.snapshot.storage.SnapshotStorage
+          .make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](
+            snapshotFileStorage,
+            snapshotInfoFileStorage,
+            inMemoryCapacity = 5L,
+            SnapshotOrdinal.MinValue,
+            hs,
+            checkpointStorage
+          )
+      }
+    } yield (storage, writeAttempts, ordinalReadAttempts, hashReadAttempts)
+  }
+
+  def mkStorageWithContextReadbackFailure(
+    tmpDir: File,
+    persistedContext: GlobalSnapshotInfo
+  )(implicit K: KryoSerializer[IO], J: JsonSerializer[IO], H: Hasher[IO], S: Supervisor[IO]) = {
+    val snapshotsPath = Path((tmpDir / "snapshots").pathAsString)
+    val snapshotInfoPath = Path((tmpDir / "snapshot-info").pathAsString)
+    val checkpointsPath = Path((tmpDir / "checkpoints").pathAsString)
+
+    for {
+      snapshotFileStorage <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](snapshotsPath)
+      snapshotInfoFileStorage <- {
+        val storage = new SnapshotInfoLocalFileSystemStorage[IO, GlobalSnapshotStateProof, GlobalSnapshotInfo](snapshotInfoPath) {
+          def deserializeFallback(bytes: Array[Byte]): Either[Throwable, GlobalSnapshotInfo] =
+            K.deserialize[GlobalSnapshotInfoV2](bytes).map(_.toGlobalSnapshotInfo)
+
+          override def write(ordinal: SnapshotOrdinal, snapshotInfo: GlobalSnapshotInfo): IO[Unit] =
+            super.write(ordinal, persistedContext)
+        }
+
+        storage.createDirectoryIfNotExists().rethrowT.as(storage)
+      }
+      checkpointStorage <- CombinedSnapshotCheckpointFileSystemStorage
+        .make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](checkpointsPath)
+      storage <- {
+        implicit val hs = HasherSelector.forSyncAlwaysCurrent(H)
+        io.constellationnetwork.node.shared.infrastructure.snapshot.storage.SnapshotStorage
+          .make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](
+            snapshotFileStorage,
+            snapshotInfoFileStorage,
+            inMemoryCapacity = 5L,
+            SnapshotOrdinal.MinValue,
+            hs,
+            checkpointStorage
+          )
+      }
+    } yield storage
   }
 
   def mkSnapshots(
@@ -528,7 +631,10 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
         contextAfterFailure <- snapshotInfoFiles.read(original.ordinal)
       } yield
         expect.all(
-          publication.isLeft,
+          publication match {
+            case Left(_: SnapshotStorage.SnapshotOrdinalCollision) => true
+            case _                                                 => false
+          },
           headAfterFailure.contains((original, originalContext)),
           cachedAtTarget.contains(original),
           contextAfterFailure.contains(originalContext)
@@ -536,7 +642,93 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
     }
   }
 
-  test("validated lower-head publication evicts a deleted future suffix from positive caches") { res =>
+  test("validated head publication classifies either missing snapshot index and leaves the visible head unchanged") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        ordinalIndexFixture <- mkStorageWithSnapshotIndexReadbackFailure(tmpDir / "missing-ordinal", removeHashIndex = false)
+        hashIndexFixture <- mkStorageWithSnapshotIndexReadbackFailure(tmpDir / "missing-hash", removeHashIndex = true)
+        (ordinalIndexStorage, _, _, _) = ordinalIndexFixture
+        (hashIndexStorage, _, _, _) = hashIndexFixture
+        (genesis, target) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        ordinalIndexPublication <- ordinalIndexStorage.setHeadForRecovery(target, context).attempt
+        hashIndexPublication <- hashIndexStorage.setHeadForRecovery(target, context).attempt
+        ordinalIndexHead <- ordinalIndexStorage.head
+        hashIndexHead <- hashIndexStorage.head
+      } yield
+        expect.all(
+          ordinalIndexPublication match {
+            case Left(_: SnapshotStorage.SnapshotIndexReadbackFailure) => true
+            case _                                                     => false
+          },
+          hashIndexPublication match {
+            case Left(_: SnapshotStorage.SnapshotIndexReadbackFailure) => true
+            case _                                                     => false
+          },
+          ordinalIndexHead.isEmpty,
+          hashIndexHead.isEmpty
+        )
+    }
+  }
+
+  test("validated head publication attempts one write and one readback proof while retaining the write failure") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      val writeFailure = new RuntimeException("injected snapshot write failure")
+
+      for {
+        fixture <- mkStorageWithSnapshotIndexReadbackFailure(tmpDir, removeHashIndex = false, writeFailure.some)
+        (storage, writeAttempts, ordinalReadAttempts, hashReadAttempts) = fixture
+        (genesis, target) <- mkSnapshots
+        publication <- storage.setHeadForRecovery(target, genesis.info.toGlobalSnapshotInfo).attempt
+        writes <- writeAttempts.get
+        ordinalReads <- ordinalReadAttempts.get
+        hashReads <- hashReadAttempts.get
+        headAfterFailure <- storage.head
+      } yield
+        expect.all(
+          publication match {
+            case Left(error: SnapshotStorage.SnapshotIndexReadbackFailure) =>
+              error.getSuppressed.toList.contains(writeFailure)
+            case _ => false
+          },
+          writes === 1,
+          ordinalReads === 1,
+          hashReads === 1,
+          headAfterFailure.isEmpty
+        )
+    }
+  }
+
+  test("validated head publication classifies a mismatched context readback and leaves the visible head unchanged") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        (genesis, target) <- mkSnapshots
+        suppliedContext = genesis.info.toGlobalSnapshotInfo.copy(
+          balances = SortedMap(
+            address.Address("DAG2AUdecqFwEGcgAcH1ac2wrsg8acrgGwrQojzw") -> balance.Balance(100L)
+          )
+        )
+        storage <- mkStorageWithContextReadbackFailure(tmpDir, GlobalSnapshotInfo.empty)
+        publication <- storage.setHeadForRecovery(target, suppliedContext).attempt
+        headAfterFailure <- storage.head
+      } yield
+        expect.all(
+          publication match {
+            case Left(_: SnapshotStorage.SnapshotContextReadbackFailure) => true
+            case _                                                       => false
+          },
+          headAfterFailure.isEmpty
+        )
+    }
+  }
+
+  test("validated lower-head publication treats an occupied same-value target as idempotent and evicts its cached future suffix") { res =>
     implicit val (supervisor, kryo, json, hasher, securityProvider) = res
 
     File.temporaryDirectory() { tmpDir =>
@@ -575,7 +767,258 @@ object SnapshotStorageSuite extends MutableIOSuite with Checkers {
     }
   }
 
-  test("validated head retry clears a stale not-persisted marker only after exact disk readback succeeds") { res =>
+  test("validated head publication retains a pending cached-only lower value") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, notPersisted) = built
+        (genesis, lower) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        lowerHash <- lower.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        target <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          lower.value.copy(
+            ordinal = lower.ordinal.next,
+            lastSnapshotHash = lowerHash
+          ),
+          keyPair
+        )
+        _ <- storage.prepend(lower, context)
+        _ <- snapshotFiles.delete(lower.ordinal)
+        _ <- snapshotFiles.delete(lowerHash)
+        _ <- notPersisted.update(_ + lower.ordinal)
+        _ <- storage.setHeadForRecovery(target, context)
+        cachedLower <- storage.get(lower.ordinal)
+        persistedOrdinal <- snapshotFiles.read(lower.ordinal)
+        persistedHash <- snapshotFiles.read(lowerHash)
+        pendingAfterPublication <- notPersisted.get
+        headAfterPublication <- storage.head
+      } yield
+        expect.all(
+          cachedLower.contains(lower),
+          persistedOrdinal.isEmpty,
+          persistedHash.isEmpty,
+          pendingAfterPublication.contains(lower.ordinal),
+          headAfterPublication.contains((target, context))
+        )
+    }
+  }
+
+  test("validated head publication clears a stale pending marker for a matching durable lower value") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, ordinalCache, hashCache, notPersisted) = built
+        (genesis, lower) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        lowerHash <- lower.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        target <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          lower.value.copy(
+            ordinal = lower.ordinal.next,
+            lastSnapshotHash = lowerHash
+          ),
+          keyPair
+        )
+        _ <- storage.prepend(lower, context)
+        _ <- notPersisted.update(_ + lower.ordinal)
+        persistedOrdinalBeforePublication <- snapshotFiles.read(lower.ordinal)
+        pendingBeforePublication <- notPersisted.get
+        _ <- storage.setHeadForRecovery(target, context)
+        cachedOrdinalAfterPublication <- ordinalCache(lower.ordinal).get
+        cachedHashAfterPublication <- hashCache(lowerHash).get
+        pendingAfterPublication <- notPersisted.get
+        headAfterPublication <- storage.head
+      } yield
+        expect.all(
+          persistedOrdinalBeforePublication.contains(lower),
+          pendingBeforePublication.contains(lower.ordinal),
+          cachedOrdinalAfterPublication.contains(lowerHash),
+          cachedHashAfterPublication.contains(lower),
+          !pendingAfterPublication.contains(lower.ordinal),
+          headAfterPublication.contains((target, context))
+        )
+    }
+  }
+
+  test("validated head publication retains a hash-durable lower value whose ordinal index is missing") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, notPersisted) = built
+        (genesis, lower) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        lowerHash <- lower.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        target <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          lower.value.copy(
+            ordinal = lower.ordinal.next,
+            lastSnapshotHash = lowerHash
+          ),
+          keyPair
+        )
+        _ <- storage.prepend(lower, context)
+        _ <- snapshotFiles.delete(lower.ordinal)
+        pendingBeforePublication <- notPersisted.get
+        _ <- storage.setHeadForRecovery(target, context)
+        cachedLower <- storage.get(lower.ordinal)
+        persistedOrdinal <- snapshotFiles.read(lower.ordinal)
+        persistedHash <- snapshotFiles.read(lowerHash)
+        pendingAfterPublication <- notPersisted.get
+        headAfterPublication <- storage.head
+      } yield
+        expect.all(
+          !pendingBeforePublication.contains(lower.ordinal),
+          cachedLower.contains(lower),
+          persistedOrdinal.isEmpty,
+          persistedHash.contains(lower),
+          !pendingAfterPublication.contains(lower.ordinal),
+          headAfterPublication.contains((target, context))
+        )
+    }
+  }
+
+  test("validated head publication evicts an unsupported missing lower value") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, notPersisted) = built
+        (genesis, lower) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        lowerHash <- lower.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        target <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          lower.value.copy(
+            ordinal = lower.ordinal.next,
+            lastSnapshotHash = lowerHash
+          ),
+          keyPair
+        )
+        _ <- storage.prepend(lower, context)
+        _ <- snapshotFiles.delete(lower.ordinal)
+        _ <- snapshotFiles.delete(lowerHash)
+        pendingBeforePublication <- notPersisted.get
+        _ <- storage.setHeadForRecovery(target, context)
+        byOrdinalAfterPublication <- storage.get(lower.ordinal)
+        byHashAfterPublication <- storage.get(lowerHash)
+        pendingAfterPublication <- notPersisted.get
+        headAfterPublication <- storage.head
+      } yield
+        expect.all(
+          !pendingBeforePublication.contains(lower.ordinal),
+          byOrdinalAfterPublication.isEmpty,
+          byHashAfterPublication.isEmpty,
+          !pendingAfterPublication.contains(lower.ordinal),
+          headAfterPublication.contains((target, context))
+        )
+    }
+  }
+
+  test("validated head publication propagates a typed lower-history read failure without changing the head") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        (genesis, lower) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        lowerHash <- lower.value.hash
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        target <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          lower.value.copy(
+            ordinal = lower.ordinal.next,
+            lastSnapshotHash = lowerHash
+          ),
+          keyPair
+        )
+        readFailure = new RuntimeException("injected lower-history read failure")
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex, historicalReadFailure = (lower.ordinal -> readFailure).some)
+        (storage, _, _, _, _, _, _, _) = built
+        _ <- storage.prepend(lower, context)
+        headBeforePublication <- storage.head
+        publication <- storage.setHeadForRecovery(target, context).attempt
+        headAfterFailure <- storage.head
+      } yield
+        expect.all(
+          headBeforePublication.contains((lower, context)),
+          publication match {
+            case Left(error: SnapshotStorage.SnapshotIndexReadbackFailure) =>
+              error.ordinal === lower.ordinal && error.expectedHash === lowerHash && (error.getCause eq readFailure)
+            case _ => false
+          },
+          headAfterFailure === headBeforePublication
+        )
+    }
+  }
+
+  test("validated head publication evicts a replaced lower fork and its stale pending marker") { res =>
+    implicit val (supervisor, kryo, json, hasher, securityProvider) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        mutex <- Mutex[IO]
+        built <- mkInspectableStorage(tmpDir, mutex)
+        (storage, snapshotFiles, _, _, _, _, _, notPersisted) = built
+        (genesis, canonicalBase) <- mkSnapshots
+        context = genesis.info.toGlobalSnapshotInfo
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        forkBase <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          canonicalBase.value.copy(version = semver.SnapshotVersion("1.0.0")),
+          keyPair
+        )
+        forkBaseHash <- forkBase.value.hash
+        forkTarget <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          forkBase.value.copy(
+            ordinal = forkBase.ordinal.next,
+            lastSnapshotHash = forkBaseHash
+          ),
+          keyPair
+        )
+        canonicalBaseHash <- canonicalBase.value.hash
+        canonicalTarget <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          canonicalBase.value.copy(
+            ordinal = canonicalBase.ordinal.next,
+            lastSnapshotHash = canonicalBaseHash
+          ),
+          keyPair
+        )
+        _ <- storage.prepend(forkBase, context)
+        _ <- storage.prepend(forkTarget, context)
+        _ <- snapshotFiles.replaceForRecovery(canonicalBase)
+        _ <- snapshotFiles.replaceForRecovery(canonicalTarget)
+        _ <- notPersisted.update(_ + forkBase.ordinal)
+        staleBeforePublication <- storage.get(canonicalBase.ordinal)
+        pendingBeforePublication <- notPersisted.get
+        _ <- storage.setHeadForRecovery(canonicalTarget, context)
+        baseAfterPublication <- storage.get(canonicalBase.ordinal)
+        forkHashAfterPublication <- storage.get(forkBaseHash)
+        pendingAfterPublication <- notPersisted.get
+        headAfterPublication <- storage.head
+      } yield
+        expect.all(
+          staleBeforePublication.contains(forkBase),
+          pendingBeforePublication.contains(forkBase.ordinal),
+          baseAfterPublication.contains(canonicalBase),
+          forkHashAfterPublication.isEmpty,
+          !pendingAfterPublication.contains(forkBase.ordinal),
+          headAfterPublication.contains((canonicalTarget, context))
+        )
+    }
+  }
+
+  test("validated head retry clears a stale not-persisted marker only after same-value disk readback succeeds") { res =>
     implicit val (supervisor, kryo, json, hasher, securityProvider) = res
 
     File.temporaryDirectory() { tmpDir =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/SnapshotStorage.scala
@@ -23,8 +23,11 @@ trait SnapshotStorage[F[_], S <: Snapshot, State] {
   def get(hash: Hash): F[Option[Signed[S]]]
   def getHash(ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[Option[Hash]]
 
-  /** Reset head to the given snapshot for incremental recovery. Unlike prepend, this does not require sequential ordinals — it directly
-    * sets the head.
+  /** Publish an already validated download or recovery terminal pair as the visible head. Unlike `prepend`, this does not require
+    * sequential ordinals because full download may have already installed a canonical suffix directly on disk.
+    *
+    * This storage operation grants no branch-selection or rollback authority. Callers must validate and authorize the exact artifact and
+    * state before invoking it; filesystem-backed implementations make that pair durable and reconcile lookup caches before publication.
     */
   def setHeadForRecovery(snapshot: Signed[S], state: State)(implicit hasher: Hasher[F]): F[Unit]
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/domain/snapshot/storage/SnapshotStorage.scala
@@ -26,8 +26,10 @@ trait SnapshotStorage[F[_], S <: Snapshot, State] {
   /** Publish an already validated download or recovery terminal pair as the visible head. Unlike `prepend`, this does not require
     * sequential ordinals because full download may have already installed a canonical suffix directly on disk.
     *
-    * This storage operation grants no branch-selection or rollback authority. Callers must validate and authorize the exact artifact and
-    * state before invoking it; filesystem-backed implementations make that pair durable and reconcile lookup caches before publication.
+    * This storage operation grants no branch-selection or rollback authority. Callers must validate and authorize the target snapshot
+    * value/hash, semantically equal state, and persisted ancestry before invoking it. Filesystem-backed implementations make the target
+    * pair durable and reconcile positive caches against that validated persisted history before publication; they do not select a branch or
+    * repair lower files.
     */
   def setHeadForRecovery(snapshot: Signed[S], state: State)(implicit hasher: Hasher[F]): F[Unit]
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorage.scala
@@ -206,7 +206,10 @@ object LastNGlobalSnapshotStorage {
 
               case Right(globalSnapshotStorage) =>
                 for {
-                  maybeSnapshot <- globalSnapshotStorage.get(snapshotOrdinal)
+                  // The validated child, not an ordinal index, selects its parent.
+                  // An abandoned same-ordinal branch must neither become authority
+                  // nor prevent exact peer fallback when the declared hash is absent.
+                  maybeSnapshot <- globalSnapshotStorage.get(expectedHash)
                   result <- maybeSnapshot match {
                     case Some(snapshot) =>
                       snapshot.some.pure[F]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
@@ -188,33 +188,65 @@ object SnapshotStorage {
         }
         .void
 
-    def enqueue(snapshot: Signed[S], snapshotInfo: C)(implicit hasher: Hasher[F]) =
-      persistenceMutex.lock.surround {
-        snapshot.value.hash.flatMap { hash =>
+    def enqueueUnlocked(
+      snapshot: Signed[S],
+      snapshotInfo: C,
+      populatePositiveCachesBeforePersistence: Boolean,
+      requireExactSnapshotPersistence: Boolean
+    )(implicit hasher: Hasher[F]): F[Hash] =
+      snapshot.value.hash.flatMap { hash =>
+        val populatePositiveCaches = Applicative[F].whenA(populatePositiveCachesBeforePersistence) {
           hashCache(hash).set(snapshot.some) >>
-            ordinalCache(snapshot.ordinal).set(hash.some) >>
-            snapshotLocalFileSystemStorage.write(snapshot).handleErrorWith { e =>
-              snapshotExists(snapshot).ifM(
-                logger.info(s"Snapshot is already saved on disk. hash=$hash ordinal=${snapshot.ordinal}"),
-                logger.error(e)(s"Failed writing snapshot to disk! hash=$hash ordinal=${snapshot.ordinal}") >>
-                  notPersistedCache.update(current => current + snapshot.ordinal)
-              )
-            } >>
-            snapshotInfoLocalFileSystemStorage
-              .write(snapshot.ordinal, snapshotInfo)
-              .handleErrorWith { error =>
-                logger.error(error)(s"Failed writing required snapshot info to disk! ordinal=${snapshot.ordinal}") >>
-                  error.raiseError[F, Unit]
-              }
-              .flatMap { _ =>
-                snapshotInfoCutoffQueue.offer(snapshot.ordinal) >>
-                  snapshot.ordinal
-                    .partialPreviousN(inMemoryCapacity)
-                    .fold(Applicative[F].unit)(offloadQueue.offer) >>
-                  combinedSnapshotCheckpointFileSystemStorage.tryWrite(snapshot.ordinal, snapshot, snapshotInfo, hash)
-              }
+            ordinalCache(snapshot.ordinal).set(hash.some)
         }
+
+        val persistSnapshot = snapshotLocalFileSystemStorage.write(snapshot).handleErrorWith { error =>
+          snapshotExists(snapshot).ifM(
+            logger.info(s"Snapshot is already saved on disk. hash=$hash ordinal=${snapshot.ordinal}"),
+            logger.error(error)(s"Failed writing snapshot to disk! hash=$hash ordinal=${snapshot.ordinal}") >>
+              (if (requireExactSnapshotPersistence) error.raiseError[F, Unit]
+               else notPersistedCache.update(current => current + snapshot.ordinal))
+          )
+        }
+
+        val proveExactSnapshotPersistence = Applicative[F].whenA(requireExactSnapshotPersistence) {
+          snapshotExists(snapshot).flatMap {
+            MonadThrow[F].raiseUnless(_)(
+              new IllegalStateException(
+                s"Snapshot is not durably readable from both indexes. hash=$hash ordinal=${snapshot.ordinal}"
+              )
+            )
+          }
+        }
+
+        populatePositiveCaches >>
+          persistSnapshot >>
+          proveExactSnapshotPersistence >>
+          snapshotInfoLocalFileSystemStorage
+            .write(snapshot.ordinal, snapshotInfo)
+            .handleErrorWith { error =>
+              logger.error(error)(s"Failed writing required snapshot info to disk! ordinal=${snapshot.ordinal}") >>
+                error.raiseError[F, Unit]
+            }
+            .flatMap { _ =>
+              snapshotInfoCutoffQueue.offer(snapshot.ordinal) >>
+                snapshot.ordinal
+                  .partialPreviousN(inMemoryCapacity)
+                  .fold(Applicative[F].unit)(offloadQueue.offer) >>
+                combinedSnapshotCheckpointFileSystemStorage.tryWrite(snapshot.ordinal, snapshot, snapshotInfo, hash)
+            }
+            .as(hash)
       }
+
+    def enqueue(snapshot: Signed[S], snapshotInfo: C)(implicit hasher: Hasher[F]): F[Unit] =
+      persistenceMutex.lock.surround(
+        enqueueUnlocked(
+          snapshot,
+          snapshotInfo,
+          populatePositiveCachesBeforePersistence = true,
+          requireExactSnapshotPersistence = false
+        ).void
+      )
 
     def snapshotExists(snapshot: Signed[S])(implicit hasher: Hasher[F]): F[Boolean] =
       snapshot.toHashed
@@ -301,10 +333,64 @@ object SnapshotStorage {
             _.traverse(_.toHashed.map(_.hash))
           }
 
-        def setHeadForRecovery(snapshot: Signed[S], state: C)(implicit hasher: Hasher[F]): F[Unit] =
-          logger.info(s"[SnapshotStorage] Recovery: setting head to ordinal=${snapshot.ordinal.show}") >>
-            enqueue(snapshot, state) >>
-            headRef.set((snapshot, hasher, state).some).void
+        /** Publish an already validated download/recovery terminal pair as the public storage head.
+          *
+          * The method name does not grant rollback authority. Callers must establish authority and validate the exact artifact/context
+          * before entering this boundary. Publication itself is serialized with ordinary persistence and becomes visible only after both
+          * snapshot indexes and the context are durable and all process-local lookup caches agree with the new head.
+          */
+        def setHeadForRecovery(snapshot: Signed[S], state: C)(implicit hasher: Hasher[F]): F[Unit] = {
+          def reconcilePositiveCaches(hashed: Hashed[S]): F[Unit] =
+            for {
+              cachedOrdinals <- ordinalCache.keys
+              cachedOrdinalValues <- cachedOrdinals.toList.traverse { ordinal =>
+                ordinalCache(ordinal).get.map(ordinal -> _)
+              }
+              cachedHashes <- hashCache.keys
+              staleOrdinalValues = cachedOrdinalValues.collect {
+                case (ordinal, Some(hash)) if ordinal > snapshot.ordinal || (ordinal === snapshot.ordinal && hash =!= hashed.hash) =>
+                  ordinal -> hash
+              }
+              staleOrdinals = staleOrdinalValues.map(_._1).toSet
+              staleHashesFromOrdinals = staleOrdinalValues.map(_._2).toSet
+              staleHashesFromValues <- cachedHashes.toList.filterA { hash =>
+                hashCache(hash).get.map(
+                  _.exists(cached => cached.ordinal > snapshot.ordinal || (cached.ordinal === snapshot.ordinal && hash =!= hashed.hash))
+                )
+              }
+              staleHashes = staleHashesFromOrdinals ++ staleHashesFromValues
+              _ <- staleOrdinals.toList.traverse_(ordinal => ordinalCache(ordinal).set(none))
+              _ <- staleHashes.toList.traverse_(hash => hashCache(hash).set(none))
+              _ <- hashCache(hashed.hash).set(snapshot.some)
+              _ <- ordinalCache(snapshot.ordinal).set(hashed.hash.some)
+            } yield ()
+
+          persistenceMutex.lock.surround {
+            for {
+              _ <- logger.info(s"[SnapshotStorage] Publishing validated download/recovery head ordinal=${snapshot.ordinal.show}")
+              hash <- enqueueUnlocked(
+                snapshot,
+                state,
+                populatePositiveCachesBeforePersistence = false,
+                requireExactSnapshotPersistence = true
+              )
+              hashed <- snapshot.toHashed
+              _ <- MonadThrow[F].raiseUnless(hash === hashed.hash)(
+                new IllegalStateException(
+                  s"Published snapshot hash changed during persistence ordinal=${snapshot.ordinal} expected=${hashed.hash} actual=$hash"
+                )
+              )
+              persistedState <- snapshotInfoLocalFileSystemStorage.read(snapshot.ordinal)
+              _ <- MonadThrow[F].raiseUnless(persistedState.exists(java.util.Objects.equals(_, state)))(
+                new IllegalStateException(s"Snapshot context exact disk readback failed ordinal=${snapshot.ordinal}")
+              )
+              _ <- reconcilePositiveCaches(hashed)
+              _ <- notPersistedCache.update(_.filter(_ < snapshot.ordinal))
+              _ <- Async[F].delay(negativeCache.invalidateAll())
+              _ <- headRef.set((snapshot, hasher, state).some).void
+            } yield ()
+          }
+        }
 
         private def replaceExactRecoveryHead(snapshot: Signed[S], state: C)(implicit hasher: Hasher[F]): F[Unit] =
           snapshot.toHashed.flatMap { hashed =>

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
@@ -4,7 +4,7 @@ import cats.Order._
 import cats.effect.std.{Mutex, Queue, Supervisor}
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
-import cats.{Applicative, MonadThrow}
+import cats.{Applicative, Eq, MonadThrow}
 
 import scala.concurrent.duration._
 
@@ -57,7 +57,7 @@ object SnapshotStorage {
     }
   }
 
-  def make[F[_]: Async, S <: Snapshot: Encoder, C <: SnapshotInfo[_]](
+  def make[F[_]: Async, S <: Snapshot: Encoder, C <: SnapshotInfo[_]: Eq](
     snapshotLocalFileSystemStorage: SnapshotLocalFileSystemStorage[F, S],
     snapshotInfoLocalFileSystemStorage: SnapshotInfoLocalFileSystemStorage[F, _, C],
     inMemoryCapacity: NonNegLong,
@@ -86,7 +86,7 @@ object SnapshotStorage {
         )
     }
 
-  def make[F[_]: Async, S <: Snapshot: Encoder, C <: SnapshotInfo[_]](
+  def make[F[_]: Async, S <: Snapshot: Encoder, C <: SnapshotInfo[_]: Eq](
     headRef: SignallingRef[F, Option[(Signed[S], Hasher[F], C)]],
     ordinalCache: MapRef[F, SnapshotOrdinal, Option[Hash]],
     hashCache: MapRef[F, Hash, Option[Signed[S]]],
@@ -381,7 +381,10 @@ object SnapshotStorage {
                 )
               )
               persistedState <- snapshotInfoLocalFileSystemStorage.read(snapshot.ordinal)
-              _ <- MonadThrow[F].raiseUnless(persistedState.exists(java.util.Objects.equals(_, state)))(
+              // Snapshot contexts can contain byte arrays (for example metagraph data-application state).
+              // Case-class/Java equality compares those arrays by reference, which makes a correctly decoded
+              // disk value look different from the in-memory value. Use the schema's content-aware Eq.
+              _ <- MonadThrow[F].raiseUnless(persistedState.exists(_ === state))(
                 new IllegalStateException(s"Snapshot context exact disk readback failed ordinal=${snapshot.ordinal}")
               )
               _ <- reconcilePositiveCaches(hashed)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
@@ -405,11 +405,11 @@ object SnapshotStorage {
               }
               .handleErrorWith(error => SnapshotIndexReadbackFailure(ordinal, cachedHash, error).raiseError[F, Option[Hash]])
 
-          /** Reconcile lower positive-cache entries with caller-validated persisted history without writing lower files or inferring a fork
-            * point. Any readable ordinal index settles its retry marker. A missing/undecodable ordinal retains its cached value and marker
-            * when persistence is pending, or retains only the cached value when its hash index still proves the same snapshot value/hash;
-            * otherwise both positive-cache entries and any stale retry marker are removed.
-            */
+          /* Reconcile lower positive-cache entries with caller-validated persisted history without writing lower files or inferring a fork
+           * point. Any readable ordinal index settles its retry marker. A missing/undecodable ordinal retains its cached value and marker
+           * when persistence is pending, or retains only the cached value when its hash index still proves the same snapshot value/hash;
+           * otherwise both positive-cache entries and any stale retry marker are removed.
+           */
           def reconcileValidatedHistoryCacheEntries: F[Unit] =
             for {
               cachedOrdinals <- ordinalCache.keys
@@ -444,10 +444,10 @@ object SnapshotStorage {
               _ <- notPersistedCache.update(_ -- (evictedOrdinals ++ ordinalBackedOrdinals))
             } yield ()
 
-          /** Remove only the abandoned target/future suffix from process-local positive caches. Lower entries are reconciled separately
-            * against the caller-validated persisted ancestry. Neither operation selects a branch, infers a fork point, or repairs lower
-            * files.
-            */
+          /* Remove only the abandoned target/future suffix from process-local positive caches. Lower entries are reconciled separately
+           * against the caller-validated persisted ancestry. Neither operation selects a branch, infers a fork point, or repairs lower
+           * files.
+           */
           def reconcilePublishedSuffixCaches(hashed: Hashed[S]): F[Unit] =
             for {
               cachedOrdinals <- ordinalCache.keys

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotStorage.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import cats.{Applicative, Eq, MonadThrow}
 
 import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 import io.constellationnetwork.cutoff.{LogarithmicOrdinalCutoff, OrdinalCutoff}
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
@@ -31,6 +32,33 @@ import io.circe.Encoder
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object SnapshotStorage {
+
+  sealed abstract class HeadPublicationFailure(message: String, cause: Throwable = null)
+      extends RuntimeException(message, cause)
+      with NoStackTrace
+
+  final case class SnapshotOrdinalCollision(
+    ordinal: SnapshotOrdinal,
+    expectedHash: Hash,
+    actualHash: Hash
+  ) extends HeadPublicationFailure(
+        s"Snapshot ordinal is occupied by a different value. ordinal=$ordinal expected=$expectedHash actual=$actualHash"
+      )
+
+  final case class SnapshotIndexReadbackFailure(
+    ordinal: SnapshotOrdinal,
+    expectedHash: Hash,
+    cause: Throwable = null
+  ) extends HeadPublicationFailure(
+        s"Snapshot is not durably readable from both indexes. hash=$expectedHash ordinal=$ordinal",
+        cause
+      )
+
+  final case class SnapshotContextReadbackFailure(ordinal: SnapshotOrdinal, cause: Throwable = null)
+      extends HeadPublicationFailure(
+        s"Persisted snapshot context is not semantically equal to the supplied context. ordinal=$ordinal",
+        cause
+      )
 
   /** Scaffeine cache for negative ordinal lookups. Caches ordinals confirmed absent from filesystem to avoid repeated stat() calls from
     * community nodes requesting pruned snapshots. Short TTL (30s) ensures new snapshots become visible quickly.
@@ -192,36 +220,58 @@ object SnapshotStorage {
       snapshot: Signed[S],
       snapshotInfo: C,
       populatePositiveCachesBeforePersistence: Boolean,
-      requireExactSnapshotPersistence: Boolean
+      requireSnapshotValueReadback: Boolean
     )(implicit hasher: Hasher[F]): F[Hash] =
       snapshot.value.hash.flatMap { hash =>
+        def proveSnapshotValuePersistence: F[Unit] =
+          for {
+            ordinalValue <- snapshotLocalFileSystemStorage
+              .read(snapshot.ordinal)
+              .flatMap(_.traverse(_.toHashed))
+              .handleErrorWith(error => SnapshotIndexReadbackFailure(snapshot.ordinal, hash, error).raiseError[F, Option[Hashed[S]]])
+            _ <- ordinalValue.collect {
+              case actual if actual.hash =!= hash =>
+                SnapshotOrdinalCollision(snapshot.ordinal, hash, actual.hash)
+            }.traverse_(MonadThrow[F].raiseError[Unit])
+            hashValue <- snapshotLocalFileSystemStorage
+              .read(hash)
+              .flatMap(_.traverse(_.toHashed))
+              .handleErrorWith(error => SnapshotIndexReadbackFailure(snapshot.ordinal, hash, error).raiseError[F, Option[Hashed[S]]])
+            _ <- MonadThrow[F].raiseUnless(
+              ordinalValue.exists(_.hash === hash) && hashValue.exists(_.hash === hash)
+            )(SnapshotIndexReadbackFailure(snapshot.ordinal, hash))
+          } yield ()
+
         val populatePositiveCaches = Applicative[F].whenA(populatePositiveCachesBeforePersistence) {
           hashCache(hash).set(snapshot.some) >>
             ordinalCache(snapshot.ordinal).set(hash.some)
         }
 
-        val persistSnapshot = snapshotLocalFileSystemStorage.write(snapshot).handleErrorWith { error =>
-          snapshotExists(snapshot).ifM(
-            logger.info(s"Snapshot is already saved on disk. hash=$hash ordinal=${snapshot.ordinal}"),
-            logger.error(error)(s"Failed writing snapshot to disk! hash=$hash ordinal=${snapshot.ordinal}") >>
-              (if (requireExactSnapshotPersistence) error.raiseError[F, Unit]
-               else notPersistedCache.update(current => current + snapshot.ordinal))
-          )
-        }
-
-        val proveExactSnapshotPersistence = Applicative[F].whenA(requireExactSnapshotPersistence) {
-          snapshotExists(snapshot).flatMap {
-            MonadThrow[F].raiseUnless(_)(
-              new IllegalStateException(
-                s"Snapshot is not durably readable from both indexes. hash=$hash ordinal=${snapshot.ordinal}"
+        val persistSnapshot =
+          if (requireSnapshotValueReadback)
+            for {
+              writeResult <- snapshotLocalFileSystemStorage.write(snapshot).attempt
+              readbackResult <- proveSnapshotValuePersistence.attempt
+              _ <- (writeResult, readbackResult) match {
+                case (Left(writeError), Left(readbackError)) =>
+                  Async[F].delay(readbackError.addSuppressed(writeError)) >> readbackError.raiseError[F, Unit]
+                case (Right(_), Left(readbackError)) => readbackError.raiseError[F, Unit]
+                case (Left(_), Right(_)) =>
+                  logger.info(s"Snapshot is already saved on disk. hash=$hash ordinal=${snapshot.ordinal}")
+                case (Right(_), Right(_)) => Applicative[F].unit
+              }
+            } yield ()
+          else
+            snapshotLocalFileSystemStorage.write(snapshot).handleErrorWith { error =>
+              snapshotExists(snapshot).ifM(
+                logger.info(s"Snapshot is already saved on disk. hash=$hash ordinal=${snapshot.ordinal}"),
+                logger.error(error)(s"Failed writing snapshot to disk! hash=$hash ordinal=${snapshot.ordinal}") >>
+                  notPersistedCache.update(current => current + snapshot.ordinal)
               )
-            )
-          }
-        }
+            }
 
         populatePositiveCaches >>
           persistSnapshot >>
-          proveExactSnapshotPersistence >>
           snapshotInfoLocalFileSystemStorage
             .write(snapshot.ordinal, snapshotInfo)
             .handleErrorWith { error =>
@@ -244,7 +294,7 @@ object SnapshotStorage {
           snapshot,
           snapshotInfo,
           populatePositiveCachesBeforePersistence = true,
-          requireExactSnapshotPersistence = false
+          requireSnapshotValueReadback = false
         ).void
       )
 
@@ -335,12 +385,70 @@ object SnapshotStorage {
 
         /** Publish an already validated download/recovery terminal pair as the public storage head.
           *
-          * The method name does not grant rollback authority. Callers must establish authority and validate the exact artifact/context
-          * before entering this boundary. Publication itself is serialized with ordinary persistence and becomes visible only after both
-          * snapshot indexes and the context are durable and all process-local lookup caches agree with the new head.
+          * A lower head may be published only when the target ordinal is absent or already contains the same canonical snapshot value/hash,
+          * and the caller has validated that target and its persisted ancestry. Storage reconciles positive caches against that validated
+          * persisted history before publication. The method rejects a different snapshot occupying the target ordinal; it does not select a
+          * branch, replace a suffix, or repair lower files. Publication is serialized with ordinary persistence and becomes visible only
+          * after both target snapshot indexes and the semantically equal context are durable and all process-local lookup caches agree with
+          * the new head.
           */
         def setHeadForRecovery(snapshot: Signed[S], state: C)(implicit hasher: Hasher[F]): F[Unit] = {
-          def reconcilePositiveCaches(hashed: Hashed[S]): F[Unit] =
+
+          def readHistoricalHash(
+            ordinal: SnapshotOrdinal,
+            cachedHash: Hash,
+            read: F[Option[Signed[S]]]
+          ): F[Option[Hash]] =
+            hasherSelector
+              .forOrdinal(ordinal) { historicalHasher =>
+                read.flatMap(_.traverse(value => historicalHasher.hash(value.value)))
+              }
+              .handleErrorWith(error => SnapshotIndexReadbackFailure(ordinal, cachedHash, error).raiseError[F, Option[Hash]])
+
+          /** Reconcile lower positive-cache entries with caller-validated persisted history without writing lower files or inferring a fork
+            * point. Any readable ordinal index settles its retry marker. A missing/undecodable ordinal retains its cached value and marker
+            * when persistence is pending, or retains only the cached value when its hash index still proves the same snapshot value/hash;
+            * otherwise both positive-cache entries and any stale retry marker are removed.
+            */
+          def reconcileValidatedHistoryCacheEntries: F[Unit] =
+            for {
+              cachedOrdinals <- ordinalCache.keys
+              pendingOrdinals <- notPersistedCache.get
+              reconciliationEntries <- cachedOrdinals.toList.filter(_ < snapshot.ordinal).flatTraverse { ordinal =>
+                ordinalCache(ordinal).get.flatMap {
+                  case Some(cachedHash) =>
+                    readHistoricalHash(ordinal, cachedHash, snapshotLocalFileSystemStorage.read(ordinal)).flatMap {
+                      case Some(persistedHash) =>
+                        (persistedHash =!= cachedHash, true).pure[F]
+                      case None if pendingOrdinals.contains(ordinal) =>
+                        (false, false).pure[F]
+                      case None =>
+                        readHistoricalHash(ordinal, cachedHash, snapshotLocalFileSystemStorage.read(cachedHash))
+                          .map(hash => (!hash.contains(cachedHash), false))
+                    }.map {
+                      case (evict, ordinalIndexReadable) => List((ordinal, cachedHash, evict, ordinalIndexReadable))
+                    }
+                  case None => List.empty[(SnapshotOrdinal, Hash, Boolean, Boolean)].pure[F]
+                }
+              }
+              evictedEntries = reconciliationEntries.collect {
+                case (ordinal, cachedHash, true, _) => ordinal -> cachedHash
+              }
+              evictedOrdinals = evictedEntries.map(_._1).toSet
+              ordinalBackedOrdinals = reconciliationEntries.collect {
+                case (ordinal, _, _, true) => ordinal
+              }.toSet
+              _ <- evictedEntries.traverse_ {
+                case (ordinal, hash) => ordinalCache(ordinal).set(none) >> hashCache(hash).set(none)
+              }
+              _ <- notPersistedCache.update(_ -- (evictedOrdinals ++ ordinalBackedOrdinals))
+            } yield ()
+
+          /** Remove only the abandoned target/future suffix from process-local positive caches. Lower entries are reconciled separately
+            * against the caller-validated persisted ancestry. Neither operation selects a branch, infers a fork point, or repairs lower
+            * files.
+            */
+          def reconcilePublishedSuffixCaches(hashed: Hashed[S]): F[Unit] =
             for {
               cachedOrdinals <- ordinalCache.keys
               cachedOrdinalValues <- cachedOrdinals.toList.traverse { ordinal =>
@@ -372,7 +480,7 @@ object SnapshotStorage {
                 snapshot,
                 state,
                 populatePositiveCachesBeforePersistence = false,
-                requireExactSnapshotPersistence = true
+                requireSnapshotValueReadback = true
               )
               hashed <- snapshot.toHashed
               _ <- MonadThrow[F].raiseUnless(hash === hashed.hash)(
@@ -380,14 +488,17 @@ object SnapshotStorage {
                   s"Published snapshot hash changed during persistence ordinal=${snapshot.ordinal} expected=${hashed.hash} actual=$hash"
                 )
               )
-              persistedState <- snapshotInfoLocalFileSystemStorage.read(snapshot.ordinal)
+              persistedState <- snapshotInfoLocalFileSystemStorage.read(snapshot.ordinal).handleErrorWith { error =>
+                SnapshotContextReadbackFailure(snapshot.ordinal, error).raiseError[F, Option[C]]
+              }
               // Snapshot contexts can contain byte arrays (for example metagraph data-application state).
               // Case-class/Java equality compares those arrays by reference, which makes a correctly decoded
               // disk value look different from the in-memory value. Use the schema's content-aware Eq.
               _ <- MonadThrow[F].raiseUnless(persistedState.exists(_ === state))(
-                new IllegalStateException(s"Snapshot context exact disk readback failed ordinal=${snapshot.ordinal}")
+                SnapshotContextReadbackFailure(snapshot.ordinal)
               )
-              _ <- reconcilePositiveCaches(hashed)
+              _ <- reconcileValidatedHistoryCacheEntries
+              _ <- reconcilePublishedSuffixCaches(hashed)
               _ <- notPersistedCache.update(_.filter(_ < snapshot.ordinal))
               _ <- Async[F].delay(negativeCache.invalidateAll())
               _ <- headRef.set((snapshot, hasher, state).some).void

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorageInitializationSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/LastNGlobalSnapshotStorageInitializationSuite.scala
@@ -10,6 +10,7 @@ import scala.collection.mutable.ListBuffer
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.node.shared.config.types.LastGlobalSnapshotsSyncConfig
 import io.constellationnetwork.node.shared.domain.snapshot.services.GlobalL0Service
+import io.constellationnetwork.node.shared.domain.snapshot.storage.SnapshotStorage
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.height.{Height, SubHeight}
@@ -112,6 +113,26 @@ object LastNGlobalSnapshotStorageInitializationSuite extends SimpleIOSuite {
       }
       .map(_._2)
 
+  private def archive(
+    getByOrdinal: SnapshotOrdinal => IO[Option[Signed[GlobalIncrementalSnapshot]]],
+    getByHash: Hash => IO[Option[Signed[GlobalIncrementalSnapshot]]]
+  ): SnapshotStorage[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo] =
+    new SnapshotStorage[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo] {
+      private def unused[A]: IO[A] = IO.raiseError(new IllegalStateException("unexpected archive operation"))
+
+      def prepend(snapshot: Signed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo)(implicit hasher: Hasher[IO]): IO[Boolean] =
+        unused
+      def head: IO[Option[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = unused
+      def headSnapshot: IO[Option[Signed[GlobalIncrementalSnapshot]]] = unused
+      def get(ordinal: SnapshotOrdinal): IO[Option[Signed[GlobalIncrementalSnapshot]]] = getByOrdinal(ordinal)
+      def getHashed(ordinal: SnapshotOrdinal)(implicit hasher: Hasher[IO]): IO[Option[Hashed[GlobalIncrementalSnapshot]]] = unused
+      def get(hash: Hash): IO[Option[Signed[GlobalIncrementalSnapshot]]] = getByHash(hash)
+      def getHash(ordinal: SnapshotOrdinal)(implicit hasher: Hasher[IO]): IO[Option[Hash]] = unused
+      def setHeadForRecovery(snapshot: Signed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo)(
+        implicit hasher: Hasher[IO]
+      ): IO[Unit] = unused
+    }
+
   test("a failed required-window fetch leaves initialization retryable in the same process") {
     SecurityProvider.forAsync[IO].use { implicit securityProvider =>
       for {
@@ -148,7 +169,10 @@ object LastNGlobalSnapshotStorageInitializationSuite extends SimpleIOSuite {
         expect(first.isLeft) &&
           expect(afterFailure.isEmpty) &&
           expect(afterRetry.exists(_._1.hash === parent.hash)) &&
-          expect(retained.exists(_.ordinal === SnapshotOrdinal.unsafeApply(98L)))
+          expect.same(
+            (50L to 100L).iterator.map(SnapshotOrdinal.unsafeApply).toSet,
+            retained.map(_.ordinal).toSet
+          )
     }
   }
 
@@ -177,6 +201,122 @@ object LastNGlobalSnapshotStorageInitializationSuite extends SimpleIOSuite {
             Set(SnapshotOrdinal.unsafeApply(98L), SnapshotOrdinal.unsafeApply(99L), SnapshotOrdinal.unsafeApply(100L)),
             retained.map(_.ordinal).toSet
           )
+    }
+  }
+
+  test("a local rollback archive is resolved by child-declared hash before peer fallback") {
+    SecurityProvider.forAsync[IO].use { implicit securityProvider =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+        implicit0(hasherSelector: HasherSelector[IO]) = HasherSelector.forSyncAlwaysCurrent(hasher)
+        keyPair <- KeyPairGenerator.makeKeyPair[IO]
+        snapshots <- chain(98L, 100L, keyPair)
+        byHash = snapshots.valuesIterator.map(snapshot => snapshot.hash -> snapshot.signed).toMap
+        hashRequests <- Ref.of[IO, List[Hash]](List.empty)
+        ordinalRequests <- Ref.of[IO, Int](0)
+        peerFallbacks <- Ref.of[IO, Int](0)
+        localArchive = archive(
+          _ => ordinalRequests.update(_ + 1) >> IO.raiseError(new IllegalStateException("ordinal lookup must not select lineage")),
+          hash => hashRequests.update(_ :+ hash) >> byHash.get(hash).pure[IO]
+        )
+        peerFallback = (_: Option[Hash], _: SnapshotOrdinal) =>
+          peerFallbacks.update(_ + 1) >> IO.raiseError[Signed[GlobalIncrementalSnapshot]](
+            new IllegalStateException("peer fallback must not be needed")
+          )
+        storage <- LastNGlobalSnapshotStorage.make[IO](LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(2)))
+        parent = snapshots(SnapshotOrdinal.unsafeApply(100L))
+        _ <- storage.setInitialFetchingGL0(parent, info, localArchive.asRight.some, peerFallback.some)
+        requestedHashes <- hashRequests.get
+        ordinalRequestCount <- ordinalRequests.get
+        fallbackCount <- peerFallbacks.get
+        retained <- storage.getLastN
+      } yield
+        expect.same(
+          List(
+            snapshots(SnapshotOrdinal.unsafeApply(99L)).hash,
+            snapshots(SnapshotOrdinal.unsafeApply(98L)).hash
+          ),
+          requestedHashes
+        ) &&
+          expect.same(0, ordinalRequestCount) &&
+          expect.same(0, fallbackCount) &&
+          expect.same(
+            Set(SnapshotOrdinal.unsafeApply(98L), SnapshotOrdinal.unsafeApply(99L), SnapshotOrdinal.unsafeApply(100L)),
+            retained.map(_.ordinal).toSet
+          )
+    }
+  }
+
+  test("a stale same-ordinal branch cannot block exact peer fallback") {
+    SecurityProvider.forAsync[IO].use { implicit securityProvider =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+        implicit0(hasherSelector: HasherSelector[IO]) = HasherSelector.forSyncAlwaysCurrent(hasher)
+        canonicalKey <- KeyPairGenerator.makeKeyPair[IO]
+        staleKey <- KeyPairGenerator.makeKeyPair[IO]
+        canonical <- chain(99L, 100L, canonicalKey)
+        stale <- snapshot(SnapshotOrdinal.unsafeApply(99L), Hash.empty, staleKey)
+        ordinalRequests <- Ref.of[IO, Int](0)
+        peerRequests <- Ref.of[IO, List[(Option[Hash], SnapshotOrdinal)]](List.empty)
+        localArchive = archive(
+          _ => ordinalRequests.update(_ + 1).as(stale.signed.some),
+          _ => none[Signed[GlobalIncrementalSnapshot]].pure[IO]
+        )
+        peerFallback = (hash: Option[Hash], ordinal: SnapshotOrdinal) =>
+          peerRequests.update(_ :+ (hash -> ordinal)) >> canonical
+            .get(ordinal)
+            .liftTo[IO](new IllegalStateException(s"missing $ordinal"))
+            .map(_.signed)
+        storage <- LastNGlobalSnapshotStorage.make[IO](LastGlobalSnapshotsSyncConfig(NonNegLong(1L), PosInt(1)))
+        parent = canonical(SnapshotOrdinal.unsafeApply(100L))
+        _ <- storage.setInitialFetchingGL0(parent, info, localArchive.asRight.some, peerFallback.some)
+        ordinalRequestCount <- ordinalRequests.get
+        requested <- peerRequests.get
+        retained <- storage.getLastN
+      } yield
+        expect.same(0, ordinalRequestCount) &&
+          expect.same(List((parent.signed.value.lastSnapshotHash.some, SnapshotOrdinal.unsafeApply(99L))), requested) &&
+          expect(retained.exists(_.hash === canonical(SnapshotOrdinal.unsafeApply(99L)).hash)) &&
+          expect(!retained.exists(_.hash === stale.hash))
+    }
+  }
+
+  test("a readable invalid local hash result fails closed without peer substitution") {
+    SecurityProvider.forAsync[IO].use { implicit securityProvider =>
+      for {
+        implicit0(serializer: JsonSerializer[IO]) <- JsonSerializer.forAsync[IO]
+        implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+        implicit0(hasherSelector: HasherSelector[IO]) = HasherSelector.forSyncAlwaysCurrent(hasher)
+        canonicalKey <- KeyPairGenerator.makeKeyPair[IO]
+        wrongKey <- KeyPairGenerator.makeKeyPair[IO]
+        canonical <- chain(99L, 100L, canonicalKey)
+        wrong <- snapshot(SnapshotOrdinal.unsafeApply(99L), Hash.empty, wrongKey)
+        peerFallbacks <- Ref.of[IO, Int](0)
+        localArchive = archive(
+          _ => none[Signed[GlobalIncrementalSnapshot]].pure[IO],
+          _ => wrong.signed.some.pure[IO]
+        )
+        peerFallback = (_: Option[Hash], _: SnapshotOrdinal) =>
+          peerFallbacks.update(_ + 1) >> canonical(SnapshotOrdinal.unsafeApply(99L)).signed.pure[IO]
+        storage <- LastNGlobalSnapshotStorage.make[IO](LastGlobalSnapshotsSyncConfig(NonNegLong(1L), PosInt(1)))
+        result <- storage
+          .setInitialFetchingGL0(
+            canonical(SnapshotOrdinal.unsafeApply(100L)),
+            info,
+            localArchive.asRight.some,
+            peerFallback.some
+          )
+          .attempt
+        fallbackCount <- peerFallbacks.get
+        combined <- storage.getCombined
+        retained <- storage.getLastN
+      } yield
+        expect(result.left.exists(_.getMessage.contains("hash mismatch"))) &&
+          expect.same(0, fallbackCount) &&
+          expect(combined.isEmpty) &&
+          expect(retained.isEmpty)
     }
   }
 


### PR DESCRIPTION
## Summary

This follow-on closes snapshot-storage and lifecycle gaps exposed while qualifying v35 recovery against real assembled jars:

- rebuild rollback Last-N from the local canonical archive by child-declared hash, with exact peer fallback only when local bytes are absent;
- publish downloaded snapshot values and semantically equal contexts durably before exposing the public head;
- classify target collisions, snapshot-index readback failures, and context readback failures with structured logs and bounded metrics;
- reconcile target, future, and lower positive caches against caller-validated persisted history while preserving legitimate pending or hash-durable lower entries;
- publish the full-download, follower-catch-up, or recovery terminal pair before consensus initialization;
- retain ordinal-1 snapshot context only for development active-from-genesis certified replay; scheduled non-genesis and dormant behavior remain unchanged;
- add a production-shaped rollback-lead/forward-download Just E2E; configure GL0 E2E quorum at 2/3 and exercise `dag-cluster` with four GL0 nodes.

## Consensus compatibility

Classification: runtime/storage-publication behavior plus test-only E2E configuration.

- No signed schema, codec, hash/signature construction, or persisted-format change.
- No consensus value, production quorum, committee, trigger, or leader-selection change.
- No activation ordinal or recovery-authority change.
- No Currency L0 consensus or L1 production change.
- No automatic rollback, conflicting-target overwrite, arbitrary-LCA repair, lock clearing, or peer-majority history authority.
- Production DAG L0 remains unchanged at 2/3 quorum. GL0 CI now also uses a 2/3 fallback; `dag-cluster` runs four GL0 nodes, `rollback-download-head` retains its explicit three-node/2/3 override, and `committee-rewards` retains five nodes. Currency L0 keeps its separate quorum setting.

The operated scenario matches the permissioned deployment topology: one `run-rollback` lead starts first and every other node starts as `run-validator`.

## Review resolution

- A lower head may publish only when its target ordinal is absent or already contains the same canonical snapshot value/hash after the caller validates the target and persisted ancestry.
- A conflicting target fails closed as `SnapshotOrdinalCollision`; Global download does not gain suffix-overwrite authority.
- Exact target publication performs one write attempt followed by one proof across both snapshot indexes. A failed proof retains the original write failure as a suppressed cause.
- Context readback uses content-aware schema equality and is described as semantic equality rather than proof-envelope or byte equality.
- Lower caches use the ordinal-selected hasher and reconcile against persisted ordinal values, pending writes, and readable hash-index evidence before head publication. Unsupported entries and stale retry markers are removed.
- Publication failures emit `dag_download_head_publication_failure_total` with `path`, `direction`, and `reason`. Success remains post-durable and before consensus initialization.
- The shared `LocalFileSystemStorage.link` behavior is unchanged; the publication boundary independently proves both target indexes and fails with a typed error when either is unavailable.
- The E2E wording now states that it proves rollback-lead initialization and forward full download. It does not claim to exercise backward publication.

## Review guide

1. `144c910eb`: hash-bound local-first rollback window reconstruction.
2. `cdb0bfa26`: serialized durable head publication and cache reconciliation.
3. `bbf4d5844`: publication-before-consensus lifecycle ordering.
4. `e56c81fc6`: active-from-genesis test root retention.
5. `b5a5cb59b` and `0a8c98df5`: assembled-jar E2E and CI registration.
6. `43f9087a6`: content-aware persisted-context equality for array-bearing metagraph state.
7. `130af5239` and `2578f338c`: publication/hash/signature assertions.
8. `77dddbe85`: review corrections for publication failures, cache reconciliation, metrics, documentation, and CI quorum propagation.
9. `eefed9d03`: use ordinary comments for local helpers so SDK Scaladoc generation succeeds.
10. `16b0a019e`: use the GL0 2/3 E2E fallback and four GL0 nodes for `dag-cluster`, preserving all other matrix topologies.

## Verification

- `SnapshotStorageSuite`: 31 passed.
- `DownloadSuite`: 23 passed.
- `DownloadHeadPublicationSuite`: 2 passed.
- `SnapshotLocalFileSystemStorageSuite`: 25 passed.
- Focused review total: 81 passed.
- Whole-project `sbt compile` passed on `eefed9d03` after the branch rebase onto current `develop`.
- `sdk/doc` passed after correcting the local helper comments that caused the first post-update JAR build to fail.
- `scalafmtCheckAll` passed.
- `scalafixAll --check --rules OrganizeImports` passed.
- Commitlint passed for `eefed9d03` and the complete rebased PR commit range.
- Shell syntax, workflow/Compose YAML parsing, rendered quorum assertions, and `git diff --check` passed.

### CI configuration follow-up (`16b0a019e`)

The previously missing Compose pass-through made unanimity effective for ordinary CI rows. That setting prevents current seated signers from satisfying the next larger committee's finality floor during ordinary certified admission. The user-approved follow-up uses the existing GL0 2/3 policy instead of changing admission authority or tiering.

- Only `dag-cluster` gains `--num-gl0=4`; its existing checker requires three snapshot proofs. Other matrix rows and test assertion code are unchanged.
- Whole-project `sbt compile` passed at `16b0a019e`.
- Commitlint passed for the new commit and the complete PR range.
- Workflow and five Compose files passed YAML parsing.
- All 12 matrix rows rendered GL0 quorum `0.6666666666666666`; all four `dag-cluster` node configurations rendered with distinct names and public ports.
- Rendered GL1/ML0/CL1/DL1 received no quorum override; Currency L0's committed default remains `1.0`.
- The Just dry-run confirmed that the four-node override follows the default. Normalized workflow comparison confirmed only the fallback and `dag-cluster` node count changed.
- Runner, environment-parser and rollback shell syntax, plus `git diff --check`, passed.
- Claude Fable completed two focused read-only review passes. Its initial checker-call-site and environment-scoping concerns were resolved with runner/Compose evidence; its remaining comparator check was verified against the actual `signerCount >= expectedSigners` expression (two rejected, three and four accepted). This was not a full-protocol or live-E2E review.
- Provisioning four processes and observing a three-proof snapshot do not independently establish four admitted signing seats or Byzantine fault tolerance. No new identity-based participation assertion is claimed.
- Fresh full-matrix CI, including `dag-cluster`, `committee-rewards`, and rollback/rejoin, remains required before merge.

### Real-process qualification

Before the final review-correction commit, three consecutive runs passed on the same assembled GL0 jar:

- Git application head: `f592fa92e6477214167d1db40b953bc4d6129da5`
- GL0 jar SHA-256: `40e4313549b5ef4603330f0755e364fe452bb58ec0de793ef73eba52a84e7b6f`

Each run proved rollback-lead initialization with validators stopped, restoration of production by the healthy pair, forward full download by the lagged validator, target hash agreement, later participation by the restored validator, cluster convergence, and continued production.

A fourth run first populated GL0 with the standard three-node test metagraph and a signed Currency snapshot carrying non-empty byte-array application state, then repeated the lifecycle successfully.

The `77dddbe85` cache/observability correction and `eefed9d03` documentation-build fix have source-level and focused regression validation. The [E2E matrix at `eefed9d03`](https://github.com/Constellation-Labs/tessellation/actions/runs/34396900061) finished with 10 passing rows and failures in `dag-cluster` and `committee-rewards`. The `16b0a019e` workflow follow-up requires a fresh complete E2E matrix; no new local live-process run or full-matrix pass is claimed.

## Deliberate limits

This PR hardens existing rollback/download handoff. It does not implement backward conflicting-target replacement or arbitrary historical-LCA fork repair. Those remain separate protocol work.
