### PR TITLE
chore(node-shared): update BioFi genesis address in mainnet allowance list

### DIFF
--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/statechannel/StateChannelAllowanceLists.scala
@@ -119,7 +119,7 @@ object StateChannelAllowanceLists {
               "1391276cd637be03331ae5914a5a063c549fbcc6515b140d1ccc0af7c67631804991ba0dae4c1d95b84f77dc812dd71ed2a1817e50c92b722e9b8182683366ed"
             ),
           // BioFi
-          Address("DAG7rJcErad85KV3GzNNYa727vW5c555XksBx9Hv") ->
+          Address("DAG3eCKB9FgkjM3s8yoCJzGtp8niQ4WqTxhzun7s") ->
             NonEmptySet.of(
               "9002807a99139d207c7b20d3065f72dbf77c8563e1a2e6d2969f64928c6082dbacfb399d67bacbc62a7997fc69b8dd5c035e3acf6ed696da7f4cebee5f76cdc8",
               "866d3c60d9ea2ed7b3db2a04ba736ae8b00a0c20e98e270ddda3c73602f348ef4ce5d65e55daa52221310ebb25b826b1de495664917a3f510f6b82226d12ffe7",


### PR DESCRIPTION
## Summary

Replaces the BioFi genesis address in the Mainnet state channel allowance list with `DAG3eCKB9FgkjM3s8yoCJzGtp8niQ4WqTxhzun7s`.

Change the genesis address based on BioFi request. Customer reason: "We found that my Previous AI gave the wrong ID as a Metagraph ID. ... This has now been fixed."

The peer IDs for the entry are unchanged. The previous address `DAG7rJcErad85KV3GzNNYa727vW5c555XksBx9Hv` appeared nowhere else in the repo.

## Test plan

- No behavior beyond the allowance list entry changes; existing tests cover the allowance list wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)