### PR TITLE
fix(config): align activation defaults and consensus checks

### DIFF
--- a/.claude/commands/debug-e2e-logs.md
+++ b/.claude/commands/debug-e2e-logs.md
@@ -6,6 +6,12 @@ description: "Diagnose an E2E fork-recovery failure from persisted per-node logs
 
 Use this slash command when the user reports an E2E test failure — fork-recovery, consensus stall, committee divergence, pre-isolation sync timeout, etc. It codifies the procedure documented in `reference_e2e_log_analysis.md`. Do not jump to fixes or blame a recent commit without running this procedure first.
 
+Read `docker/README.md` first for the canonical Just lifecycle, artifact locations, staged-JAR
+provenance checks, and cleanup matrix. Use
+`docs/operations/local-e2e-cluster-investigation.md` before teardown when the failed cluster is
+still queryable. This command is the persisted-log analysis companion, not a replacement E2E
+harness.
+
 ## Inputs
 
 - **$ARGUMENTS** (optional): free-text notes from the user about the failure (which node stuck, which ordinal, what test output showed, which commit to investigate). If empty, use the most recent prior user message as context.
@@ -17,7 +23,11 @@ ls -la /home/scas/git/tessellation/nodes/0/gl0-logs/
 wc -l /home/scas/git/tessellation/nodes/*/gl0-logs/gl0-run.log
 ```
 
-If logs aren't present (no `nodes/<N>/gl0-logs/gl0-run.log`), tell the user the E2E teardown wiped them and propose adding `docker logs gl0-N > ... .log` capture to `docker/bin/test-fork-recovery.sh`. Stop.
+If logs aren't present (no `nodes/<N>/gl0-logs/gl0-run.log`), do not assume ordinary Docker teardown
+removed them: `just down` and `--cleanup` preserve host-mounted logs. Check whether another run,
+`just clean-data`, or `just clean-configs` replaced the `nodes/` tree, and whether CI uploaded a
+`runner-logs/` artifact. If no evidence remains, report the exact gap before proposing changes.
+Stop.
 
 If logs are present, continue.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,5 @@ Affected signed/persisted types, hashes, proofs, or historical behavior:
 Snapshot Streaming, Block Explorer, SDK, and metagraph impact:
 
 Activation/replay tests and external artifact versions:
+
+Activation domain, comparator, missing/default behavior, and historical-boundary evidence:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Consensus compatibility
 
-<!-- Read docs/adr/0034-consensus-schema-change-governance.md for consensus-adjacent changes. -->
+<!-- Read docs/adr/0034-consensus-schema-change-governance.md for consensus-adjacent changes. Select exactly one classification. -->
 
 - [ ] Not consensus-adjacent
 - [ ] Runtime-only behavior; encodings/hash rules and historical replay are unchanged

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Consensus compatibility
+
+<!-- Read docs/adr/0034-consensus-schema-change-governance.md for consensus-adjacent changes. -->
+
+- [ ] Not consensus-adjacent
+- [ ] Runtime-only behavior; encodings/hash rules and historical replay are unchanged
+- [ ] Replay/state-transition change with stable schema and an explicit compatibility boundary
+- [ ] Schema/wire change with an approved schema-change package
+
+Classification and evidence:
+
+Affected signed/persisted types, hashes, proofs, or historical behavior:
+
+Snapshot Streaming, Block Explorer, SDK, and metagraph impact:
+
+Activation/replay tests and external artifact versions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ encodings, hash/signature construction, persisted history, replay semantics, Sna
 Block Explorer, public APIs, SDKs, or metagraph artifacts automatically compatible. Schema/wire
 changes require an explicit design and rollout decision; replay/state-transition changes require a
 historical compatibility boundary when old artifacts would otherwise re-derive differently.
+Missing `FieldsAddedOrdinals` threshold mappings are disabled, never active from genesis; an
+explicit `0` is required for active-from-genesis behavior.
 
 When classification is uncertain, treat the change as schema/wire-impacting until the exact signed
 and persisted surfaces and external consumers have been audited. Do not implement or approve an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ historical compatibility boundary when old artifacts would otherwise re-derive d
 Missing `FieldsAddedOrdinals` threshold mappings are disabled, never active from genesis; an
 explicit `0` is required for active-from-genesis behavior.
 
+Before adding or renumbering an ADR, inspect `docs/adr/` on the latest target branch, choose the
+next unused four-digit number, and recheck after the final rebase. If another change claimed the
+number first, renumber the newer proposed ADR and update every reference before merge.
+
 When classification is uncertain, treat the change as schema/wire-impacting until the exact signed
 and persisted surfaces and external consumers have been audited. Do not implement or approve an
 unplanned schema change as an incidental part of a behavioral fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Repository agent instructions
+
+## Consensus and history compatibility
+
+Before changing consensus, snapshot construction/acceptance, hashing, serialization, state proofs,
+persistence, P2P messages, or SDK-visible types, read
+[`docs/adr/0034-consensus-schema-change-governance.md`](docs/adr/0034-consensus-schema-change-governance.md).
+
+Every affected PR must classify itself as runtime-only, replay/state-transition, or schema/wire.
+Do not call a change schema-neutral merely because it does not edit a file under `schema/`.
+
+A coordinated cold restart permits the fleet to adopt new runtime behavior together, including
+behavior that produces different future consensus outcomes. It does not make changes to signed
+encodings, hash/signature construction, persisted history, replay semantics, Snapshot Streaming,
+Block Explorer, public APIs, SDKs, or metagraph artifacts automatically compatible. Schema/wire
+changes require an explicit design and rollout decision; replay/state-transition changes require a
+historical compatibility boundary when old artifacts would otherwise re-derive differently.
+
+When classification is uncertain, treat the change as schema/wire-impacting until the exact signed
+and persisted surfaces and external consumers have been audited. Do not implement or approve an
+unplanned schema change as an incidental part of a behavioral fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ outcomes—to change together. It does not make signed encodings, hash/signature
 persisted history, replay semantics, Snapshot Streaming, Block Explorer, SDK, or metagraph changes
 compatible. Do not implement an unapproved schema change as part of a behavioral fix. If impact is
 uncertain, treat it as schema/wire until the signed, persisted, and external surfaces are audited.
+Missing `FieldsAddedOrdinals` threshold mappings are disabled; active-from-genesis behavior must use
+an explicit `0`.
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ uncertain, treat it as schema/wire until the signed, persisted, and external sur
 Missing `FieldsAddedOrdinals` threshold mappings are disabled; active-from-genesis behavior must use
 an explicit `0`.
 
+Before adding or renumbering an ADR, inspect `docs/adr/` on the latest target branch, choose the
+next unused four-digit number, and recheck after the final rebase. If another change claimed the
+number first, renumber the newer proposed ADR and update every reference before merge.
+
 ## Project Overview
 
 Tessellation is the Constellation Network Node Software - a DAG (Directed Acyclic Graph) based distributed ledger with Layer 0 (L0) and Layer 1 (L1) validators. Written in Scala 2.13, designed for Kubernetes deployment.
@@ -39,6 +43,16 @@ sbt dagL1/assembly
 
 ## Docker-based Development
 
+The canonical local Just/Docker lifecycle, output locations, JAR provenance checks, and cleanup
+matrix are in [`docker/README.md`](docker/README.md). Read it before starting or cleaning an E2E
+run. Diagnose a still-running failed cluster with
+[`docs/operations/local-e2e-cluster-investigation.md`](docs/operations/local-e2e-cluster-investigation.md),
+then use [`.claude/commands/debug-e2e-logs.md`](.claude/commands/debug-e2e-logs.md) for persisted-log
+analysis. Do not create a parallel test harness for behavior already covered by `just`.
+
+Any change to `justfile`, the runner/assembly/cleanup scripts under `docker/bin/`, output paths, or
+CI artifact collection must update `docker/README.md` in the same change.
+
 ```bash
 just test                 # Full test suite with Docker
 just test --skip-assembly # Skip compilation, reuse JARs
@@ -46,6 +60,10 @@ just up                   # Start test environment
 just down                 # Teardown environment
 just check                # Lint + format check + tests
 ```
+
+`--skip-assembly` trusts the existing `docker/jars/` bytes without comparing them to Git HEAD.
+Verify the JAR manifest and digest before using it. A new ordinary run replaces `nodes/`, so capture
+the prior run's logs first.
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Consensus Schema Governance
+
+Before changing consensus, snapshot construction/acceptance, hashing, serialization, state proofs,
+persistence, P2P messages, or SDK-visible types, read
+[`docs/adr/0034-consensus-schema-change-governance.md`](docs/adr/0034-consensus-schema-change-governance.md).
+
+Every affected PR must classify itself as runtime-only, replay/state-transition, or schema/wire.
+A coordinated full-cluster cold restart allows runtime behavior—and therefore future consensus
+outcomes—to change together. It does not make signed encodings, hash/signature construction,
+persisted history, replay semantics, Snapshot Streaming, Block Explorer, SDK, or metagraph changes
+compatible. Do not implement an unapproved schema change as part of a behavioral fix. If impact is
+uncertain, treat it as schema/wire until the signed, persisted, and external surfaces are audited.
+
 ## Project Overview
 
 Tessellation is the Constellation Network Node Software - a DAG (Directed Acyclic Graph) based distributed ledger with Layer 0 (L0) and Layer 1 (L1) validators. Written in Scala 2.13, designed for Kubernetes deployment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,18 @@ git push -u origin 747-update-contrib
 
 ## Coding Standards
 
+### Architecture decisions and consensus compatibility
+
+Use [`docs/adr/TEMPLATE.md`](docs/adr/TEMPLATE.md) for new architecture decisions. Before assigning
+an ADR number, inspect `docs/adr/` on the latest target branch, use the next unused four-digit
+number, and recheck after the final rebase. Renumber the newer proposed ADR if another change
+claimed the number first.
+
+Consensus-adjacent changes must follow
+[`ADR-0034`](docs/adr/0034-consensus-schema-change-governance.md) and select exactly one compatibility
+classification in the pull-request template. A coordinated cold restart does not by itself make
+signed history or external schemas compatible.
+
 ### Public-network protocol baseline
 
 IntegrationNet, Testnet, and Mainnet have all permanently crossed the historical Kryo-to-JSON

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Written in Scala 2.13.
 
 ### Development with Docker (Recommended)
 
+See [docker/README.md](docker/README.md) for the canonical local E2E lifecycle, artifact locations,
+staged-JAR provenance checks, and exact cleanup semantics.
+
 ```bash
 just test              # Full test suite
 just test --skip-assembly  # Skip compilation, reuse JARs

--- a/build.sbt
+++ b/build.sbt
@@ -455,7 +455,7 @@ lazy val rosetta = (project in file("modules/rosetta"))
 lazy val dagL1 = (project in file("modules/dag-l1"))
   .enablePlugins(AshScriptPlugin)
   .enablePlugins(JavaAppPackaging)
-  .dependsOn(kernel, shared % "compile->compile;test->test", nodeShared, testShared % Test)
+  .dependsOn(kernel, shared % "compile->compile;test->test", nodeShared % "compile->compile;test->test", testShared % Test)
   .configs(IntegrationTest)
   .settings(
     name := "tessellation-dag-l1",
@@ -591,7 +591,7 @@ lazy val dagL0 = (project in file("modules/dag-l0"))
   )
 
 lazy val currencyL1 = (project in file("modules/currency-l1"))
-  .dependsOn(dagL1, shared % "compile->compile;test->test", testShared % Test, nodeShared)
+  .dependsOn(dagL1, shared % "compile->compile;test->test", testShared % Test, nodeShared % "compile->compile;test->test")
   .settings(
     name := "tessellation-currency-l1",
     Defaults.itSettings,

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,113 +1,255 @@
-# Docker Development Workflow
+# Local Docker and E2E workflow
 
-In this directory, there is a Dockerfile covering all major internal services within the same image, 
-using a unified entrypoint and health check. There is a docker-compose.yaml covering the GL0 / dag-l1 
-core services, along with additional compose overrides for common deployment or test patterns. There 
-is also a docker-compose.metagraph.yaml demonstrating the basic template used for running ML0/CL1/DL1 
-services. Each set of compose files is meant to represent a single 'node' or deployment, with the expectation 
-that you would run N unique services per compute node (sharing the same keypair.)
+This is the canonical operator guide for the repository's local `just`/Docker E2E
+infrastructure. Keep it aligned with the executable sources below whenever their behavior changes:
 
-This is primarily intended for internal developers, although it can also be used for custom deployments. 
-For the most common runtime commands, please refer to the `justfile` in the top level directory. You 
-can also use `./docker/run.sh` to automatically install just and run commands with the same arguments.
+- [`../justfile`](../justfile) — public commands;
+- [`bin/set-env.sh`](bin/set-env.sh) — supported flags and defaults;
+- [`bin/compose-runner.sh`](bin/compose-runner.sh) — build, startup, test, and exit lifecycle;
+- [`bin/assembly.sh`](bin/assembly.sh) — assembly and staged-JAR behavior; and
+- [`bin/tessellation-docker-cleanup.sh`](bin/tessellation-docker-cleanup.sh) — scoped Docker cleanup.
 
-All environment variables and arguments for justfile commands are exposed in `bin/set-env.sh` for the 
-main `compose-runner.sh` script. Below are listed the most common commands you might run during development.
+For diagnosing a cluster while it is still running, use
+[`../docs/operations/local-e2e-cluster-investigation.md`](../docs/operations/local-e2e-cluster-investigation.md).
+Claude agents should also use [`../.claude/commands/debug-e2e-logs.md`](../.claude/commands/debug-e2e-logs.md)
+for the per-node persisted-log procedure. Do not create a parallel E2E harness when an existing
+`just` scenario can exercise the behavior.
 
+## Common commands
 
-## Frequently Used Developer Commands
+```bash
+just --list
+just test --list-tests
 
-`just test`
+# Build the requested assemblies, start the cluster, and run one scenario.
+just test --test=dag-cluster
 
-This assembles L0 by default using the auto-incremental recompilation cache, and if no jars 
-are found, it will build all of them with sbt assembly, and invoke all tests that only require the gl0 / dag-l0. By default, this test will NOT stop docker containers after running, nor will it cleanup 
-the environment afterwards. By default, this will kill all docker containers / volumes with names defined in here, so it 
-requires exclusive access to container names (unless alternatively configured.)
+# Reuse the exact JARs currently staged in docker/jars/. See the provenance warning below.
+just test --skip-assembly --test=dag-cluster
 
-`just up` 
+# Start a cluster without running the JS/shell E2E scenarios.
+just up
 
-This runs all the commands required to setup and start all relevant containers (in common with `just test`), but 
-skips the cluster start checks and end to end tests.
+# Build/stage the node JARs and Docker image without starting containers.
+# --skip-streaming avoids the separate Snapshot Streaming build.
+just build --skip-streaming
 
-`just down`
+# Remove the local containers after a test exits. Host-mounted nodes/ logs and data remain.
+just test --test=dag-cluster --cleanup
 
-Cleanup all docker containers / artifacts created by `just up`
-
-`just build`
-
-Same as `up`, except skips the container start.
-
-`just test --cleanup-docker-at-end` 
-
-Will run same options as before, but enforce a cleanup / terminate containers at end of test. 
-
-`just test --use-test-metagraph`
-
-The same as the prior command, except this will use the locally defined template metagraph and invoke all tests, including the tests that require the 'default' test metagraph.
-
-`just test --metagraph=./your-path-to-a-different-metagraph`
-
-Rather than using a test metagraph, this uses a real metagraph repository located at a local directory. 
-By default, this will assemble the ML0, please use `--cl1` to also include metagraph layer 1, and `--dl1` to assemble data layer 1. By default, if any jars are missing, this will assemble them all. Additionally, 
-if making changes to tessellation and a metagraph at the same time, please use `--publish` to enforce 
-locally publishing the required artifacts, or if you want to compile yourself with whatever options just use
-
-`just test --skip-assembly --metagraph=../ded --skip-metagraph-assembly`
-
-
-`just test --skip-assembly`
-
- To quickly rebuild the docker images / clear the data and re-build your environment, instead run with the skip-assembly option to avoid all sbt assembly, again, if no jars are found, it will assemble all required for first run.
-
-`just test --clean-assembly`
-
-The `test` command does not run `sbt clean` by default, including this will wipe 
-out the sbt incremental cache and `target` folders.
-
-`just test --l1`
-
-Use this command if you made changes to the L1, it will include it in the assembly 
-process, and update the jars in the dockerfile as part of that.
-
-`just clean`
-
-This will purge all docker containers, sbt cache, target folder, and node environment deployment directories.
-
-`just clean-docker`
-
-This cleans all script / docker related local artifacts, but not sbt
-
-`just build --version v3.2.0`
-
-This will build a docker image off of your current directory, setting the version to a custom value.
-
-`just debug-main`
-
-This is intended for deploying a custom version from your current git branch to a live mainnet network node 
-for capturing debug information, heap dumps, profile data, or custom metrics or log statements. 
-
-Requires rsync to be installed.
-
-This assumes you have already set in your ~/.ssh/config the following:
-
+# Stop and remove the scoped Tessellation Docker resources after inspection.
+just down
 ```
+
+Bare `just test` passes `--use-test-metagraph` and runs every registered scenario, including
+Snapshot Streaming unless `--skip-streaming` is supplied. Prefer an explicit `--test=<name>` while
+iterating.
+
+The supported automatic teardown option is `--cleanup`. The formerly documented
+`--cleanup-docker-at-end` option does not exist.
+
+`--clean-assembly` is currently parsed by `set-env.sh` but not consumed by the assembly runner. It
+does not run `sbt clean` and must not be relied upon. Use the explicit cleanup procedure below.
+
+## Lifecycle and evidence preservation
+
+A local `just test` or `just up` performs these operations before starting the cluster:
+
+1. Starts scoped cleanup of containers named `gl0-*`, `gl1-*`, `ml0-*`, `cl1-*`, `dl1-*`,
+   Snapshot Streaming, their named volumes, and `tessellation_common`.
+2. Builds or reuses assemblies, copies them into `docker/jars/`, and builds
+   `constellationnetwork/tessellation:test`.
+3. By default, deletes and recreates the repository-root `nodes/` tree before generating keys,
+   environment files, and Compose files.
+4. Starts services and runs the selected scenario.
+
+Consequences:
+
+- A failed test normally leaves the cluster running and queryable. Inspect it before teardown.
+- Starting the next ordinary run destroys the previous run's `nodes/` logs and data.
+- `--cleanup` and `just down` remove containers, so capture `docker logs` first if those streams are
+  needed. The host-mounted application logs under `nodes/` remain until a later run or explicit
+  node cleanup.
+- `just down --clean` has no additional effect for a local cluster. The `--clean` switch is only
+  consumed by remote teardown.
+
+Before cleanup, record the run identity:
+
+```bash
+git rev-parse HEAD
+sha256sum docker/jars/gl0.jar
+unzip -p docker/jars/gl0.jar META-INF/MANIFEST.MF \
+  | grep -E '^(Implementation|Specification)-Version:'
+for n in nodes/*/peer_id; do printf '%s ' "$n"; head -c 16 "$n"; echo; done
+```
+
+Peer IDs are key-derived and must be mapped from `nodes/<index>/peer_id` for the specific run. Do
+not reuse a node-to-peer map from earlier evidence.
+
+## Output locations
+
+| Output | Local path | Lifetime |
+|---|---|---|
+| GL0 application logs | `nodes/<i>/gl0-logs/` | Survive container removal; removed by the next ordinary run, `just clean-data`, or `just clean-configs` |
+| Other layer logs | `nodes/<i>/{gl1,ml0,cl1,dl1}-logs/` | Same |
+| Node state | `nodes/<i>/{gl0,gl1,ml0,cl1,dl1}-data/` | Same |
+| Run keys/config/identity | `nodes/<i>/{.env,peer_id,address,key.p12,...}` | Removed by the next ordinary run or `just clean-configs` |
+| SBT assembly outputs | `modules/<module>/target/scala-2.13/` | Removed by `sbt clean`/`just clean` |
+| Test-metagraph build outputs | `.github/templates/metagraphs/project_template/**/target/` | Removed by `just clean` |
+| JARs staged for Docker | `docker/jars/` | Replaced by a non-skipped assembly; **not** removed by `just clean` |
+| Local node image | `constellationnetwork/tessellation:test` | **Not** removed by `just clean` or `just clean-docker` |
+| JS dependencies | `.github/action_scripts/node_modules/` | Recreated by `npm ci`; not removed by `just clean` |
+| Snapshot Streaming build | `docker/snapshot-streaming/{.build,snapshot-streaming.jar,block-explorer,data}/` | Partially reused; not fully removed by `just clean` |
+| Locally published SDK | `~/.ivy2/local/io.constellationnetwork/tessellation-sdk_2.13/<exact-version>/` | Versioned shared cache; not removed by `just clean` |
+
+Container stdout/stderr is separate from the bind-mounted logs and is available through
+`docker logs <container>` only while that container still exists.
+
+### CI and scenario-specific evidence
+
+GitHub's E2E workflow creates `runner-logs/`, captures container status, `docker logs`, and copies of
+the node log directories, then uploads an `e2e-<scenario>-logs-<run>` artifact. That directory is CI
+staging, not the normal local log location.
+
+The `rollback-download-head` scenario writes a self-contained local bundle to
+`${ROLLBACK_DOWNLOAD_EVIDENCE_ROOT:-${TMPDIR:-/tmp}/tessellation-e2e-evidence}/rollback-download-head-<UTC timestamp>/`.
+Other scenario scripts must document any nonstandard evidence root in their header. Long-term,
+deliberately retained investigation evidence may be copied into the relevant `.workspace/<case>/`
+tree with commit/JAR/run provenance; Just does not do that automatically.
+
+## Staged-JAR provenance
+
+`--skip-assembly` trusts whatever nonempty JARs are already in `docker/jars/`. It does not compare
+their manifest version or digest with the checked-out commit. Before using it, verify the manifest
+and SHA-256 as shown above. If provenance is unknown or does not match the intended commit, rebuild
+without `--skip-assembly`.
+
+There are three distinct copies of locally built node code:
+
+1. assembly JARs under each module's `target/`;
+2. renamed copies under `docker/jars/`; and
+3. those staged copies embedded in `constellationnetwork/tessellation:test`.
+
+Cleaning only one layer does not produce a clean-room run.
+
+## Cleanup matrix
+
+Never remove bind-mounted node data while the containers are running. Start with `just down`.
+
+| Command | Removes | Preserves |
+|---|---|---|
+| `just down` | Scoped Tessellation containers, named volumes, Snapshot Streaming data, and `tessellation_common` | `nodes/`, SBT targets, `docker/jars/`, image |
+| `just clean-data` | Layer `*-data/` and `*-logs/` under `nodes/` and legacy `docker/nodes/` | Keys, peer IDs, `.env`, Compose files, JARs |
+| `just clean-configs` | Entire `nodes/` and legacy `docker/nodes/`, then recreates empty `nodes/` | Build outputs, staged JARs, image |
+| `just clean-docker` | Same scoped Docker resources as `just down` | Node bind mounts, build outputs, staged JARs, image |
+| `just clean` | Main-repo and test-metagraph SBT targets, generated node tree, scoped Docker resources | `docker/jars/`, image, Snapshot Streaming build/JAR/clone, JS dependencies, local Ivy publications |
+| `just purge-docker` | **All** containers, volumes, and networks on the host | Not scoped to Tessellation; do not use on a shared workstation |
+
+Because `just clean-data` and `just clean-configs` do not stop live containers, never invoke them
+before `just down`. `just clean` currently calls node cleanup before its Docker cleanup, so the safe
+full sequence also starts with `just down`.
+
+### Clean-room core E2E build
+
+After preserving any needed evidence:
+
+```bash
+just down
+just clean
+rm -f -- docker/jars/*.jar
+docker image rm constellationnetwork/tessellation:test 2>/dev/null || true
+```
+
+The next run must omit `--skip-assembly`.
+
+### Additional Snapshot Streaming cleanup
+
+```bash
+rm -f -- docker/snapshot-streaming/*.jar
+rm -f -- docker/snapshot-streaming/application.conf
+rm -rf -- docker/snapshot-streaming/.build
+rm -rf -- docker/snapshot-streaming/block-explorer
+rm -rf -- docker/snapshot-streaming/data
+```
+
+Successful Snapshot Streaming builds normally delete `.build`; an interrupted build may leave it.
+
+### External metagraph and `publishLocal` cleanup
+
+`just clean` cleans the in-repository test-metagraph template, not a metagraph supplied through
+`--metagraph=/path`. Clean an external metagraph in its own repository:
+
+```bash
+(cd /path/to/metagraph && sbt clean)
+```
+
+Metagraph and Snapshot Streaming builds may run `sdk/publishLocal`. That publishes a versioned SDK
+under `~/.ivy2/local/io.constellationnetwork/tessellation-sdk_2.13/`. Do not delete the whole Ivy or
+Coursier cache: other worktrees and metagraphs can depend on it. If removal is required, first
+record `TESSELLATION_VERSION` from runner output and delete only that exact version directory.
+
+## Metagraph and release-oriented builds
+
+Use the in-repository template metagraph and run its registered scenarios:
+
+```bash
+just test --use-test-metagraph --test=currency
+```
+
+Use an external metagraph repository:
+
+```bash
+just test --metagraph=/path/to/metagraph --test=currency
+```
+
+By default the runner assembles ML0. Add `--cl1` or `--dl1` for those layers. When the metagraph
+must compile against changes in this Tessellation worktree, `--publish` publishes this checkout's
+SDK under the derived `TESSELLATION_VERSION` before assembling the metagraph. If both repositories'
+JARs were built deliberately in advance, they can be reused with:
+
+```bash
+just test --skip-assembly \
+  --metagraph=/path/to/metagraph \
+  --skip-metagraph-assembly \
+  --test=currency
+```
+
+Verify both the staged Tessellation and metagraph JAR provenance before using that fast path.
+
+`--l1` includes DAG L1 in the Tessellation assembly selection. A version can be supplied explicitly
+for local build metadata with, for example, `just build --skip-streaming --version=v4.1.0-rc.14`.
+
+## Remote debug helper
+
+`just debug-main` builds from the current branch, copies a debug GL0 deployment to configured SSH
+hosts, and tails its logs. It is intended for disposable diagnostic nodes, not ordinary local E2E
+or coordinated public-network release deployment. It requires `rsync` and SSH aliases similar to:
+
+```sshconfig
 Host genesis
-  HostName 52.53.46.33
+  HostName <mainnet-source-ip>
   User admin
+
 Host dest
-  HostName <your-node-ip-here>
+  HostName <debug-node-ip>
   User root
 ```
 
-Additionally, it assumes you have a keypair at /root/key.p12, and .env file at 
-/root/.env containing the information necessary to load your keypair. Please fill out below 
-as necessary, here is an example you need to replace with your own data.
+The remote environment must supply the appropriate keystore and credentials. Review
+`docker/bin/debug/mn-replicate.sh` before use; it performs remote mutations and is outside the local
+cleanup contract documented above.
 
-```
-ENV CL_KEYALIAS="alias"
-ENV CL_PASSWORD="password"
-```
+## Local topology
 
-The remainder of environment variables will be generated automatically, it is run on root on the remote VM, 
-so should be used with a disposable VM or one you otherwise do not carry state on. It will auto-install 
-all dependencies, only run the GL0, and tail the logs.
+Each node index uses host ports `<prefix><index>0` for public HTTP and `+2` for CLI/join:
+
+| Layer | Prefix | Example for index 0 |
+|---|---:|---:|
+| GL0 | 90 | 9000 / 9002 |
+| GL1 | 91 | 9100 / 9102 |
+| ML0 | 92 | 9200 / 9202 |
+| CL1 | 93 | 9300 / 9302 |
+| DL1 | 94 | 9400 / 9402 |
+
+The default bridge is `tessellation_common` on `172.32.0.0/24`. Each node directory receives its
+own Compose configuration, environment, key, and bind-mounted log/data directories.

--- a/docker/bin/compose-runner-down.sh
+++ b/docker/bin/compose-runner-down.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Dispatcher for `just down`. Routes to local cleanup or remote stop.
+# --clean is consumed only by remote-stop.sh; local teardown preserves nodes/ bind mounts.
 
 set -e
 

--- a/docker/bin/set-env.sh
+++ b/docker/bin/set-env.sh
@@ -101,6 +101,8 @@ for arg in "$@"; do
       export CL_DOCKER_BIND_INTERFACE=""
       ;;
     --clean-assembly)
+      # Legacy parsed flag. CLEAN_ASSEMBLY is not currently consumed by assembly.sh;
+      # docker/README.md documents the explicit clean-room procedure instead.
       export CLEAN_ASSEMBLY=true
       ;;
     --do-exit)

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -452,6 +452,10 @@ sbt "dagL0/test"             # Single module
 ## Build & Deploy
 
 ### Local Development
+
+The canonical `just`/Docker E2E lifecycle, artifact paths, staged-JAR provenance checks, and cleanup
+matrix are documented in [`docker/README.md`](../docker/README.md).
+
 ```bash
 sbt compile                  # Compile all
 sbt runLinter                # Format + lint

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -63,8 +63,9 @@ The detailed, code-accurate references for the rewritten subsystems live under `
 - [fields-added-ordinals.md](operations/fields-added-ordinals.md) - ordinal-gating, the no-env-gating principle, GSI dust sweep
 - [consensus-config-reference.md](operations/consensus-config-reference.md) - operator config knobs + `CL_` overrides
 - [v4-launch-runbook.md](release/v4-launch-runbook.md) - coordinated cold restart + gate-ordinal checklist
+- [ADR-0034](adr/0034-consensus-schema-change-governance.md) - mandatory runtime/replay/schema classification and cross-consumer schema-change package
 
-**Decisions**: [docs/adr/](adr/) (ADRs 0001-0015; 0005/0006 are superseded by the tier/committee rewrite).
+**Decisions**: [docs/adr/](adr/) (0005/0006 are superseded by the tier/committee rewrite).
 
 ## Directory Structure
 

--- a/docs/adr/0034-consensus-schema-change-governance.md
+++ b/docs/adr/0034-consensus-schema-change-governance.md
@@ -10,7 +10,8 @@ Proposed
 
 Tessellation public networks adopt one software version through a coordinated full-cluster cold
 restart. That operating model lets every validator change runtime consensus behavior together and
-avoids mixed-version state machines. It does not erase or rewrite already signed history, and it
+does not support mixed-version operation. Joining rejects different advertised versions; every
+deployment uses a full cold restart. It does not erase or rewrite already signed history, and it
 does not update Snapshot Streaming, Block Explorer, metagraph binaries, SDK consumers, or archived
 artifacts.
 
@@ -89,8 +90,15 @@ golden fixture changes, the PR is not runtime-only until that difference is expl
   `AppEnvironment` inside consensus logic.
 - Every missing `FieldsAddedOrdinals` threshold mapping resolves to the disabled
   `SnapshotOrdinal.MaxValue` sentinel. Active-from-genesis behavior requires an explicit `0`.
-  Any future exception requires an explicit per-gate rationale, source comment, and regression
-  test rather than an ad hoc fallback at one consumer.
+  Required historical cutovers must be explicit; retaining pre-fix behavior is not universally
+  safe for a fresh network. Ordinary tests select current behavior explicitly; historical tests
+  declare the boundary they exercise. Any future exception requires an explicit per-gate
+  rationale, source comment, and regression test rather than an ad hoc fallback at one consumer.
+- Distinguish first-active thresholds from last-legacy boundaries and exact-key events.
+  `lastKryoHashOrdinal` retains its existing `MinValue` default (`<=` is Kryo, `>` is JSON);
+  `lastLegacyStateProofOrdinal` retains `MaxValue`. Do not normalize those defaults merely to
+  match `FieldsAddedOrdinals`. Exact-key dust sweeps execute at their configured ordinal during
+  production or replay and do nothing at other ordinals.
 - Record the gate's ordinal/epoch domain, exact comparator (`>=`, `>`, or exact-key), missing/default
   semantics, and whether the resolved value is included in `deterministicConfigHash`.
 - For new behavior, choose and announce a strictly future activation only after the release and
@@ -104,12 +112,28 @@ golden fixture changes, the PR is not runtime-only until that difference is expl
 - Test `A-1`, `A`, and `A+1`, restart and rollback across `A`, and long-range replay beginning
   before `A`. Include state-root/hash assertions, not only successful decoding.
 
+### Activation configuration and deployment checks
+
+Both L0 applications resolve the shared activation configuration into the same effective config
+used for joining and consensus. `deterministicConfigHash` includes every `FieldsAddedOrdinals`
+threshold, the complete dust-sweep schedule, and the shared hashing, state-proof, and incremental
+staking boundaries. It compares settings among nodes running the same software version; release
+version checks separately reject different versions. Changes to this configuration fingerprint
+ship through the normal full-cluster cold restart. They do not require mixed-version operation.
+
+Named layer configurations fall back to shared `application.conf`. Packaged HOCON is configuration,
+not an immutable code literal. Review the resolved values and retain the packaged-config regression
+table; matching hashes cannot detect a historically wrong value deployed identically everywhere.
+Snapshot Streaming has a separate build/deployment and does not acquire alignment merely because
+node join checks pass. Its SDK/config update follows the node update on `develop` and remains a
+consumer qualification requirement before deployment.
+
 ### Required schema-change package
 
 A class-3 change blocks merge until the PR or a linked ADR records:
 
 Every numbered item must be completed or marked not applicable with evidence. For example, an
-internal P2P message can require wire-version and mixed-version analysis without changing Snapshot
+internal P2P message can require wire-version and version-rejection checks without changing Snapshot
 Streaming, the SDK, or metagraph schemas; the review record must say why those consumers are not
 affected rather than inventing unnecessary work for them.
 

--- a/docs/adr/0034-consensus-schema-change-governance.md
+++ b/docs/adr/0034-consensus-schema-change-governance.md
@@ -87,8 +87,16 @@ golden fixture changes, the PR is not runtime-only until that difference is expl
 
 - Select behavior from artifact-carried ordinal/epoch context, never directly from
   `AppEnvironment` inside consensus logic.
-- Public environment mappings fail closed while unset. Choose and announce a strictly future
-  activation only after the release and consumer plan is approved.
+- Every missing `FieldsAddedOrdinals` threshold mapping resolves to the disabled
+  `SnapshotOrdinal.MaxValue` sentinel. Active-from-genesis behavior requires an explicit `0`.
+  Any future exception requires an explicit per-gate rationale, source comment, and regression
+  test rather than an ad hoc fallback at one consumer.
+- Record the gate's ordinal/epoch domain, exact comparator (`>=`, `>`, or exact-key), missing/default
+  semantics, and whether the resolved value is included in `deterministicConfigHash`.
+- For new behavior, choose and announce a strictly future activation only after the release and
+  consumer plan is approved. A replay correction may instead pin the exact historical cutover at
+  which the corrected behavior already entered signed history, but only with retained chain/release
+  evidence for that boundary.
 - Preserve the old derivation below the boundary. Never move an already-crossed gate forward or
   reinterpret the signed interval behind it.
 - Use the same selector in producer, validator, follower, download/recovery, and external

--- a/docs/adr/0034-consensus-schema-change-governance.md
+++ b/docs/adr/0034-consensus-schema-change-governance.md
@@ -108,6 +108,11 @@ golden fixture changes, the PR is not runtime-only until that difference is expl
 
 A class-3 change blocks merge until the PR or a linked ADR records:
 
+Every numbered item must be completed or marked not applicable with evidence. For example, an
+internal P2P message can require wire-version and mixed-version analysis without changing Snapshot
+Streaming, the SDK, or metagraph schemas; the review record must say why those consumers are not
+affected rather than inventing unnecessary work for them.
+
 1. the explicit human approval to change schema and why a runtime-only or stable-schema solution is
    insufficient;
 2. the exact types, fields, codecs, canonical ordering, hash/signature preimages, persistence, and

--- a/docs/adr/0034-consensus-schema-change-governance.md
+++ b/docs/adr/0034-consensus-schema-change-governance.md
@@ -1,0 +1,163 @@
+# 34. Consensus schema change governance
+
+Date: 2026-09-06
+
+## Status
+
+Proposed
+
+## Context
+
+Tessellation public networks adopt one software version through a coordinated full-cluster cold
+restart. That operating model lets every validator change runtime consensus behavior together and
+avoids mixed-version state machines. It does not erase or rewrite already signed history, and it
+does not update Snapshot Streaming, Block Explorer, metagraph binaries, SDK consumers, or archived
+artifacts.
+
+Consequently, "the fleet cold-restarts" and "the change is schema-compatible" are independent
+claims. A behavior change can be safe at a cold restart while a field, codec, hash preimage, state
+proof, or historical state-transition change can still make external consumers halt or make old
+history impossible to replay. Even an optional field is a schema change once producers emit it or
+its presence changes signed bytes.
+
+Schema impact has also been easy to miss when the edited file is outside a directory named
+`schema`. A change to a Circe codec, canonical collection, JSON printer, hasher, state-proof
+assembler, version projection, or acceptance function can alter consensus bytes or replay without
+changing a case-class declaration.
+
+## Decision
+
+Every consensus-adjacent change must declare one of the following compatibility classes before it
+is approved:
+
+1. **Runtime-only behavior.** The change affects live scheduling, liveness, transport retries,
+   in-memory coordination, proposal/leader/event selection, observability, or an equivalent
+   internal mechanism. It may intentionally produce different future consensus outcomes. It does
+   not change the representation or meaning of signed/hashable values, codec or hash/signature
+   construction, persisted formats, public/P2P payload schemas, state-proof construction, or the
+   deterministic interpretation of already-signed artifacts. A coordinated cold restart plus
+   proportionate behavioral tests is sufficient.
+2. **Replay or state-transition behavior with a stable schema.** The encoded type shape stays the
+   same, but an old artifact could be accepted, rejected, applied, or hashed differently, or could
+   derive a different state/root. Preserve the historical path and select the new behavior using a
+   deterministic activation boundary. Test both sides and replay across the boundary. A cold
+   restart alone is not sufficient.
+3. **Schema or wire change.** The change can alter encoded bytes, hash/signature preimages, field
+   presence or meaning, public/P2P payloads, persisted formats, state proofs, or SDK-visible
+   consensus types. It requires an explicit schema design and cross-consumer rollout. It must not
+   be introduced incidentally in a behavioral PR.
+
+If the classification is uncertain, use class 3 until the affected surfaces are proven not to
+change. File location is not evidence of compatibility.
+
+### Schema-sensitive surfaces
+
+The following are examples, not an exhaustive path allowlist:
+
+- `GlobalSnapshot`, `GlobalIncrementalSnapshot`, `GlobalSnapshotInfo`,
+  `GlobalSnapshotStateProof`, Currency snapshot variants, versioned historical projections, and
+  signed consensus/QC/sidecar artifacts;
+- Circe encoders/decoders, discriminator/default/null behavior, canonical collection ordering,
+  `JsonSerializer`, Kryo registrations retained for historical reads, and binary codecs;
+- every value used as a hash or signature preimage, plus Merkle/MPT key encoding and state-proof
+  assembly;
+- acceptance and context functions whose output must reproduce historical state or roots;
+- P2P/HTTP payloads, routes, and persistence formats consumed across process or release boundaries;
+- SDK and project-template types used by Currency L0/L1, Data L1, or specialized state channels;
+  and
+- Snapshot Streaming and Block Explorer decoding, validation, database projection, and replay.
+
+Internal storage or behavior is not automatically safe: if it survives a release, controls replay,
+or becomes part of an externally visible artifact, it belongs in the audit.
+
+### Required evidence for runtime-only classification
+
+The PR must identify why the change cannot affect:
+
+- serialized type shape, canonical encoding, or hash/signature construction (future values and
+  outcomes may differ as the stated purpose of the behavior change);
+- historical acceptance, context reconstruction, state roots, or ordinal-gate selection;
+- files or sidecars that must be read after restart or by another version; and
+- Snapshot Streaming, Block Explorer, SDK, metagraph, or public API consumers.
+
+Tests should demonstrate the relevant behavior without updating golden wire/hash fixtures. If a
+golden fixture changes, the PR is not runtime-only until that difference is explained and approved.
+
+### Required evidence for replay/state-transition changes
+
+- Select behavior from artifact-carried ordinal/epoch context, never directly from
+  `AppEnvironment` inside consensus logic.
+- Public environment mappings fail closed while unset. Choose and announce a strictly future
+  activation only after the release and consumer plan is approved.
+- Preserve the old derivation below the boundary. Never move an already-crossed gate forward or
+  reinterpret the signed interval behind it.
+- Use the same selector in producer, validator, follower, download/recovery, and external
+  re-derivation paths.
+- Test `A-1`, `A`, and `A+1`, restart and rollback across `A`, and long-range replay beginning
+  before `A`. Include state-root/hash assertions, not only successful decoding.
+
+### Required schema-change package
+
+A class-3 change blocks merge until the PR or a linked ADR records:
+
+1. the explicit human approval to change schema and why a runtime-only or stable-schema solution is
+   insufficient;
+2. the exact types, fields, codecs, canonical ordering, hash/signature preimages, persistence, and
+   semantic meaning that change;
+3. the old/new compatibility matrix for producers and every consumer, including historical
+   decoding and replay;
+4. a versioned or ordinal-gated transition whose old path remains capable of validating old
+   history;
+5. the exact Snapshot Streaming source, configuration, artifact digest, state-proof validation,
+   and database/reindex or migration plan;
+6. the exact SDK/project-template and active metagraph rebuild plan, including Currency L0/L1 and
+   Data L1 where applicable;
+7. Block Explorer/API compatibility and reconciliation expectations;
+8. golden old/new serialization and hash fixtures, boundary replay, restart/rollback, fresh-node,
+   and representative external-consumer tests; and
+9. release notes, operator notice, activation gates, and a post-activation reconciliation plan.
+
+An optional field or drop-null encoding may be a useful migration tool, but it does not waive this
+package. Decoder compatibility alone is insufficient when hashes or signatures cover the encoded
+value.
+
+### Schema freeze
+
+Once a release candidate, Snapshot Streaming artifact, SDK/metagraph rebuild, or activation notice
+has been finalized against a schema, that schema is frozen. A later schema-affecting change requires
+a new reviewed candidate and, where external operators or activation timing are affected, a new
+artifact set and announcement. Do not silently amend the schema to finish unrelated correctness or
+liveness work.
+
+Behavioral fixes may continue during the freeze when their runtime-only or replay-compatible
+classification is supported by evidence. The freeze protects interfaces and historical meaning,
+not implementation details.
+
+### Review record
+
+Consensus-adjacent PR descriptions must contain a `Consensus compatibility` section with:
+
+- the selected class and rationale;
+- affected signed/persisted types and hash/state-proof paths, or evidence that there are none;
+- replay and activation implications;
+- Snapshot Streaming, Block Explorer, SDK, and metagraph impact; and
+- the exact tests and external artifacts used as evidence.
+
+The pull-request template exposes this declaration to humans and coding agents. Repository-level
+`AGENTS.md` and `CLAUDE.md` both point to this ADR so Codex and Claude load the same authority rather
+than maintaining divergent agent-specific rules.
+
+## Consequences
+
+- Full cold restarts remain available for frequent consensus behavior improvements without
+  pretending that persisted and external interfaces disappear.
+- Schema work becomes deliberate, separately reviewable, and coupled to the consumers that can
+  otherwise halt or diverge.
+- Some changes initially described as behavior-only will require an ordinal gate because they
+  alter historical interpretation even though their case classes are unchanged.
+- The classification and evidence add review work. That cost is intentional because a false
+  schema-neutral claim can invalidate replay or strand external metagraph and indexing systems.
+- Documentation and a PR declaration improve discovery but are not a complete mechanical guard.
+  CODEOWNERS and broader golden compatibility fixtures should be added after the responsible owner
+  or team and protected path set are explicitly selected; a path-only detector cannot find every
+  semantic schema change.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,5 +1,11 @@
 # N. Brief decision title
 
+<!--
+Before assigning N, inspect docs/adr/ on the latest target branch and use the next unused
+four-digit number. Recheck after the final rebase. If another change claimed the number first,
+renumber the newer proposed ADR and update every reference before merge.
+-->
+
 Date: yyyy-mm-dd
 
 ## Status

--- a/docs/operations/fields-added-ordinals.md
+++ b/docs/operations/fields-added-ordinals.md
@@ -39,13 +39,21 @@ case class FieldsAddedOrdinals(
 
 Each gate is loaded from the `fields-added-ordinals` HOCON block (`application.conf:210-395`). Resolution first picks the entry for the running environment. Two value conventions appear:
 
-- A **threshold gate** (`Map[AppEnvironment, SnapshotOrdinal]`): every in-repository consumer resolves an absent environment through `resolveWithDisabledDefault` to `SnapshotOrdinal.MaxValue`. The threshold can therefore never be crossed in ordinary operation, and an incomplete configuration retains the OLD path rather than silently enabling new behavior from genesis. Set an explicit environment entry to `0` to activate from genesis, to a future ordinal for a new coordinated behavior change, or to the exact evidence-backed historical cutover when the gate exists to reproduce behavior already present in signed history. Each gate must document whether its comparison is `>=` or `>`; changing that comparator changes the replay boundary. A finite placeholder such as `9999999` is not the same as the missing-map sentinel: it remains deliberately dormant only until the chain reaches that value.
+- A **threshold gate** (`Map[AppEnvironment, SnapshotOrdinal]`): every in-repository consumer calls the gate's named `...For(environment)` accessor. Those accessors share one private config-layer resolver that maps an absent environment to `SnapshotOrdinal.MaxValue`; callers do not read the raw map or choose a fallback. The threshold can therefore never be crossed in ordinary operation, and an incomplete configuration retains the OLD path rather than silently enabling new behavior from genesis. Set an explicit environment entry to `0` to activate from genesis, to a future ordinal for a new coordinated behavior change, or to the exact evidence-backed historical cutover when the gate exists to reproduce behavior already present in signed history. Each gate must document whether its comparison is `>=` or `>`; changing that comparator changes the replay boundary. A finite placeholder such as `9999999` is not the same as the missing-map sentinel: it remains deliberately dormant only until the chain reaches that value.
 - An **exact-key gate** (`dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]`): the behavior fires only at exactly the keyed ordinal (`dustSweeps.get(env).flatMap(_.get(ordinal))`), once, and never replays.
 
 Missing means disabled uniformly across every `FieldsAddedOrdinals` threshold map. There is no
 in-tree threshold-gate exception. Any future exception requires an explicit per-gate rationale,
-source comment, and regression test; it must not be introduced by an ad hoc `MinValue` fallback at
-one consumer. Exact-key maps remain naturally disabled when the environment/key is absent.
+source comment, and regression test; it must not be introduced by reading a raw map or choosing a
+fallback at one consumer. Exact-key maps use their named exact-key accessor and remain naturally
+disabled when the environment/key is absent.
+
+The older top-level `incremental-delegated-staking-starting-ordinal` map is not part of
+`FieldsAddedOrdinals`, but it follows the same missing-means-disabled policy through
+`SharedConfig.incrementalDelegatedStakingStartingOrdinalFor`. Its comparison is `ordinal > gate`,
+so an absent environment resolves to `SnapshotOrdinal.MaxValue`. All shipped environments have an
+explicit historical value; this fallback only prevents an incomplete config from enabling the
+record transformation at genesis.
 
 Per-environment activation ordinals differ because the same fix crosses different points of different chains. The behavior itself is identical code on every network; only WHEN it activates is per-environment. Examples from `application.conf:210-293`:
 

--- a/docs/operations/fields-added-ordinals.md
+++ b/docs/operations/fields-added-ordinals.md
@@ -5,11 +5,11 @@
 
 ## Summary
 
-Snapshots are signed. Once an ordinal is finalized, its artifact bytes are fixed forever, and any node that replays history (a fresh sync, a rollback, a cold restart) MUST re-derive byte-identical state or it forks. This makes shipping a fix to deterministic behavior hazardous: the new code path would change the bytes of already-signed history. `FieldsAddedOrdinals` is the primitive that resolves this. It is a record of per-environment **activation ordinals** (`config/types.scala:27-48`): each new or changed deterministic behavior is gated so that history strictly below its ordinal re-derives on the OLD path (byte-identical to what was signed), while at and after the ordinal the new behavior applies. The decision is always `ordinal >= gate`, **never** a branch on `AppEnvironment`. The values are HOCON literals packaged into the assembly jar and have no environment-variable overrides. They must be identical across the cluster and finalized before assembly. Most remain outside `deterministicConfigHash`; the Currency snapshot protocol-v1 gate is explicitly copied into each L0's effective hash because it changes cross-layer artifact derivation. A config fence detects disagreement, but it cannot make a unanimously wrong activation ordinal safe.
+Snapshots are signed. Once an ordinal is finalized, its artifact bytes are fixed forever, and any node that replays history (a fresh sync, a rollback, a cold restart) MUST re-derive byte-identical state or it forks. This makes shipping a fix to deterministic behavior hazardous: the new code path would change the bytes of already-signed history. `FieldsAddedOrdinals` is the primitive that resolves this. It is a record of per-environment **activation ordinals** (`config/types.scala:29-104`): each new or changed deterministic behavior is gated so that history on the legacy side of its boundary re-derives on the OLD path (byte-identical to what was signed), while the new behavior applies on the other side. Most threshold gates use `ordinal >= gate`; a small number deliberately use `>` because the named ordinal is the last legacy observation, and dust sweeps use exact-key equality. Consensus code selects the configured ordinal for its environment and must never branch behavior directly on `AppEnvironment`. The values are HOCON literals packaged into the assembly jar and have no environment-variable overrides. They must be identical across the cluster and finalized before assembly. Most remain outside `deterministicConfigHash`; the Currency snapshot protocol-v1 gate is explicitly copied into each L0's effective hash because it changes cross-layer artifact derivation. A config fence detects disagreement, but it cannot make a unanimously wrong activation ordinal safe.
 
 ## Mechanism
 
-`FieldsAddedOrdinals` is a flat record of maps, one per gated behavior (`config/types.scala:27-49`):
+`FieldsAddedOrdinals` is a flat record of maps, one per gated behavior (`config/types.scala:29-104`):
 
 ```scala
 case class FieldsAddedOrdinals(
@@ -27,20 +27,25 @@ case class FieldsAddedOrdinals(
   subTrieRoots: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
   delegatedRewardsFullCommittee: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
   feeTransactionSecurity: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+  fixingFeeTransactionBalanceOverflow: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+  dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] = Map.empty,
   currencySnapshotProtocolV1: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
-  dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] = Map.empty
+  fixingDataApplicationFeeValidation: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+  fixingAllowSpendDestinationCredit: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+  preventingAllowSpendResurrection: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
+  fixingGlobalAllowSpendExpiration: Map[AppEnvironment, SnapshotOrdinal] = Map.empty
 )
 ```
 
-Each gate is loaded from the `fields-added-ordinals` HOCON block (`application.conf:210-293`). Resolution is always the same shape: pick the entry for the running environment, then compare the snapshot ordinal against it. Two value conventions appear:
+Each gate is loaded from the `fields-added-ordinals` HOCON block (`application.conf:210-395`). Resolution first picks the entry for the running environment. Two value conventions appear:
 
-- A **threshold gate** (`Map[AppEnvironment, SnapshotOrdinal]`): the behavior is gated by `ordinal >= gate`. Absent-environment resolution **fails closed** to `SnapshotOrdinal.MaxValue` (e.g. `scFeeBalanceFromContext.getOrElse(environment, SnapshotOrdinal.MaxValue)` at `GlobalSnapshotConsensus.scala:152` and `SharedServices.scala:195`): the `ordinal >= gate` check never fires, so an unset environment keeps the OLD path rather than silently activating the new one from genesis. Set an env entry to `0` to turn the new path on from genesis (as testnet does), or to a future launch ordinal to switch over at that ordinal. A high placeholder such as `9999999` does the same as the fail-closed default explicitly: it keeps the OLD path live until replaced with the real launch ordinal.
+- A **threshold gate** (`Map[AppEnvironment, SnapshotOrdinal]`): every in-repository consumer resolves an absent environment through `resolveWithDisabledDefault` to `SnapshotOrdinal.MaxValue`. The threshold can therefore never be crossed in ordinary operation, and an incomplete configuration retains the OLD path rather than silently enabling new behavior from genesis. Set an explicit environment entry to `0` to activate from genesis, to a future ordinal for a new coordinated behavior change, or to the exact evidence-backed historical cutover when the gate exists to reproduce behavior already present in signed history. Each gate must document whether its comparison is `>=` or `>`; changing that comparator changes the replay boundary. A finite placeholder such as `9999999` is not the same as the missing-map sentinel: it remains deliberately dormant only until the chain reaches that value.
 - An **exact-key gate** (`dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]`): the behavior fires only at exactly the keyed ordinal (`dustSweeps.get(env).flatMap(_.get(ordinal))`), once, and never replays.
 
-`feeTransactionSecurity` follows the replay-safe missing-environment default:
-`SnapshotOrdinal.MaxValue`. Missing configuration therefore retains the historical path rather
-than applying stricter validation retroactively to signed history. The shipped configuration
-contains an explicit entry for every environment.
+Missing means disabled uniformly across every `FieldsAddedOrdinals` threshold map. There is no
+in-tree threshold-gate exception. Any future exception requires an explicit per-gate rationale,
+source comment, and regression test; it must not be introduced by an ad hoc `MinValue` fallback at
+one consumer. Exact-key maps remain naturally disabled when the environment/key is absent.
 
 Per-environment activation ordinals differ because the same fix crosses different points of different chains. The behavior itself is identical code on every network; only WHEN it activates is per-environment. Examples from `application.conf:210-293`:
 
@@ -54,9 +59,17 @@ Per-environment activation ordinals differ because the same fix crosses differen
 | `delegated-rewards-full-committee` | 9999999 | 9999999 | 5880000 | 0 |
 | `fee-transaction-security` | 9999999 | 9999999 | 5880000 | 0 |
 | `currency-snapshot-protocol-v1` | absent | absent | absent | 0 |
+| `fixing-fee-transaction-balance-overflow` | 6814499 | 3255000 | 5905000 | 0 |
+| `fixing-data-application-fee-validation` | 6818000 | 9999999 | 9999999 | 0 |
+| `fixing-allow-spend-destination-credit` | 6818000 | 9999999 | 9999999 | 0 |
+| `preventing-allow-spend-resurrection` | 6828500 | 9999999 | 9999999 | 0 |
+| `fixing-global-allow-spend-expiration` | 6828500 | 9999999 | 9999999 | 0 |
 | `dust-sweeps` | (none) | {3154700} | (none) | (none) |
 
-A `9999999` entry is a not-yet-activated placeholder: the chain has not reached it, so the OLD path is still live on that environment. A `0` entry means the new path is active from genesis on that environment. An absent environment (no map entry) means the behavior never activates there.
+A `9999999` entry is a not-yet-activated placeholder only while the chain remains below it. A `0`
+entry means the new path is active from genesis on that environment. An absent threshold mapping
+resolves to `SnapshotOrdinal.MaxValue` and is the repository's disabled convention; an absent
+exact-key sweep means no sweep is scheduled.
 
 ## Reward gates: three values with different jobs
 

--- a/docs/operations/fields-added-ordinals.md
+++ b/docs/operations/fields-added-ordinals.md
@@ -5,11 +5,11 @@
 
 ## Summary
 
-Snapshots are signed. Once an ordinal is finalized, its artifact bytes are fixed forever, and any node that replays history (a fresh sync, a rollback, a cold restart) MUST re-derive byte-identical state or it forks. This makes shipping a fix to deterministic behavior hazardous: the new code path would change the bytes of already-signed history. `FieldsAddedOrdinals` is the primitive that resolves this. It is a record of per-environment **activation ordinals** (`config/types.scala:29-104`): each new or changed deterministic behavior is gated so that history on the legacy side of its boundary re-derives on the OLD path (byte-identical to what was signed), while the new behavior applies on the other side. Most threshold gates use `ordinal >= gate`; a small number deliberately use `>` because the named ordinal is the last legacy observation, and dust sweeps use exact-key equality. Consensus code selects the configured ordinal for its environment and must never branch behavior directly on `AppEnvironment`. The values are HOCON literals packaged into the assembly jar and have no environment-variable overrides. They must be identical across the cluster and finalized before assembly. Most remain outside `deterministicConfigHash`; the Currency snapshot protocol-v1 gate is explicitly copied into each L0's effective hash because it changes cross-layer artifact derivation. A config fence detects disagreement, but it cannot make a unanimously wrong activation ordinal safe.
+Snapshots are signed. Once an ordinal is finalized, its artifact bytes are fixed forever, and any node that replays history (a fresh sync, a rollback, a cold restart) MUST re-derive byte-identical state or it forks. This makes shipping a fix to deterministic behavior hazardous: the new code path would change the bytes of already-signed history. `FieldsAddedOrdinals` is the primitive that resolves this. It is a record of per-environment **activation ordinals** (`config/types.scala`): each new or changed deterministic behavior is gated so that history on the legacy side of its boundary re-derives on the OLD path (byte-identical to what was signed), while the new behavior applies on the other side. Most threshold gates use `ordinal >= gate`; a small number deliberately use `>` because the named ordinal is the last legacy observation, and dust sweeps use exact-key equality. Consensus code selects the configured ordinal for its environment and must never branch behavior directly on `AppEnvironment`. The values are HOCON configuration packaged into the assembly jar, with no dedicated environment-variable overrides for these gates. Named application configs fall back to the shared `application.conf`; packaging a named config does not by itself discard shared settings. Explicit configuration replacement remains possible, so the resolved values must agree across the cluster. Both L0 applications include every resolved `FieldsAddedOrdinals` threshold, the complete dust-sweep schedule, and the shared hashing, state-proof, and incremental-staking boundaries in `deterministicConfigHash`. The same effective configuration is used for joining and live consensus. A config fence detects disagreement, but it cannot make a unanimously wrong activation ordinal safe.
 
 ## Mechanism
 
-`FieldsAddedOrdinals` is a flat record of maps, one per gated behavior (`config/types.scala:29-104`):
+`FieldsAddedOrdinals` is a flat record of maps, one per gated behavior (`config/types.scala`):
 
 ```scala
 case class FieldsAddedOrdinals(
@@ -37,10 +37,10 @@ case class FieldsAddedOrdinals(
 )
 ```
 
-Each gate is loaded from the `fields-added-ordinals` HOCON block (`application.conf:210-395`). Resolution first picks the entry for the running environment. Two value conventions appear:
+Each gate is loaded from the `fields-added-ordinals` HOCON block (`application.conf`). Resolution first picks the entry for the running environment. The record has two value conventions:
 
-- A **threshold gate** (`Map[AppEnvironment, SnapshotOrdinal]`): every in-repository consumer calls the gate's named `...For(environment)` accessor. Those accessors share one private config-layer resolver that maps an absent environment to `SnapshotOrdinal.MaxValue`; callers do not read the raw map or choose a fallback. The threshold can therefore never be crossed in ordinary operation, and an incomplete configuration retains the OLD path rather than silently enabling new behavior from genesis. Set an explicit environment entry to `0` to activate from genesis, to a future ordinal for a new coordinated behavior change, or to the exact evidence-backed historical cutover when the gate exists to reproduce behavior already present in signed history. Each gate must document whether its comparison is `>=` or `>`; changing that comparator changes the replay boundary. A finite placeholder such as `9999999` is not the same as the missing-map sentinel: it remains deliberately dormant only until the chain reaches that value.
-- An **exact-key gate** (`dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]`): the behavior fires only at exactly the keyed ordinal (`dustSweeps.get(env).flatMap(_.get(ordinal))`), once, and never replays.
+- A **threshold gate** (`Map[AppEnvironment, SnapshotOrdinal]`): node consumers call the gate's named `...For(environment)` accessor. Those accessors share one private config-layer resolver that maps an absent environment to `SnapshotOrdinal.MaxValue`; callers do not read the raw map or choose a fallback. The threshold can therefore never be crossed in ordinary operation, and an incomplete configuration retains the OLD path rather than silently enabling new behavior from genesis. Set an explicit environment entry to `0` to activate from genesis, to a future ordinal for a new coordinated behavior change, or to the exact evidence-backed historical cutover when the gate exists to reproduce behavior already present in signed history. Each gate must document whether its comparison is `>=` or `>`; changing that comparator changes the replay boundary. A finite placeholder such as `9999999` is not the same as the missing-map sentinel: it remains deliberately dormant only until the chain reaches that value.
+- An **exact-key gate** (`dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]`): the behavior fires only at exactly the keyed ordinal (`dustSweeps.get(env).flatMap(_.get(ordinal))`), when that snapshot is produced or replayed; other ordinals do nothing.
 
 Missing means disabled uniformly across every `FieldsAddedOrdinals` threshold map. There is no
 in-tree threshold-gate exception. Any future exception requires an explicit per-gate rationale,
@@ -48,14 +48,24 @@ source comment, and regression test; it must not be introduced by reading a raw 
 fallback at one consumer. Exact-key maps use their named exact-key accessor and remain naturally
 disabled when the environment/key is absent.
 
+These are first-active thresholds, including historical corrections. Their disabled fallback is
+not a promise that old behavior is safe for a new network: established historical cutovers must
+remain explicit, and fresh-network tests explicitly select current behavior.
+
+The separate last-legacy boundaries have different semantics. `last-kryo-hash-ordinal` selects
+Kryo through the boundary (`<=`) and JSON above it; its existing missing default is `MinValue`
+(Kryo at zero, JSON above zero). `last-legacy-state-proof-ordinal` defaults to `MaxValue`, retaining
+legacy proofs. Preserve each boundary's established comparator and default rather than applying
+the first-active convention to it.
+
 The older top-level `incremental-delegated-staking-starting-ordinal` map is not part of
 `FieldsAddedOrdinals`, but it follows the same missing-means-disabled policy through
-`SharedConfig.incrementalDelegatedStakingStartingOrdinalFor`. Its comparison is `ordinal > gate`,
+`SnapshotOrdinalConfig.incrementalDelegatedStakingStartingOrdinalFor(environment)`. Its comparison is `ordinal > gate`,
 so an absent environment resolves to `SnapshotOrdinal.MaxValue`. All shipped environments have an
 explicit historical value; this fallback only prevents an incomplete config from enabling the
 record transformation at genesis.
 
-Per-environment activation ordinals differ because the same fix crosses different points of different chains. The behavior itself is identical code on every network; only WHEN it activates is per-environment. Examples from `application.conf:210-293`:
+Per-environment activation ordinals differ because the same fix crosses different points of different chains. The behavior itself is identical code on every network; only WHEN it activates is per-environment. Examples from `application.conf`:
 
 | Gate | mainnet | testnet | integrationnet | dev |
 |------|---------|---------|----------------|-----|
@@ -79,6 +89,20 @@ entry means the new path is active from genesis on that environment. An absent t
 resolves to `SnapshotOrdinal.MaxValue` and is the repository's disabled convention; an absent
 exact-key sweep means no sweep is scheduled.
 
+## Regression coverage and consumer alignment
+
+`FieldsAddedOrdinalsSuite` compares the packaged configuration with an independently reviewed
+expected table for every environment, including intentional absences, historical boundaries, and
+the complete dust schedule. New gates must be added to that table. The shared test fixture enables
+all current thresholds; tests of historical behavior must explicitly override their boundary.
+`ConsensusOrdinalConfigSuite` checks that changing or removing activation values changes the
+consensus hash, and that unrelated environments and configuration ordering do not.
+
+Snapshot Streaming is updated separately after the node changes reach `develop`. Its current
+compatibility patch retains the older missing-environment defaults for four thresholds; this
+follow-up must align it with the SDK accessors and qualify the resulting indexer artifact. Existing
+explicit packaged values agree. This PR does not update or claim qualification of that consumer.
+
 ## Reward gates: three values with different jobs
 
 Reward-path diagnosis requires an ordinal gate and an epoch gate. They must not be
@@ -100,9 +124,9 @@ versus delegated rewards. See
 
 The load-bearing rule:
 
-> New consensus functionality is ALWAYS present in the code for every network. You gate WHEN it activates by ordinal, never branch consensus behavior on `AppEnvironment`. Per-environment differences belong in the shared per-environment ordinal map, finalized before assembly. The release version and consensus config hash fence incompatible peers, but neither verifies these ordinal values.
+> New consensus functionality is ALWAYS present in the code for every network. You gate WHEN it activates by ordinal, never branch consensus behavior on `AppEnvironment`. Per-environment differences belong in the shared per-environment ordinal map, finalized before assembly. The release version rejects different software versions; the consensus config hash also rejects disagreement about the resolved activation values. Neither proves that a value agreed by every node is historically correct.
 
-Concretely, the read sites compare `ordinal >= gate`, never `if (environment == Mainnet)`. See `GlobalSnapshotStateChannelEventsProcessor.scala:325`:
+Concretely, the read sites compare `ordinal >= gate`, never `if (environment == Mainnet)`. See `GlobalSnapshotStateChannelEventsProcessor.scala`:
 
 ```scala
 if (snapshotOrdinal >= scFeeBalanceFromContextOrdinal)
@@ -111,9 +135,9 @@ else
   mptStore.getBalance(feeAddress).map(_.getOrElse(Balance.empty))               // old path
 ```
 
-A consensus knob that is testnet-only in HOCON (so mainnet silently falls to a no-op default) **violates this principle**, because the per-environment behavior difference then lives in a runtime branch rather than in consensus-agreed state, and a future contributor cannot see, from the gate, that mainnet behaves differently. The correct way to express a per-environment consensus difference is a `Map[AppEnvironment, T]` config value that is resolved ONCE at the construction site and folded into `deterministicConfigHash` (see below). That way a divergent operator value is refused at Facility-handshake time rather than producing a silent fork.
+A consensus knob that is testnet-only in HOCON (so mainnet silently falls to a no-op default) **violates this principle**, because the per-environment behavior difference then lives in a runtime branch rather than in consensus-agreed state, and a future contributor cannot see, from the gate, that mainnet behaves differently. The correct way to express a per-environment consensus difference is a `Map[AppEnvironment, T]` config value that is resolved ONCE at the construction site and folded into `deterministicConfigHash` (see below). That way a divergent operator value is rejected during L0 joining rather than producing a silent fork.
 
-The same discipline applies to env-keyed consensus knobs that are not ordinal gates (for example `coreCommitteeSize`, `quorumShrinkActivationViews`, `rewardRotationEpochRounds`): they are resolved per environment at one construction point and folded into `deterministicConfigHash` (`types.scala:1019-1043`), so the per-environment value is part of the consensus contract, not a runtime branch.
+The same discipline applies to env-keyed consensus knobs that are not ordinal gates (for example `coreCommitteeSize`, `quorumShrinkActivationViews`, `rewardRotationEpochRounds`): they are resolved per environment at one construction point and folded into `deterministicConfigHash` (`types.scala`), so the per-environment value is part of the consensus contract, not a runtime branch.
 
 ## Protocol and replay fences operators must not conflate
 
@@ -121,7 +145,7 @@ The same discipline applies to env-keyed consensus knobs that are not ordinal ga
 |-----------|------------|------------------|----------------------------|
 | **FieldsAddedOrdinals** | per-env activation ordinals for deterministic behavior changes | **Yes** | a mismatched ordinal changes artifact bytes at the boundary -> fork |
 | **Tessellation and metagraph version hashes** | hashes of the reported release versions | No | a divergent value is rejected during the join handshake |
-| **deterministicConfigHash** | a hash of the exact consensus-critical projection resolved by `SnapshotConfig.resolveEffectiveConsensusConfig` | No (it is a config FENCE, not signed into history) | L0 requires presence and exact equality at join; Facility processing also reports a mismatch; it does NOT change replayed bytes |
+| **deterministicConfigHash** | a hash of the effective consensus settings, including the shared activation configuration added by `ConsensusConfig.withSharedConfig` | It binds live declarations/trigger statements; it does not select historical snapshot derivation | L0 requires presence and exact equality at join; Facility processing also reports a mismatch; it does NOT change replayed bytes |
 | **consensusSchemaVersion** | a single integer wire-version fence (currently `35`), folded INTO `deterministicConfigHash` | No | a divergent value fences out mixed-wire-version peers at handshake; it is not signed into the snapshot artifact |
 | **certifiedConsensusActivationKey** | the environment-resolved v35 consensus behavior boundary, folded INTO `deterministicConfigHash` | Yes for active consensus behavior, but not a public snapshot field | a mismatched value fences at config/Facility checks; crossing the agreed key switches to the certified state machine and canonical legacy-window reset |
 | **currencySnapshotProtocolV1** | Global-ordinal authorization for the signed Currency snapshot `0.0.1 -> 1.0.0` semantics transition; its resolved value is copied into `ConsensusConfig` | **Yes** | divergent values are fenced at joining; crossing the agreed global key changes Currency artifact bytes and replay mode |
@@ -131,42 +155,42 @@ The distinction that matters for operators: ordinal gates (`FieldsAddedOrdinals`
 
 ## Worked example: the ordinal-gated GSI dust sweep
 
-`GlobalSnapshotDustSweep` (`GlobalSnapshotDustSweep.scala:16-150`) is a one-time, consensus-critical, post-construction state-deflation transform armed via the `dustSweeps` gate. The testnet global state is dominated by a deliberately-injected dust population (hundreds of thousands of addresses each holding exactly 12345 datum, all pure receivers with empty transaction refs). The sweep removes that sub-threshold liquid dust at a single coordinated ordinal during a network-wide cold restart, collapsing the state from roughly 80MB to roughly 1MB.
+`GlobalSnapshotDustSweep` (`GlobalSnapshotDustSweep.scala`) is a one-time, consensus-critical, post-construction state-deflation transform armed via the `dustSweeps` gate. The testnet global state is dominated by a deliberately-injected dust population (hundreds of thousands of addresses each holding exactly 12345 datum, all pure receivers with empty transaction refs). The sweep removes that sub-threshold liquid dust at a single coordinated ordinal during a network-wide cold restart, collapsing the state from roughly 80MB to roughly 1MB.
 
 It is consensus-critical: every honest node MUST compute the identical swept `GlobalSnapshotInfo` and the identical MPT state root at the sweep ordinal, or the cluster forks. The transform is a pure function of the GSI map contents at a fixed ordinal (sorted maps, commutative datum sum), so every node at the sweep ordinal computes the identical pruned GSI and root.
 
 ### Where it wires into the acceptance path
 
-`applyDustSweep` runs inside `GlobalSnapshotAcceptanceManager` AFTER the GSI is fully built but BEFORE the MPT sync and proof, so the returned GSI, the MPT-sync input, and `buildProof` all derive from the same swept state (`GlobalSnapshotAcceptanceManager.scala:1086-1090`):
+`applyDustSweep` runs inside `GlobalSnapshotAcceptanceManager` AFTER the GSI is fully built but BEFORE the MPT sync and proof, so the returned GSI, the MPT-sync input, and `buildProof` all derive from the same swept state (`GlobalSnapshotAcceptanceManager.scala`):
 
 ```scala
 (sweptGsi, didSweep) =
-  GlobalSnapshotDustSweep.applyDustSweep(gsi, ordinal, environment, fieldsAddedOrdinals.dustSweeps)
+  GlobalSnapshotDustSweep.applyDustSweep(gsi, fieldsAddedOrdinals.dustSweepFor(environment, ordinal))
 ```
 
-Off the sweep ordinal this is a no-op (one map lookup returning `None`; `didSweep = false`), and `sweptGsi` is the same value as `gsi`, so the normal incremental MPT path is unchanged. At exactly the sweep ordinal, the MPT is rebuilt in one shot from the swept state via `syncFull` rather than streaming hundreds of thousands of incremental deletions (`GlobalSnapshotAcceptanceManager.scala:1154-1160`). `syncFull` yields the identical canonical root the incremental path would produce for the same entry set (the MPT root is a pure function of the entry set), so consensus still agrees and the producer resumes correct incremental syncs from the pruned base afterward.
+Off the sweep ordinal this is a no-op (one map lookup returning `None`; `didSweep = false`), and `sweptGsi` is the same value as `gsi`, so the normal incremental MPT path is unchanged. At exactly the sweep ordinal, the MPT is rebuilt in one shot from the swept state via `syncFull` rather than streaming hundreds of thousands of incremental deletions (`GlobalSnapshotAcceptanceManager.scala`). `syncFull` yields the identical canonical root the incremental path would produce for the same entry set (the MPT root is a pure function of the entry set), so consensus still agrees and the producer resumes correct incremental syncs from the pruned base afterward.
 
 ### Safety gates
 
-An address is swept only if ALL of the following hold (`GlobalSnapshotDustSweep.scala:28-44`, `:121-150`):
+An address is swept only if ALL of the following hold (`GlobalSnapshotDustSweep.scala`, `:121-150`):
 
-1. **Ordinal gate.** The sweep fires only when `dustSweeps.get(env).flatMap(_.get(ordinal))` returns a `DustSweep` (exact-key lookup). It fires exactly once at its ordinal, never replays, and an absent environment never sweeps.
+1. **Ordinal gate.** The sweep fires only when `dustSweeps.get(env).flatMap(_.get(ordinal))` returns a `DustSweep` (exact-key lookup). It fires at its configured ordinal during production or historical replay; an absent environment never sweeps.
 2. **Dust threshold.** Only `balance.value <= threshold.value`.
 3. **Empty-ref gate.** Only an address whose `lastTxRef` is absent or `TransactionReference.empty` (ordinal 0). An address that ever SENT has a non-empty ref; pruning it would reset its nonce and reopen a transaction-replay vector. The dust population is entirely pure receivers, so this gate loses zero coverage.
-4. **Complete exclusion.** An address that appears as a key (including nested inner-map keys) in ANY non-balance Address-keyed GSI field is never swept (`addressesWithNonBalanceState`, `GlobalSnapshotDustSweep.scala:77-112`, 13 fields). Locking / staking / collateralizing debits the liquid `balances` entry, so a real staker can legitimately sit near zero liquid balance; sweeping their dust would be wrong.
+4. **Complete exclusion.** An address that appears as a key (including nested inner-map keys) in ANY non-balance Address-keyed GSI field is never swept (`addressesWithNonBalanceState`, `GlobalSnapshotDustSweep.scala`, 14 fields). Locking / staking / collateralizing debits the liquid `balances` entry, so a real staker can legitimately sit near zero liquid balance; sweeping their dust would be wrong.
 5. **Not the collection address.** The treasury sink itself is never a sweep candidate.
 
-The subtlety worth calling out: `lastTxRefs` is Address-keyed but is DELIBERATELY EXCLUDED from the gate-4 protected set (`GlobalSnapshotDustSweep.scala:68-72`). Every pure receiver (the entire dust population) holds an empty-ref `lastTxRefs` entry, so treating `lastTxRefs` keys as protected would exclude the whole dust population and the sweep would silently remove nothing (verified live: roughly 444k of roughly 444.5k `lastTxRefs` entries are empty). The transaction-nonce / replay concern is handled instead by the empty-ref gate (gate 3). Mishandling this one field is the difference between a working sweep and a silent no-op.
+The subtlety worth calling out: `lastTxRefs` is Address-keyed but is DELIBERATELY EXCLUDED from the gate-4 protected set (`GlobalSnapshotDustSweep.scala`). Every pure receiver (the entire dust population) holds an empty-ref `lastTxRefs` entry, so treating `lastTxRefs` keys as protected would exclude the whole dust population and the sweep would silently remove nothing (verified live: roughly 444k of roughly 444.5k `lastTxRefs` entries are empty). The transaction-nonce / replay concern is handled instead by the empty-ref gate (gate 3). Mishandling this one field is the difference between a working sweep and a silent no-op.
 
-The `DustSweep` config carries the threshold and the disposition (`config/types.scala:50-61`): `collectionAddress = None` burns the collected sum (reported total supply drops), `Some(addr)` credits it to a treasury (total supply preserved).
+The `DustSweep` config carries the threshold and the disposition (`config/types.scala`): `collectionAddress = None` burns the collected sum (reported total supply drops), `Some(addr)` credits it to a treasury (total supply preserved).
 
 ## Second example: scFeeBalanceFromContext
 
-`scFeeBalanceFromContext` (`config/types.scala:38-42`) is a threshold gate over the balance source used by the state-channel fee-affordability check. At and after the gate the check reads the metagraph owner's balance from the deterministic `accept()` context (`lastGlobalSnapshotInfo.balances`); below it from the pre-fix `mptStore.getBalance` path, so already-signed history re-derives byte-identically (`GlobalSnapshotStateChannelEventsProcessor.scala:325`). testnet is `3101393` -- the exact ordinal where testnet switched from the v4.0.0 `mptStore` build to the alpha.0 context build (it stalled at 3101392 on 2026-03-17 and resumed at 3101393 on 2026-04-02), so the v4.0.0 `mptStore` window below the gate replays correctly. IntegrationNet is scheduled for `5880000` with the other v4.1 gates. Mainnet retains the `9999999` placeholder until its own context-deploy ordinal is selected (`application.conf:275-284`).
+`scFeeBalanceFromContext` (`config/types.scala`) is a threshold gate over the balance source used by the state-channel fee-affordability check. At and after the gate the check reads the metagraph owner's balance from the deterministic `accept()` context (`lastGlobalSnapshotInfo.balances`); below it from the pre-fix `mptStore.getBalance` path, so already-signed history re-derives byte-identically (`GlobalSnapshotStateChannelEventsProcessor.scala`). testnet is `3101393` -- the exact ordinal where testnet switched from the v4.0.0 `mptStore` build to the alpha.0 context build (it stalled at 3101392 on 2026-03-17 and resumed at 3101393 on 2026-04-02), so the v4.0.0 `mptStore` window below the gate replays correctly. IntegrationNet is scheduled for `5880000` with the other v4.1 gates. Mainnet retains the `9999999` placeholder until its own context-deploy ordinal is selected (`application.conf`).
 
 ## Third example: subTrieRoots
 
-`subTrieRoots` (`config/types.scala:43-46`) is a threshold gate over the per-field MPT roots carried in `GlobalSnapshotStateProof`. Below the gate, MPT-format proofs keep the legacy shape: the overall `mptRoot` is present and the per-field proof slots remain empty. At and after the gate, those slots carry per-`GlobalStateFieldId` roots so a state-root mismatch can be localized to the divergent field (`GlobalSnapshotInfo.assembleMptProof`). This changes signed proof bytes, so each public network must retain `9999999` until a coordinated cold-restart ordinal and compatible Snapshot Streaming deployment are selected. IntegrationNet activated at `5880000`; do not move that gate forward, because replay of already-signed ordinals from `5880000` through the new gate would re-derive the old proof shape and fail validation. Moving it also cannot repair a stale indexer. `TessellationIOApp` resolves the environment entry once and passes it into `GlobalStateProofSelector`; absent environments fail closed to `SnapshotOrdinal.MaxValue`.
+`subTrieRoots` (`config/types.scala`) is a threshold gate over the per-field MPT roots carried in `GlobalSnapshotStateProof`. Below the gate, MPT-format proofs keep the legacy shape: the overall `mptRoot` is present and the per-field proof slots remain empty. At and after the gate, those slots carry per-`GlobalStateFieldId` roots so a state-root mismatch can be localized to the divergent field (`GlobalSnapshotInfo.assembleMptProof`). This changes signed proof bytes, so each public network must retain `9999999` until a coordinated cold-restart ordinal and compatible Snapshot Streaming deployment are selected. IntegrationNet activated at `5880000`; do not move that gate forward, because replay of already-signed ordinals from `5880000` through the new gate would re-derive the old proof shape and fail validation. Moving it also cannot repair a stale indexer. `TessellationIOApp` resolves the environment entry once and passes it into `GlobalStateProofSelector`; absent environments fail closed to `SnapshotOrdinal.MaxValue`.
 
 Development activates this gate at ordinal `0` so CI exercises the signed proof shape. The Tessellation build applies the matching Snapshot Streaming compatibility patch: both SS entry points resolve the two-argument `GlobalStateProofSelector`, and proof validation reuses `GlobalSnapshotInfo.assembleMptProof` instead of constructing an mpt-root-only literal. This is compatibility evidence only; every public environment still requires a separately versioned, tested, and deployed Snapshot Streaming artifact before its gate is crossed (or before resuming from an already-post-gate checkpoint).
 
@@ -185,16 +209,16 @@ Currency Snapshot ordinals never activate this platform rule. See
 
 ## Operator checklist
 
-- Ordinal gates are **consensus-critical** and must match cluster-wide. They live in `application.conf` and are packaged into the assembly jar (compile-time literals), so changing one is itself a coordinated jar redeploy.
+- Ordinal gates are **consensus-critical** and must match cluster-wide. They live in shared HOCON configuration packaged into the assembly. Deployments use one software version and a full-cluster cold restart; version mismatches are rejected at joining. The config hash additionally checks agreement among nodes running that version.
 - Before launch, replace every mainnet placeholder with the real coordinated launch ordinal:
-  - `sc-fee-balance-from-context.mainnet` (`9999999`, `application.conf:275-284`): set it to its context-deploy ordinal. testnet is pinned to its real cutover (`3101393`); IntegrationNet is scheduled for `5880000`. An unset env fails closed to the `mptStore` path.
+  - `sc-fee-balance-from-context.mainnet` (`9999999`, `application.conf`): set it to its context-deploy ordinal. testnet is pinned to its real cutover (`3101393`); IntegrationNet is scheduled for `5880000`. An unset env fails closed to the `mptStore` path.
   - `sub-trie-roots.mainnet` and `.testnet` (`9999999`): set each to its proof-field activation ordinal only when that network is ready to change signed `GlobalSnapshotStateProof` bytes. IntegrationNet activated at `5880000` and requires matching Snapshot Streaming support for every current deployment. For a cold restart at checkpoint `N`, use `N + 1` only on a network that has not already crossed its selected gate.
   - `delegated-rewards-full-committee.<env>`: set the deploying environment to the first ordinal produced by the corrected jar. Below it, the historical evidence-score filter must remain available for replay.
   - `fee-transaction-security.<env>`: set the deploying environment to the first global ordinal observed only after every Currency L1 and ML0 node is upgraded. IntegrationNet is scheduled for `5880000`.
   - `currency-snapshot-protocol-v1.<env>`: set one future GLOBAL L0 ordinal only after every active Currency stack is upgraded. Active lineages transition their existing signed `version` to `1.0.0`; dormant lineages must upgrade before returning. See [ADR-0033](../adr/0033-versioned-currency-snapshot-history.md).
-  - `dust-sweeps` has no mainnet entry yet (`application.conf:286-292`). If a mainnet sweep is intended, add one.
-- For the dust sweep specifically, FINALIZE the ordinal right before deploy: it must be an ordinal the chain reaches AFTER the deflating jar is live cluster-wide. A too-early crossing on the old jar misses the sweep until a rollback re-crosses it (`application.conf:281-285`). Bump it up if the chain nears it before the coordinated cold restart completes.
-- Most historical gates do not participate in `deterministicConfigHash`. Currency snapshot protocol v1 is deliberately resolved into both DAG and Currency L0 effective consensus configs and therefore does. The advertised jar metadata hash is still not a substitute for either the release-version gate or this config fence. A unanimously wrong ordinal remains dangerous even when every node reports the same hash, so verify gates by inspection before assembly and deploy the identical artifact cluster-wide.
+  - `dust-sweeps` has no mainnet entry yet (`application.conf`). If a mainnet sweep is intended, add one.
+- For the dust sweep specifically, FINALIZE the ordinal right before deploy: it must be an ordinal the chain reaches AFTER the deflating jar is live cluster-wide. A too-early crossing on the old jar misses the sweep until a rollback re-crosses it (`application.conf`). Bump it up if the chain nears it before the coordinated cold restart completes.
+- Every resolved threshold in `FieldsAddedOrdinals`, the full dust-sweep schedule (ordinals, thresholds, and burn/credit destinations), and the three shared hashing/state-proof/staking boundaries enter both L0 config hashes. Only the running environment is included. Currency protocol-v1 retains its existing explicit activation field as well. The advertised jar metadata hash is still not a substitute for either the release-version gate or this config fence. A unanimously wrong ordinal remains dangerous even when every node reports the same hash, so verify gates by inspection before assembly and deploy the identical artifact cluster-wide.
 
 ## Key code references
 
@@ -203,15 +227,15 @@ Currency Snapshot ordinals never activate this platform rule. See
 | `FieldsAddedOrdinals` record | `config/types.scala` |
 | `DustSweep` config | `config/types.scala` |
 | HOCON block | `application.conf` |
-| Dust sweep transform | `GlobalSnapshotDustSweep.scala:16-150` |
-| Dust sweep acceptance wiring + `syncFull` | `GlobalSnapshotAcceptanceManager.scala:1086-1160` |
-| `scFeeBalanceFromContext` read site | `GlobalSnapshotStateChannelEventsProcessor.scala:325` |
-| `scFeeBalanceFromContext` resolution | `GlobalSnapshotConsensus.scala:150`, `SharedServices.scala:193` |
-| `subTrieRoots` proof assembly | `GlobalSnapshotInfo.scala:274-323` |
-| `subTrieRoots` selector wiring | `TessellationIOApp.scala:117-121`, `StateProofSelector.scala:33-41` |
+| Dust sweep transform | `GlobalSnapshotDustSweep.scala` |
+| Dust sweep acceptance wiring + `syncFull` | `GlobalSnapshotAcceptanceManager.scala` |
+| `scFeeBalanceFromContext` read site | `GlobalSnapshotStateChannelEventsProcessor.scala` |
+| `scFeeBalanceFromContext` resolution | `GlobalSnapshotConsensus.scala`, `SharedServices.scala` |
+| `subTrieRoots` proof assembly | `GlobalSnapshotInfo.scala` |
+| `subTrieRoots` selector wiring | `TessellationIOApp.scala`, `StateProofSelector.scala` |
 | `feeTransactionSecurity` signature validation | `FeeTransactionSignatureValidator.scala` |
 | `feeTransactionSecurity` ML0 final-acceptance gate | `CurrencySnapshotAcceptanceManager.scala` |
 | Currency snapshot protocol transition | `CurrencySnapshotSemantics.scala`, `CurrencySnapshotAcceptanceManager.scala` |
-| `deterministicConfigHash` folded string | `config/types.scala:950-1044` (folded string ends `:1043`) |
+| `deterministicConfigHash` folded string | `config/types.scala` (`ConsensusConfig.deterministicConfigHash`) |
 | `consensusSchemaVersion` | `config/types.scala` (`ConsensusConfig`) |
 | `certifiedConsensusActivationOrdinal` | `config/types.scala` (`SnapshotConfig`) |

--- a/docs/operations/local-e2e-cluster-investigation.md
+++ b/docs/operations/local-e2e-cluster-investigation.md
@@ -1,10 +1,11 @@
 # Interrogating a live local E2E cluster
 
-Companion to the log-analysis procedure (memory `reference_e2e_log_analysis` / the `debug-e2e-logs`
-skill). That one covers **reading the persisted per-node logs** after a run -- where they live, the
-peer-id rotation trap, and the parallel-subagent method. This one covers **querying the cluster
-while it is still running**, which is a different and usually faster route to a root cause. Neither
-restates the other.
+Companion to the canonical [local Docker/E2E workflow](../../docker/README.md) and the log-analysis
+procedure (memory `reference_e2e_log_analysis` / the `debug-e2e-logs` command). The workflow covers
+build inputs, artifact locations, and exact cleanup semantics. The log procedure covers **reading
+the persisted per-node logs** after a run, including the peer-id rotation trap. This document covers
+**querying the cluster while it is still running**, which is a different and usually faster route
+to a root cause.
 
 Written from the `committee-rewards` diagnosis on 2026-07-30, where the test's own criteria -- not
 the node -- were wrong, and only live queries could show it.
@@ -20,8 +21,20 @@ docker ps --format '{{.Names}}\t{{.Status}}'
 curl -s localhost:9000/global-snapshots/latest | jq '.value.ordinal, .value.epochProgress'
 ```
 
-Do **not** run `just down` until you are finished. When done: `just down --clean` (also wipes
-`nodes/*/data`).
+Do **not** run `just down` until you have captured any needed `docker logs`. When done, use:
+
+```bash
+just down
+```
+
+This removes the scoped containers, named volumes, and network but preserves the host-mounted
+`nodes/` data and application logs. If those are no longer needed, run `just clean-data` afterward
+to remove only layer data/logs, or `just clean-configs` to remove the entire generated node tree.
+Both destructive node-cleanup commands require the containers to be stopped first.
+
+Do not rely on `just down --clean` locally: `--clean` only changes remote teardown behavior. Also
+do not start another ordinary `just test` until the evidence is captured; the next run deletes and
+recreates `nodes/` by default.
 
 ## Port map
 

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -30,6 +30,7 @@ Before performing a release or merging a PR with breaking changes, ensure you ha
 - Release Process (internal runbook)
 - [Tessellation GitHub Releases](https://github.com/Constellation-Labs/tessellation/releases)
 - [Conventional Commits](https://www.conventionalcommits.org/) (see also [`docs/adr/0015-conventional-commits.md`](../adr/0015-conventional-commits.md))
+- [Consensus schema change governance](../adr/0034-consensus-schema-change-governance.md)
 
 ## Mandatory pre-stop evidence and monitoring gate
 
@@ -79,6 +80,16 @@ actions. See
 [Global L0 trusted recovery seed committee](../operations/global-l0-recovery-seed-committee.md).
 
 ## Functionality Definitions
+
+### Consensus Compatibility Classification
+
+A coordinated cold restart lets the complete fleet adopt new runtime behavior together, but is not
+evidence that signed history or external consumers remain compatible. Every consensus-adjacent PR
+must classify itself as runtime-only, replay/state-transition with stable schema, or schema/wire.
+The latter two require the compatibility and rollout evidence in
+[ADR-0034](../adr/0034-consensus-schema-change-governance.md). Schema changes are frozen once the
+release candidate and dependent Snapshot Streaming/SDK/metagraph artifacts or announcements are
+finalized; changing them requires a newly reviewed release package.
 
 ### Release Artifacts Construction
 

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -106,7 +106,13 @@ The preferred mechanism for introducing breaking changes. Gives node operators a
 - **Epoch-based flags** (preferred) - Enable breaking behavior at a specific approximate point in time. Epoch is a vector clock that loosely approximates actual time.
 - **Ordinal-based flags** - Should be avoided when possible, as ordinals cannot accurately proxy for time over longer periods, but may be necessary due to technical constraints.
 
-Configuration lives in `modules/node-shared/src/main/resources/application.conf`. The current primary ordinal-gate surface is the `fields-added-ordinals` block, a `Map[AppEnvironment, SnapshotOrdinal]` family plus the `dust-sweeps` `Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]`. Live sub-keys include `sc-fee-balance-from-context`, `dust-sweeps`, `set-sum-fix`, `fixing-allow-spend-and-token-lock-validation`, `sub-trie-roots`, `delegated-rewards-full-committee`, `fee-transaction-security`, and the historical migration gates. Older keys like `last-legacy-state-proof-ordinal` and `incremental-delegated-staking-starting-ordinal` still exist but are no longer where new gates land.
+Configuration lives in `modules/node-shared/src/main/resources/application.conf`. The current primary ordinal-gate surface is the `fields-added-ordinals` block, a `Map[AppEnvironment, SnapshotOrdinal]` family plus the `dust-sweeps` `Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]`. Live sub-keys include `sc-fee-balance-from-context`, `dust-sweeps`, `set-sum-fix`, `fixing-allow-spend-and-token-lock-validation`, `sub-trie-roots`, `delegated-rewards-full-committee`, `fee-transaction-security`, `currency-snapshot-protocol-v1`, `fixing-fee-transaction-balance-overflow`, `fixing-data-application-fee-validation`, `fixing-allow-spend-destination-credit`, `preventing-allow-spend-resurrection`, `fixing-global-allow-spend-expiration`, and the historical migration gates. Older keys like `last-legacy-state-proof-ordinal` and `incremental-delegated-staking-starting-ordinal` still exist but are no longer where new gates land.
+
+Every `FieldsAddedOrdinals` threshold map follows one missing-value contract: an absent environment
+resolves to `SnapshotOrdinal.MaxValue` and is disabled. Active-from-genesis behavior requires an
+explicit `0`. Exact-key maps such as `dust-sweeps` are disabled naturally when no environment/key
+entry exists. Each gate must separately document its ordinal/epoch domain and comparator; do not
+infer `>=` when a historical replay boundary intentionally uses `>`.
 
 Several `fields-added-ordinals` gates require the deploy-time rule that **the chain must cross the gate ordinal only after the new jar is live cluster-wide** (a too-early crossing on the old jar misses the gated behaviour; for the dust sweep, a missed sweep is not re-attempted until a rollback re-crosses the ordinal). See the gate-setting checklist in [`v4-launch-runbook.md`](v4-launch-runbook.md).
 

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -134,7 +134,9 @@ Stages proceed in order, with exceptions only for emergency maintenance or requi
 
 ### 1. Merge to Develop
 
-Requires PR approval only. Does not deploy code anywhere manually. Breaking changes should ideally be documented as part of the merged commits using conventional commit format, but documentation can be deferred to later stages.
+Requires PR approval only. Does not deploy code anywhere manually. Breaking changes must carry
+their compatibility classification, required ADR/schema package, and conventional-commit marker in
+the merged work. Only non-blocking release-note polish may be deferred to a later release stage.
 
 ### 2. Testnet Release
 

--- a/justfile
+++ b/justfile
@@ -21,7 +21,8 @@ up *extra_args:
 	@just _check_deps
 	@bash docker/bin/compose-runner.sh --up {{ extra_args }}
 
-# Destroy test environment. Use --remote=n0,n1,n2 for remote nodes, --clean to wipe data.
+# Destroy the local test environment while preserving host-mounted nodes/ data and logs.
+# For remote nodes, --clean additionally wipes remote data; it has no extra local effect.
 down *extra_args:
 	@bash docker/bin/compose-runner-down.sh {{ extra_args }}
 

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/CurrencyL0App.scala
@@ -119,16 +119,7 @@ abstract class CurrencyL0App(
       val appConfig = method.appConfig(reader, sharedConfig)
       SnapshotConfig
         .resolveEffectiveConsensusConfig(appConfig.snapshot, appConfig.environment)
-        .map(
-          _.copy(
-            lastGlobalSnapshotSyncOffset = sharedConfig.lastGlobalSnapshotsSync.syncOffset.value,
-            lastGlobalSnapshotsInMemory = sharedConfig.lastGlobalSnapshotsSync.maxLastGlobalSnapshotsInMemory.value,
-            currencySnapshotProtocolV1ActivationOrdinal = sharedConfig.fieldsAddedOrdinals
-              .currencySnapshotProtocolV1For(appConfig.environment)
-              .value
-              .value
-          )
-        )
+        .map(_.withSharedConfig(sharedConfig))
         .liftTo[IO]
         .map(_.some)
     }

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -169,7 +169,10 @@ object Services {
         .pure[F]
 
       creator = CurrencySnapshotCreator.make[F](
-        sharedCfg.fieldsAddedOrdinals.tessellation3Migration.getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue),
+        sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
+          sharedCfg.fieldsAddedOrdinals.tessellation3Migration,
+          sharedCfg.environment
+        ),
         sharedServices.currencySnapshotAcceptanceManager,
         dataApplicationAcceptanceManager,
         cfg.snapshotSize,
@@ -183,8 +186,7 @@ object Services {
         signedValidator,
         maybeRewards,
         maybeDataApplication,
-        sharedCfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
-          .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue)
+        sharedCfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(sharedCfg.environment)
       )
 
       addressService = AddressService.make[F, CurrencyIncrementalSnapshot, CurrencySnapshotInfo](cfg.shared.addresses, storages.snapshot)

--- a/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
+++ b/modules/currency-l0/src/main/scala/io/constellationnetwork/currency/l0/modules/Services.scala
@@ -169,10 +169,7 @@ object Services {
         .pure[F]
 
       creator = CurrencySnapshotCreator.make[F](
-        sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
-          sharedCfg.fieldsAddedOrdinals.tessellation3Migration,
-          sharedCfg.environment
-        ),
+        sharedCfg.fieldsAddedOrdinals.tessellation3MigrationFor(sharedCfg.environment),
         sharedServices.currencySnapshotAcceptanceManager,
         dataApplicationAcceptanceManager,
         cfg.snapshotSize,

--- a/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/ConfigLoadSuite.scala
+++ b/modules/currency-l0/src/test/scala/io/constellationnetwork/currency/l0/ConfigLoadSuite.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 
 import io.constellationnetwork.currency.l0.config.types.AppConfigReader
 import io.constellationnetwork.env.AppEnvironment
-import io.constellationnetwork.node.shared.config.types.SnapshotConfig
+import io.constellationnetwork.node.shared.config.types.{SharedConfigReader, SnapshotConfig}
 import io.constellationnetwork.node.shared.ext.pureconfig._
 
 import eu.timepit.refined.pureconfig._
@@ -16,7 +16,7 @@ import weaver.SimpleIOSuite
 
 object ConfigLoadSuite extends SimpleIOSuite {
 
-  private val source: ConfigSource =
+  private val source =
     ConfigSource.resources("currency-l0.conf").withFallback(ConfigSource.default)
 
   test("the packaged Currency L0 config preserves distinct selector and controller caps in the join hash") {
@@ -36,4 +36,31 @@ object ConfigLoadSuite extends SimpleIOSuite {
         )
     }
   }
+  AppEnvironment.values.foreach { environment =>
+    test(s"${environment.entryName}: the named L0 config retains all shared activation values") {
+      for {
+        shared <- source.loadF[IO, SharedConfigReader]()
+        defaults <- ConfigSource.resources("application.conf").withFallback(source).loadF[IO, SharedConfigReader]()
+        app <- source.loadF[IO, AppConfigReader]()
+      } yield
+        SnapshotConfig
+          .resolveEffectiveConsensusConfig(app.snapshot, environment)
+          .fold(
+            error => failure(error.getMessage),
+            resolved => {
+              val effective = resolved.withSharedConfig(shared, environment)
+              expect.same(Some(defaults.ordinalConfigHashFor(environment)), effective.ordinalConfigHash) &&
+              expect.same(
+                resolved.withSharedConfig(defaults, environment).deterministicConfigHash,
+                effective.deterministicConfigHash
+              ) &&
+              expect.same(
+                shared.fieldsAddedOrdinals.currencySnapshotProtocolV1For(environment).value.value,
+                effective.currencySnapshotProtocolV1ActivationOrdinal
+              )
+            }
+          )
+    }
+  }
+
 }

--- a/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
+++ b/modules/currency-l1/src/test/scala/io/constellationnetwork/currency/l1/domain/snapshots/programs/CurrencySnapshotProcessorSuite.scala
@@ -10,6 +10,7 @@ import io.constellationnetwork.env.AppEnvironment.Dev
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
+import io.constellationnetwork.node.shared.config.FieldsAddedOrdinalsFixtures
 import io.constellationnetwork.node.shared.config.types._
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockAcceptanceManager
 import io.constellationnetwork.node.shared.domain.tokenlock.block.TokenLockBlockAcceptanceManager
@@ -80,19 +81,7 @@ object CurrencySnapshotProcessorSuite extends SimpleIOSuite with TransactionGene
 
           currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager
             .make(
-              FieldsAddedOrdinals(
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map.empty,
-                Map(Dev -> SnapshotOrdinal.MinValue)
-              ),
+              FieldsAddedOrdinalsFixtures.current,
               Dev,
               LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(50)),
               BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/Main.scala
@@ -77,16 +77,7 @@ object Main
       val appConfig = method.appConfig(reader, sharedConfig)
       SnapshotConfig
         .resolveEffectiveConsensusConfig(appConfig.snapshot, appConfig.environment)
-        .map(
-          _.copy(
-            lastGlobalSnapshotSyncOffset = sharedConfig.lastGlobalSnapshotsSync.syncOffset.value,
-            lastGlobalSnapshotsInMemory = sharedConfig.lastGlobalSnapshotsSync.maxLastGlobalSnapshotsInMemory.value,
-            currencySnapshotProtocolV1ActivationOrdinal = sharedConfig.fieldsAddedOrdinals
-              .currencySnapshotProtocolV1For(appConfig.environment)
-              .value
-              .value
-          )
-        )
+        .map(_.withSharedConfig(sharedConfig))
         .liftTo[IO]
         .map(_.some)
     }

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -256,20 +256,10 @@ object GlobalSnapshotConsensus {
           UpdateNodeParametersCutter.make(effectiveConsensusConfig.eventCutter.maxUpdateNodeParametersSize),
           appConfig.environment,
           DefaultDelegatedRewardsConfigProvider,
-          sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
-            sharedCfg.fieldsAddedOrdinals.tessellation3Migration,
-            sharedCfg.environment
-          ),
-          sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
-            sharedCfg.fieldsAddedOrdinals.setSumFix,
-            sharedCfg.environment
-          ),
-          sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
-            sharedCfg.fieldsAddedOrdinals.delegatedRewardsFullCommittee,
-            sharedCfg.environment
-          ),
-          sharedCfg.incrementalDelegatedStakingStartingOrdinal
-            .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue),
+          sharedCfg.fieldsAddedOrdinals.tessellation3MigrationFor(sharedCfg.environment),
+          sharedCfg.fieldsAddedOrdinals.setSumFixFor(sharedCfg.environment),
+          sharedCfg.fieldsAddedOrdinals.delegatedRewardsFullCommitteeFor(sharedCfg.environment),
+          sharedCfg.incrementalDelegatedStakingStartingOrdinalFor,
           mptStore,
           effectiveConsensusConfig.activeAdmissionPromoteThreshold
         )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -259,7 +259,7 @@ object GlobalSnapshotConsensus {
           sharedCfg.fieldsAddedOrdinals.tessellation3MigrationFor(sharedCfg.environment),
           sharedCfg.fieldsAddedOrdinals.setSumFixFor(sharedCfg.environment),
           sharedCfg.fieldsAddedOrdinals.delegatedRewardsFullCommitteeFor(sharedCfg.environment),
-          sharedCfg.incrementalDelegatedStakingStartingOrdinalFor,
+          sharedCfg.incrementalDelegatedStakingStartingOrdinalFor(sharedCfg.environment),
           mptStore,
           effectiveConsensusConfig.activeAdmissionPromoteThreshold
         )

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensus.scala
@@ -256,12 +256,18 @@ object GlobalSnapshotConsensus {
           UpdateNodeParametersCutter.make(effectiveConsensusConfig.eventCutter.maxUpdateNodeParametersSize),
           appConfig.environment,
           DefaultDelegatedRewardsConfigProvider,
-          sharedCfg.fieldsAddedOrdinals.tessellation3Migration
-            .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue),
-          sharedCfg.fieldsAddedOrdinals.setSumFix
-            .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue),
-          sharedCfg.fieldsAddedOrdinals.delegatedRewardsFullCommittee
-            .getOrElse(sharedCfg.environment, SnapshotOrdinal.MaxValue),
+          sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
+            sharedCfg.fieldsAddedOrdinals.tessellation3Migration,
+            sharedCfg.environment
+          ),
+          sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
+            sharedCfg.fieldsAddedOrdinals.setSumFix,
+            sharedCfg.environment
+          ),
+          sharedCfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
+            sharedCfg.fieldsAddedOrdinals.delegatedRewardsFullCommittee,
+            sharedCfg.environment
+          ),
           sharedCfg.incrementalDelegatedStakingStartingOrdinal
             .getOrElse(sharedCfg.environment, SnapshotOrdinal.MinValue),
           mptStore,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/ConfigLoadSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/ConfigLoadSuite.scala
@@ -29,7 +29,7 @@ object ConfigLoadSuite extends SimpleIOSuite {
 
   // Mirror of TessellationIOApp.loadConfigAs with Main.configFiles = List("dag-l0.conf"). Held in
   // sync by hand (configFiles is protected) -- it is a stable single-element list.
-  private val source: ConfigSource =
+  private val source =
     List("dag-l0.conf").foldRight(ConfigSource.default) { (file, acc) =>
       ConfigSource.resources(file).withFallback(acc)
     }
@@ -109,4 +109,31 @@ object ConfigLoadSuite extends SimpleIOSuite {
       expect(SnapshotConfig.resolveEffectiveConsensusConfig(invalid, AppEnvironment.Integrationnet).isLeft)
     }
   }
+  AppEnvironment.values.foreach { environment =>
+    test(s"${environment.entryName}: the named L0 config retains all shared activation values") {
+      for {
+        shared <- source.loadF[IO, SharedConfigReader]()
+        defaults <- ConfigSource.resources("application.conf").withFallback(source).loadF[IO, SharedConfigReader]()
+        app <- source.loadF[IO, AppConfigReader]()
+      } yield
+        SnapshotConfig
+          .resolveEffectiveConsensusConfig(app.snapshot, environment)
+          .fold(
+            error => failure(error.getMessage),
+            resolved => {
+              val effective = resolved.withSharedConfig(shared, environment)
+              expect.same(Some(defaults.ordinalConfigHashFor(environment)), effective.ordinalConfigHash) &&
+              expect.same(
+                resolved.withSharedConfig(defaults, environment).deterministicConfigHash,
+                effective.deterministicConfigHash
+              ) &&
+              expect.same(
+                shared.fieldsAddedOrdinals.currencySnapshotProtocolV1For(environment).value.value,
+                effective.currencySnapshotProtocolV1ActivationOrdinal
+              )
+            }
+          )
+    }
+  }
+
 }

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotConsensusFunctionsSuite.scala
@@ -25,8 +25,8 @@ import io.constellationnetwork.env.AppEnvironment.Dev
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.json.JsonSerializer
-import io.constellationnetwork.node.shared.config.DelegatedRewardsConfigProvider
 import io.constellationnetwork.node.shared.config.types._
+import io.constellationnetwork.node.shared.config.{DelegatedRewardsConfigProvider, FieldsAddedOrdinalsFixtures}
 import io.constellationnetwork.node.shared.domain.block.processing._
 import io.constellationnetwork.node.shared.domain.delegatedStake.{
   UpdateDelegatedStakeAcceptanceManager,
@@ -363,18 +363,7 @@ object GlobalSnapshotConsensusFunctionsSuite extends MutableIOSuite with Checker
 
     GlobalSnapshotAcceptanceManager
       .make[IO](
-        FieldsAddedOrdinals(
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty
-        ),
+        FieldsAddedOrdinalsFixtures.current,
         MetagraphsSyncConfig(PosInt(100)),
         Dev,
         bam,

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotStateChannelEventsProcessorSuite.scala
@@ -15,6 +15,7 @@ import io.constellationnetwork.env.AppEnvironment.Dev
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
+import io.constellationnetwork.node.shared.config.FieldsAddedOrdinalsFixtures
 import io.constellationnetwork.node.shared.config.types._
 import io.constellationnetwork.node.shared.domain.statechannel._
 import io.constellationnetwork.node.shared.domain.swap.block.AllowSpendBlockAcceptanceManager
@@ -123,19 +124,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
 
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
-        FieldsAddedOrdinals(
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map(Dev -> SnapshotOrdinal.MinValue)
-        ),
+        FieldsAddedOrdinalsFixtures.current,
         Dev,
         LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
@@ -186,19 +175,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
           currencySnapshotContextFns,
           feeCalculator,
           mptStore,
-          FieldsAddedOrdinals(
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            scFeeBalanceFromContext = Map(Dev -> SnapshotOrdinal.MinValue)
-          ),
+          FieldsAddedOrdinalsFixtures.current,
           Dev
         )
     } yield processor
@@ -407,19 +384,7 @@ object GlobalSnapshotStateChannelEventsProcessorSuite extends MutableIOSuite {
         contextFns,
         FeeCalculator.make(SortedMap.empty),
         mptStore,
-        FieldsAddedOrdinals(
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          scFeeBalanceFromContext = Map(Dev -> SnapshotOrdinal.MinValue)
-        ),
+        FieldsAddedOrdinalsFixtures.current,
         Dev
       )
       snapshotInfo = mkGlobalSnapshotInfo(SortedMap(address -> parentHash)).copy(

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/GlobalSnapshotTraverseSuite.scala
@@ -15,8 +15,8 @@ import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
-import io.constellationnetwork.node.shared.config.DefaultDelegatedRewardsConfigProvider
 import io.constellationnetwork.node.shared.config.types._
+import io.constellationnetwork.node.shared.config.{DefaultDelegatedRewardsConfigProvider, FieldsAddedOrdinalsFixtures}
 import io.constellationnetwork.node.shared.domain.delegatedStake.UpdateDelegatedStakeAcceptanceManager
 import io.constellationnetwork.node.shared.domain.node.UpdateNodeParametersAcceptanceManager
 import io.constellationnetwork.node.shared.domain.nodeCollateral.UpdateNodeCollateralAcceptanceManager
@@ -339,19 +339,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
       lastGlobalSnapshotStorage = LastSnapshotStorage.make[IO, GlobalIncrementalSnapshot, GlobalSnapshotInfo](lastSnapR)
 
       currencySnapshotAcceptanceManager <- CurrencySnapshotAcceptanceManager.make(
-        FieldsAddedOrdinals(
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map.empty,
-          Map(Dev -> SnapshotOrdinal.MinValue)
-        ),
+        FieldsAddedOrdinalsFixtures.current,
         Dev,
         LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
         BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, txHasher),
@@ -393,19 +381,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
           currencySnapshotContextFns,
           feeCalculator,
           mptStore,
-          FieldsAddedOrdinals(
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            scFeeBalanceFromContext = Map(Dev -> SnapshotOrdinal.MinValue)
-          ),
+          FieldsAddedOrdinalsFixtures.current,
           Dev
         )
       updateNodeParametersAcceptanceManager = UpdateNodeParametersAcceptanceManager.make(validators.updateNodeParametersValidator)
@@ -420,19 +396,7 @@ object GlobalSnapshotTraverseSuite extends MutableIOSuite with Checkers {
 
       snapshotAcceptanceManager = GlobalSnapshotAcceptanceManager
         .make[IO](
-          FieldsAddedOrdinals(
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map.empty,
-            Map(Dev -> SnapshotOrdinal.MinValue)
-          ),
+          FieldsAddedOrdinalsFixtures.current,
           MetagraphsSyncConfig(PosInt(100)),
           Dev,
           blockAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -22,8 +22,8 @@ import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.collection.MapRefUtils._
 import io.constellationnetwork.json.{JsonBrotliBinarySerializer, JsonSerializer}
 import io.constellationnetwork.kryo.KryoSerializer
-import io.constellationnetwork.node.shared.config.DefaultDelegatedRewardsConfigProvider
 import io.constellationnetwork.node.shared.config.types._
+import io.constellationnetwork.node.shared.config.{DefaultDelegatedRewardsConfigProvider, FieldsAddedOrdinalsFixtures}
 import io.constellationnetwork.node.shared.domain.delegatedStake.UpdateDelegatedStakeAcceptanceManager
 import io.constellationnetwork.node.shared.domain.globalAlignment.GlobalL0AlignmentStorage
 import io.constellationnetwork.node.shared.domain.node.UpdateNodeParametersAcceptanceManager
@@ -82,27 +82,6 @@ import weaver.SimpleIOSuite
 
 object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
   val TestValidationErrorStorageMaxSize: PosInt = PosInt(16)
-
-  private val devActivation: Map[AppEnvironment, SnapshotOrdinal] = Map(Dev -> SnapshotOrdinal.MinValue)
-
-  /** Snapshot reconciliation tests operate on post-migration state. The relevant gates are explicit so missing configuration remains
-    * unambiguously disabled.
-    */
-  private val postMigrationFieldsAddedOrdinals = FieldsAddedOrdinals(
-    tessellation3Migration = devActivation,
-    tessellation301Migration = devActivation,
-    checkSyncGlobalSnapshotField = devActivation,
-    metagraphSyncData = devActivation,
-    updatedLastSyncGlobalOrder = devActivation,
-    updatedLastSyncGlobalFromPeersInConsensus = devActivation,
-    updatingCombineFunctionSpendActions = devActivation,
-    fixingAllowSpendExpiration = devActivation,
-    fixingAllowSpendAndTokenLockValidation = devActivation,
-    setSumFix = devActivation,
-    fixingDataApplicationFeeValidation = devActivation,
-    fixingAllowSpendDestinationCredit = devActivation,
-    preventingAllowSpendResurrection = devActivation
-  )
 
   type TestResources = (
     SnapshotProcessor[IO, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
@@ -206,7 +185,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
                 CurrencySnapshotAcceptanceManager
                   .make(
-                    postMigrationFieldsAddedOrdinals,
+                    FieldsAddedOrdinalsFixtures.current,
                     Dev,
                     LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
                     BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
@@ -270,7 +249,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               globalSnapshotAcceptanceManager = {
                 implicit val testGlobalStateProofSelector: GlobalStateProofSelector = GlobalStateProofSelector(SnapshotOrdinal.MinValue)
                 GlobalSnapshotAcceptanceManager.make(
-                  postMigrationFieldsAddedOrdinals,
+                  FieldsAddedOrdinalsFixtures.current,
                   MetagraphsSyncConfig(PosInt(100)),
                   Dev,
                   BlockAcceptanceManager.make[IO](validators.blockValidator, Hasher.forKryo[IO]),
@@ -283,7 +262,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                       currencySnapshotContextFns,
                       feeCalculator,
                       mptStore,
-                      postMigrationFieldsAddedOrdinals.copy(scFeeBalanceFromContext = devActivation),
+                      FieldsAddedOrdinalsFixtures.current,
                       Dev
                     ),
                   updateNodeParametersAcceptanceManager,

--- a/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
+++ b/modules/dag-l1/src/test/scala/io/constellationnetwork/dag/l1/domain/snapshot/programs/SnapshotProcessorSuite.scala
@@ -16,6 +16,7 @@ import io.constellationnetwork.dag.l1.domain.block.BlockStorage
 import io.constellationnetwork.dag.l1.domain.block.BlockStorage._
 import io.constellationnetwork.dag.l1.domain.snapshot.programs.SnapshotProcessor._
 import io.constellationnetwork.dag.l1.domain.transaction._
+import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.env.AppEnvironment.{Dev, Mainnet}
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.ext.collection.MapRefUtils._
@@ -81,6 +82,27 @@ import weaver.SimpleIOSuite
 
 object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
   val TestValidationErrorStorageMaxSize: PosInt = PosInt(16)
+
+  private val devActivation: Map[AppEnvironment, SnapshotOrdinal] = Map(Dev -> SnapshotOrdinal.MinValue)
+
+  /** Snapshot reconciliation tests operate on post-migration state. The relevant gates are explicit so missing configuration remains
+    * unambiguously disabled.
+    */
+  private val postMigrationFieldsAddedOrdinals = FieldsAddedOrdinals(
+    tessellation3Migration = devActivation,
+    tessellation301Migration = devActivation,
+    checkSyncGlobalSnapshotField = devActivation,
+    metagraphSyncData = devActivation,
+    updatedLastSyncGlobalOrder = devActivation,
+    updatedLastSyncGlobalFromPeersInConsensus = devActivation,
+    updatingCombineFunctionSpendActions = devActivation,
+    fixingAllowSpendExpiration = devActivation,
+    fixingAllowSpendAndTokenLockValidation = devActivation,
+    setSumFix = devActivation,
+    fixingDataApplicationFeeValidation = devActivation,
+    fixingAllowSpendDestinationCredit = devActivation,
+    preventingAllowSpendResurrection = devActivation
+  )
 
   type TestResources = (
     SnapshotProcessor[IO, GlobalSnapshotStateProof, GlobalIncrementalSnapshot, GlobalSnapshotInfo],
@@ -184,18 +206,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
 
                 CurrencySnapshotAcceptanceManager
                   .make(
-                    FieldsAddedOrdinals(
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty
-                    ),
+                    postMigrationFieldsAddedOrdinals,
                     Dev,
                     LastGlobalSnapshotsSyncConfig(NonNegLong(2L), PosInt(10)),
                     BlockAcceptanceManager.make[IO](validators.currencyBlockValidator, Hasher.forKryo[IO]),
@@ -259,18 +270,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
               globalSnapshotAcceptanceManager = {
                 implicit val testGlobalStateProofSelector: GlobalStateProofSelector = GlobalStateProofSelector(SnapshotOrdinal.MinValue)
                 GlobalSnapshotAcceptanceManager.make(
-                  FieldsAddedOrdinals(
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty,
-                    Map.empty
-                  ),
+                  postMigrationFieldsAddedOrdinals,
                   MetagraphsSyncConfig(PosInt(100)),
                   Dev,
                   BlockAcceptanceManager.make[IO](validators.blockValidator, Hasher.forKryo[IO]),
@@ -283,19 +283,7 @@ object SnapshotProcessorSuite extends SimpleIOSuite with TransactionGenerator {
                       currencySnapshotContextFns,
                       feeCalculator,
                       mptStore,
-                      FieldsAddedOrdinals(
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        Map.empty,
-                        scFeeBalanceFromContext = Map(Dev -> SnapshotOrdinal.MinValue)
-                      ),
+                      postMigrationFieldsAddedOrdinals.copy(scFeeBalanceFromContext = devActivation),
                       Dev
                     ),
                   updateNodeParametersAcceptanceManager,

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -120,6 +120,8 @@ last-legacy-state-proof-ordinal {
 }
 
 incremental-delegated-staking-starting-ordinal {
+  # A legacy top-level threshold gate. SharedConfig resolves a missing environment to
+  # SnapshotOrdinal.MaxValue, matching the fields-added-ordinals disabled convention.
   mainnet: 5960000,
   testnet: 3070000,
   integrationnet: 5075000,

--- a/modules/node-shared/src/main/resources/application.conf
+++ b/modules/node-shared/src/main/resources/application.conf
@@ -208,6 +208,9 @@ last-global-snapshots-sync {
 }
 
 fields-added-ordinals {
+  # Every threshold map uses the same fallback: a missing environment resolves to
+  # SnapshotOrdinal.MaxValue and remains disabled. Use an explicit 0 for active-from-genesis
+  # behavior. Exact-key maps such as dust-sweeps are disabled naturally when absent.
   tessellation-3-migration {
     mainnet: 4409045,
     testnet: 2497000,

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
@@ -125,7 +125,7 @@ abstract class TessellationIOApp[A <: CliMethod](
         implicit val _globalStateProofSelector: GlobalStateProofSelector =
           GlobalStateProofSelector(
             cfg.lastLegacyStateProofOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MaxValue),
-            cfg.fieldsAddedOrdinals.subTrieRoots.getOrElse(cfg.environment, SnapshotOrdinal.MaxValue)
+            cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(cfg.fieldsAddedOrdinals.subTrieRoots, cfg.environment)
           )
 
         implicit val _currencyStateProofSelector: CurrencyStateProofSelector =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
@@ -119,12 +119,12 @@ abstract class TessellationIOApp[A <: CliMethod](
 
         val _hashSelect = new HashSelect {
           def select(ordinal: SnapshotOrdinal): HashLogic =
-            if (ordinal <= cfg.lastKryoHashOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MinValue)) KryoHash else JsonHash
+            if (ordinal <= cfg.lastKryoHashOrdinalFor(cfg.environment)) KryoHash else JsonHash
         }
 
         implicit val _globalStateProofSelector: GlobalStateProofSelector =
           GlobalStateProofSelector(
-            cfg.lastLegacyStateProofOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MaxValue),
+            cfg.lastLegacyStateProofOrdinalFor(cfg.environment),
             cfg.fieldsAddedOrdinals.subTrieRootsFor(cfg.environment)
           )
 

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/app/TessellationIOApp.scala
@@ -125,7 +125,7 @@ abstract class TessellationIOApp[A <: CliMethod](
         implicit val _globalStateProofSelector: GlobalStateProofSelector =
           GlobalStateProofSelector(
             cfg.lastLegacyStateProofOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MaxValue),
-            cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(cfg.fieldsAddedOrdinals.subTrieRoots, cfg.environment)
+            cfg.fieldsAddedOrdinals.subTrieRootsFor(cfg.environment)
           )
 
         implicit val _currencyStateProofSelector: CurrencyStateProofSelector =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -81,17 +81,27 @@ object types {
     // instead of also being refunded to its source. The separate gate preserves already-signed history.
     fixingGlobalAllowSpendExpiration: Map[AppEnvironment, SnapshotOrdinal] = Map.empty
   ) {
+
+    /** Resolve a threshold gate for one environment. A missing mapping must retain the historical path rather than silently enabling new
+      * behavior from genesis. Exact-key gates such as `dustSweeps` use absence as their natural disabled state instead.
+      */
+    private[constellationnetwork] def resolveWithDisabledDefault(
+      ordinals: Map[AppEnvironment, SnapshotOrdinal],
+      environment: AppEnvironment
+    ): SnapshotOrdinal =
+      ordinals.getOrElse(environment, SnapshotOrdinal.MaxValue)
+
     def feeTransactionSecurityFor(environment: AppEnvironment): SnapshotOrdinal =
-      feeTransactionSecurity.getOrElse(environment, SnapshotOrdinal.MaxValue)
+      resolveWithDisabledDefault(feeTransactionSecurity, environment)
 
     def currencySnapshotProtocolV1For(environment: AppEnvironment): SnapshotOrdinal =
-      currencySnapshotProtocolV1.getOrElse(environment, SnapshotOrdinal.MaxValue)
+      resolveWithDisabledDefault(currencySnapshotProtocolV1, environment)
 
     def fixingDataApplicationFeeValidationFor(environment: AppEnvironment): SnapshotOrdinal =
-      fixingDataApplicationFeeValidation.getOrElse(environment, SnapshotOrdinal.MinValue)
+      resolveWithDisabledDefault(fixingDataApplicationFeeValidation, environment)
 
     def fixingAllowSpendDestinationCreditFor(environment: AppEnvironment): SnapshotOrdinal =
-      fixingAllowSpendDestinationCredit.getOrElse(environment, SnapshotOrdinal.MinValue)
+      resolveWithDisabledDefault(fixingAllowSpendDestinationCredit, environment)
   }
 
   /** A single ordinal-gated GSI dust sweep (state deflation).

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -24,6 +24,19 @@ import fs2.io.file.Path
 
 object types {
 
+  /** Resolves an ordinal threshold for one environment. Missing configuration must preserve the historical path instead of enabling changed
+    * deterministic behavior from genesis.
+    *
+    * Exact-key schedules such as `FieldsAddedOrdinals.dustSweeps` do not use this resolver: absence is already their disabled state.
+    */
+  private[config] object SnapshotOrdinalGate {
+    def resolveOrDisabled(
+      ordinals: Map[AppEnvironment, SnapshotOrdinal],
+      environment: AppEnvironment
+    ): SnapshotOrdinal =
+      ordinals.getOrElse(environment, SnapshotOrdinal.MaxValue)
+  }
+
   // Keep this parameter order aligned with the explicit forProduct reader in ext.pureconfig.
   // Fields share similar map types, so reordering them without updating that reader can miswire gates.
   case class FieldsAddedOrdinals(
@@ -82,26 +95,68 @@ object types {
     fixingGlobalAllowSpendExpiration: Map[AppEnvironment, SnapshotOrdinal] = Map.empty
   ) {
 
-    /** Resolve a threshold gate for one environment. A missing mapping must retain the historical path rather than silently enabling new
-      * behavior from genesis. Exact-key gates such as `dustSweeps` use absence as their natural disabled state instead.
-      */
-    private[constellationnetwork] def resolveWithDisabledDefault(
-      ordinals: Map[AppEnvironment, SnapshotOrdinal],
-      environment: AppEnvironment
-    ): SnapshotOrdinal =
-      ordinals.getOrElse(environment, SnapshotOrdinal.MaxValue)
+    def tessellation3MigrationFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(tessellation3Migration, environment)
+
+    def tessellation301MigrationFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(tessellation301Migration, environment)
+
+    def checkSyncGlobalSnapshotFieldFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(checkSyncGlobalSnapshotField, environment)
+
+    def metagraphSyncDataFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(metagraphSyncData, environment)
+
+    def updatedLastSyncGlobalOrderFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(updatedLastSyncGlobalOrder, environment)
+
+    def updatedLastSyncGlobalFromPeersInConsensusFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(updatedLastSyncGlobalFromPeersInConsensus, environment)
+
+    def updatingCombineFunctionSpendActionsFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(updatingCombineFunctionSpendActions, environment)
+
+    def fixingAllowSpendExpirationFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(fixingAllowSpendExpiration, environment)
+
+    def fixingAllowSpendAndTokenLockValidationFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(fixingAllowSpendAndTokenLockValidation, environment)
+
+    def setSumFixFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(setSumFix, environment)
+
+    def scFeeBalanceFromContextFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(scFeeBalanceFromContext, environment)
+
+    def subTrieRootsFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(subTrieRoots, environment)
+
+    def delegatedRewardsFullCommitteeFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(delegatedRewardsFullCommittee, environment)
 
     def feeTransactionSecurityFor(environment: AppEnvironment): SnapshotOrdinal =
-      resolveWithDisabledDefault(feeTransactionSecurity, environment)
+      SnapshotOrdinalGate.resolveOrDisabled(feeTransactionSecurity, environment)
+
+    def fixingFeeTransactionBalanceOverflowFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(fixingFeeTransactionBalanceOverflow, environment)
+
+    def dustSweepFor(environment: AppEnvironment, ordinal: SnapshotOrdinal): Option[DustSweep] =
+      dustSweeps.get(environment).flatMap(_.get(ordinal))
 
     def currencySnapshotProtocolV1For(environment: AppEnvironment): SnapshotOrdinal =
-      resolveWithDisabledDefault(currencySnapshotProtocolV1, environment)
+      SnapshotOrdinalGate.resolveOrDisabled(currencySnapshotProtocolV1, environment)
 
     def fixingDataApplicationFeeValidationFor(environment: AppEnvironment): SnapshotOrdinal =
-      resolveWithDisabledDefault(fixingDataApplicationFeeValidation, environment)
+      SnapshotOrdinalGate.resolveOrDisabled(fixingDataApplicationFeeValidation, environment)
 
     def fixingAllowSpendDestinationCreditFor(environment: AppEnvironment): SnapshotOrdinal =
-      resolveWithDisabledDefault(fixingAllowSpendDestinationCredit, environment)
+      SnapshotOrdinalGate.resolveOrDisabled(fixingAllowSpendDestinationCredit, environment)
+
+    def preventingAllowSpendResurrectionFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(preventingAllowSpendResurrection, environment)
+
+    def fixingGlobalAllowSpendExpirationFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(fixingGlobalAllowSpendExpiration, environment)
   }
 
   /** A single ordinal-gated GSI dust sweep (state deflation).
@@ -205,7 +260,10 @@ object types {
     mptSnapshotInfoPath: Path,
     snapshotServingConfig: Option[SnapshotServingConfig] = None,
     localHealthMonitor: LocalHealthMonitorConfig = LocalHealthMonitorConfig.default
-  )
+  ) {
+    def incrementalDelegatedStakingStartingOrdinalFor: SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(incrementalDelegatedStakingStartingOrdinal, environment)
+  }
 
   case class SharedTrustConfig(
     storage: TrustStorageConfig

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/config/types.scala
@@ -24,8 +24,8 @@ import fs2.io.file.Path
 
 object types {
 
-  /** Resolves an ordinal threshold for one environment. Missing configuration must preserve the historical path instead of enabling changed
-    * deterministic behavior from genesis.
+  /** Resolves a first-active threshold for one environment. Missing configuration does not enable the new behavior. Required historical
+    * cutovers must be configured explicitly: retaining the old path is not a claim that pre-fix behavior is safe for a new network.
     *
     * Exact-key schedules such as `FieldsAddedOrdinals.dustSweeps` do not use this resolver: absence is already their disabled state.
     */
@@ -69,9 +69,9 @@ object types {
     // snapshot contains, so an ungated rollout diverges any node syncing from genesis. Mainnet activates at the mint ordinal.
     fixingFeeTransactionBalanceOverflow: Map[AppEnvironment, SnapshotOrdinal] = Map.empty,
     // Ordinal-gated GSI dust sweeps (state deflation), per environment, keyed by the ordinal each sweep fires at. Loaded from
-    // the `fields-added-ordinals.dust-sweeps` HOCON block. This runtime configuration is not covered by the join-time
-    // `versionHash`, which hashes the advertised version string (or `CL_VERSION_HASH`), so operators must deploy one reviewed value
-    // per environment. Default empty: an environment with no entry never sweeps. See `DustSweep` and `GlobalSnapshotDustSweep`.
+    // the `fields-added-ordinals.dust-sweeps` HOCON block. Both L0 config hashes bind the resolved schedule, threshold, and destination;
+    // the separate `versionHash` checks the advertised software version. Default empty: no entry means no sweep.
+    // See `DustSweep` and `GlobalSnapshotDustSweep`.
     dustSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] = Map.empty,
     // Appended to preserve positional source compatibility for existing SDK consumers.
     // At/after this GLOBAL L0 ordinal a Currency snapshot lineage may transition from
@@ -157,6 +157,31 @@ object types {
 
     def fixingGlobalAllowSpendExpirationFor(environment: AppEnvironment): SnapshotOrdinal =
       SnapshotOrdinalGate.resolveOrDisabled(fixingGlobalAllowSpendExpiration, environment)
+
+    /** The same accessors used by snapshot consumers, in a stable order for the consensus configuration hash. */
+    def resolvedThresholdsFor(environment: AppEnvironment): SortedMap[String, SnapshotOrdinal] =
+      SortedMap(
+        "tessellation3Migration" -> tessellation3MigrationFor(environment),
+        "tessellation301Migration" -> tessellation301MigrationFor(environment),
+        "checkSyncGlobalSnapshotField" -> checkSyncGlobalSnapshotFieldFor(environment),
+        "metagraphSyncData" -> metagraphSyncDataFor(environment),
+        "updatedLastSyncGlobalOrder" -> updatedLastSyncGlobalOrderFor(environment),
+        "updatedLastSyncGlobalFromPeersInConsensus" -> updatedLastSyncGlobalFromPeersInConsensusFor(environment),
+        "updatingCombineFunctionSpendActions" -> updatingCombineFunctionSpendActionsFor(environment),
+        "fixingAllowSpendExpiration" -> fixingAllowSpendExpirationFor(environment),
+        "fixingAllowSpendAndTokenLockValidation" -> fixingAllowSpendAndTokenLockValidationFor(environment),
+        "setSumFix" -> setSumFixFor(environment),
+        "scFeeBalanceFromContext" -> scFeeBalanceFromContextFor(environment),
+        "subTrieRoots" -> subTrieRootsFor(environment),
+        "delegatedRewardsFullCommittee" -> delegatedRewardsFullCommitteeFor(environment),
+        "feeTransactionSecurity" -> feeTransactionSecurityFor(environment),
+        "fixingFeeTransactionBalanceOverflow" -> fixingFeeTransactionBalanceOverflowFor(environment),
+        "currencySnapshotProtocolV1" -> currencySnapshotProtocolV1For(environment),
+        "fixingDataApplicationFeeValidation" -> fixingDataApplicationFeeValidationFor(environment),
+        "fixingAllowSpendDestinationCredit" -> fixingAllowSpendDestinationCreditFor(environment),
+        "preventingAllowSpendResurrection" -> preventingAllowSpendResurrectionFor(environment),
+        "fixingGlobalAllowSpendExpiration" -> fixingGlobalAllowSpendExpirationFor(environment)
+      )
   }
 
   /** A single ordinal-gated GSI dust sweep (state deflation).
@@ -205,6 +230,45 @@ object types {
     val default: LocalHealthMonitorConfig = LocalHealthMonitorConfig()
   }
 
+  /** Shared by the loaded configuration and its runtime projection. Only the selected environment enters the hash. */
+  trait SnapshotOrdinalConfig {
+    def lastGlobalSnapshotsSync: LastGlobalSnapshotsSyncConfig
+    def fieldsAddedOrdinals: FieldsAddedOrdinals
+    def lastKryoHashOrdinal: Map[AppEnvironment, SnapshotOrdinal]
+    def lastLegacyStateProofOrdinal: Map[AppEnvironment, SnapshotOrdinal]
+    def incrementalDelegatedStakingStartingOrdinal: Map[AppEnvironment, SnapshotOrdinal]
+
+    // These are last-legacy boundaries, not first-active thresholds. Preserve their existing defaults.
+    def lastKryoHashOrdinalFor(environment: AppEnvironment): SnapshotOrdinal =
+      lastKryoHashOrdinal.getOrElse(environment, SnapshotOrdinal.MinValue)
+
+    def lastLegacyStateProofOrdinalFor(environment: AppEnvironment): SnapshotOrdinal =
+      lastLegacyStateProofOrdinal.getOrElse(environment, SnapshotOrdinal.MaxValue)
+
+    def incrementalDelegatedStakingStartingOrdinalFor(environment: AppEnvironment): SnapshotOrdinal =
+      SnapshotOrdinalGate.resolveOrDisabled(incrementalDelegatedStakingStartingOrdinal, environment)
+
+    def ordinalConfigHashFor(environment: AppEnvironment): Hash = {
+      val thresholds = fieldsAddedOrdinals
+        .resolvedThresholdsFor(environment)
+        .updated("lastKryoHashOrdinal", lastKryoHashOrdinalFor(environment))
+        .updated("lastLegacyStateProofOrdinal", lastLegacyStateProofOrdinalFor(environment))
+        .updated("incrementalDelegatedStakingStartingOrdinal", incrementalDelegatedStakingStartingOrdinalFor(environment))
+      val thresholdValues = thresholds.iterator.map { case (name, ordinal) => s"$name=${ordinal.value.value}" }.mkString(",")
+      // Bind the whole schedule, including burn/credit disposition. SortedMap fixes ordering;
+      // field names and validated addresses cannot contain the separators used here.
+      val sweeps = fieldsAddedOrdinals.dustSweeps
+        .getOrElse(environment, SortedMap.empty[SnapshotOrdinal, DustSweep])
+        .iterator
+        .map {
+          case (ordinal, sweep) =>
+            s"${ordinal.value.value}:${sweep.threshold.value.value}:${sweep.collectionAddress.fold("burn")(_.value.value)}"
+        }
+        .mkString(",")
+      Hash.fromBytes(s"$thresholdValues;dustSweeps=[$sweeps]".getBytes("UTF-8"))
+    }
+  }
+
   case class SharedConfigReader(
     gossip: GossipConfig,
     leavingDelay: FiniteDuration,
@@ -229,7 +293,7 @@ object types {
     snapshotBinarySenderTimeouts: SnapshotBinarySenderTimeoutsConfig,
     clickHouseConfig: ClickHouseAppConfig,
     snapshotServing: Option[SnapshotServingConfig] = None
-  )
+  ) extends SnapshotOrdinalConfig
 
   case class SharedConfig(
     environment: AppEnvironment,
@@ -260,10 +324,7 @@ object types {
     mptSnapshotInfoPath: Path,
     snapshotServingConfig: Option[SnapshotServingConfig] = None,
     localHealthMonitor: LocalHealthMonitorConfig = LocalHealthMonitorConfig.default
-  ) {
-    def incrementalDelegatedStakingStartingOrdinalFor: SnapshotOrdinal =
-      SnapshotOrdinalGate.resolveOrDisabled(incrementalDelegatedStakingStartingOrdinal, environment)
-  }
+  ) extends SnapshotOrdinalConfig
 
   case class SharedTrustConfig(
     storage: TrustStorageConfig
@@ -1028,8 +1089,24 @@ object types {
     lastGlobalSnapshotsInMemory: Int = 0,
     // Global-ordinal boundary at which Currency snapshot protocol 1.0.0 becomes
     // legal. This is distinct from each L0's local v35 consensus-envelope key.
-    currencySnapshotProtocolV1ActivationOrdinal: Long = Long.MaxValue
+    currencySnapshotProtocolV1ActivationOrdinal: Long = Long.MaxValue,
+    // Resolved shared activation thresholds and dust-sweep schedule. Populated from the same
+    // SharedConfig used by snapshot consumers, before both joining and consensus construction.
+    ordinalConfigHash: Option[Hash] = None
   ) {
+    def withSharedConfig(sharedConfig: SharedConfig): ConsensusConfig =
+      withSharedConfig(sharedConfig, sharedConfig.environment)
+
+    def withSharedConfig(sharedConfig: SnapshotOrdinalConfig, environment: AppEnvironment): ConsensusConfig =
+      copy(
+        lastGlobalSnapshotSyncOffset = sharedConfig.lastGlobalSnapshotsSync.syncOffset.value,
+        lastGlobalSnapshotsInMemory = sharedConfig.lastGlobalSnapshotsSync.maxLastGlobalSnapshotsInMemory.value,
+        currencySnapshotProtocolV1ActivationOrdinal = sharedConfig.fieldsAddedOrdinals
+          .currencySnapshotProtocolV1For(environment)
+          .value
+          .value,
+        ordinalConfigHash = Some(sharedConfig.ordinalConfigHashFor(environment))
+      )
 
     def certifiedConsensusActiveAt(key: Long): Boolean =
       key >= certifiedConsensusActivationKey
@@ -1178,6 +1255,7 @@ object types {
           s"lastGlobalSnapshotSyncOffset=$lastGlobalSnapshotSyncOffset," +
           s"lastGlobalSnapshotsInMemory=$lastGlobalSnapshotsInMemory," +
           s"currencySnapshotProtocolV1ActivationOrdinal=$currencySnapshotProtocolV1ActivationOrdinal," +
+          s"ordinalConfigHash=${ordinalConfigHash.fold("unresolved")(_.value)}," +
           // v7 schema-version anchor; explicit fence against mixed-wire-version cluster joins.
           s"consensusSchemaVersion=$consensusSchemaVersion"
       Hash.fromBytes(configString.getBytes("UTF-8"))

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/ext/pureconfig/pureconfig.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/ext/pureconfig/pureconfig.scala
@@ -18,6 +18,7 @@ import io.constellationnetwork.schema.priceOracle.TokenPair
 import io.constellationnetwork.schema.priceOracle.TokenPair.DAG_USD
 import io.constellationnetwork.schema.transaction.TransactionFee
 import io.constellationnetwork.schema.{NonNegFraction, SnapshotOrdinal}
+import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
 
 import _root_.pureconfig.ConvertHelpers.catchReadError
@@ -35,6 +36,7 @@ package object pureconfig {
   implicit val balanceReader: ConfigReader[Balance] = ConfigReader[NonNegLong].map(Balance(_))
   implicit val transactionFeeReader: ConfigReader[TransactionFee] = ConfigReader[NonNegLong].map(TransactionFee(_))
   implicit val peerIdReader: ConfigReader[PeerId] = ConfigReader[String].map(Hex(_)).map(PeerId(_))
+  implicit val hashReader: ConfigReader[Hash] = ConfigReader[String].map(Hash(_))
   implicit val ordinalReader: ConfigReader[SnapshotOrdinal] = ConfigReader[NonNegLong].map(SnapshotOrdinal(_))
   implicit val epochProgressReader: ConfigReader[EpochProgress] = ConfigReader[NonNegLong].map(EpochProgress(_))
   implicit val environmentToOrdinalMapReader: ConfigReader[Map[AppEnvironment, SnapshotOrdinal]] =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
@@ -200,23 +200,23 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
     metagraphId = lastSnapshotContext.address
 
     checkSyncGlobalSnapshotField =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.checkSyncGlobalSnapshotField, environment)
+      fieldsAddedOrdinals.checkSyncGlobalSnapshotFieldFor(environment)
     tessellation3MigrationStartingOrdinal =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.tessellation3Migration, environment)
+      fieldsAddedOrdinals.tessellation3MigrationFor(environment)
     metagraphSyncDataStartingOrdinal =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.metagraphSyncData, environment)
+      fieldsAddedOrdinals.metagraphSyncDataFor(environment)
     updatedLastSyncGlobalOrder =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.updatedLastSyncGlobalOrder, environment)
+      fieldsAddedOrdinals.updatedLastSyncGlobalOrderFor(environment)
     updatedLastSyncGlobalFromPeersInConsensus =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensus, environment)
+      fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensusFor(environment)
     updatingCombineFunctionSpendActions =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.updatingCombineFunctionSpendActions, environment)
+      fieldsAddedOrdinals.updatingCombineFunctionSpendActionsFor(environment)
     fixingAllowSpendExpiration =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingAllowSpendExpiration, environment)
+      fieldsAddedOrdinals.fixingAllowSpendExpirationFor(environment)
     fixingAllowSpendAndTokenLockValidation =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation, environment)
+      fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidationFor(environment)
     preventingAllowSpendResurrection =
-      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.preventingAllowSpendResurrection, environment)
+      fieldsAddedOrdinals.preventingAllowSpendResurrectionFor(environment)
 
     acceptanceBlocksResult <- blockOps.acceptBlocks(
       blocksForAcceptance,
@@ -262,7 +262,7 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
       updatedBalancesByRewards,
       feeTransactionsForAcceptance,
       maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >
-        fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow, environment)
+        fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflowFor(environment)
     )
 
     callerSharedArtifacts = sharedArtifactsForAcceptance

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/currency/CurrencySnapshotAcceptanceManager.scala
@@ -199,24 +199,24 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
     initialAllowSpendRef <- AllowSpendReference.emptyCurrency(lastSnapshotContext.address)
     metagraphId = lastSnapshotContext.address
 
-    checkSyncGlobalSnapshotField = fieldsAddedOrdinals.checkSyncGlobalSnapshotField
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    tessellation3MigrationStartingOrdinal = fieldsAddedOrdinals.tessellation3Migration
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    metagraphSyncDataStartingOrdinal = fieldsAddedOrdinals.metagraphSyncData
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    updatedLastSyncGlobalOrder = fieldsAddedOrdinals.updatedLastSyncGlobalOrder
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    updatedLastSyncGlobalFromPeersInConsensus = fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensus
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    updatingCombineFunctionSpendActions = fieldsAddedOrdinals.updatingCombineFunctionSpendActions
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    fixingAllowSpendExpiration = fieldsAddedOrdinals.fixingAllowSpendExpiration
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    fixingAllowSpendAndTokenLockValidation = fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
-    preventingAllowSpendResurrection = fieldsAddedOrdinals.preventingAllowSpendResurrection
-      .getOrElse(environment, SnapshotOrdinal.MinValue)
+    checkSyncGlobalSnapshotField =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.checkSyncGlobalSnapshotField, environment)
+    tessellation3MigrationStartingOrdinal =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.tessellation3Migration, environment)
+    metagraphSyncDataStartingOrdinal =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.metagraphSyncData, environment)
+    updatedLastSyncGlobalOrder =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.updatedLastSyncGlobalOrder, environment)
+    updatedLastSyncGlobalFromPeersInConsensus =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensus, environment)
+    updatingCombineFunctionSpendActions =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.updatingCombineFunctionSpendActions, environment)
+    fixingAllowSpendExpiration =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingAllowSpendExpiration, environment)
+    fixingAllowSpendAndTokenLockValidation =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation, environment)
+    preventingAllowSpendResurrection =
+      fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.preventingAllowSpendResurrection, environment)
 
     acceptanceBlocksResult <- blockOps.acceptBlocks(
       blocksForAcceptance,
@@ -262,7 +262,7 @@ private class CurrencySnapshotAcceptanceManagerImpl[F[_]: Async: Parallel: JsonS
       updatedBalancesByRewards,
       feeTransactionsForAcceptance,
       maybeLastGlobalSyncView.map(_.ordinal).getOrElse(SnapshotOrdinal.MinValue) >
-        fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow.getOrElse(environment, SnapshotOrdinal.MaxValue)
+        fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow, environment)
     )
 
     callerSharedArtifacts = sharedArtifactsForAcceptance

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -649,27 +649,27 @@ object GlobalSnapshotAcceptanceManager {
         implicit val hasher: Hasher[F] = HasherSelector[F].getForOrdinal(ordinal)
 
         val tessellation3MigrationStartingOrdinal =
-          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.tessellation3Migration, environment)
+          fieldsAddedOrdinals.tessellation3MigrationFor(environment)
 
         val tessellation301MigrationStartingOrdinal =
-          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.tessellation301Migration, environment)
+          fieldsAddedOrdinals.tessellation301MigrationFor(environment)
 
         val metagraphSyncDataStartingOrdinal =
-          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.metagraphSyncData, environment)
+          fieldsAddedOrdinals.metagraphSyncDataFor(environment)
 
         val preventingAllowSpendResurrectionOrdinal =
-          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.preventingAllowSpendResurrection, environment)
+          fieldsAddedOrdinals.preventingAllowSpendResurrectionFor(environment)
 
         // Below the activation ordinal the retired-reference ledger is neither read nor written, so signed history
         // replays byte-identically: the new GlobalSnapshotInfo field stays None and JsonSerializer drops nulls.
         val preventAllowSpendResurrection = ordinal > preventingAllowSpendResurrectionOrdinal
 
         val fixingGlobalAllowSpendExpirationOrdinal =
-          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingGlobalAllowSpendExpiration, environment)
+          fieldsAddedOrdinals.fixingGlobalAllowSpendExpirationFor(environment)
         val suppressSpentExpiredAllowSpends = ordinal >= fixingGlobalAllowSpendExpirationOrdinal
 
         val fixingAllowSpendAndTokenLockValidation =
-          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation, environment)
+          fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidationFor(environment)
 
         loggerBundle.app.withOrdinal(ordinal) {
           for {
@@ -1148,7 +1148,8 @@ object GlobalSnapshotAcceptanceManager {
             // Applied to the fully-built GSI BEFORE the MPT sync and proof so that the returned GSI, the MPT-sync input,
             // and buildProof all derive from the SAME swept state (sweptGsi == gsi2). Off the sweep ordinal this is a no-op
             // (didSweep = false) and gsi2 is the same value as gsi, so the normal incremental MPT path is unchanged.
-            (sweptGsi, didSweep) = GlobalSnapshotDustSweep.applyDustSweep(gsi, ordinal, environment, fieldsAddedOrdinals.dustSweeps)
+            (sweptGsi, didSweep) =
+              GlobalSnapshotDustSweep.applyDustSweep(gsi, fieldsAddedOrdinals.dustSweepFor(environment, ordinal))
 
             _ <- loggerBundle.app
               .info(

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotAcceptanceManager.scala
@@ -648,28 +648,28 @@ object GlobalSnapshotAcceptanceManager {
       ] = {
         implicit val hasher: Hasher[F] = HasherSelector[F].getForOrdinal(ordinal)
 
-        val tessellation3MigrationStartingOrdinal = fieldsAddedOrdinals.tessellation3Migration
-          .getOrElse(environment, SnapshotOrdinal.MinValue)
+        val tessellation3MigrationStartingOrdinal =
+          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.tessellation3Migration, environment)
 
-        val tessellation301MigrationStartingOrdinal = fieldsAddedOrdinals.tessellation301Migration
-          .getOrElse(environment, SnapshotOrdinal.MinValue)
+        val tessellation301MigrationStartingOrdinal =
+          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.tessellation301Migration, environment)
 
-        val metagraphSyncDataStartingOrdinal = fieldsAddedOrdinals.metagraphSyncData
-          .getOrElse(environment, SnapshotOrdinal.MinValue)
+        val metagraphSyncDataStartingOrdinal =
+          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.metagraphSyncData, environment)
 
-        val preventingAllowSpendResurrectionOrdinal = fieldsAddedOrdinals.preventingAllowSpendResurrection
-          .getOrElse(environment, SnapshotOrdinal.MinValue)
+        val preventingAllowSpendResurrectionOrdinal =
+          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.preventingAllowSpendResurrection, environment)
 
         // Below the activation ordinal the retired-reference ledger is neither read nor written, so signed history
         // replays byte-identically: the new GlobalSnapshotInfo field stays None and JsonSerializer drops nulls.
         val preventAllowSpendResurrection = ordinal > preventingAllowSpendResurrectionOrdinal
 
-        val fixingGlobalAllowSpendExpirationOrdinal = fieldsAddedOrdinals.fixingGlobalAllowSpendExpiration
-          .getOrElse(environment, SnapshotOrdinal.MaxValue)
+        val fixingGlobalAllowSpendExpirationOrdinal =
+          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingGlobalAllowSpendExpiration, environment)
         val suppressSpentExpiredAllowSpends = ordinal >= fixingGlobalAllowSpendExpirationOrdinal
 
-        val fixingAllowSpendAndTokenLockValidation = fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation
-          .getOrElse(environment, SnapshotOrdinal.MinValue)
+        val fixingAllowSpendAndTokenLockValidation =
+          fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation, environment)
 
         loggerBundle.app.withOrdinal(ordinal) {
           for {

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotDustSweep.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotDustSweep.scala
@@ -4,12 +4,11 @@ import cats.syntax.eq._
 
 import scala.collection.immutable.SortedMap
 
-import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.node.shared.config.types.DustSweep
+import io.constellationnetwork.schema.GlobalSnapshotInfo
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.balance.Balance
 import io.constellationnetwork.schema.transaction.TransactionReference
-import io.constellationnetwork.schema.{GlobalSnapshotInfo, SnapshotOrdinal}
 
 import eu.timepit.refined.types.numeric.NonNegLong
 
@@ -22,13 +21,13 @@ import eu.timepit.refined.types.numeric.NonNegLong
   * '''This is consensus-critical.''' Every honest node MUST compute the identical swept `GlobalSnapshotInfo` and the identical MPT state
   * root at the sweep ordinal, or the cluster forks. The transform is a pure function of the GSI map contents at a fixed ordinal (sorted
   * maps, commutative datum sum), so every node at the sweep ordinal computes the identical pruned GSI and root. The gating, threshold, and
-  * burn-vs-treasury choice come from the per-environment compile-time `dustSweeps` config literal (NOT HOCON): the advertised release plus
-  * the environment is the determinism fence.
+  * burn-vs-treasury choice come from the per-environment `dustSweeps` HOCON packaged into the assembly: the advertised release plus the
+  * environment is the determinism fence.
   *
   * Safety gates (an address is swept only if ALL hold):
   *
-  *   1. ORDINAL GATE: the sweep fires only when `dustSweeps.get(env).flatMap(_.get(ordinal))` returns a `DustSweep` (exact-key lookup). An
-  *      entry fires exactly once at its ordinal and never replays; an absent environment never sweeps.
+  *   1. ORDINAL GATE: `FieldsAddedOrdinals.dustSweepFor` passes a `DustSweep` only at an exact configured environment/ordinal key. An entry
+  *      fires exactly once at its ordinal and never replays; an absent environment never sweeps.
   *
   * 2. DUST THRESHOLD: only an address with `balance.value <= threshold.value` is eligible.
   *
@@ -126,18 +125,15 @@ object GlobalSnapshotDustSweep {
 
   /** Apply the ordinal-gated dust sweep as a post-construction transform.
     *
-    * Returns `(gsi, false)` unchanged for any ordinal/environment outside the gate (the normal path: one map lookup returning `None`). At
-    * exactly a configured sweep ordinal it partitions `balances` by the dust threshold, the empty-ref gate, the exclusion set, and the
-    * collection-address guard, credits the collected sum to the treasury (or burns it), prunes the swept addresses' `lastTxRefs`, and
-    * returns `(swept gsi, true)`.
+    * Returns `(gsi, false)` unchanged when the resolved sweep is absent. For a configured sweep it partitions `balances` by the dust
+    * threshold, the empty-ref gate, the exclusion set, and the collection-address guard, credits the collected sum to the treasury (or
+    * burns it), prunes the swept addresses' `lastTxRefs`, and returns `(swept gsi, true)`.
     */
   def applyDustSweep(
     gsi: GlobalSnapshotInfo,
-    ordinal: SnapshotOrdinal,
-    env: AppEnvironment,
-    sweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]]
+    sweep: Option[DustSweep]
   ): (GlobalSnapshotInfo, Boolean) =
-    sweeps.get(env).flatMap(_.get(ordinal)) match {
+    sweep match {
       case None => (gsi, false) // normal path, ~free
       case Some(DustSweep(threshold, collection)) =>
         val protectedAddrs = addressesWithNonBalanceState(gsi) // single union Set[Address]

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotDustSweep.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotDustSweep.scala
@@ -21,13 +21,14 @@ import eu.timepit.refined.types.numeric.NonNegLong
   * '''This is consensus-critical.''' Every honest node MUST compute the identical swept `GlobalSnapshotInfo` and the identical MPT state
   * root at the sweep ordinal, or the cluster forks. The transform is a pure function of the GSI map contents at a fixed ordinal (sorted
   * maps, commutative datum sum), so every node at the sweep ordinal computes the identical pruned GSI and root. The gating, threshold, and
-  * burn-vs-treasury choice come from the per-environment `dustSweeps` HOCON packaged into the assembly: the advertised release plus the
-  * environment is the determinism fence.
+  * burn-vs-treasury choice come from the per-environment `dustSweeps` HOCON packaged into the assembly. Both L0 consensus config hashes
+  * include the resolved schedule, thresholds, and destinations; the separate version check rejects different software versions. Deploy one
+  * reviewed configuration through the normal full-cluster cold restart. Matching hashes do not prove a shared value is correct.
   *
   * Safety gates (an address is swept only if ALL hold):
   *
   *   1. ORDINAL GATE: `FieldsAddedOrdinals.dustSweepFor` passes a `DustSweep` only at an exact configured environment/ordinal key. An entry
-  *      fires exactly once at its ordinal and never replays; an absent environment never sweeps.
+  *      fires at its ordinal during production or historical replay; an absent environment never sweeps.
   *
   * 2. DUST THRESHOLD: only an address with `balance.value <= threshold.value` is eligible.
   *

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
@@ -90,7 +90,7 @@ object GlobalSnapshotStateChannelEventsProcessor {
       // ordinal. Fail closed: an unset env defaults to MaxValue so the context-balance path stays OFF
       // (the gate never fires) rather than activating from genesis and diverging replay.
       private val scFeeBalanceFromContextOrdinal: SnapshotOrdinal =
-        fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.scFeeBalanceFromContext, environment)
+        fieldsAddedOrdinals.scFeeBalanceFromContextFor(environment)
 
       def deserialize[A: Decoder](binary: Signed[StateChannelSnapshotBinary]): F[Option[A]] =
         JsonSerializer[F].deserialize[A](binary.value.content).map(_.toOption)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotStateChannelEventsProcessor.scala
@@ -90,7 +90,7 @@ object GlobalSnapshotStateChannelEventsProcessor {
       // ordinal. Fail closed: an unset env defaults to MaxValue so the context-balance path stays OFF
       // (the gate never fires) rather than activating from genesis and diverging replay.
       private val scFeeBalanceFromContextOrdinal: SnapshotOrdinal =
-        fieldsAddedOrdinals.scFeeBalanceFromContext.getOrElse(environment, SnapshotOrdinal.MaxValue)
+        fieldsAddedOrdinals.resolveWithDisabledDefault(fieldsAddedOrdinals.scFeeBalanceFromContext, environment)
 
       def deserialize[A: Decoder](binary: Signed[StateChannelSnapshotBinary]): F[Option[A]] =
         JsonSerializer[F].deserialize[A](binary.value.content).map(_.toOption)

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -154,7 +154,10 @@ object SharedServices {
 
       currencySnapshotValidator = CurrencySnapshotValidator.make[F](
         CurrencySnapshotCreator.make[F](
-          cfg.fieldsAddedOrdinals.tessellation3Migration.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
+          cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
+            cfg.fieldsAddedOrdinals.tessellation3Migration,
+            cfg.environment
+          ),
           currencySnapshotAcceptanceManager,
           None,
           cfg.snapshotSize,
@@ -164,8 +167,7 @@ object SharedServices {
         validators.signedValidator,
         None,
         None,
-        cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit
-          .getOrElse(cfg.environment, SnapshotOrdinal.MinValue)
+        cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(cfg.environment)
       )
       currencySnapshotContextFns = CurrencySnapshotContextFunctions.make(
         currencySnapshotValidator
@@ -212,11 +214,11 @@ object SharedServices {
         globalSnapshotAcceptanceManager,
         updateDelegatedStakeAcceptanceManager,
         cfg.delegatedStaking.withdrawalTimeLimit.getOrElse(cfg.environment, EpochProgress.MinValue),
-        cfg.fieldsAddedOrdinals.tessellation3Migration.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
-        cfg.fieldsAddedOrdinals.setSumFix.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
+        cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(cfg.fieldsAddedOrdinals.tessellation3Migration, cfg.environment),
+        cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(cfg.fieldsAddedOrdinals.setSumFix, cfg.environment),
         storages.mptStore,
         cfg.incrementalDelegatedStakingStartingOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
-        cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCredit.getOrElse(cfg.environment, SnapshotOrdinal.MinValue)
+        cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(cfg.environment)
       )
     } yield
       new SharedServices[F, A](

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -154,10 +154,7 @@ object SharedServices {
 
       currencySnapshotValidator = CurrencySnapshotValidator.make[F](
         CurrencySnapshotCreator.make[F](
-          cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(
-            cfg.fieldsAddedOrdinals.tessellation3Migration,
-            cfg.environment
-          ),
+          cfg.fieldsAddedOrdinals.tessellation3MigrationFor(cfg.environment),
           currencySnapshotAcceptanceManager,
           None,
           cfg.snapshotSize,
@@ -214,10 +211,10 @@ object SharedServices {
         globalSnapshotAcceptanceManager,
         updateDelegatedStakeAcceptanceManager,
         cfg.delegatedStaking.withdrawalTimeLimit.getOrElse(cfg.environment, EpochProgress.MinValue),
-        cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(cfg.fieldsAddedOrdinals.tessellation3Migration, cfg.environment),
-        cfg.fieldsAddedOrdinals.resolveWithDisabledDefault(cfg.fieldsAddedOrdinals.setSumFix, cfg.environment),
+        cfg.fieldsAddedOrdinals.tessellation3MigrationFor(cfg.environment),
+        cfg.fieldsAddedOrdinals.setSumFixFor(cfg.environment),
         storages.mptStore,
-        cfg.incrementalDelegatedStakingStartingOrdinal.getOrElse(cfg.environment, SnapshotOrdinal.MinValue),
+        cfg.incrementalDelegatedStakingStartingOrdinalFor,
         cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(cfg.environment)
       )
     } yield

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/modules/SharedServices.scala
@@ -214,7 +214,7 @@ object SharedServices {
         cfg.fieldsAddedOrdinals.tessellation3MigrationFor(cfg.environment),
         cfg.fieldsAddedOrdinals.setSumFixFor(cfg.environment),
         storages.mptStore,
-        cfg.incrementalDelegatedStakingStartingOrdinalFor,
+        cfg.incrementalDelegatedStakingStartingOrdinalFor(cfg.environment),
         cfg.fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(cfg.environment)
       )
     } yield

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/ConsensusOrdinalConfigSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/ConsensusOrdinalConfigSuite.scala
@@ -1,0 +1,125 @@
+package io.constellationnetwork.node.shared.config
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.env.AppEnvironment
+import io.constellationnetwork.node.shared.config.types.{ConsensusConfig, EventCutterConfig, SharedConfigReader}
+import io.constellationnetwork.node.shared.ext.pureconfig._
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import com.typesafe.config.ConfigValueFactory
+import eu.timepit.refined.auto._
+import eu.timepit.refined.pureconfig._
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+import pureconfig.module.enumeratum._
+import weaver.SimpleIOSuite
+
+object ConsensusOrdinalConfigSuite extends SimpleIOSuite {
+  // SharedConfigReader also requires this layer-specific setting; both L0 configs supply it.
+  private val source = ConfigSource
+    .string("state-after-joining = WaitingForDownload")
+    .withFallback(ConfigSource.resources("application.conf"))
+  private lazy val packaged = source.loadOrThrow[SharedConfigReader]
+  private lazy val raw = source.config().fold(errors => throw new IllegalStateException(errors.toString), identity)
+  private val base = ConsensusConfig(10.seconds, 10.seconds, 100L, 10.seconds, EventCutterConfig(1024, 1024))
+
+  private def hash(config: SharedConfigReader, environment: AppEnvironment) =
+    base.withSharedConfig(config, environment).deterministicConfigHash
+
+  private def replace(path: String, value: AnyRef): SharedConfigReader =
+    ConfigSource.fromConfig(raw.withValue(path, ConfigValueFactory.fromAnyRef(value))).loadOrThrow[SharedConfigReader]
+
+  // Derive the inventory from the case class, not the hash implementation, so an omitted new
+  // activation input fails this suite. Dust schedules are tested separately below.
+  private val thresholdPaths = FieldsAddedOrdinalsFixtures.current.productElementNames
+    .filterNot(_ == "dustSweeps")
+    .map {
+      case "tessellation3Migration"   => "fields-added-ordinals.tessellation-3-migration"
+      case "tessellation301Migration" => "fields-added-ordinals.tessellation-301-migration"
+      case name                       => "fields-added-ordinals." + name.replaceAll("([A-Z])", "-$1").toLowerCase
+    }
+    .toList ++ List("last-kryo-hash-ordinal", "last-legacy-state-proof-ordinal", "incremental-delegated-staking-starting-ordinal")
+
+  AppEnvironment.values.foreach { environment =>
+    thresholdPaths.foreach { path =>
+      pureTest(s"$path: a different ${environment.entryName} activation changes the consensus hash") {
+        val changed = replace(s"$path.${environment.entryName}", Long.box(42L))
+        expect(hash(packaged, environment) != hash(changed, environment))
+      }
+    }
+  }
+
+  thresholdPaths.filterNot(_ == "fields-added-ordinals.currency-snapshot-protocol-v1").foreach { path =>
+    pureTest(s"$path: removing an explicit Mainnet activation changes the consensus hash") {
+      val incomplete = ConfigSource.fromConfig(raw.withoutPath(s"$path.mainnet")).loadOrThrow[SharedConfigReader]
+      expect(hash(packaged, AppEnvironment.Mainnet) != hash(incomplete, AppEnvironment.Mainnet))
+    }
+  }
+
+  pureTest("only the running environment's activation values enter its consensus hash") {
+    val changed = replace("fields-added-ordinals.fixing-fee-transaction-balance-overflow.mainnet", Long.box(42L))
+    expect.same(hash(packaged, AppEnvironment.Dev), hash(changed, AppEnvironment.Dev)) &&
+    expect.same(hash(packaged, AppEnvironment.Testnet), hash(changed, AppEnvironment.Testnet))
+  }
+
+  pureTest("absent first-active thresholds hash identically to explicit disabled thresholds") {
+    val explicit = replace("fields-added-ordinals.currency-snapshot-protocol-v1.mainnet", Long.box(Long.MaxValue))
+    expect.same(hash(packaged, AppEnvironment.Mainnet), hash(explicit, AppEnvironment.Mainnet))
+  }
+
+  pureTest("last-legacy defaults retain their existing distinct meanings") {
+    val missing = packaged.copy(lastKryoHashOrdinal = Map.empty, lastLegacyStateProofOrdinal = Map.empty)
+    val explicit = missing.copy(
+      lastKryoHashOrdinal = Map(AppEnvironment.Mainnet -> SnapshotOrdinal.MinValue),
+      lastLegacyStateProofOrdinal = Map(AppEnvironment.Mainnet -> SnapshotOrdinal.MaxValue)
+    )
+    expect.same(SnapshotOrdinal.MinValue, missing.lastKryoHashOrdinalFor(AppEnvironment.Mainnet)) &&
+    expect.same(SnapshotOrdinal.MaxValue, missing.lastLegacyStateProofOrdinalFor(AppEnvironment.Mainnet)) &&
+    expect.same(hash(missing, AppEnvironment.Mainnet), hash(explicit, AppEnvironment.Mainnet))
+  }
+
+  pureTest("changing a dust sweep's ordinal, threshold, or burn/credit destination changes the hash") {
+    val threshold = replace("fields-added-ordinals.dust-sweeps.testnet.3154700.threshold", Long.box(100001L))
+    val destination = replace(
+      "fields-added-ordinals.dust-sweeps.testnet.3154700.collection-address",
+      "DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM"
+    )
+    val ordinal = ConfigSource
+      .fromConfig(
+        raw
+          .withoutPath("fields-added-ordinals.dust-sweeps.testnet.3154700")
+          .withValue("fields-added-ordinals.dust-sweeps.testnet.3154701", raw.getValue("fields-added-ordinals.dust-sweeps.testnet.3154700"))
+      )
+      .loadOrThrow[SharedConfigReader]
+    val original = hash(packaged, AppEnvironment.Testnet)
+    expect(List(threshold, destination, ordinal).forall(config => hash(config, AppEnvironment.Testnet) != original))
+  }
+
+  pureTest("the complete dust schedule is hashed independently of configuration key order") {
+    val first = "fields-added-ordinals.dust-sweeps.testnet.3154701.threshold"
+    val second = "fields-added-ordinals.dust-sweeps.testnet.3154702.threshold"
+    val one = ConfigValueFactory.fromAnyRef(Long.box(1L))
+    val two = ConfigValueFactory.fromAnyRef(Long.box(2L))
+    val forward = ConfigSource.fromConfig(raw.withValue(first, one).withValue(second, two)).loadOrThrow[SharedConfigReader]
+    val reverse = ConfigSource.fromConfig(raw.withValue(second, two).withValue(first, one)).loadOrThrow[SharedConfigReader]
+    expect.same(hash(forward, AppEnvironment.Testnet), hash(reverse, AppEnvironment.Testnet)) &&
+    expect(hash(packaged, AppEnvironment.Testnet) != hash(forward, AppEnvironment.Testnet)) &&
+    expect.same(hash(packaged, AppEnvironment.Mainnet), hash(forward, AppEnvironment.Mainnet))
+  }
+
+  pureTest("the effective L0 config includes shared activation values before it is used for joining or consensus") {
+    val effective = base.withSharedConfig(packaged, AppEnvironment.Dev)
+    expect.same(Some(packaged.ordinalConfigHashFor(AppEnvironment.Dev)), effective.ordinalConfigHash) &&
+    expect.same(0L, effective.currencySnapshotProtocolV1ActivationOrdinal) &&
+    expect.same(packaged.lastGlobalSnapshotsSync.syncOffset.value, effective.lastGlobalSnapshotSyncOffset) &&
+    expect.same(packaged.lastGlobalSnapshotsSync.maxLastGlobalSnapshotsInMemory.value, effective.lastGlobalSnapshotsInMemory) &&
+    expect(effective.deterministicConfigHash != base.deterministicConfigHash)
+  }
+
+  pureTest("removing the required activation block fails config loading rather than silently disabling every gate") {
+    expect(source.load[SharedConfigReader].isRight) &&
+    expect(ConfigSource.fromConfig(raw.withoutPath("fields-added-ordinals")).load[SharedConfigReader].isLeft) &&
+    expect(ConfigSource.fromConfig(raw.withoutPath("fields-added-ordinals.tessellation-3-migration")).load[SharedConfigReader].isLeft)
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsFixtures.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsFixtures.scala
@@ -1,0 +1,33 @@
+package io.constellationnetwork.node.shared.config
+
+import io.constellationnetwork.env.AppEnvironment
+import io.constellationnetwork.node.shared.config.types.FieldsAddedOrdinals
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+object FieldsAddedOrdinalsFixtures {
+  private val active: Map[AppEnvironment, SnapshotOrdinal] = Map(AppEnvironment.Dev -> SnapshotOrdinal.MinValue)
+
+  /** Ordinary tests exercise current behavior. Historical tests must explicitly override the boundary they exercise. */
+  val current: FieldsAddedOrdinals = FieldsAddedOrdinals(
+    tessellation3Migration = active,
+    tessellation301Migration = active,
+    checkSyncGlobalSnapshotField = active,
+    metagraphSyncData = active,
+    updatedLastSyncGlobalOrder = active,
+    updatedLastSyncGlobalFromPeersInConsensus = active,
+    updatingCombineFunctionSpendActions = active,
+    fixingAllowSpendExpiration = active,
+    fixingAllowSpendAndTokenLockValidation = active,
+    setSumFix = active,
+    scFeeBalanceFromContext = active,
+    subTrieRoots = active,
+    delegatedRewardsFullCommittee = active,
+    feeTransactionSecurity = active,
+    fixingFeeTransactionBalanceOverflow = active,
+    currencySnapshotProtocolV1 = active,
+    fixingDataApplicationFeeValidation = active,
+    fixingAllowSpendDestinationCredit = active,
+    preventingAllowSpendResurrection = active,
+    fixingGlobalAllowSpendExpiration = active
+  )
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsSuite.scala
@@ -9,11 +9,25 @@ import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.node.shared.config.types.{DustSweep, FieldsAddedOrdinals}
 import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.balance.Balance
 
 import pureconfig.ConfigSource
 import weaver.SimpleIOSuite
 
 object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
+
+  private val disabledFieldsAddedOrdinals = FieldsAddedOrdinals(
+    tessellation3Migration = Map.empty,
+    tessellation301Migration = Map.empty,
+    checkSyncGlobalSnapshotField = Map.empty,
+    metagraphSyncData = Map.empty,
+    updatedLastSyncGlobalOrder = Map.empty,
+    updatedLastSyncGlobalFromPeersInConsensus = Map.empty,
+    updatingCombineFunctionSpendActions = Map.empty,
+    fixingAllowSpendExpiration = Map.empty,
+    fixingAllowSpendAndTokenLockValidation = Map.empty,
+    setSumFix = Map.empty
+  )
 
   test("loads an explicit fee transaction security activation for every environment") {
     IO {
@@ -67,54 +81,52 @@ object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
   }
 
   test("keeps every threshold gate disabled when an environment entry is absent") {
-    val fieldsAddedOrdinals = FieldsAddedOrdinals(
-      tessellation3Migration = Map.empty,
-      tessellation301Migration = Map.empty,
-      checkSyncGlobalSnapshotField = Map.empty,
-      metagraphSyncData = Map.empty,
-      updatedLastSyncGlobalOrder = Map.empty,
-      updatedLastSyncGlobalFromPeersInConsensus = Map.empty,
-      updatingCombineFunctionSpendActions = Map.empty,
-      fixingAllowSpendExpiration = Map.empty,
-      fixingAllowSpendAndTokenLockValidation = Map.empty,
-      setSumFix = Map.empty,
-      feeTransactionSecurity = Map.empty
-    )
+    val fieldsAddedOrdinals = disabledFieldsAddedOrdinals
 
-    val thresholdGates = List(
-      fieldsAddedOrdinals.tessellation3Migration,
-      fieldsAddedOrdinals.tessellation301Migration,
-      fieldsAddedOrdinals.checkSyncGlobalSnapshotField,
-      fieldsAddedOrdinals.metagraphSyncData,
-      fieldsAddedOrdinals.updatedLastSyncGlobalOrder,
-      fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensus,
-      fieldsAddedOrdinals.updatingCombineFunctionSpendActions,
-      fieldsAddedOrdinals.fixingAllowSpendExpiration,
-      fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation,
-      fieldsAddedOrdinals.setSumFix,
-      fieldsAddedOrdinals.scFeeBalanceFromContext,
-      fieldsAddedOrdinals.subTrieRoots,
-      fieldsAddedOrdinals.delegatedRewardsFullCommittee,
-      fieldsAddedOrdinals.feeTransactionSecurity,
-      fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow,
-      fieldsAddedOrdinals.currencySnapshotProtocolV1,
-      fieldsAddedOrdinals.fixingDataApplicationFeeValidation,
-      fieldsAddedOrdinals.fixingAllowSpendDestinationCredit,
-      fieldsAddedOrdinals.preventingAllowSpendResurrection,
-      fieldsAddedOrdinals.fixingGlobalAllowSpendExpiration
+    val mainnetThresholds = List(
+      fieldsAddedOrdinals.tessellation3MigrationFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.tessellation301MigrationFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.checkSyncGlobalSnapshotFieldFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.metagraphSyncDataFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.updatedLastSyncGlobalOrderFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensusFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.updatingCombineFunctionSpendActionsFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.fixingAllowSpendExpirationFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidationFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.setSumFixFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.scFeeBalanceFromContextFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.subTrieRootsFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.delegatedRewardsFullCommitteeFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.feeTransactionSecurityFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflowFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.currencySnapshotProtocolV1For(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.fixingDataApplicationFeeValidationFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.preventingAllowSpendResurrectionFor(AppEnvironment.Mainnet),
+      fieldsAddedOrdinals.fixingGlobalAllowSpendExpirationFor(AppEnvironment.Mainnet)
     )
 
     IO {
-      expect(
-        thresholdGates.forall(
-          fieldsAddedOrdinals.resolveWithDisabledDefault(_, AppEnvironment.Mainnet) === SnapshotOrdinal.MaxValue
-        )
-      ) &&
+      expect(mainnetThresholds.forall(_ === SnapshotOrdinal.MaxValue)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.feeTransactionSecurityFor(AppEnvironment.Mainnet)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.currencySnapshotProtocolV1For(AppEnvironment.Mainnet)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.fixingDataApplicationFeeValidationFor(AppEnvironment.Mainnet)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(AppEnvironment.Mainnet)) &&
-      expect(fieldsAddedOrdinals.dustSweeps.get(AppEnvironment.Mainnet).isEmpty)
+      expect(fieldsAddedOrdinals.dustSweepFor(AppEnvironment.Mainnet, SnapshotOrdinal.MinValue).isEmpty)
+    }
+  }
+
+  test("resolves an exact-key dust sweep only for its configured environment and ordinal") {
+    val activationOrdinal = SnapshotOrdinal.unsafeApply(1000L)
+    val sweep = DustSweep(Balance.empty, None)
+    val fieldsAddedOrdinals = disabledFieldsAddedOrdinals.copy(
+      dustSweeps = Map(AppEnvironment.Dev -> SortedMap(activationOrdinal -> sweep))
+    )
+
+    IO {
+      expect.same(Some(sweep), fieldsAddedOrdinals.dustSweepFor(AppEnvironment.Dev, activationOrdinal)) &&
+      expect(fieldsAddedOrdinals.dustSweepFor(AppEnvironment.Dev, SnapshotOrdinal.unsafeApply(999L)).isEmpty) &&
+      expect(fieldsAddedOrdinals.dustSweepFor(AppEnvironment.Mainnet, activationOrdinal).isEmpty)
     }
   }
 

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsSuite.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.node.shared.ext.pureconfig._
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.balance.Balance
 
+import eu.timepit.refined.auto._
 import pureconfig.ConfigSource
 import weaver.SimpleIOSuite
 
@@ -28,6 +29,86 @@ object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
     fixingAllowSpendAndTokenLockValidation = Map.empty,
     setSumFix = Map.empty
   )
+
+  // Independent expected values: changing a signed-history boundary requires review of this table,
+  // not regenerating it from application.conf. Absence is intentional only where recorded here.
+  private def allEnvironments(mainnet: Long, testnet: Long, integrationnet: Long): Map[AppEnvironment, SnapshotOrdinal] =
+    Map(
+      AppEnvironment.Mainnet -> SnapshotOrdinal.unsafeApply(mainnet),
+      AppEnvironment.Testnet -> SnapshotOrdinal.unsafeApply(testnet),
+      AppEnvironment.Integrationnet -> SnapshotOrdinal.unsafeApply(integrationnet),
+      AppEnvironment.Dev -> SnapshotOrdinal.MinValue
+    )
+
+  private val expectedThresholds: Map[String, Map[AppEnvironment, SnapshotOrdinal]] = Map(
+    "tessellation3Migration" -> allEnvironments(4409045L, 2497000L, 3330000L),
+    "tessellation301Migration" -> allEnvironments(4915254L, 2500000L, 3584112L),
+    "checkSyncGlobalSnapshotField" -> allEnvironments(4488000L, 2497000L, 3369135L),
+    "metagraphSyncData" -> allEnvironments(4915254L, 2497000L, 3584112L),
+    "updatedLastSyncGlobalOrder" -> allEnvironments(4915254L, 2691665L, 3648655L),
+    "updatedLastSyncGlobalFromPeersInConsensus" -> allEnvironments(4915254L, 2694780L, 3669310L),
+    "updatingCombineFunctionSpendActions" -> allEnvironments(4957662L, 2987405L, 3975600L),
+    "fixingAllowSpendExpiration" -> allEnvironments(5033174L, 2987405L, 3975600L),
+    "fixingAllowSpendAndTokenLockValidation" -> allEnvironments(5058096L, 9999999L, 5880000L),
+    "setSumFix" -> allEnvironments(9999999L, 9999999L, 5880000L),
+    "scFeeBalanceFromContext" -> allEnvironments(9999999L, 3101393L, 5880000L),
+    "subTrieRoots" -> allEnvironments(9999999L, 9999999L, 5880000L),
+    "delegatedRewardsFullCommittee" -> allEnvironments(9999999L, 9999999L, 5880000L),
+    "feeTransactionSecurity" -> allEnvironments(9999999L, 9999999L, 5880000L),
+    "fixingFeeTransactionBalanceOverflow" -> allEnvironments(6814499L, 3255000L, 5905000L),
+    "currencySnapshotProtocolV1" -> Map(AppEnvironment.Dev -> SnapshotOrdinal.MinValue),
+    "fixingDataApplicationFeeValidation" -> allEnvironments(6818000L, 9999999L, 9999999L),
+    "fixingAllowSpendDestinationCredit" -> allEnvironments(6818000L, 9999999L, 9999999L),
+    "preventingAllowSpendResurrection" -> allEnvironments(6828500L, 9999999L, 9999999L),
+    "fixingGlobalAllowSpendExpiration" -> allEnvironments(6828500L, 9999999L, 9999999L)
+  )
+
+  test("pins every packaged threshold and intentional absence in every environment") {
+    IO {
+      val fields = ConfigSource.resources("application.conf").at("fields-added-ordinals").loadOrThrow[FieldsAddedOrdinals]
+      // Product names deliberately make a newly added gate fail until the independent table covers it.
+      val actual = fields.productElementNames.zip(fields.productIterator).filterNot(_._1 == "dustSweeps").toMap
+      expect.same(expectedThresholds, actual) &&
+      AppEnvironment.values.foldLeft(success) { (result, environment) =>
+        result && expect.same(
+          SortedMap.from(expectedThresholds.map { case (name, values) => name -> values.getOrElse(environment, SnapshotOrdinal.MaxValue) }),
+          fields.resolvedThresholdsFor(environment)
+        )
+      }
+    }
+  }
+
+  test("pins the separate historical hash, state-proof, staking boundaries and complete dust schedule") {
+    IO {
+      val source = ConfigSource.resources("application.conf")
+      val fields = source.at("fields-added-ordinals").loadOrThrow[FieldsAddedOrdinals]
+      expect.same(
+        allEnvironments(2572384L, 1933590L, 1527434L),
+        source.at("last-kryo-hash-ordinal").loadOrThrow[Map[AppEnvironment, SnapshotOrdinal]]
+      ) &&
+      expect.same(
+        allEnvironments(5960000L, 3070000L, 5075000L),
+        source.at("last-legacy-state-proof-ordinal").loadOrThrow[Map[AppEnvironment, SnapshotOrdinal]]
+      ) &&
+      expect.same(
+        allEnvironments(5960000L, 3070000L, 5075000L),
+        source.at("incremental-delegated-staking-starting-ordinal").loadOrThrow[Map[AppEnvironment, SnapshotOrdinal]]
+      ) &&
+      expect.same(
+        Map(AppEnvironment.Testnet -> SortedMap(SnapshotOrdinal.unsafeApply(3154700L) -> DustSweep(Balance(100000L), None))),
+        fields.dustSweeps
+      )
+    }
+  }
+
+  pureTest("the shared ordinary-test fixture explicitly enables every current threshold") {
+    val current = FieldsAddedOrdinalsFixtures.current
+    val expected = Map(AppEnvironment.Dev -> SnapshotOrdinal.MinValue)
+    val maps = current.productElementNames.zip(current.productIterator).filterNot(_._1 == "dustSweeps").toList
+    expect.same(expectedThresholds.keySet, maps.map(_._1).toSet) &&
+    expect(maps.forall(_._2 == expected)) &&
+    expect(current.dustSweeps.isEmpty)
+  }
 
   test("loads an explicit fee transaction security activation for every environment") {
     IO {
@@ -83,7 +164,7 @@ object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
   test("keeps every threshold gate disabled when an environment entry is absent") {
     val fieldsAddedOrdinals = disabledFieldsAddedOrdinals
 
-    val mainnetThresholds = List(
+    val absentEnvironmentThresholds = List(
       fieldsAddedOrdinals.tessellation3MigrationFor(AppEnvironment.Mainnet),
       fieldsAddedOrdinals.tessellation301MigrationFor(AppEnvironment.Mainnet),
       fieldsAddedOrdinals.checkSyncGlobalSnapshotFieldFor(AppEnvironment.Mainnet),
@@ -107,7 +188,7 @@ object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
     )
 
     IO {
-      expect(mainnetThresholds.forall(_ === SnapshotOrdinal.MaxValue)) &&
+      expect(absentEnvironmentThresholds.forall(_ === SnapshotOrdinal.MaxValue)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.feeTransactionSecurityFor(AppEnvironment.Mainnet)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.currencySnapshotProtocolV1For(AppEnvironment.Mainnet)) &&
       expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.fixingDataApplicationFeeValidationFor(AppEnvironment.Mainnet)) &&

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/config/FieldsAddedOrdinalsSuite.scala
@@ -1,6 +1,7 @@
 package io.constellationnetwork.node.shared.config
 
 import cats.effect.IO
+import cats.syntax.eq._
 
 import scala.collection.immutable.SortedMap
 
@@ -65,7 +66,7 @@ object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
     }
   }
 
-  test("keeps fee transaction security disabled when an environment entry is absent") {
+  test("keeps every threshold gate disabled when an environment entry is absent") {
     val fieldsAddedOrdinals = FieldsAddedOrdinals(
       tessellation3Migration = Map.empty,
       tessellation301Migration = Map.empty,
@@ -80,12 +81,41 @@ object FieldsAddedOrdinalsSuite extends SimpleIOSuite {
       feeTransactionSecurity = Map.empty
     )
 
-    IO(
-      expect.same(
-        SnapshotOrdinal.MaxValue,
-        fieldsAddedOrdinals.feeTransactionSecurityFor(AppEnvironment.Mainnet)
-      )
+    val thresholdGates = List(
+      fieldsAddedOrdinals.tessellation3Migration,
+      fieldsAddedOrdinals.tessellation301Migration,
+      fieldsAddedOrdinals.checkSyncGlobalSnapshotField,
+      fieldsAddedOrdinals.metagraphSyncData,
+      fieldsAddedOrdinals.updatedLastSyncGlobalOrder,
+      fieldsAddedOrdinals.updatedLastSyncGlobalFromPeersInConsensus,
+      fieldsAddedOrdinals.updatingCombineFunctionSpendActions,
+      fieldsAddedOrdinals.fixingAllowSpendExpiration,
+      fieldsAddedOrdinals.fixingAllowSpendAndTokenLockValidation,
+      fieldsAddedOrdinals.setSumFix,
+      fieldsAddedOrdinals.scFeeBalanceFromContext,
+      fieldsAddedOrdinals.subTrieRoots,
+      fieldsAddedOrdinals.delegatedRewardsFullCommittee,
+      fieldsAddedOrdinals.feeTransactionSecurity,
+      fieldsAddedOrdinals.fixingFeeTransactionBalanceOverflow,
+      fieldsAddedOrdinals.currencySnapshotProtocolV1,
+      fieldsAddedOrdinals.fixingDataApplicationFeeValidation,
+      fieldsAddedOrdinals.fixingAllowSpendDestinationCredit,
+      fieldsAddedOrdinals.preventingAllowSpendResurrection,
+      fieldsAddedOrdinals.fixingGlobalAllowSpendExpiration
     )
+
+    IO {
+      expect(
+        thresholdGates.forall(
+          fieldsAddedOrdinals.resolveWithDisabledDefault(_, AppEnvironment.Mainnet) === SnapshotOrdinal.MaxValue
+        )
+      ) &&
+      expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.feeTransactionSecurityFor(AppEnvironment.Mainnet)) &&
+      expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.currencySnapshotProtocolV1For(AppEnvironment.Mainnet)) &&
+      expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.fixingDataApplicationFeeValidationFor(AppEnvironment.Mainnet)) &&
+      expect.same(SnapshotOrdinal.MaxValue, fieldsAddedOrdinals.fixingAllowSpendDestinationCreditFor(AppEnvironment.Mainnet)) &&
+      expect(fieldsAddedOrdinals.dustSweeps.get(AppEnvironment.Mainnet).isEmpty)
+    }
   }
 
   test("Currency snapshot protocol v1 is enabled for dev and fails closed for every public environment") {

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotDustSweepSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/GlobalSnapshotDustSweepSuite.scala
@@ -6,7 +6,6 @@ import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 
-import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.merkletree.{Proof, ProofEntry}
@@ -50,10 +49,6 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
   implicit val stateProofSelector: GlobalStateProofSelector =
     GlobalStateProofSelector(SnapshotOrdinal.unsafeApply(Long.MaxValue))
 
-  private val testEnv: AppEnvironment = AppEnvironment.Dev
-  private val sweepOrdinal: SnapshotOrdinal = SnapshotOrdinal.unsafeApply(1000L)
-  private val otherOrdinal: SnapshotOrdinal = SnapshotOrdinal.unsafeApply(999L)
-
   // Distinct test addresses (DAG-prefixed refined literals).
   private val dust1 = Address("DAG0y4eLqhhXUafeE3mgBstezPTnr8L3tZjAtMWB")
   private val dust2 = Address("DAG0y4eLqhhXUafeE3mgBstezPTnr8L3tZjAtMWC")
@@ -66,11 +61,9 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
 
   private def bal(v: Long): Balance = Balance(NonNegLong.unsafeFrom(v))
 
-  private def burnSweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] =
-    Map(testEnv -> SortedMap(sweepOrdinal -> DustSweep(threshold, none)))
+  private val burnSweep: DustSweep = DustSweep(threshold, none)
 
-  private def treasurySweeps: Map[AppEnvironment, SortedMap[SnapshotOrdinal, DustSweep]] =
-    Map(testEnv -> SortedMap(sweepOrdinal -> DustSweep(threshold, treasury.some)))
+  private val treasurySweep: DustSweep = DustSweep(threshold, treasury.some)
 
   // A non-empty lastTxRef (a "has sent" sender): ordinal 1, non-empty hash.
   private val nonEmptyTxRef: TransactionReference =
@@ -120,8 +113,8 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
     )
     val pre = gsiWith(balances)
 
-    val (sweptA, didA) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, treasurySweeps)
-    val (sweptB, didB) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, treasurySweeps)
+    val (sweptA, didA) = GlobalSnapshotDustSweep.applyDustSweep(pre, treasurySweep.some)
+    val (sweptB, didB) = GlobalSnapshotDustSweep.applyDustSweep(pre, treasurySweep.some)
 
     for {
       rootA <- sweptA.allStateEntries[IO].buildMpt
@@ -281,7 +274,7 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
       activeDelegatedStakes = Some(SortedMap(dust1 -> SortedSet(stakeRecord)))
     )
 
-    val (swept, did) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, burnSweeps)
+    val (swept, did) = GlobalSnapshotDustSweep.applyDustSweep(pre, burnSweep.some)
 
     IO {
       expect.all(
@@ -312,8 +305,8 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
     val supplyBefore = balances.values.foldLeft(0L)(_ + _.value.value)
     val sweptSum = 3L * dustValue
 
-    val (burned, didBurn) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, burnSweeps)
-    val (swept, didSweep) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, treasurySweeps)
+    val (burned, didBurn) = GlobalSnapshotDustSweep.applyDustSweep(pre, burnSweep.some)
+    val (swept, didSweep) = GlobalSnapshotDustSweep.applyDustSweep(pre, treasurySweep.some)
 
     val burnedSupply = burned.balances.values.foldLeft(0L)(_ + _.value.value)
     val treasurySupply = swept.balances.values.foldLeft(0L)(_ + _.value.value)
@@ -335,23 +328,17 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
 
   // --- Test 5: off-ordinal no-op (returns (gsi,false), byte-identical) ------------------------
 
-  test("off-ordinal no-op: applyDustSweep at a non-sweep ordinal returns (gsi, false) unchanged") { _ =>
+  test("absent resolved sweep is a reference-identical no-op") { _ =>
     val balances = SortedMap(dust1 -> bal(dustValue), dust2 -> bal(dustValue), whale -> bal(50_000_000L))
     val pre = gsiWith(balances)
 
-    val (resOther, didOther) = GlobalSnapshotDustSweep.applyDustSweep(pre, otherOrdinal, testEnv, burnSweeps)
-    val (resEnv, didEnv) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, AppEnvironment.Mainnet, burnSweeps)
-    val (resEmpty, didEmpty) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, Map.empty)
+    val (result, didSweep) = GlobalSnapshotDustSweep.applyDustSweep(pre, none)
 
     IO {
       expect.all(
-        !didOther,
-        !didEnv,
-        !didEmpty,
+        !didSweep,
         // reference-identical input on the no-op path
-        resOther eq pre,
-        resEnv eq pre,
-        resEmpty eq pre
+        result eq pre
       )
     }
   }
@@ -368,7 +355,7 @@ object GlobalSnapshotDustSweepSuite extends MutableIOSuite {
       lastTxRefs = SortedMap(dust1 -> nonEmptyTxRef, dust3 -> TransactionReference.empty)
     )
 
-    val (swept, did) = GlobalSnapshotDustSweep.applyDustSweep(pre, sweepOrdinal, testEnv, burnSweeps)
+    val (swept, did) = GlobalSnapshotDustSweep.applyDustSweep(pre, burnSweep.some)
 
     IO {
       expect.all(

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
@@ -70,6 +70,27 @@ import io.circe.Json
 
 object Mocks {
 
+  private val devActivation: Map[AppEnvironment, SnapshotOrdinal] = Map(AppEnvironment.Dev -> SnapshotOrdinal.MinValue)
+
+  /** The acceptance-manager tests exercise behavior after the historical migration gates. Those gates are explicit so an empty map keeps
+    * its production meaning: disabled.
+    */
+  private val postMigrationFieldsAddedOrdinals = FieldsAddedOrdinals(
+    tessellation3Migration = devActivation,
+    tessellation301Migration = devActivation,
+    checkSyncGlobalSnapshotField = devActivation,
+    metagraphSyncData = devActivation,
+    updatedLastSyncGlobalOrder = devActivation,
+    updatedLastSyncGlobalFromPeersInConsensus = devActivation,
+    updatingCombineFunctionSpendActions = devActivation,
+    fixingAllowSpendExpiration = devActivation,
+    fixingAllowSpendAndTokenLockValidation = devActivation,
+    setSumFix = devActivation,
+    fixingDataApplicationFeeValidation = devActivation,
+    fixingAllowSpendDestinationCredit = devActivation,
+    preventingAllowSpendResurrection = devActivation
+  )
+
   private[snapshot] def mkManager(
     initialSnapshotInfo: Option[GlobalSnapshotInfo] = None
   )(implicit h: Hasher[IO], sp: SecurityProvider[IO]): IO[GlobalSnapshotAcceptanceManager[IO]] = {
@@ -271,18 +292,7 @@ object Mocks {
               initialSnapshotInfo.traverse_(info => mptStore.syncFromGlobalSnapshotInfo(info, SnapshotOrdinal.MinValue)) >>
                 GlobalSnapshotAcceptanceManager
                   .make[IO](
-                    FieldsAddedOrdinals(
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty,
-                      Map.empty
-                    ),
+                    postMigrationFieldsAddedOrdinals,
                     MetagraphsSyncConfig(PosInt(100)),
                     AppEnvironment.Dev,
                     blockAcceptanceManager = mockBlockAcceptanceManager,

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/managers/global/Mocks.scala
@@ -17,6 +17,7 @@ import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.env.AppEnvironment
 import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.config.FieldsAddedOrdinalsFixtures
 import io.constellationnetwork.node.shared.config.types._
 import io.constellationnetwork.node.shared.domain.block.processing._
 import io.constellationnetwork.node.shared.domain.delegatedStake.{
@@ -69,27 +70,6 @@ import eu.timepit.refined.types.numeric.{NonNegLong, PosInt, PosLong}
 import io.circe.Json
 
 object Mocks {
-
-  private val devActivation: Map[AppEnvironment, SnapshotOrdinal] = Map(AppEnvironment.Dev -> SnapshotOrdinal.MinValue)
-
-  /** The acceptance-manager tests exercise behavior after the historical migration gates. Those gates are explicit so an empty map keeps
-    * its production meaning: disabled.
-    */
-  private val postMigrationFieldsAddedOrdinals = FieldsAddedOrdinals(
-    tessellation3Migration = devActivation,
-    tessellation301Migration = devActivation,
-    checkSyncGlobalSnapshotField = devActivation,
-    metagraphSyncData = devActivation,
-    updatedLastSyncGlobalOrder = devActivation,
-    updatedLastSyncGlobalFromPeersInConsensus = devActivation,
-    updatingCombineFunctionSpendActions = devActivation,
-    fixingAllowSpendExpiration = devActivation,
-    fixingAllowSpendAndTokenLockValidation = devActivation,
-    setSumFix = devActivation,
-    fixingDataApplicationFeeValidation = devActivation,
-    fixingAllowSpendDestinationCredit = devActivation,
-    preventingAllowSpendResurrection = devActivation
-  )
 
   private[snapshot] def mkManager(
     initialSnapshotInfo: Option[GlobalSnapshotInfo] = None
@@ -292,7 +272,7 @@ object Mocks {
               initialSnapshotInfo.traverse_(info => mptStore.syncFromGlobalSnapshotInfo(info, SnapshotOrdinal.MinValue)) >>
                 GlobalSnapshotAcceptanceManager
                   .make[IO](
-                    postMigrationFieldsAddedOrdinals,
+                    FieldsAddedOrdinalsFixtures.current,
                     MetagraphsSyncConfig(PosInt(100)),
                     AppEnvironment.Dev,
                     blockAcceptanceManager = mockBlockAcceptanceManager,


### PR DESCRIPTION
## Summary

Missing environment entries previously selected inconsistent ordinal defaults, and several tests relied on those defaults to enable current behavior. This PR centralizes disabled defaults, makes ordinary test fixtures explicitly enable current behavior, and protects configured historical boundaries with a complete expected-value table.

DAG and Currency L0 also include all resolved FieldsAddedOrdinals thresholds, the three shared hashing/state-proof/staking boundaries, and the complete dust-sweep schedule in the existing consensus config hash. Nodes running the same version reject disagreement about these settings during joining. Every deployment uses one software version and a full-cluster cold restart; version mismatches remain independently rejected.

The PR adds ADR-0034 and shared contributor/Codex/Claude guidance, consolidates the existing local Just/Docker E2E documentation, and records collision-safe ADR allocation.

## Consensus compatibility

- [ ] Not consensus-adjacent
- [ ] Runtime-only behavior; encodings/hash rules and historical replay are unchanged
- [x] Replay/state-transition change with stable schema and an explicit compatibility boundary
- [ ] Schema/wire change with an approved schema-change package

The original fallback change affects incomplete/custom configuration: absent first-active thresholds select MaxValue instead of activating selected rules from genesis. Packaged activation values and existing comparison operators are unchanged. Established historical cutovers remain explicit; ordinary tests enable current behavior, while historical tests specify the boundary they exercise.

The follow-up intentionally changes the existing consensus configuration hash, including the value advertised at joining, in live Facility declarations, and in their signed trigger statements. The same resolved configuration supplies joining and the running consensus engine. It does not change snapshot encodings, snapshot hash/signature construction, state-proof shapes, or persisted snapshot history. No activation ordinal or additional rollout process is introduced; the change ships through the normal full-cluster cold restart.

Last-legacy hashing and state-proof selectors retain their established defaults. Dust sweeps retain exact-key behavior, including historical replay. All configured activation numbers remain unchanged.

## Consumer alignment

Snapshot Streaming will be updated separately after develop includes these changes. Its compatibility patch still contains four older missing-environment fallback sites; the follow-up must align them with the SDK accessors and qualify the resulting consumer artifact. Explicit packaged values already agree. This PR does not claim completion of that separate build/deployment or change Block Explorer schemas.

## Validation

- Full affected-module suites: `nodeShared/test` (1,562 passed), `dagL0/test` (238 passed; two existing ignored generator tests), `dagL1/test` (50 passed), `currencyL0/test` (160 passed), and `currencyL1/test` (24 passed): **2,034 passed, zero failures**.
- Full-project `sbt compile`, `scalafmtCheckAll`, and `scalafixAll --check --rules OrganizeImports` passed. Full compilation and formatting were also repeated successfully at committed head `5459dd3f6` before pushing.
- Commitlint passed for the actual new commit and all five outgoing commits against refreshed `origin/develop`; `git diff --check` passed.
- All five packaged `.conf` files are byte-identical to the reviewed PR head. Snapshot Streaming's patch is unchanged.
- GitHub CI runs separately on the pushed commit; local Docker E2E was not rerun for this follow-up.
