### PR TITLE
fix(mainnet): recover damaged download anchors

### DIFF
--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/programs/Download.scala
@@ -56,6 +56,7 @@ object Download {
     val minBatchSizeToStartObserving: Long = 1L
     val observationOffset = NonNegLong(4L)
     val fetchSnapshotDelayBetweenTrials = 10.seconds
+    private val maxPersistedSearchAttempts: Int = 200
 
     type DownloadResult = (Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)
     type ObservationLimit = SnapshotOrdinal
@@ -276,8 +277,11 @@ object Download {
       go(Map.empty, hash, ordinal)
     }
 
-    def isSnapshotPersistedOrReachedGenesis(hash: Hash, ordinal: SnapshotOrdinal): F[Boolean] = {
-      def isSnapshotPersisted = snapshotStorage.isPersisted(hash)
+    def isSnapshotPersistedOrReachedGenesis(hash: Hash, ordinal: SnapshotOrdinal)(
+      implicit hasherSelector: HasherSelector[F]
+    ): F[Boolean] = {
+      def isSnapshotPersisted =
+        hasherSelector.forOrdinal(ordinal)(implicit hasher => snapshotStorage.ensurePersistedAnchor(hash, ordinal))
 
       def didReachGenesis = ordinal === lastFullGlobalSnapshotOrdinal
 
@@ -374,13 +378,37 @@ object Download {
       state
         .map(_.pure[F])
         .getOrElse {
+          def findHighestValidPersisted(
+            lte: SnapshotOrdinal,
+            attempts: Int
+          ): F[Option[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
+            if (attempts <= 0) none[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)].pure[F]
+            else
+              snapshotStorage.getHighestSnapshotInfoOrdinal(lte).flatMap {
+                case None => none[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)].pure[F]
+                case Some(ordinal) =>
+                  hasherSelector
+                    .forOrdinal(ordinal)(implicit hasher => snapshotStorage.readCombined(ordinal))
+                    .attempt
+                    .flatMap {
+                      case Right(Some(result)) => result.some.pure[F]
+                      case result =>
+                        val warning = result.swap.toOption
+                          .fold(logger.warn(s"Skipping unreadable persisted recovery anchor ordinal=${ordinal.show}"))(
+                            logger.warn(_)(s"Skipping invalid persisted recovery anchor ordinal=${ordinal.show}")
+                          )
+
+                        warning >>
+                          PartialPrevious[SnapshotOrdinal]
+                            .partialPrevious(ordinal)
+                            .map(findHighestValidPersisted(_, attempts - 1))
+                            .getOrElse(none[(Signed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)].pure[F])
+                    }
+              }
+
           startingOrdinal
-            .flatTraverse(ordinal => hasherSelector.forOrdinal(ordinal)(implicit hasher => snapshotStorage.readCombined(ordinal)))
-            .flatMap {
-              _.map(_.pure[F]).getOrElse(
-                getGenesisSnapshot(tmpMap)
-              )
-            }
+            .flatTraverse(findHighestValidPersisted(_, maxPersistedSearchAttempts))
+            .flatMap(_.fold(getGenesisSnapshot(tmpMap))(_.pure[F]))
         }
         .flatMap {
           case (s, c) =>

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/storages/SnapshotDownloadStorage.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/domain/snapshot/storages/SnapshotDownloadStorage.scala
@@ -14,7 +14,10 @@ trait SnapshotDownloadStorage[F[_]] {
 
   def deletePersisted(ordinal: SnapshotOrdinal): F[Unit]
 
-  def isPersisted(hash: Hash): F[Boolean]
+  /** Return true only when the hash file, ordinal index, and snapshot-info form a readable recovery anchor. The implementation may repair
+    * the narrow torn-write case where exact hash-indexed bytes exist but the ordinal hardlink is absent.
+    */
+  def ensurePersistedAnchor(hash: Hash, ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[Boolean]
 
   def hasCorrectSnapshotInfo(ordinal: SnapshotOrdinal, proof: GlobalSnapshotStateProof)(implicit hasher: Hasher[F]): F[Boolean]
   def getHighestSnapshotInfoOrdinal(lte: SnapshotOrdinal): F[Option[SnapshotOrdinal]]

--- a/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
+++ b/modules/dag-l0/src/main/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorage.scala
@@ -48,7 +48,18 @@ object SnapshotDownloadStorage {
 
       def deletePersisted(ordinal: SnapshotOrdinal): F[Unit] = persistedStorage.delete(ordinal)
 
-      def isPersisted(hash: Hash): F[Boolean] = persistedStorage.exists(hash)
+      private def hasSnapshotInfo(ordinal: SnapshotOrdinal): F[Boolean] =
+        hashSelect.select(ordinal) match {
+          case JsonHash => snapshotInfoStorage.read(ordinal).map(_.isDefined)
+          case KryoHash => snapshotInfoKryoStorage.read(ordinal).map(_.isDefined)
+        }
+
+      def ensurePersistedAnchor(hash: Hash, ordinal: SnapshotOrdinal)(implicit hasher: Hasher[F]): F[Boolean] =
+        persistedStorage.ensureOrdinalLink(hash, ordinal).flatMap {
+          case status if status.usable => hasSnapshotInfo(ordinal)
+          case status =>
+            logger.warn(s"Rejected unusable persisted recovery anchor ordinal=${ordinal.show} reason=$status").as(false)
+        }
 
       def hasCorrectSnapshotInfo(
         ordinal: SnapshotOrdinal,
@@ -65,7 +76,15 @@ object SnapshotDownloadStorage {
       def getHighestSnapshotInfoOrdinal(lte: SnapshotOrdinal): F[Option[SnapshotOrdinal]] =
         snapshotInfoStorage.listStoredOrdinals
           .flatMap(_.filter(_ <= lte).compile.toList)
-          .map(_.maximumOption)
+          .flatMap { ordinals =>
+            def findReadable(remaining: List[SnapshotOrdinal]): F[Option[SnapshotOrdinal]] =
+              remaining match {
+                case head :: tail => hasSnapshotInfo(head).ifM(head.some.pure[F], findReadable(tail))
+                case Nil          => none[SnapshotOrdinal].pure[F]
+              }
+
+            findReadable(ordinals.sorted.reverse)
+          }
 
       def readCombined(
         ordinal: SnapshotOrdinal
@@ -106,7 +125,8 @@ object SnapshotDownloadStorage {
 
       def moveTmpToPersisted(snapshot: Signed[GlobalIncrementalSnapshot]): F[Unit] =
         HasherSelector[F].forOrdinal(snapshot.ordinal) { implicit hasher =>
-          persistedStorage.getPath(snapshot).flatMap(tmpStorage.moveByOrdinal(snapshot, _) >> persistedStorage.link(snapshot))
+          persistedStorage.replaceForRecovery(snapshot) >>
+            tmpStorage.delete(snapshot.ordinal)
         }
 
       def readGenesis(ordinal: SnapshotOrdinal): F[Option[Signed[GlobalSnapshot]]] = fullGlobalSnapshotStorage.read(ordinal)

--- a/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorageRecoverySuite.scala
+++ b/modules/dag-l0/src/test/scala/io/constellationnetwork/dag/l0/infrastructure/snapshot/SnapshotDownloadStorageRecoverySuite.scala
@@ -1,0 +1,167 @@
+package io.constellationnetwork.dag.l0.infrastructure.snapshot
+
+import cats.effect.{IO, Resource}
+
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.kryo.KryoSerializer
+import io.constellationnetwork.node.shared.infrastructure.snapshot.storage._
+import io.constellationnetwork.node.shared.nodeSharedKryoRegistrar
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.signature.Signed
+
+import better.files.File
+import eu.timepit.refined.types.numeric.NonNegLong
+import fs2.io.file.Path
+import weaver.MutableIOSuite
+
+object SnapshotDownloadStorageRecoverySuite extends MutableIOSuite {
+
+  type Res = (KryoSerializer[IO], JsonSerializer[IO], Hasher[IO], SecurityProvider[IO])
+
+  override def sharedResource: Resource[IO, Res] = for {
+    implicit0(kryoSerializer: KryoSerializer[IO]) <- KryoSerializer.forAsync[IO](nodeSharedKryoRegistrar)
+    implicit0(jsonSerializer: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    securityProvider <- SecurityProvider.forAsync[IO]
+    hasher = Hasher.forJson[IO]
+  } yield (kryoSerializer, jsonSerializer, hasher, securityProvider)
+
+  private val jsonHashSelect = new HashSelect {
+    def select(ordinal: SnapshotOrdinal): HashLogic = JsonHash
+  }
+
+  private final case class RecoveryStorages(
+    download: io.constellationnetwork.dag.l0.domain.snapshot.storages.SnapshotDownloadStorage[IO],
+    tmp: SnapshotLocalFileSystemStorage[IO, GlobalIncrementalSnapshot],
+    persisted: SnapshotLocalFileSystemStorage[IO, GlobalIncrementalSnapshot],
+    info: SnapshotInfoLocalFileSystemStorage[IO, GlobalSnapshotStateProof, GlobalSnapshotInfo]
+  )
+
+  private def makeStorages(root: File)(
+    implicit kryoSerializer: KryoSerializer[IO],
+    jsonSerializer: JsonSerializer[IO],
+    hasherSelector: HasherSelector[IO]
+  ): IO[RecoveryStorages] = {
+    def path(name: String): Path = Path((root / name).pathAsString)
+
+    for {
+      tmp <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](path("tmp"))
+      persisted <- GlobalIncrementalSnapshotLocalFileSystemStorage.make[IO](path("persisted"))
+      full <- GlobalSnapshotLocalFileSystemStorage.make[IO](path("full"))
+      info <- GlobalSnapshotInfoLocalFileSystemStorage.make[IO](path("info"))
+      kryoInfo <- GlobalSnapshotInfoKryoLocalFileSystemStorage.make[IO](path("info"))
+      download = SnapshotDownloadStorage.make[IO](tmp, persisted, full, info, kryoInfo, jsonHashSelect)
+    } yield RecoveryStorages(download, tmp, persisted, info)
+  }
+
+  private def makeSnapshot(
+    implicit hasher: Hasher[IO],
+    securityProvider: SecurityProvider[IO]
+  ): IO[Signed[GlobalIncrementalSnapshot]] =
+    for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      genesis <- Signed.forAsyncHasher[IO, GlobalSnapshot](
+        GlobalSnapshot.mkGenesis(Map.empty, EpochProgress.MinValue),
+        keyPair
+      )
+      incremental <- GlobalIncrementalSnapshot.fromGlobalSnapshot[IO](genesis.value)
+      snapshot <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](incremental, keyPair)
+    } yield snapshot
+
+  test("getHighestSnapshotInfoOrdinal skips a damaged highest file") { res =>
+    implicit val (kryoSerializer, jsonSerializer, hasher, _) = res
+    implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(hasher)
+
+    File.temporaryDirectory() { root =>
+      val lower = SnapshotOrdinal.unsafeApply(1L)
+      val higher = SnapshotOrdinal.unsafeApply(2L)
+
+      for {
+        storages <- makeStorages(root)
+        _ <- storages.info.write(lower, GlobalSnapshotInfo.empty)
+        _ <- storages.info.write(higher, GlobalSnapshotInfo.empty)
+        _ <- IO.blocking((root / "info" / higher.value.value.toString).writeByteArray(Array[Byte](1, 2, 3)))
+        selected <- storages.download.getHighestSnapshotInfoOrdinal(higher)
+      } yield expect.same(Some(lower), selected)
+    }
+  }
+
+  test("ensurePersistedAnchor repairs a missing ordinal index and rejects damaged snapshot-info") { res =>
+    implicit val (kryoSerializer, jsonSerializer, hasher, securityProvider) = res
+    implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(hasher)
+
+    File.temporaryDirectory() { root =>
+      for {
+        storages <- makeStorages(root)
+        snapshot <- makeSnapshot
+        hashed <- snapshot.toHashed[IO]
+        _ <- storages.download.writePersisted(snapshot)
+        _ <- storages.info.write(snapshot.ordinal, GlobalSnapshotInfo.empty)
+        _ <- storages.persisted.delete(snapshot.ordinal)
+        repaired <- storages.download.ensurePersistedAnchor(hashed.hash, snapshot.ordinal)
+        byOrdinal <- storages.persisted.read(snapshot.ordinal)
+        _ <- IO.blocking((root / "info" / snapshot.ordinal.value.value.toString).writeByteArray(Array[Byte](1, 2, 3)))
+        rejected <- storages.download.ensurePersistedAnchor(hashed.hash, snapshot.ordinal)
+      } yield expect.all(repaired, byOrdinal.contains(snapshot), !rejected)
+    }
+  }
+
+  test("an unreadable persisted snapshot is rejected and replaced by a validated recovery envelope") { res =>
+    implicit val (kryoSerializer, jsonSerializer, hasher, securityProvider) = res
+    implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(hasher)
+
+    File.temporaryDirectory() { root =>
+      for {
+        storages <- makeStorages(root)
+        snapshot <- makeSnapshot
+        hashed <- snapshot.toHashed[IO]
+        _ <- storages.download.writePersisted(snapshot)
+        _ <- storages.info.write(snapshot.ordinal, GlobalSnapshotInfo.empty)
+        hashPath <- storages.persisted.getPath(hashed.hash)
+        _ <- IO.blocking(hashPath.writeByteArray(Array[Byte](1, 2, 3)))
+        rejected <- storages.download.ensurePersistedAnchor(hashed.hash, snapshot.ordinal)
+        _ <- storages.download.moveTmpToPersisted(snapshot)
+        byHash <- storages.persisted.read(hashed.hash)
+        byOrdinal <- storages.persisted.read(snapshot.ordinal)
+      } yield expect.all(!rejected, byHash.contains(snapshot), byOrdinal.contains(snapshot))
+    }
+  }
+
+  test("recovery promotion replaces both indexes and converges without a temporary copy after restart") { res =>
+    implicit val (kryoSerializer, jsonSerializer, hasher, securityProvider) = res
+    implicit val hasherSelector: HasherSelector[IO] = HasherSelector.forSyncAlwaysCurrent(hasher)
+
+    File.temporaryDirectory() { root =>
+      for {
+        storages <- makeStorages(root)
+        original <- makeSnapshot
+        replacementKey <- KeyPairGenerator.makeKeyPair[IO]
+        replacement <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          original.value.copy(epochProgress = EpochProgress(NonNegLong.unsafeFrom(1L))),
+          replacementKey
+        )
+        originalHashed <- original.toHashed[IO]
+        replacementHashed <- replacement.toHashed[IO]
+        _ <- storages.download.writePersisted(original)
+        _ <- storages.tmp.writeUnderOrdinal(replacement)
+        _ <- storages.tmp.delete(replacement.ordinal)
+        _ <- storages.download.moveTmpToPersisted(replacement)
+        restarted <- makeStorages(root)
+        _ <- restarted.download.moveTmpToPersisted(replacement)
+        oldByHash <- restarted.persisted.read(originalHashed.hash)
+        replacementByHash <- restarted.persisted.read(replacementHashed.hash)
+        replacementByOrdinal <- restarted.persisted.read(replacement.ordinal)
+        temporary <- restarted.tmp.read(replacement.ordinal)
+      } yield
+        expect.all(
+          originalHashed.hash != replacementHashed.hash,
+          oldByHash.isEmpty,
+          replacementByHash.contains(replacement),
+          replacementByOrdinal.contains(replacement),
+          temporary.isEmpty
+        )
+    }
+  }
+}

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/gossip/p2p/GossipClient.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/gossip/p2p/GossipClient.scala
@@ -50,9 +50,19 @@ object GossipClient {
 
       def queryPeerRumors(request: PeerRumorInquiryRequest): PeerResponse[Stream[F, *], Signed[PeerRumorRaw]] =
         PeerResponse("rumors/peer/query", POST)(timeoutClient, session) { (req, c) =>
-          c.stream(req.withEntity(request)).flatMap { resp =>
-            resp.body.chunks.parseJsonStream[Json].evalMap(_.as[Signed[PeerRumorRaw]].liftTo[F])
-          }
+          // Bound acquisition and decoding, then release the response before emitting.
+          // Downstream hashing and queue backpressure must not consume the peer's deadline.
+          Stream
+            .eval(
+              c.stream(req.withEntity(request))
+                .flatMap { resp =>
+                  resp.body.chunks.parseJsonStream[Json].evalMap(_.as[Signed[PeerRumorRaw]].liftTo[F])
+                }
+                .compile
+                .toList
+                .timeout(gossipTimeoutsConfig.client)
+            )
+            .flatMap(Stream.emits)
         }
 
       def getInitialPeerRumors: PeerResponse[Stream[F, *], Signed[PeerRumorRaw]] =

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorage.scala
@@ -1,5 +1,7 @@
 package io.constellationnetwork.node.shared.infrastructure.snapshot.storage
 
+import java.util.Arrays
+
 import cats.Applicative
 import cats.effect.Async
 import cats.syntax.all._
@@ -11,6 +13,7 @@ import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
 import io.constellationnetwork.node.shared.infrastructure.snapshot.storage.SnapshotLocalFileSystemStorage.UnableToPersistSnapshot
+import io.constellationnetwork.node.shared.infrastructure.storage.CrashSafeAtomicFileWriter
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.snapshot.Snapshot
 import io.constellationnetwork.security.hash.Hash
@@ -63,6 +66,41 @@ abstract class SnapshotLocalFileSystemStorage[
     write(ordinalName, snapshot)
   }
 
+  /** Replace both persisted indexes with a validated recovery snapshot. Each index replacement is atomic; retry repairs a crash between the
+    * two replacements before the snapshot is used by consensus.
+    */
+  def replaceForRecovery(snapshot: Signed[S])(implicit hasher: Hasher[F]): F[Unit] =
+    for {
+      bytes <- JsonSerializer[F].serialize(snapshot)
+      hashName <- toHashName(snapshot.value)
+      ordinalName = toOrdinalName(snapshot.value)
+      previousHashName <- read(snapshot.ordinal).flatMap(_.traverse(previous => toHashName(previous.value)))
+      _ <- atomicReplace(hashName, bytes)
+      _ <- previousHashName.filterNot(_ === hashName).traverse_(delete)
+      _ <- previousHashName.filterNot(_ === hashName).traverse_ { previous =>
+        exists(previous).flatMap(
+          Async[F].raiseWhen(_)(new IllegalStateException(s"Recovery abandoned-hash cleanup failed: $previous"))
+        )
+      }
+      _ <- atomicReplace(ordinalName, bytes)
+      hashBytes <- readBytes(hashName).flatMap(
+        _.liftTo[F](new IllegalStateException(s"Recovery hash index missing after replace: $hashName"))
+      )
+      ordinalBytes <- readBytes(ordinalName).flatMap(
+        _.liftTo[F](new IllegalStateException(s"Recovery ordinal index missing after replace: $ordinalName"))
+      )
+      _ <- Async[F].raiseUnless(Arrays.equals(bytes, hashBytes) && Arrays.equals(bytes, ordinalBytes))(
+        new IllegalStateException(s"Recovery snapshot exact disk readback failed ordinal=${snapshot.ordinal}")
+      )
+    } yield ()
+
+  private def atomicReplace(fileName: String, bytes: Array[Byte]): F[Unit] = {
+    val target = path.toNioPath.resolve(fileName)
+    val parent = Path.fromNioPath(target.getParent)
+
+    CrashSafeAtomicFileWriter.make[F](parent).flatMap(_.write(target.getFileName.toString, bytes))
+  }
+
   def read(ordinal: SnapshotOrdinal): F[Option[Signed[S]]] =
     read(toOrdinalName(ordinal))
 
@@ -74,6 +112,62 @@ abstract class SnapshotLocalFileSystemStorage[
 
   def exists(hash: Hash): F[Boolean] =
     exists(toHashName(hash))
+
+  /** Verify the two persisted indexes and repair only a missing ordinal hardlink when the hash-indexed bytes decode and match exactly. */
+  def ensureOrdinalLink(expectedHash: Hash, expectedOrdinal: SnapshotOrdinal)(
+    implicit hasher: Hasher[F]
+  ): F[SnapshotLocalFileSystemStorage.OrdinalLinkStatus] = {
+    import SnapshotLocalFileSystemStorage.OrdinalLinkStatus
+
+    def identify(snapshot: Signed[S]): F[(SnapshotOrdinal, Hash)] =
+      snapshot.toHashed.map(hashed => (hashed.ordinal, hashed.hash))
+
+    def exact(snapshot: Signed[S]): F[Boolean] =
+      identify(snapshot).map { case (ordinal, hash) => ordinal === expectedOrdinal && hash === expectedHash }
+
+    read(expectedOrdinal).flatMap {
+      case Some(snapshot) =>
+        identify(snapshot).flatMap {
+          case (ordinal, hash) if ordinal === expectedOrdinal && hash === expectedHash =>
+            read(expectedHash).flatMap {
+              case Some(hashSnapshot) =>
+                identify(hashSnapshot).map {
+                  case (hashOrdinal, hashValue) if hashOrdinal === expectedOrdinal && hashValue === expectedHash =>
+                    OrdinalLinkStatus.Linked
+                  case (hashOrdinal, hashValue) => OrdinalLinkStatus.HashContentMismatch(hashOrdinal, hashValue)
+                }
+              case None =>
+                exists(expectedHash).map {
+                  case true  => OrdinalLinkStatus.HashUnreadable
+                  case false => OrdinalLinkStatus.HashIndexMissing
+                }
+            }
+          case (ordinal, hash) => OrdinalLinkStatus.OrdinalOccupied(ordinal, hash).pure[F].widen
+        }
+      case None =>
+        exists(expectedHash).ifM(
+          read(expectedHash).flatMap {
+            case Some(snapshot) =>
+              exact(snapshot).ifM(
+                write(snapshot).handleErrorWith {
+                  case _: UnableToPersistSnapshot => Applicative[F].unit
+                  case error                      => error.raiseError[F, Unit]
+                } >> read(expectedOrdinal).flatMap {
+                  case Some(relinked) =>
+                    exact(relinked).map {
+                      case true  => OrdinalLinkStatus.Repaired
+                      case false => OrdinalLinkStatus.RepairIncomplete
+                    }
+                  case None => OrdinalLinkStatus.RepairIncomplete.pure[F].widen
+                },
+                identify(snapshot).map { case (ordinal, hash) => OrdinalLinkStatus.HashContentMismatch(ordinal, hash) }
+              )
+            case None => OrdinalLinkStatus.HashUnreadable.pure[F].widen
+          },
+          OrdinalLinkStatus.Missing.pure[F].widen
+        )
+    }
+  }
 
   def delete(ordinal: SnapshotOrdinal): F[Unit] =
     delete(toOrdinalName(ordinal))
@@ -244,6 +338,21 @@ abstract class SnapshotLocalFileSystemStorage[
 }
 
 object SnapshotLocalFileSystemStorage {
+
+  sealed trait OrdinalLinkStatus {
+    def usable: Boolean = false
+  }
+
+  object OrdinalLinkStatus {
+    case object Linked extends OrdinalLinkStatus { override val usable: Boolean = true }
+    case object Repaired extends OrdinalLinkStatus { override val usable: Boolean = true }
+    case object Missing extends OrdinalLinkStatus
+    case object HashIndexMissing extends OrdinalLinkStatus
+    case object HashUnreadable extends OrdinalLinkStatus
+    case object RepairIncomplete extends OrdinalLinkStatus
+    final case class OrdinalOccupied(actualOrdinal: SnapshotOrdinal, actualHash: Hash) extends OrdinalLinkStatus
+    final case class HashContentMismatch(actualOrdinal: SnapshotOrdinal, actualHash: Hash) extends OrdinalLinkStatus
+  }
 
   case class UnableToPersistSnapshot(ordinalName: String, hashName: String, hashFileExists: Boolean) extends NoStackTrace {
     override val getMessage: String = s"Ordinal $ordinalName exists. File $hashName exists: $hashFileExists."

--- a/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/storage/CrashSafeAtomicFileWriter.scala
+++ b/modules/node-shared/src/main/scala/io/constellationnetwork/node/shared/infrastructure/storage/CrashSafeAtomicFileWriter.scala
@@ -1,0 +1,72 @@
+package io.constellationnetwork.node.shared.infrastructure.storage
+
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.{Files => JFiles, _}
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import fs2.io.file.Path
+
+/** Crash-safe atomic replacement for node-local byte files. */
+final class CrashSafeAtomicFileWriter[F[_]: Async] private (base: Path) {
+
+  private val nioBase = base.toNioPath
+
+  private def destination(fileName: String): java.nio.file.Path = {
+    val resolved = nioBase.resolve(fileName)
+    require(
+      resolved.getParent.equals(nioBase) && resolved.getFileName.toString === fileName,
+      s"invalid atomic file name=$fileName"
+    )
+    resolved
+  }
+
+  def write(fileName: String, bytes: Array[Byte]): F[Unit] = {
+    val target = destination(fileName)
+
+    Async[F].bracketCase(Async[F].blocking(JFiles.createTempFile(nioBase, s".atomic-$fileName.", ".tmp"))) { temp =>
+      Async[F].blocking {
+        val channel = FileChannel.open(temp, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
+        try {
+          val buffer = ByteBuffer.wrap(bytes)
+          while (buffer.hasRemaining) channel.write(buffer)
+          channel.force(true)
+        } finally channel.close()
+
+        try
+          JFiles.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        catch {
+          case error: AtomicMoveNotSupportedException =>
+            throw new IllegalStateException("atomic move is required for crash-safe local snapshot recovery", error)
+        }
+      } >> forceDirectory
+    } {
+      case (_, cats.effect.kernel.Outcome.Succeeded(_)) => Async[F].unit
+      case (temp, _)                                    => Async[F].blocking(JFiles.deleteIfExists(temp)).void.handleError(_ => ())
+    }
+  }
+
+  private def initialize: F[Unit] =
+    Async[F].blocking(JFiles.createDirectories(nioBase)).void >> forceDirectory
+
+  private def forceDirectory: F[Unit] =
+    Async[F].blocking {
+      try {
+        val directory = FileChannel.open(nioBase, StandardOpenOption.READ)
+        try directory.force(true)
+        finally directory.close()
+      } catch {
+        case _: UnsupportedOperationException                                                      => ()
+        case _: AccessDeniedException if System.getProperty("os.name").toLowerCase.contains("win") => ()
+      }
+    }
+}
+
+object CrashSafeAtomicFileWriter {
+  def make[F[_]: Async](base: Path): F[CrashSafeAtomicFileWriter[F]] = {
+    val writer = new CrashSafeAtomicFileWriter[F](base)
+    writer.initialize.as(writer)
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/gossip/p2p/GossipResponseDeadlineSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/gossip/p2p/GossipResponseDeadlineSuite.scala
@@ -1,0 +1,213 @@
+package io.constellationnetwork.node.shared.infrastructure.gossip.p2p
+
+import java.util.concurrent.TimeoutException
+
+import cats.data.NonEmptySet
+import cats.effect.std.{Random, Supervisor}
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+import io.constellationnetwork.node.shared.config.types.{GossipRoundConfig, GossipTimeoutsConfig}
+import io.constellationnetwork.node.shared.domain.cluster.services.Session
+import io.constellationnetwork.node.shared.domain.healthcheck.LocalHealthcheck
+import io.constellationnetwork.node.shared.http.p2p.headers.`X-Id`
+import io.constellationnetwork.node.shared.infrastructure.cluster.storage.ClusterStorage
+import io.constellationnetwork.node.shared.infrastructure.gossip.GossipRoundRunner
+import io.constellationnetwork.node.shared.infrastructure.metrics.{Metrics, NoOpMetrics}
+import io.constellationnetwork.schema.cluster._
+import io.constellationnetwork.schema.generation.Generation
+import io.constellationnetwork.schema.gossip._
+import io.constellationnetwork.schema.node.NodeState
+import io.constellationnetwork.schema.peer._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+
+import com.comcast.ip4s.{Host, Port}
+import eu.timepit.refined.auto._
+import fs2.Stream
+import io.circe.Json
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.client.Client
+import weaver.SimpleIOSuite
+
+object GossipResponseDeadlineSuite extends SimpleIOSuite {
+  private val id = PeerId(Hex("1" * 128))
+  private val context = P2PContext(Host.fromString("127.0.0.1").get, Port.fromInt(9001).get, id)
+  // Transport/decode fixtures only; signature and session authentication are not under test.
+  private val session = new Session[IO] {
+    def createSession: IO[SessionToken] = IO.raiseError(new IllegalStateException("unused"))
+    def verifyToken(peer: PeerId, token: Option[SessionToken]): IO[TokenVerificationResult] = IO.pure(TokenValid)
+  }
+  private val config = GossipTimeoutsConfig(10.seconds, 5.seconds)
+  private val rumor = Signed(
+    PeerRumorRaw(id, Ordinal.MinValue, Json.fromString("test"), ContentType("test")),
+    NonEmptySet.one(SignatureProof(id.toId, Signature(Hex("1" * 128))))
+  )
+  private def query(client: Client[IO]): Stream[IO, Signed[PeerRumorRaw]] =
+    GossipClient.make(client, session, config).queryPeerRumors(PeerRumorInquiryRequest(Map.empty)).run(context)
+
+  test("acquisition and unfinished body share one deadline and release the response exactly once") {
+    TestControl.executeEmbed {
+      for {
+        acquired <- Ref.of[IO, Int](0)
+        released <- Ref.of[IO, Int](0)
+        transport = Client[IO] { _ =>
+          Resource.eval(IO.sleep(4.seconds)) >> Resource.make(
+            acquired.update(_ + 1).as(Response[IO]().putHeaders(`X-Id`(id)).withBodyStream(Stream.never[IO]))
+          )(_ => released.update(_ + 1))
+        }
+        start <- IO.monotonic
+        result <- query(transport).compile.drain.attempt
+        elapsed <- IO.monotonic.map(_ - start)
+        count <- acquired.get
+        freed <- released.get
+      } yield
+        expect(result.left.exists(_.isInstanceOf[TimeoutException])) &&
+          expect.same(elapsed, 5.seconds) && expect.same(count, 1) && expect.same(freed, 1)
+    }
+  }
+
+  test("continually trickled bytes do not reset the total deadline and the response is released") {
+    TestControl.executeEmbed {
+      for {
+        chunks <- Ref.of[IO, Int](0)
+        released <- Ref.of[IO, Int](0)
+        body = Stream.repeatEval(IO.sleep(100.millis) >> chunks.update(_ + 1).as(32.toByte))
+        transport = Client[IO] { _ =>
+          Resource.make(IO.pure(Response[IO]().putHeaders(`X-Id`(id)).withBodyStream(body)))(_ => released.update(_ + 1))
+        }
+        start <- IO.monotonic
+        result <- query(transport).compile.drain.attempt
+        elapsed <- IO.monotonic.map(_ - start)
+        received <- chunks.get
+        freed <- released.get
+      } yield
+        expect(result.left.exists(_.isInstanceOf[TimeoutException])) &&
+          expect.same(elapsed, 5.seconds) && expect(received > 1) && expect.same(freed, 1)
+    }
+  }
+
+  test("a decoded prefix is not emitted when the response body never completes") {
+    TestControl.executeEmbed {
+      for {
+        emitted <- Ref.of[IO, Int](0)
+        body = Stream.emits((rumor.asJson.noSpaces + "\n").getBytes("UTF-8")).covary[IO] ++ Stream.never[IO]
+        transport = Client[IO](_ => Resource.pure(Response[IO]().putHeaders(`X-Id`(id)).withBodyStream(body)))
+        result <- query(transport).evalTap(_ => emitted.update(_ + 1)).compile.drain.attempt
+        count <- emitted.get
+      } yield expect(result.left.exists(_.isInstanceOf[TimeoutException])) && expect.same(count, 0)
+    }
+  }
+
+  test("complete decoded response is released before downstream work exceeding five seconds") {
+    TestControl.executeEmbed {
+      for {
+        released <- Ref.of[IO, Int](0)
+        transport = Client[IO] { _ =>
+          Resource.make(IO.pure(Response[IO]().putHeaders(`X-Id`(id)).withEntity(rumor.asJson.noSpaces)))(_ => released.update(_ + 1))
+        }
+        start <- IO.monotonic
+        result <- query(transport).evalMap(r => released.get.flatMap(n => IO.sleep(6.seconds).as((r, n)))).compile.toList
+        elapsed <- IO.monotonic.map(_ - start)
+        count <- released.get
+      } yield expect.same(result, List((rumor, 1))) && expect.same(elapsed, 6.seconds) && expect.same(count, 1)
+    }
+  }
+
+  test("slow local processing completes through the real runner without a peer healthcheck") {
+    TestControl.executeEmbed {
+      implicit val metrics: Metrics[IO] = NoOpMetrics.make
+      Supervisor[IO].use { implicit supervisor =>
+        Random.scalaUtilRandomSeedInt[IO](0).flatMap { implicit random =>
+          val peer = Peer(
+            id,
+            context.ip,
+            Port.fromInt(9000).get,
+            context.port,
+            ClusterSessionToken(Generation.MinValue),
+            SessionToken(Generation.MinValue),
+            NodeState.Ready,
+            Responsive,
+            Hash.empty
+          )
+          for {
+            completed <- Ref.of[IO, Int](0)
+            healthchecks <- Ref.of[IO, Int](0)
+            cluster <- ClusterStorage.make[IO](ClusterId("8d07c061-d42f-4d9c-9efc-37e0d1ee73e7"), Map(peer.id -> peer))
+            transport = Client[IO](_ => Resource.pure(Response[IO]().putHeaders(`X-Id`(id)).withEntity(rumor.asJson.noSpaces)))
+            health = new LocalHealthcheck[IO] {
+              def start(p: Peer): IO[Unit] = healthchecks.update(_ + 1)
+              def cancel(peerId: PeerId): IO[Unit] = IO.unit
+            }
+            runner <- GossipRoundRunner.make[IO](
+              cluster,
+              health,
+              _ => query(transport).evalMap(_ => IO.sleep(6.seconds)).compile.drain >> completed.update(_ + 1),
+              "peer",
+              GossipRoundConfig(1, 200.millis, 1)
+            )
+            _ <- runner.runForever
+            _ <- IO.sleep(7.seconds)
+            successes <- completed.get
+            errors <- healthchecks.get
+          } yield expect.same(successes, 1) && expect.same(errors, 0)
+        }
+      }
+    }
+  }
+
+  test("caller cancellation releases an acquired response before the deadline") {
+    TestControl.executeEmbed {
+      for {
+        released <- Ref.of[IO, Int](0)
+        transport = Client[IO] { _ =>
+          Resource.make(IO.pure(Response[IO]().putHeaders(`X-Id`(id)).withBodyStream(Stream.never[IO])))(_ => released.update(_ + 1))
+        }
+        fiber <- query(transport).compile.drain.start
+        _ <- IO.sleep(1.second)
+        _ <- fiber.cancel
+        count <- released.get
+      } yield expect.same(count, 1)
+    }
+  }
+
+  test("malformed JSON or a decoded rumor with missing fields fails and releases the response") {
+    List("not-json", "{}").traverse { body =>
+      for {
+        released <- Ref.of[IO, Int](0)
+        transport = Client[IO] { _ =>
+          Resource.make(IO.pure(Response[IO]().putHeaders(`X-Id`(id)).withEntity(body)))(_ => released.update(_ + 1))
+        }
+        result <- query(transport).compile.drain.attempt
+        count <- released.get
+      } yield expect(result.isLeft) && expect.same(count, 1)
+    }.map(_.reduce(_ && _))
+  }
+
+  test("common queries, offers and both initialization calls retain their six-second body lifetime") {
+    TestControl.executeEmbed {
+      val transport = Client[IO] { req =>
+        val content = req.uri.path.renderString match {
+          case "/rumors/common/offer" => "{\"offer\":[]}"
+          case "/rumors/common/init"  => "{\"seen\":[]}"
+          case _                      => ""
+        }
+        val body = Stream.sleep_[IO](6.seconds) ++ Stream.emits(content.getBytes("UTF-8")).covary[IO]
+        Resource.pure(Response[IO]().putHeaders(`X-Id`(id)).withBodyStream(body))
+      }
+      val client = GossipClient.make(transport, session, config)
+      List(
+        client.queryCommonRumors(QueryCommonRumorsRequest(Set.empty)).run(context).compile.drain,
+        client.getCommonRumorOffer.run(context).void,
+        client.getInitialPeerRumors.run(context).compile.drain,
+        client.getInitialCommonRumorHashes.run(context).void
+      ).traverse(_.attempt).map(results => expect(results.forall(_.isRight)))
+    }
+  }
+}

--- a/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorageSuite.scala
+++ b/modules/node-shared/src/test/scala/io/constellationnetwork/node/shared/infrastructure/snapshot/storage/SnapshotLocalFileSystemStorageSuite.scala
@@ -18,6 +18,7 @@ import io.constellationnetwork.storage.PathGenerator._
 
 import better.files._
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
 import fs2.io.file.Path
 import weaver.MutableIOSuite
 import weaver.scalacheck.Checkers
@@ -148,6 +149,56 @@ object SnapshotLocalFileSystemStorageSuite extends MutableIOSuite with Checkers 
             } yield expect.all(hashFile.exists, ordinalFile.isSameFileAs(hashFile))
         }
       }
+    }
+  }
+
+  test("ensureOrdinalLink - repairs a missing ordinal index only from exact hash-indexed bytes") { res =>
+    implicit val (_, kryo, j, h, sp) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      mkLocalFileSystemStorage(tmpDir).flatMap { storage =>
+        mkSnapshots.flatMap {
+          case (_, snapshot) =>
+            for {
+              hashed <- snapshot.toHashed
+              _ <- storage.write(snapshot)
+              _ <- storage.delete(snapshot.ordinal)
+              status <- storage.ensureOrdinalLink(hashed.hash, snapshot.ordinal)
+              repaired <- storage.read(snapshot.ordinal)
+            } yield expect.all(status == SnapshotLocalFileSystemStorage.OrdinalLinkStatus.Repaired, repaired.contains(snapshot))
+        }
+      }
+    }
+  }
+
+  test("replaceForRecovery - replaces both indexes and removes an abandoned same-ordinal hash across restart") { res =>
+    implicit val (_, kryo, j, h, sp) = res
+
+    File.temporaryDirectory() { tmpDir =>
+      for {
+        storage <- mkLocalFileSystemStorage(tmpDir)
+        snapshots <- mkSnapshots
+        (_, original) = snapshots
+        replacementKey <- KeyPairGenerator.makeKeyPair[IO]
+        replacement <- Signed.forAsyncHasher[IO, GlobalIncrementalSnapshot](
+          original.value.copy(epochProgress = EpochProgress(NonNegLong.unsafeFrom(1L))),
+          replacementKey
+        )
+        originalHash <- original.toHashed.map(_.hash)
+        replacementHash <- replacement.toHashed.map(_.hash)
+        _ <- storage.write(original)
+        _ <- storage.replaceForRecovery(replacement)
+        restarted <- mkLocalFileSystemStorage(tmpDir)
+        oldByHash <- restarted.read(originalHash)
+        replacementByHash <- restarted.read(replacementHash)
+        replacementByOrdinal <- restarted.read(replacement.ordinal)
+      } yield
+        expect.all(
+          originalHash != replacementHash,
+          oldByHash.isEmpty,
+          replacementByHash.contains(replacement),
+          replacementByOrdinal.contains(replacement)
+        )
     }
   }
 

--- a/modules/shared/src/main/scala/io/constellationnetwork/storage/LocalFileSystemStorage.scala
+++ b/modules/shared/src/main/scala/io/constellationnetwork/storage/LocalFileSystemStorage.scala
@@ -28,18 +28,22 @@ abstract class SerializableLocalFileSystemStorage[F[_]: JsonSerializer, A: Encod
   def read(fileName: String): F[Option[A]] =
     readBytes(fileName).flatMap {
       _.flatTraverse { bytes =>
-        JsonSerializer[F].deserialize[A](bytes).flatMap { result =>
-          result.fold(
-            jsonErr =>
-              deserializeFallback(bytes) match {
-                case Right(value) => value.some.pure[F]
-                case Left(fallbackErr) =>
-                  logger.warn(
-                    s"Failed to deserialize $fileName - JSON error: ${jsonErr.getMessage}, Fallback error: ${fallbackErr.getMessage}"
-                  ) >> none[A].pure[F]
-              },
-            value => value.some.pure[F]
-          )
+        def useFallback(jsonErr: Throwable): F[Option[A]] =
+          logger.warn(
+            s"Failed to deserialize $fileName - JSON error: ${jsonErr.getMessage}, using the fallback deserializer..."
+          ) >>
+            F.delay(deserializeFallback(bytes)).attempt.map(_.flatten).flatMap {
+              case Right(value) => value.some.pure[F]
+              case Left(fallbackErr) =>
+                logger.warn(
+                  s"Failed to deserialize $fileName - Fallback error: ${fallbackErr.getMessage}"
+                ) >> none[A].pure[F]
+            }
+
+        JsonSerializer[F].deserialize[A](bytes).attempt.flatMap {
+          case Right(Right(value)) => value.some.pure[F]
+          case Right(Left(error))  => useFallback(error)
+          case Left(error)         => useFallback(error)
         }
       }
     }

--- a/modules/shared/src/test/scala/io/constellationnetwork/storage/LocalFileSystemStorageSuite.scala
+++ b/modules/shared/src/test/scala/io/constellationnetwork/storage/LocalFileSystemStorageSuite.scala
@@ -1,0 +1,35 @@
+package io.constellationnetwork.storage
+
+import cats.effect.IO
+
+import io.constellationnetwork.json.JsonSerializer
+
+import better.files.File
+import fs2.io.file.Path
+import io.circe.{Decoder, Encoder}
+import weaver.SimpleIOSuite
+
+object LocalFileSystemStorageSuite extends SimpleIOSuite {
+
+  test("read returns None when both deserializers throw") {
+    File.temporaryDirectory() { root =>
+      implicit val jsonSerializer: JsonSerializer[IO] = new JsonSerializer[IO] {
+        def serialize[A: Encoder](content: A): IO[Array[Byte]] = IO.pure(Array.emptyByteArray)
+
+        def deserialize[A: Decoder](content: Array[Byte]): IO[Either[Throwable, A]] =
+          IO.raiseError(new IllegalArgumentException("damaged JSON bytes"))
+      }
+
+      val storage = new SerializableLocalFileSystemStorage[IO, String](Path(root.pathAsString)) {
+        def deserializeFallback(bytes: Array[Byte]): Either[Throwable, String] =
+          throw new IllegalStateException("damaged fallback bytes")
+      }
+
+      for {
+        _ <- storage.createDirectoryIfNotExists().rethrowT
+        _ <- storage.write("damaged", Array[Byte](1, 2, 3))
+        result <- storage.read("damaged")
+      } yield expect.same(None, result)
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Mainnet DAG L0 can remain in `WaitingForDownload` when the newest local snapshot
or snapshot-info path exists but its bytes cannot be decoded. Decoder exceptions
can escape storage, and retries can repeatedly select the same unusable anchor.

## Branch relationship

This is a Mainnet v3.5.31 backport and adaptation of the damaged-file recovery
work already merged into `develop` by #1588. The v4.1 implementation builds on
the larger crash-safe storage foundation from #1566; Mainnet does not have that
full storage stack, so this PR carries only the compatible pieces required for
safe recovery.

This PR is not intended to be forward-merged into `develop`. Mainnet deliberately
skips a mismatched persisted pair without deleting it and lets validated replay
replace it. The v4.1 implementation may delete a mismatched pair before
continuing. That difference is intentional.

The first commit is the exact organization-hosted Mainnet gossip fix from #1600.
The damaged-anchor recovery is a separate commit with no changed-file overlap;
stacking it here preserves the exact Mainnet candidate used for qualification.

## Changes

- Contain failures from both the primary JSON decoder and the historical fallback
  decoder.
- Keep expected JSON-to-Kryo fallback quiet; warn only when both decoders fail.
- Keep the highest persisted snapshot-info filename as evidence that this is
  recovery rather than a fresh-node bootstrap.
- Descend through lower candidate ordinals and validate each snapshot/info pair
  with the hasher selected for that historical ordinal.
- If persisted state existed but the bounded search finds no valid anchor, fail
  loudly for operator intervention instead of silently starting a
  multi-million-snapshot genesis replay.
- Use genesis only when no persisted snapshot-info filenames exist.
- Repair only the narrow case where an exact, readable hash-indexed snapshot
  exists and its ordinal index is missing.
- Atomically replace both persisted snapshot indexes after normal download
  validation, verify exact disk readback, and only then remove temporary data.

## Scope and safety

The existing ordinary snapshot-info writers, including live enqueue and
`persistSnapshotInfoWithCutoff`, remain unchanged and can still produce a damaged
file if a write is interrupted. Extending atomic replacement to every normal
persistence path is larger work and is intentionally outside this Mainnet
recovery hotfix. The atomic writer in this PR protects only installation of an
already validated recovery snapshot.

Downloaded snapshots still pass the existing chain, hash, and state-proof
validation. This change does not alter signatures, certificates, consensus
quorum, finality, admission, membership, or rewards. Malformed local bytes are
rejected rather than promoted.

## Verification

Review follow-up head `fdb8269a69db40353651fda8be60a69829ea7650`:

- Focused affected suites: 7/7.
- Full Shared suite: 133/133.
- Full Node Shared suite: 279/279.
- Full DAG L0 suite: 99/99, with 2 existing ignored tests.
- `scalafmtCheckAll` and `git diff --check` pass.

The original recovery commit remains separately qualified by the retained
isolated Mainnet GL0 runs:

- A damaged highest snapshot-info at ordinal 12 recovered to `Ready`, and all
  three nodes converged at ordinal 17.
- Damaged hash and ordinal snapshot indexes at ordinal 18 were rebuilt from a
  validated download; the node recovered to `Ready`, and all three nodes
  converged at ordinal 23.

The review follow-up changes logging and the exhausted-anchor failure policy; it
did not rerun those isolated network trials.
